### PR TITLE
add creation of conda and tar.bz2 packages

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,7 +40,7 @@ jobs:
           export MAMBA_ROOT_PREFIX=~/micromamba
           export MAMBA_EXE=$(pwd)/micromamba
           . $MAMBA_ROOT_PREFIX/etc/profile.d/mamba.sh
-          micromamba create -y -p ~/build_env pybind11 libsolv libarchive libcurl nlohmann_json cxx-compiler cmake gtest cpp-filesystem "cpp-tabulate>=1.2" -c conda-forge
+          micromamba create -y -p ~/build_env pybind11 libsolv libarchive libcurl nlohmann_json cxx-compiler cmake gtest cpp-filesystem "cpp-tabulate>=1.2" yaml-cpp -c conda-forge
         env:
           PYTHON_VERSION: ${{ matrix.python-version }}
       - name: build tests

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -163,13 +163,15 @@ macro(mamba_create_target target_name linkage output_name)
         find_package(CURL REQUIRED)
         find_package(LibArchive REQUIRED)
         find_package(OpenSSL REQUIRED)
+        find_package(yaml-cpp CONFIG REQUIRED)
 
         set(MAMBA_DEPENDENCIES_LIBS
             ${LIBSOLV_LIBRARIES}
             ${LIBSOLVEXT_LIBRARIES}
             ${LibArchive_LIBRARIES}
             ${CURL_LIBRARIES}
-            ${OPENSSL_LIBRARIES})
+            ${OPENSSL_LIBRARIES}
+            ${YAML_CPP_LIBRARIES})
 
         target_link_libraries(${target_name} PUBLIC
                               ${MAMBA_DEPENDENCIES_LIBS}

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ For more instructions (including OS X) check out https://gist.github.com/wolfv/f
 
 Make sure to have the following requirements in your conda environment:
 
-`mamba install cmake compilers pybind11 libsolv libarchive libcurl nlohmann_json pip cpp-filesystem -c conda-forge`
+`mamba install cmake compilers pybind11 libsolv libarchive libcurl nlohmann_json pip cpp-filesystem yaml-cpp -c conda-forge`
 
 If you build mamba in a different environment than base, you must also install conda in
 that environment:

--- a/include/mamba/package_handling.hpp
+++ b/include/mamba/package_handling.hpp
@@ -15,6 +15,19 @@
 
 namespace mamba
 {
+    enum compression_algorithm
+    {
+        bzip2,
+        zip,
+        zstd
+    };
+
+    void create_archive(const fs::path& directory,
+                        const fs::path& destination,
+                        compression_algorithm,
+                        int compression_level);
+    void create_package(const fs::path& directory, const fs::path& out_file, int compression_level);
+
     void extract_archive(const fs::path& file, const fs::path& destination);
     void extract_conda(const fs::path& file,
                        const fs::path& dest_dir,

--- a/include/mamba/package_handling.hpp
+++ b/include/mamba/package_handling.hpp
@@ -33,6 +33,7 @@ namespace mamba
                        const fs::path& dest_dir,
                        const std::vector<std::string>& parts = { "info", "pkg" });
     fs::path extract(const fs::path& file);
+    bool transmute(const fs::path& pkg_file, const fs::path& target, int compression_level);
 }  // namespace mamba
 
 #endif  // MAMBA_PACKAGE_HANDLING_HPP

--- a/src/package_handling.cpp
+++ b/src/package_handling.cpp
@@ -357,7 +357,28 @@ namespace mamba
         }
         else
         {
-            throw std::runtime_error("Unknown file format (" + std::string(file) + ")");
+            throw std::runtime_error("Unknown package format (" + file.string() + ")");
         }
+    }
+
+    bool transmute(const fs::path& pkg_file, const fs::path& target, int compression_level)
+    {
+        TemporaryDirectory extract_dir;
+
+        if (ends_with(pkg_file.string(), ".tar.bz2"))
+        {
+            extract_archive(pkg_file, extract_dir);
+        }
+        else if (ends_with(pkg_file.string(), ".conda"))
+        {
+            extract_conda(pkg_file, extract_dir);
+        }
+        else
+        {
+            throw std::runtime_error("Unknown package format (" + pkg_file.string() + ")");
+        }
+
+        create_package(extract_dir, target, compression_level);
+        return true;
     }
 }  // namespace mamba

--- a/src/py_interface.cpp
+++ b/src/py_interface.cpp
@@ -10,6 +10,7 @@
 #include "mamba/channel.hpp"
 #include "mamba/context.hpp"
 #include "mamba/pool.hpp"
+#include "mamba/package_handling.hpp"
 #include "mamba/prefix_data.hpp"
 #include "mamba/query.hpp"
 #include "mamba/repo.hpp"
@@ -173,6 +174,8 @@ PYBIND11_MODULE(mamba_api, m)
 
     m.def("get_channel_urls", &get_channel_urls);
     m.def("calculate_channel_urls", &calculate_channel_urls);
+
+    m.def("transmute", &transmute);
 
     m.attr("SOLVER_SOLVABLE") = SOLVER_SOLVABLE;
     m.attr("SOLVER_SOLVABLE_NAME") = SOLVER_SOLVABLE_NAME;


### PR DESCRIPTION
This adds some code to create .tar.bz2 and .conda packages from mamba. This will be useful in boa. Maybe this code should actually live in `boa`... 

Also we'll soon add transmutation to boa, and here we can control the compression for zstd. In conda-forge-package-handling the compression is hard coded to a very high value which makes transmutation very expensive.