### PR TITLE
Pin packages

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,6 +93,7 @@ set(MAMBA_SOURCES
     ${MAMBA_SOURCE_DIR}/package_cache.cpp
     ${MAMBA_SOURCE_DIR}/pool.cpp
     ${MAMBA_SOURCE_DIR}/prefix_data.cpp
+    ${MAMBA_SOURCE_DIR}/pinning.cpp
     ${MAMBA_SOURCE_DIR}/package_info.cpp
     ${MAMBA_SOURCE_DIR}/package_paths.cpp
     ${MAMBA_SOURCE_DIR}/query.cpp
@@ -128,6 +129,7 @@ set(MAMBA_HEADERS
     ${MAMBA_INCLUDE_DIR}/mamba/package_paths.hpp
     ${MAMBA_INCLUDE_DIR}/mamba/pool.hpp
     ${MAMBA_INCLUDE_DIR}/mamba/prefix_data.hpp
+    ${MAMBA_INCLUDE_DIR}/mamba/pinning.hpp
     ${MAMBA_INCLUDE_DIR}/mamba/query.hpp
     ${MAMBA_INCLUDE_DIR}/mamba/repo.hpp
     ${MAMBA_INCLUDE_DIR}/mamba/shell_init.hpp

--- a/include/mamba/context.hpp
+++ b/include/mamba/context.hpp
@@ -97,6 +97,8 @@ namespace mamba
         std::string channel_alias = "";
         bool override_channels_enabled = true;
 
+        std::vector<std::string> pinned_packages = {};
+
         static Context& instance();
 
         Context(const Context&) = delete;

--- a/include/mamba/pinning.hpp
+++ b/include/mamba/pinning.hpp
@@ -15,12 +15,9 @@
 
 namespace mamba
 {
-    void pin_python_spec(const PrefixData& prefix_data, std::vector<std::string>& specs);
+    std::string python_pin(const PrefixData& prefix_data, const std::vector<std::string>& specs);
 
-    void pin_config_specs(const std::vector<std::string>& config_specs,
-                          std::vector<std::string>& specs);
-
-    void pin_file_specs(const fs::path& file_specs, std::vector<std::string>& specs);
+    std::vector<std::string> file_pins(const fs::path& file);
 }
 
 #endif

--- a/include/mamba/pinning.hpp
+++ b/include/mamba/pinning.hpp
@@ -1,0 +1,26 @@
+// Copyright (c) 2019, QuantStack and Mamba Contributors
+//
+// Distributed under the terms of the BSD 3-Clause License.
+//
+// The full license is in the file LICENSE, distributed with this software.
+
+#ifndef MAMBA_PINNING_HPP
+#define MAMBA_PINNING_HPP
+
+#include "prefix_data.hpp"
+
+#include <vector>
+#include <string>
+
+
+namespace mamba
+{
+    void pin_python_spec(const PrefixData& prefix_data, std::vector<std::string>& specs);
+
+    void pin_config_specs(const std::vector<std::string>& config_specs,
+                          std::vector<std::string>& specs);
+
+    void pin_file_specs(const fs::path& file_specs, std::vector<std::string>& specs);
+}
+
+#endif

--- a/include/mamba/solver.hpp
+++ b/include/mamba/solver.hpp
@@ -46,7 +46,8 @@ namespace mamba
 
         void add_jobs(const std::vector<std::string>& jobs, int job_flag);
         void add_constraint(const std::string& job);
-        void add_pin(const std::string& job);
+        void add_pin(const std::string& pin);
+        void add_pins(const std::vector<std::string>& pins);
         void set_flags(const std::vector<std::pair<int, int>>& flags);
         void set_postsolve_flags(const std::vector<std::pair<int, int>>& flags);
         bool is_solved();

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -1,3 +1,9 @@
+// Copyright (c) 2019, QuantStack and Mamba Contributors
+//
+// Distributed under the terms of the BSD 3-Clause License.
+//
+// The full license is in the file LICENSE, distributed with this software.
+
 #include "mamba/config.hpp"
 
 #include <algorithm>
@@ -94,7 +100,8 @@ namespace mamba
 
         if (nodes.size() > 0)
         {
-            std::vector<std::string> prepend_seq_config = { "channels", "default_channels" };
+            std::vector<std::string> prepend_seq_config
+                = { "channels", "default_channels", "pinned_packages" };
             for (auto key : prepend_seq_config)
             {
                 build_prepend_seq(nodes, key, node2src, config, config_sources);

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -114,7 +114,10 @@ namespace mamba
         {
             channels = c["channels"].as<std::vector<std::string>>();
         }
-
+        if (c["pinned_packages"])
+        {
+            pinned_packages = c["pinned_packages"].as<std::vector<std::string>>();
+        }
         channel_alias = c["channel_alias"] ? c["channel_alias"].as<std::string>() : channel_alias;
         override_channels_enabled = c["override_channels_enabled"]
                                         ? c["override_channels_enabled"].as<bool>()

--- a/src/micromamba/main.cpp
+++ b/src/micromamba/main.cpp
@@ -454,7 +454,7 @@ int RETRY_SUBDIR_FETCH = 1 << 0;
 int RETRY_SOLVE_ERROR = 1 << 1;
 
 void
-install_specs(std::vector<std::string>& specs, bool create_env = false, int is_retry = 0)
+install_specs(const std::vector<std::string>& specs, bool create_env = false, int is_retry = 0)
 {
     auto& ctx = Context::instance();
 

--- a/src/micromamba/main.cpp
+++ b/src/micromamba/main.cpp
@@ -604,7 +604,7 @@ install_specs(const std::vector<std::string>& specs, bool create_env = false, in
 
     if (!create_options.no_pin)
     {
-        solver.add_pins(file_pins(prefix_data.path() / "conda-meta/pinned"));
+        solver.add_pins(file_pins(prefix_data.path() / "conda-meta" / "pinned"));
         solver.add_pins(ctx.pinned_packages);
     }
 

--- a/src/pinning.cpp
+++ b/src/pinning.cpp
@@ -1,0 +1,71 @@
+// Copyright (c) 2019, QuantStack and Mamba Contributors
+//
+// Distributed under the terms of the BSD 3-Clause License.
+//
+// The full license is in the file LICENSE, distributed with this software.
+
+#include "mamba/pinning.hpp"
+
+#include <fstream>
+
+
+namespace mamba
+{
+    void pin_python_spec(const PrefixData& prefix_data, std::vector<std::string>& specs)
+    {
+        bool py_found = false;
+        std::string py_spec = "";
+
+        for (auto spec : specs)
+        {
+            if (spec.find("python") != std::string::npos)
+            {
+                py_found = true;
+                py_spec = spec;
+                break;
+            }
+        }
+
+        if (py_found)
+        {
+            MatchSpec ms(py_spec);
+            std::regex ver_pat("=?[0-9]+\\.[0-9]+.*");
+
+            if (std::regex_match(ms.version, ver_pat))
+            {
+                return;
+            }
+        }
+
+        try
+        {
+            std::string py_version = prefix_data.records().at("python").version;
+            specs.erase(std::remove(specs.begin(), specs.end(), py_spec), specs.end());
+            specs.push_back("python=" + py_version);
+            return;
+        }
+        catch (const std::exception& e)
+        {
+            return;
+        }
+    }
+
+    void pin_config_specs(const std::vector<std::string>& config_specs,
+                          std::vector<std::string>& specs)
+    {
+        specs.insert(specs.end(), config_specs.begin(), config_specs.end());
+    }
+
+    void pin_file_specs(const fs::path& file_specs, std::vector<std::string>& specs)
+    {
+        if (fs::exists(file_specs) && !fs::is_directory(file_specs))
+        {
+            std::ifstream input_file(file_specs);
+            std::string line;
+            while (std::getline(input_file, line))
+            {
+                specs.push_back(line);
+            }
+        }
+    }
+}

--- a/src/pinning.cpp
+++ b/src/pinning.cpp
@@ -17,11 +17,12 @@ namespace mamba
         std::string py_version;
         MatchSpec ms;
 
-        try
+        auto iter = prefix_data.records().find("python");
+        if (iter != prefix_data.records().end())
         {
-            py_version = prefix_data.records().at("python").version;
+            py_version = iter->second.version;
         }
-        catch (const std::exception& e)
+        else
         {
             return "";  // Python not found in prefix
         }

--- a/src/pinning.cpp
+++ b/src/pinning.cpp
@@ -11,61 +11,47 @@
 
 namespace mamba
 {
-    void pin_python_spec(const PrefixData& prefix_data, std::vector<std::string>& specs)
+    std::string python_pin(const PrefixData& prefix_data, const std::vector<std::string>& specs)
     {
-        bool py_found = false;
-        std::string py_spec = "";
-
-        for (auto spec : specs)
-        {
-            if (spec.find("python") != std::string::npos)
-            {
-                py_found = true;
-                py_spec = spec;
-                break;
-            }
-        }
-
-        if (py_found)
-        {
-            MatchSpec ms(py_spec);
-            std::regex ver_pat("=?[0-9]+\\.[0-9]+.*");
-
-            if (std::regex_match(ms.version, ver_pat))
-            {
-                return;
-            }
-        }
+        std::string pin = "";
+        std::string py_version;
+        MatchSpec ms;
 
         try
         {
-            std::string py_version = prefix_data.records().at("python").version;
-            specs.erase(std::remove(specs.begin(), specs.end(), py_spec), specs.end());
-            specs.push_back("python=" + py_version);
-            return;
+            py_version = prefix_data.records().at("python").version;
         }
         catch (const std::exception& e)
         {
-            return;
+            return "";  // Python not found in prefix
         }
-    }
 
-    void pin_config_specs(const std::vector<std::string>& config_specs,
-                          std::vector<std::string>& specs)
-    {
-        specs.insert(specs.end(), config_specs.begin(), config_specs.end());
-    }
-
-    void pin_file_specs(const fs::path& file_specs, std::vector<std::string>& specs)
-    {
-        if (fs::exists(file_specs) && !fs::is_directory(file_specs))
+        for (auto spec : specs)
         {
-            std::ifstream input_file(file_specs);
+            ms = spec;
+            if (ms.name == "python")
+            {
+                return "";
+            }
+        }
+
+        return "python=" + py_version;
+    }
+
+    std::vector<std::string> file_pins(const fs::path& file)
+    {
+        std::vector<std::string> pins;
+
+        if (fs::exists(file) && !fs::is_directory(file))
+        {
+            std::ifstream input_file(file);
             std::string line;
             while (std::getline(input_file, line))
             {
-                specs.push_back(line);
+                pins.push_back(line);
             }
         }
+
+        return pins;
     }
 }

--- a/src/solver.cpp
+++ b/src/solver.cpp
@@ -179,7 +179,7 @@ namespace mamba
         queue_push2(&m_jobs, SOLVER_INSTALL | SOLVER_SOLVABLE_PROVIDES, inst_id);
     }
 
-    void MSolver::add_pin(const std::string& job)
+    void MSolver::add_pin(const std::string& pin)
     {
         // if we pin a package, we need to remove all packages that don't match the
         // pin from being available for installation! This is done by adding
@@ -192,7 +192,7 @@ namespace mamba
         // First we need to check if the pin is OK given the currently installed
         // packages
         Pool* pool = m_pool;
-        MatchSpec ms(job);
+        MatchSpec ms(pin);
 
         // TODO
         // if (m_prefix_data)
@@ -233,7 +233,7 @@ namespace mamba
 
         if (all_solvables.size() != 0 && matching_solvables.size() == 0)
         {
-            LOG_ERROR << "No package can be installed for pin: " << job;
+            LOG_ERROR << "No package can be installed for pin: " << pin;
             exit(1);
         }
 
@@ -253,6 +253,14 @@ namespace mamba
         Id d = pool_queuetowhatprovides(pool, &selected_pkgs);
         queue_push2(&m_jobs, SOLVER_LOCK | SOLVER_SOLVABLE_ONE_OF, d);
         queue_free(&selected_pkgs);
+    }
+
+    void MSolver::add_pins(const std::vector<std::string>& pins)
+    {
+        for (auto pin : pins)
+        {
+            add_pin(pin);
+        }
     }
 
     void MSolver::set_postsolve_flags(const std::vector<std::pair<int, int>>& flags)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -16,6 +16,7 @@ set(TEST_SRCS
     test_transfer.cpp
     test_thread_utils.cpp
     test_graph.cpp
+    test_pinning.cpp
 )
 
 add_executable(test_mamba ${TEST_SRCS})

--- a/test/test_config.cpp
+++ b/test/test_config.cpp
@@ -487,5 +487,40 @@ namespace mamba
             ASSERT_TRUE(config["channel_priority"]);
             ASSERT_EQ(config["channel_priority"].as<std::string>(), "strict");
         }
+
+        TEST_F(Configurable, pinned_packages)
+        {
+            std::string rc1 = unindent(R"(
+                pinned_packages:
+                    - jupyterlab=3
+                    - numpy=1.19)");
+            std::string rc2 = unindent(R"(
+                pinned_packages:
+                    - matplotlib
+                    - numpy=1.19)");
+            std::string rc3 = unindent(R"(
+                pinned_packages:
+                    - jupyterlab=3
+                    - bokeh
+                    - matplotlib)");
+
+            load_test_config(std::vector<std::string>({ rc1, rc2, rc3 }));
+            ASSERT_TRUE(config["pinned_packages"]);
+            EXPECT_EQ(dump(), unindent(R"(
+                        pinned_packages:
+                          - jupyterlab=3
+                          - numpy=1.19
+                          - matplotlib
+                          - bokeh)"));
+
+            load_test_config(std::vector<std::string>({ rc2, rc1, rc3 }));
+            ASSERT_TRUE(config["pinned_packages"]);
+            EXPECT_EQ(dump(), unindent(R"(
+                        pinned_packages:
+                          - matplotlib
+                          - numpy=1.19
+                          - jupyterlab=3
+                          - bokeh)"));
+        }
     }  // namespace testing
 }  // namespace mamba

--- a/test/test_pinning.cpp
+++ b/test/test_pinning.cpp
@@ -1,0 +1,146 @@
+#include <gtest/gtest.h>
+
+#include "mamba/pinning.hpp"
+
+
+namespace mamba
+{
+    namespace testing
+    {
+        TEST(pinning, pin_python_spec)
+        {
+            std::vector<std::string> specs;
+            PrefixData prefix_data("");
+            ASSERT_EQ(prefix_data.records().size(), 0);
+
+            specs = { "python" };
+            pin_python_spec(prefix_data, specs);
+            ASSERT_EQ(specs.size(), 1);
+            EXPECT_EQ(specs[0], "python");
+
+            specs = { "python=3" };
+            pin_python_spec(prefix_data, specs);
+            ASSERT_EQ(specs.size(), 1);
+            EXPECT_EQ(specs[0], "python=3");
+
+            specs = { "python==3.8" };
+            pin_python_spec(prefix_data, specs);
+            ASSERT_EQ(specs.size(), 1);
+            EXPECT_EQ(specs[0], "python==3.8");
+
+            specs = { "python==3.8.3" };
+            pin_python_spec(prefix_data, specs);
+            ASSERT_EQ(specs.size(), 1);
+            EXPECT_EQ(specs[0], "python==3.8.3");
+
+            specs = { "numpy" };
+            pin_python_spec(prefix_data, specs);
+            ASSERT_EQ(specs.size(), 1);
+            EXPECT_EQ(specs[0], "numpy");
+
+            PackageInfo pkg_info("python", "3.7.10", "abcde", 0);
+            prefix_data.m_package_records.insert({ "python", pkg_info });
+            ASSERT_EQ(prefix_data.records().size(), 1);
+
+            specs = { "python" };
+            pin_python_spec(prefix_data, specs);
+            ASSERT_EQ(specs.size(), 1);
+            EXPECT_EQ(specs[0], "python=3.7.10");
+
+            specs = { "python==3" };
+            pin_python_spec(prefix_data, specs);
+            ASSERT_EQ(specs.size(), 1);
+            EXPECT_EQ(specs[0], "python=3.7.10");
+
+            specs = { "python=3.*" };
+            pin_python_spec(prefix_data, specs);
+            ASSERT_EQ(specs.size(), 1);
+            EXPECT_EQ(specs[0], "python=3.7.10");
+
+            specs = { "python=3.8" };
+            pin_python_spec(prefix_data, specs);
+            ASSERT_EQ(specs.size(), 1);
+            EXPECT_EQ(specs[0], "python=3.8");
+
+            specs = { "python=3.8.3" };
+            pin_python_spec(prefix_data, specs);
+            ASSERT_EQ(specs.size(), 1);
+            EXPECT_EQ(specs[0], "python=3.8.3");
+
+            specs = { "numpy" };
+            pin_python_spec(prefix_data, specs);
+            ASSERT_EQ(specs.size(), 2);
+            EXPECT_EQ(specs[0], "numpy");
+            EXPECT_EQ(specs[1], "python=3.7.10");
+
+            specs = { "numpy", "python" };
+            pin_python_spec(prefix_data, specs);
+            ASSERT_EQ(specs.size(), 2);
+            EXPECT_EQ(specs[0], "numpy");
+            EXPECT_EQ(specs[1], "python=3.7.10");
+
+            specs = { "numpy", "python=3.8" };
+            pin_python_spec(prefix_data, specs);
+            ASSERT_EQ(specs.size(), 2);
+            EXPECT_EQ(specs[0], "numpy");
+            EXPECT_EQ(specs[1], "python=3.8");
+
+            specs = { "numpy", "python=3.8.3" };
+            pin_python_spec(prefix_data, specs);
+            ASSERT_EQ(specs.size(), 2);
+            EXPECT_EQ(specs[0], "numpy");
+            EXPECT_EQ(specs[1], "python=3.8.3");
+        }
+
+        TEST(pinning, pin_config_specs)
+        {
+            std::vector<std::string> specs;
+            std::vector<std::string> config_specs;
+
+            specs = { "python" };
+            config_specs = { "numpy=1.13", "jupyterlab=3" };
+            pin_config_specs(config_specs, specs);
+            ASSERT_EQ(specs.size(), 3);
+            EXPECT_EQ(specs[0], "python");
+            EXPECT_EQ(specs[1], "numpy=1.13");
+            EXPECT_EQ(specs[2], "jupyterlab=3");
+
+            specs = { "python=3.7.10" };
+            config_specs = { "numpy=1.13", "python=3.7.5" };
+            pin_config_specs(config_specs, specs);
+            ASSERT_EQ(specs.size(), 3);
+            EXPECT_EQ(specs[0], "python=3.7.10");
+            EXPECT_EQ(specs[1], "numpy=1.13");
+            EXPECT_EQ(specs[2], "python=3.7.5");
+        }
+
+        TEST(pinning, pin_file_specs)
+        {
+            std::vector<std::string> specs;
+
+            auto tempfile = std::make_unique<TemporaryFile>("pinned", "");
+            std::string path = tempfile->path();
+            std::ofstream out_file(path);
+            out_file << "numpy=1.13\njupyterlab=3";
+            out_file.close();
+
+            specs = { "python" };
+            pin_file_specs(path, specs);
+            ASSERT_EQ(specs.size(), 3);
+            EXPECT_EQ(specs[0], "python");
+            EXPECT_EQ(specs[1], "numpy=1.13");
+            EXPECT_EQ(specs[2], "jupyterlab=3");
+
+            specs = { "python=3.7.10" };
+            out_file.open(path, std::ofstream::out | std::ofstream::trunc);
+            out_file << "numpy=1.13\npython=3.7.5";
+            out_file.close();
+
+            pin_file_specs(path, specs);
+            ASSERT_EQ(specs.size(), 3);
+            EXPECT_EQ(specs[0], "python=3.7.10");
+            EXPECT_EQ(specs[1], "numpy=1.13");
+            EXPECT_EQ(specs[2], "python=3.7.5");
+        }
+    }  // namespace testing
+}  // namespace mamba

--- a/test/test_pinning.cpp
+++ b/test/test_pinning.cpp
@@ -7,116 +7,77 @@ namespace mamba
 {
     namespace testing
     {
-        TEST(pinning, pin_python_spec)
+        TEST(pinning, python_pin)
         {
             std::vector<std::string> specs;
+            std::string pin;
             PrefixData prefix_data("");
             ASSERT_EQ(prefix_data.records().size(), 0);
 
             specs = { "python" };
-            pin_python_spec(prefix_data, specs);
-            ASSERT_EQ(specs.size(), 1);
-            EXPECT_EQ(specs[0], "python");
+            pin = python_pin(prefix_data, specs);
+            EXPECT_EQ(pin, "");
+
+            specs = { "python-test" };
+            pin = python_pin(prefix_data, specs);
+            EXPECT_EQ(pin, "");
 
             specs = { "python=3" };
-            pin_python_spec(prefix_data, specs);
-            ASSERT_EQ(specs.size(), 1);
-            EXPECT_EQ(specs[0], "python=3");
+            pin = python_pin(prefix_data, specs);
+            EXPECT_EQ(pin, "");
 
             specs = { "python==3.8" };
-            pin_python_spec(prefix_data, specs);
-            ASSERT_EQ(specs.size(), 1);
-            EXPECT_EQ(specs[0], "python==3.8");
+            pin = python_pin(prefix_data, specs);
+            EXPECT_EQ(pin, "");
 
             specs = { "python==3.8.3" };
-            pin_python_spec(prefix_data, specs);
-            ASSERT_EQ(specs.size(), 1);
-            EXPECT_EQ(specs[0], "python==3.8.3");
+            pin = python_pin(prefix_data, specs);
+            EXPECT_EQ(pin, "");
 
             specs = { "numpy" };
-            pin_python_spec(prefix_data, specs);
-            ASSERT_EQ(specs.size(), 1);
-            EXPECT_EQ(specs[0], "numpy");
+            pin = python_pin(prefix_data, specs);
+            EXPECT_EQ(pin, "");
 
             PackageInfo pkg_info("python", "3.7.10", "abcde", 0);
             prefix_data.m_package_records.insert({ "python", pkg_info });
             ASSERT_EQ(prefix_data.records().size(), 1);
 
             specs = { "python" };
-            pin_python_spec(prefix_data, specs);
-            ASSERT_EQ(specs.size(), 1);
-            EXPECT_EQ(specs[0], "python=3.7.10");
-
-            specs = { "python==3" };
-            pin_python_spec(prefix_data, specs);
-            ASSERT_EQ(specs.size(), 1);
-            EXPECT_EQ(specs[0], "python=3.7.10");
-
-            specs = { "python=3.*" };
-            pin_python_spec(prefix_data, specs);
-            ASSERT_EQ(specs.size(), 1);
-            EXPECT_EQ(specs[0], "python=3.7.10");
-
-            specs = { "python=3.8" };
-            pin_python_spec(prefix_data, specs);
-            ASSERT_EQ(specs.size(), 1);
-            EXPECT_EQ(specs[0], "python=3.8");
-
-            specs = { "python=3.8.3" };
-            pin_python_spec(prefix_data, specs);
-            ASSERT_EQ(specs.size(), 1);
-            EXPECT_EQ(specs[0], "python=3.8.3");
+            pin = python_pin(prefix_data, specs);
+            EXPECT_EQ(pin, "");
 
             specs = { "numpy" };
-            pin_python_spec(prefix_data, specs);
-            ASSERT_EQ(specs.size(), 2);
-            EXPECT_EQ(specs[0], "numpy");
-            EXPECT_EQ(specs[1], "python=3.7.10");
+            pin = python_pin(prefix_data, specs);
+            EXPECT_EQ(pin, "python=3.7.10");
+
+            specs = { "python-test" };
+            pin = python_pin(prefix_data, specs);
+            EXPECT_EQ(pin, "python=3.7.10");
+
+            specs = { "python==3" };
+            pin = python_pin(prefix_data, specs);
+            EXPECT_EQ(pin, "");
+
+            specs = { "python=3.*" };
+            pin = python_pin(prefix_data, specs);
+            EXPECT_EQ(pin, "");
+
+            specs = { "python=3.8" };
+            pin = python_pin(prefix_data, specs);
+            EXPECT_EQ(pin, "");
+
+            specs = { "python=3.8.3" };
+            pin = python_pin(prefix_data, specs);
+            EXPECT_EQ(pin, "");
 
             specs = { "numpy", "python" };
-            pin_python_spec(prefix_data, specs);
-            ASSERT_EQ(specs.size(), 2);
-            EXPECT_EQ(specs[0], "numpy");
-            EXPECT_EQ(specs[1], "python=3.7.10");
-
-            specs = { "numpy", "python=3.8" };
-            pin_python_spec(prefix_data, specs);
-            ASSERT_EQ(specs.size(), 2);
-            EXPECT_EQ(specs[0], "numpy");
-            EXPECT_EQ(specs[1], "python=3.8");
-
-            specs = { "numpy", "python=3.8.3" };
-            pin_python_spec(prefix_data, specs);
-            ASSERT_EQ(specs.size(), 2);
-            EXPECT_EQ(specs[0], "numpy");
-            EXPECT_EQ(specs[1], "python=3.8.3");
+            pin = python_pin(prefix_data, specs);
+            EXPECT_EQ(pin, "");
         }
 
-        TEST(pinning, pin_config_specs)
+        TEST(pinning, file_pins)
         {
-            std::vector<std::string> specs;
-            std::vector<std::string> config_specs;
-
-            specs = { "python" };
-            config_specs = { "numpy=1.13", "jupyterlab=3" };
-            pin_config_specs(config_specs, specs);
-            ASSERT_EQ(specs.size(), 3);
-            EXPECT_EQ(specs[0], "python");
-            EXPECT_EQ(specs[1], "numpy=1.13");
-            EXPECT_EQ(specs[2], "jupyterlab=3");
-
-            specs = { "python=3.7.10" };
-            config_specs = { "numpy=1.13", "python=3.7.5" };
-            pin_config_specs(config_specs, specs);
-            ASSERT_EQ(specs.size(), 3);
-            EXPECT_EQ(specs[0], "python=3.7.10");
-            EXPECT_EQ(specs[1], "numpy=1.13");
-            EXPECT_EQ(specs[2], "python=3.7.5");
-        }
-
-        TEST(pinning, pin_file_specs)
-        {
-            std::vector<std::string> specs;
+            std::vector<std::string> pins;
 
             auto tempfile = std::make_unique<TemporaryFile>("pinned", "");
             std::string path = tempfile->path();
@@ -124,23 +85,19 @@ namespace mamba
             out_file << "numpy=1.13\njupyterlab=3";
             out_file.close();
 
-            specs = { "python" };
-            pin_file_specs(path, specs);
-            ASSERT_EQ(specs.size(), 3);
-            EXPECT_EQ(specs[0], "python");
-            EXPECT_EQ(specs[1], "numpy=1.13");
-            EXPECT_EQ(specs[2], "jupyterlab=3");
+            pins = file_pins(path);
+            ASSERT_EQ(pins.size(), 2);
+            EXPECT_EQ(pins[0], "numpy=1.13");
+            EXPECT_EQ(pins[1], "jupyterlab=3");
 
-            specs = { "python=3.7.10" };
             out_file.open(path, std::ofstream::out | std::ofstream::trunc);
             out_file << "numpy=1.13\npython=3.7.5";
             out_file.close();
 
-            pin_file_specs(path, specs);
-            ASSERT_EQ(specs.size(), 3);
-            EXPECT_EQ(specs[0], "python=3.7.10");
-            EXPECT_EQ(specs[1], "numpy=1.13");
-            EXPECT_EQ(specs[2], "python=3.7.5");
+            pins = file_pins(path);
+            ASSERT_EQ(pins.size(), 2);
+            EXPECT_EQ(pins[0], "numpy=1.13");
+            EXPECT_EQ(pins[1], "python=3.7.5");
         }
     }  // namespace testing
 }  // namespace mamba


### PR DESCRIPTION
Description
--

Add capability to pin packages:
- from rc files
- from `<prefix>/conda-meta/pinned` file

Also auto-pin python version if already installed in prefix and specs does not include python at least pinned with minor version.

Add `--no-pin` flag to `create` and `install` CLI sub-commands to disable pinned specs from files (rc or prefix located).