### PR TITLE
Missing #include <fstream>

### DIFF
--- a/include/mamba/mamba_fs.hpp
+++ b/include/mamba/mamba_fs.hpp
@@ -3,6 +3,7 @@
 
 #ifdef MAMBA_USE_STD_FS
 #include <filesystem>
+#include <fstream>
 namespace fs = std::filesystem;
 #else
 #include "ghc/filesystem.hpp"


### PR DESCRIPTION
When defining `MAMBA_USE_STD_FS`, much of the code complains about various "incomplete `*fstream` types". I suspect the Mamba codebase has an illicit dependency on `#include <fstream>`, almost certainly because it "borrows" `ghc/filesystem.hpp`'s import of same.

But `#include <filesystem>` is not required to pull in `fstream`, so explicitly import it in the `MAMBA_USE_STD_FS` branch of the `#ifdef`.