### PR TITLE
Allow overriding the platform using $CONDA_SUBDIR

### DIFF
--- a/include/mamba/context.hpp
+++ b/include/mamba/context.hpp
@@ -78,8 +78,8 @@ namespace mamba
 
         void set_verbosity(int lvl);
 
-        std::string platform() const;
-        std::vector<std::string> platforms() const;
+        static std::string platform();
+        static std::vector<std::string> platforms();
 
         std::vector<std::string> channels = {};
 

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -100,12 +100,17 @@ namespace mamba
         this->verbosity = lvl;
     }
 
-    std::string Context::platform() const
+    std::string Context::platform()
     {
-        return MAMBA_PLATFORM;
+        std::string platform = std::getenv("CONDA_SUBDIR") ? std::getenv("CONDA_SUBDIR") : "";
+        if (platform.empty()){
+            return MAMBA_PLATFORM;
+        } else {
+            return platform;
+        }
     }
 
-    std::vector<std::string> Context::platforms() const
+    std::vector<std::string> Context::platforms()
     {
         return { platform(), "noarch" };
     }

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -103,9 +103,12 @@ namespace mamba
     std::string Context::platform()
     {
         std::string platform = std::getenv("CONDA_SUBDIR") ? std::getenv("CONDA_SUBDIR") : "";
-        if (platform.empty()){
+        if (platform.empty())
+        {
             return MAMBA_PLATFORM;
-        } else {
+        }
+        else
+        {
             return platform;
         }
     }


### PR DESCRIPTION
This will allow tools like conda-lock that rely on micromamba as a cli to switch platforms simil;ar to what can be done with conda