### PR TITLE
Fix Non Standard Channel URL handling

### DIFF
--- a/src/channel.cpp
+++ b/src/channel.cpp
@@ -390,17 +390,9 @@ namespace mamba
             return channel_configuration(sp[0].size() ? sp[0] : "/", sp[1], "file", "", "");
         }
 
-        // Case 7: fallback, channel_location = host:port and channel_name = path,
-        //         bumps the first token of paths starting with /conda for
-        //         compatibiliy with Anaconda Enterprise Repository software
+        // Case 7: fallback, channel_location = host:port and channel_name = path
         spath = lstrip(spath, "/");
-        std::string bump = "";
-        if (starts_with(spath, "conda"))
-        {
-            bump = "conda";
-            spath = spath.replace(0, 6, "");
-        }
-        std::string location = URLHandler().set_host(host).set_port(port).set_path(bump).url();
+        std::string location = URLHandler().set_host(host).set_port(port).url();
         return channel_configuration(std::string(strip(location, "/")), spath, scheme, "", "");
     }
 

--- a/test/test_channel.cpp
+++ b/test/test_channel.cpp
@@ -92,6 +92,14 @@ namespace mamba
 #endif
         EXPECT_EQ(c5.name(), "channel_b");
         EXPECT_EQ(c5.platform(), platform);
+
+        std::string value6a = "http://localhost:8000/conda-forge/noarch";
+        Channel& c6a = make_channel(value6a);
+        EXPECT_EQ(c6a.url(false), value6a);
+
+        std::string value6b = "http://localhost:8000/conda_mirror/conda-forge/noarch";
+        Channel& c6b = make_channel(value6b);
+        EXPECT_EQ(c6b.url(false), value6b);
     }
 
     TEST(Channel, urls)


### PR DESCRIPTION
This PR resolves #493 where non standard URL like `http://localhost:8000/conda-forge/noarch` are rendered to `http://localhost:8000/conda/forge/noarch`.