### PR TITLE
Update the mamba banner to point to mamba-org

### DIFF
--- a/mamba/mamba.py
+++ b/mamba/mamba.py
@@ -81,7 +81,7 @@ banner = f"""
 
         mamba ({mamba.__version__}) supported by @QuantStack
 
-        GitHub:  https://github.com/TheSnakePit/mamba
+        GitHub:  https://github.com/mamba-org/mamba
         Twitter: https://twitter.com/QuantStack
 
 █████████████████████████████████████████████████████████████


### PR DESCRIPTION
Now that it shows up on the https://mybinder.org front page :) 

![image](https://user-images.githubusercontent.com/591645/94113894-dd784000-fe47-11ea-80dc-6e3c1c6e5e05.png)
