### PR TITLE
Fix activation check path

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,15 +159,21 @@ mamba install -c conda-forge cli11 cmake
 ```
 
 For the C++ tests, you need Google Tests installed (e.g. `mamba install gtest`).
-To build the program using CMake, the following line needs to be used:
+To build the program using CMake, the following lines need to be used:
 
 ```bash
+mkdir -p build
+cd build
 cmake .. \
     -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX \
     -DPYTHON_EXECUTABLE=$CONDA_PREFIX/bin/python3 \
     -DPYTHON_LIBRARIES=$CONDA_PREFIX/lib/libpython3.7m.so \
     -DENABLE_TESTS=ON
+cmake --build . -j
 ```
+
+This would generate the test program `./test/test_mamba` under the `build`
+directory which you can execute with `make test`.
 
 ### Support us
 

--- a/README.md
+++ b/README.md
@@ -173,7 +173,8 @@ cmake --build . -j
 ```
 
 This would generate the test program `./test/test_mamba` under the `build`
-directory which you can execute with `make test`.
+directory which you can execute with `make test`. To generate the executable
+`micromamba` also include the CMake option `-DBUILD_EXE=ON` in the above step.
 
 ### Support us
 

--- a/src/micromamba/main.cpp
+++ b/src/micromamba/main.cpp
@@ -321,7 +321,7 @@ init_shell_parser(CLI::App* subcom)
         else
         {
             throw std::runtime_error(
-                "Currently allowed values are: posix, bash, zsh, cmd.exe & powershell");
+                "Currently allowed values are: posix, bash, xonsh, zsh, cmd.exe & powershell");
         }
         if (shell_options.action == "init")
         {

--- a/src/micromamba/main.cpp
+++ b/src/micromamba/main.cpp
@@ -351,8 +351,7 @@ init_shell_parser(CLI::App* subcom)
             if (!fs::exists(shell_options.prefix))
             {
                 throw std::runtime_error(
-                    "Cannot activate, environment does not exist: " + shell_options.prefix + "\n"
-                );
+                    "Cannot activate, environment does not exist: " + shell_options.prefix + "\n");
             }
             std::cout << activator->activate(shell_options.prefix, shell_options.stack);
         }

--- a/src/micromamba/main.cpp
+++ b/src/micromamba/main.cpp
@@ -348,6 +348,12 @@ init_shell_parser(CLI::App* subcom)
                 shell_options.prefix
                     = Context::instance().root_prefix / "envs" / shell_options.prefix;
             }
+            if (!fs::exists(shell_options.prefix))
+            {
+                throw std::runtime_error(
+                    "Cannot activate, environment does not exist: " + shell_options.prefix + "\n"
+                );
+            }
             std::cout << activator->activate(shell_options.prefix, shell_options.stack);
         }
         else if (shell_options.action == "reactivate")


### PR DESCRIPTION
Fixes #682.

I faced some hiccups in understanding how to install for development. I also took the liberty in clarifying `cmake` steps and mentioning that `xonsh` is supported. Hope you won't mind! A test would be nice, but I leave that to the pros.

I had to also lookup the [micromamba-feedstock](https://github.com/conda-forge/micromamba-feedstock/blob/master/recipe/build.sh) to understand how the executable was generated. Should we mention the cmake option `-DBUILD_EXE=ON ` followed by `make install/local`?