### PR TITLE
Fixed interruption mechanics

### DIFF
--- a/include/mamba/thread_utils.hpp
+++ b/include/mamba/thread_utils.hpp
@@ -159,8 +159,6 @@ namespace mamba
         block_signals();
         auto f = std::bind(std::forward<Function>(func), std::forward<Args>(args)...);
         std::thread victor_the_cleaner([f, this]() {
-            pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, nullptr);
-            pthread_setcanceltype(PTHREAD_CANCEL_ASYNCHRONOUS, nullptr);
 
             wait_for_signal();
 

--- a/src/thread_utils.cpp
+++ b/src/thread_utils.cpp
@@ -24,7 +24,7 @@ namespace mamba
 
     void set_default_signal_handler()
     {
-        std::signal(SIGINT, [](int signum) { set_sig_interrupted(); });
+        //std::signal(SIGINT, [](int signum) { set_sig_interrupted(); });
     }
 
     bool is_sig_interrupted() noexcept
@@ -103,12 +103,6 @@ namespace mamba
 
     void register_cleaning_thread_id(std::thread::native_handle_type id)
     {
-#ifndef _WIN32
-        if (cleanup_id)
-        {
-            pthread_cancel(cleanup_id);
-        }
-#endif
         cleanup_id = id;
     }
 
@@ -166,13 +160,10 @@ namespace mamba
         if (is_sig_interrupted())
         {
             wait_for_cleanup();
-            std::cout << "Cleanup done." << std::endl;
         }
         m_interrupt.store(false);
+        pthread_kill(get_cleaning_thread_id(), SIGINT);
         pthread_sigmask(SIG_UNBLOCK, &sigset, nullptr);
-        set_default_signal_handler();
-        pthread_cancel(get_cleaning_thread_id());
-        register_cleaning_thread_id(0);
     }
 
     void interruption_guard::block_signals() const

--- a/test/test_thread_utils.cpp
+++ b/test/test_thread_utils.cpp
@@ -6,9 +6,14 @@
 
 namespace mamba
 {
-    TEST(thread_utils, interrupt)
+    namespace
     {
+        std::mutex res_mutex;
+    }
 #if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__))
+    int test_interruption_guard(bool interrupt)
+    {
+        
         int res = 0;
         // Ensures the compiler doe snot optimize away Context::instance()
         std::string current_command = Context::instance().current_command;
@@ -25,16 +30,53 @@ namespace mamba
             for (size_t i = 0; i < 5; ++i)
             {
                 thread t([&res]() {
-                    ++res;
+                    {
+                        std::unique_lock<std::mutex> lk(res_mutex);
+                        ++res;
+                    }
                     std::this_thread::sleep_for(std::chrono::milliseconds(300));
                 });
                 t.detach();
             }
 
-            pthread_kill(get_cleaning_thread_id(), SIGINT);
-            std::this_thread::sleep_for(std::chrono::seconds(1));
+            if (interrupt)
+            {
+                pthread_kill(get_cleaning_thread_id(), SIGINT);
+            }
+            while (get_thread_count() != 0)
+            {
+                std::this_thread::sleep_for(std::chrono::seconds(1));
+            }
         }
-        EXPECT_EQ(res, -1);
-#endif
+        return res;
     }
+
+    TEST(thread_utils, interrupt)
+    {
+        int res = test_interruption_guard(true);
+        EXPECT_EQ(res, -1);
+    }
+
+    TEST(thread_utils, no_interrupt)
+    {
+        int res = test_interruption_guard(false);
+        EXPECT_EQ(res, 5);
+    }
+
+    TEST(thread_utils, no_interrupt_then_interrupt)
+    {
+        int res1 = test_interruption_guard(false);
+        EXPECT_EQ(res1, 5);
+        int res2 = test_interruption_guard(true);
+        EXPECT_EQ(res2, -1);
+    }
+
+    TEST(thread_utils, no_interrupt_sequence)
+    {
+        int res1 = test_interruption_guard(false);
+        EXPECT_EQ(res1, 5);
+        int res2 = test_interruption_guard(false);
+        EXPECT_EQ(res2, 5);
+    }
+#endif
 }  // namespace mamba

--- a/test/test_thread_utils.cpp
+++ b/test/test_thread_utils.cpp
@@ -75,8 +75,13 @@ namespace mamba
     {
         int res1 = test_interruption_guard(false);
         EXPECT_EQ(res1, 5);
+        // Ensures the interruption guard is not allocated at the same
+        // place
+        double d = 4;
         int res2 = test_interruption_guard(false);
         EXPECT_EQ(res2, 5);
+        // Ensures the compiler does not remove d
+        EXPECT_EQ(d, 4);
     }
 #endif
 }  // namespace mamba


### PR DESCRIPTION
This assumes we don't check `is_sig_interrupted` outside of the scope of an `interruption_guard` object.