### PR TITLE
Fix -Wformat-extra-args warning in src/repo.cpp

### DIFF
--- a/src/repo.cpp
+++ b/src/repo.cpp
@@ -24,7 +24,7 @@ namespace mamba
         const size_t bufferSize = 30;
         static char MTV[bufferSize];
         MTV[0] = '\0';
-        snprintf(MTV, bufferSize, MAMBA_TOOL_VERSION, "_", solv_version);
+        snprintf(MTV, bufferSize, MAMBA_SOLV_VERSION);
         return MTV;
     }
 


### PR DESCRIPTION
Obtained using default (micro)mamba CMake installation instructions:

## Environment setup

`micromamba create -n mamba conda cmake compilers cli11 pybind11 libsolv libarchive libcurl nlohmann_json pip cpp-filesystem yaml-cpp -c conda-forge`

## Configuration

(This was aimed at a static build, such as in #572, but the error is in the source code and is independent of configuration)

```
mkdir build
cd build
cmake .. -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX -DCMAKE_BUILD_TYPE="Release" -DBUILD_EXE=ON -DBUILD_BINDINGS=OFF -DBUILD_STATIC=ON -DBUILD_SHARED=OFF -DSTATIC_DEPENDENCIES=ON
make
```

## Warning

```
/Mamba/src/repo.cpp: In function 'const char* mamba::mamba_tool_version()':
/Mamba/src/repo.cpp:16:28: warning: too many arguments for format [-Wformat-extra-args]
   16 | #define MAMBA_TOOL_VERSION "1.1"
      |                            ^~~~~
/Mamba/src/repo.cpp:27:35: note: in expansion of macro 'MAMBA_TOOL_VERSION'
   27 |         snprintf(MTV, bufferSize, MAMBA_TOOL_VERSION, "_", solv_version);
      |                                   ^~~~~~~~~~~~~~~~~~
```