### PR TITLE
Override or disable rc file(s)

### DIFF
--- a/include/mamba/config.hpp
+++ b/include/mamba/config.hpp
@@ -21,16 +21,20 @@ namespace mamba
     class Configurable
     {
     public:
-        Configurable();
-        Configurable(std::string unique_source);
+        static Configurable& instance();
 
         const YAML::Node& get_config();
         std::vector<fs::path> get_sources();
         std::vector<fs::path> get_valid_sources();
 
+        void load(std::string unique_source = "");
+
         std::string dump(bool show_sources = false);
 
     protected:
+        Configurable();
+        ~Configurable() = default;
+
         static Context& ctx()
         {
             return Context::instance();

--- a/include/mamba/config.hpp
+++ b/include/mamba/config.hpp
@@ -22,6 +22,7 @@ namespace mamba
     {
     public:
         Configurable();
+        Configurable(std::string unique_source);
 
         const YAML::Node& get_config();
         std::vector<fs::path> get_sources();
@@ -30,8 +31,6 @@ namespace mamba
         std::string dump(bool show_sources = false);
 
     protected:
-        Configurable(std::string unique_source);
-
         static Context& ctx()
         {
             return Context::instance();
@@ -44,7 +43,7 @@ namespace mamba
 
         void load_config();
         void load_config_files();
-        void update_sources();
+        void update_sources(std::string unique_source = "");
 
         void build_prepend_seq(const std::vector<std::shared_ptr<YAML::Node>>& configs,
                                const std::string& key,

--- a/include/mamba/context.hpp
+++ b/include/mamba/context.hpp
@@ -88,7 +88,7 @@ namespace mamba
 
         void set_verbosity(int lvl);
 
-        void load_config();
+        void load_config(std::string rc_file);
 
         static std::string platform();
         static std::vector<std::string> platforms();

--- a/include/mamba/context.hpp
+++ b/include/mamba/context.hpp
@@ -88,7 +88,7 @@ namespace mamba
 
         void set_verbosity(int lvl);
 
-        void load_config(std::string rc_file);
+        void load_config();
 
         static std::string platform();
         static std::vector<std::string> platforms();

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -19,16 +19,7 @@ namespace mamba
 
     Configurable::Configurable(std::string unique_source)
     {
-        sources.clear();
-        if (is_config_file(unique_source))
-        {
-            sources.push_back(unique_source);
-            LOG_DEBUG << "Configuration found at '" << unique_source << "'";
-        }
-        else
-        {
-            LOG_DEBUG << "Configuration not found at '" << unique_source << "'";
-        }
+        update_sources(unique_source);
         load_config();
     }
 
@@ -119,26 +110,35 @@ namespace mamba
         }
     }
 
-    void Configurable::update_sources()
+    void Configurable::update_sources(std::string unique_source)
     {
-        fs::path condarc_env_var = std::getenv("CONDARC") ? std::getenv("CONDARC") : "";
-        fs::path mambarc_env_var = std::getenv("MAMBARC") ? std::getenv("MAMBARC") : "";
+        std::vector<fs::path> possible_sources;
 
-        std::vector<fs::path> possible_sources = { ctx().root_prefix / ".condarc",
-                                                   ctx().root_prefix / "condarc",
-                                                   ctx().root_prefix / "condarc.d",
-                                                   ctx().root_prefix / ".mambarc",
-                                                   env::home_directory() / ".conda/.condarc",
-                                                   env::home_directory() / ".conda/condarc",
-                                                   env::home_directory() / ".conda/condarc.d",
-                                                   env::home_directory() / ".condarc",
-                                                   env::home_directory() / ".mambarc",
-                                                   ctx().target_prefix / ".condarc",
-                                                   ctx().target_prefix / "condarc",
-                                                   ctx().target_prefix / "condarc.d",
-                                                   ctx().target_prefix / ".mambarc",
-                                                   condarc_env_var,
-                                                   mambarc_env_var };
+        if (!unique_source.empty())
+        {
+            possible_sources.push_back(unique_source);
+        }
+        else
+        {
+            fs::path condarc_env_var = std::getenv("CONDARC") ? std::getenv("CONDARC") : "";
+            fs::path mambarc_env_var = std::getenv("MAMBARC") ? std::getenv("MAMBARC") : "";
+
+            possible_sources = { ctx().root_prefix / ".condarc",
+                                 ctx().root_prefix / "condarc",
+                                 ctx().root_prefix / "condarc.d",
+                                 ctx().root_prefix / ".mambarc",
+                                 env::home_directory() / ".conda/.condarc",
+                                 env::home_directory() / ".conda/condarc",
+                                 env::home_directory() / ".conda/condarc.d",
+                                 env::home_directory() / ".condarc",
+                                 env::home_directory() / ".mambarc",
+                                 ctx().target_prefix / ".condarc",
+                                 ctx().target_prefix / "condarc",
+                                 ctx().target_prefix / "condarc.d",
+                                 ctx().target_prefix / ".mambarc",
+                                 condarc_env_var,
+                                 mambarc_env_var };
+        }
 
         sources.clear();
 

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -13,11 +13,15 @@ namespace mamba
 {
     Configurable::Configurable()
     {
-        update_sources();
-        load_config();
     }
 
-    Configurable::Configurable(std::string unique_source)
+    Configurable& Configurable::instance()
+    {
+        static Configurable config;
+        return config;
+    }
+
+    void Configurable::load(std::string unique_source)
     {
         update_sources(unique_source);
         load_config();

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -105,10 +105,10 @@ namespace mamba
     }
 
 #ifdef MAMBA_USE_YAML_CPP
-    void Context::load_config(std::string rc_file)
+    void Context::load_config()
     {
-        Configurable configurable(rc_file);
-        auto c = configurable.get_config();
+        Configurable& config = Configurable::instance();
+        auto c = config.get_config();
 
         if (c["channels"])
         {

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -105,9 +105,9 @@ namespace mamba
     }
 
 #ifdef MAMBA_USE_YAML_CPP
-    void Context::load_config()
+    void Context::load_config(std::string rc_file)
     {
-        Configurable configurable;
+        Configurable configurable(rc_file);
         auto c = configurable.get_config();
 
         if (c["channels"])

--- a/src/micromamba/main.cpp
+++ b/src/micromamba/main.cpp
@@ -278,7 +278,8 @@ load_rc_files(Context& ctx)
 {
     if (!global_options.no_rc)
     {
-        ctx.load_config(global_options.rc_file);
+        Configurable::instance().load(global_options.rc_file);
+        ctx.load_config();
     }
 }
 
@@ -931,7 +932,7 @@ init_config_parser(CLI::App* subcom)
         }
         else
         {
-            Configurable config(global_options.rc_file);
+            Configurable& config = Configurable::instance();
             Console::print(config.dump(config_options.show_sources));
         }
         return 0;
@@ -951,7 +952,7 @@ init_config_parser(CLI::App* subcom)
         {
             Console::print("Configuration files (by precedence order):");
 
-            Configurable config(global_options.rc_file);
+            Configurable& config = Configurable::instance();
             auto srcs = config.get_sources();
             auto valid_srcs = config.get_valid_sources();
 

--- a/test/test_config.cpp
+++ b/test/test_config.cpp
@@ -16,7 +16,7 @@ namespace mamba
         {
         public:
             Configurable()
-                : mamba::Configurable("")  // prevent loading other sources
+                : mamba::Configurable("none")  // prevent loading other sources
             {
             }
 

--- a/test/test_config.cpp
+++ b/test/test_config.cpp
@@ -16,7 +16,7 @@ namespace mamba
         {
         public:
             Configurable()
-                : mamba::Configurable("none")  // prevent loading other sources
+                : mamba::Configurable()
             {
             }
 
@@ -29,10 +29,7 @@ namespace mamba
                 out_file << rc;
                 out_file.close();
 
-                sources.clear();
-                sources.push_back(unique_location);
-
-                load_config();
+                load(unique_location);
             }
 
             void load_test_config(std::vector<std::string> rcs)


### PR DESCRIPTION
Description
---

Add `--no-rc` flag and `--rc-file` option:
- `--no-rc` disables *all* configuration files
- `--rc-file` overrides *all others* configuration files (unique rc file)

Discussion
---
We should consider making `Configurable` class a singleton to avoid reading files multiple times.
