### PR TITLE
[DOC]: Make explicit installation into base env (closes #708)

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,10 +36,10 @@ The ecosystem also consists of `quetz`, an open source conda package server and 
 
 ### Installation
 
-It's advised to install mamba from conda-forge. If you already have conda:
+It's advised to install mamba from conda-forge. If you already have conda, install mamba into the base environment:
 
 ```
-conda install mamba -c conda-forge
+conda install mamba -n base -c conda-forge
 ```
 
 otherwise it's best to start with [Miniconda](https://docs.conda.io/en/latest/miniconda.html).

--- a/docs/source/getting_started.md
+++ b/docs/source/getting_started.md
@@ -14,13 +14,15 @@ After successful installation, you can use the mamba commands as described in [H
 For conda users
 ---------------
 
-If you are already a conda users, very good! Using mamba will feel natural.
+If you are already a conda user, very good! Using mamba will feel natural.
 
 To get mamba, install it _into the base environment_ from the `conda-forge` channel:
 
 ```
 conda install mamba -n base -c conda-forge
 ```
+
+_Note: Installing mamba into any other environment can cause unexpected behavior._
 
 There is little difference between using conda & mamba. You can swap almost all commands:
 


### PR DESCRIPTION
It's not immediately apparent from the project README that mamba must be installed into the base Conda env. I was also caught by the same `mamba env update -n foo -f bar.yml` gotcha as https://github.com/mamba-org/mamba/issues/631#issuecomment-744407332.

Since the project documentation site is not linked from the project README, this PR updates `README.md` to reflect the installation instructions in `docs/getting_started.md`, and adds a note to the doc page that foreshadows the unexpected behavior of #631.