### PR TITLE
Empty rc map value not an error

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -186,7 +186,7 @@ namespace mamba
     {
         for (auto n : configs)
         {
-            if (!(*n)[key])
+            if (!(*n)[key] || (*n)[key].IsNull())
             {
                 continue;
             }
@@ -225,19 +225,19 @@ namespace mamba
     {
         for (auto n : configs)
         {
-            if ((*n)[key])
+            if (!(*n)[key] || (*n)[key].IsNull())
             {
-                if (!(*n)[key].IsScalar())
-                {
-                    LOG_ERROR << "Error in '" << node2src.at(n) << "' at key '" << key
-                              << "' (Skipped)";
-                    continue;
-                }
-
-                result[key] = (*n)[key];
-                sources[key] = node2src.at(n);
-                break;
+                continue;
             }
+            if (!(*n)[key].IsScalar())
+            {
+                LOG_ERROR << "Error in '" << node2src.at(n) << "' at key '" << key << "' (Skipped)";
+                continue;
+            }
+
+            result[key] = (*n)[key];
+            sources[key] = node2src.at(n);
+            break;
         }
     }
 


### PR DESCRIPTION
Description
--

It is a convenience to comment/uncomment rc files and empty map values are not considered as a `yaml` syntax error at parsing.

Do not raise a log error when a rc file map value is `null`, just skip the config key silently.

