### PR TITLE
Add support for use_only_tar_bz2

### DIFF
--- a/include/mamba/context.hpp
+++ b/include/mamba/context.hpp
@@ -100,6 +100,8 @@ namespace mamba
 
         std::vector<std::string> pinned_packages = {};
 
+        bool use_only_tar_bz2 = false;
+
         static Context& instance();
 
         Context(const Context&) = delete;

--- a/mamba/utils.py
+++ b/mamba/utils.py
@@ -171,6 +171,7 @@ def init_api_context(use_mamba_experimental=False):
     api_ctx.max_retries = context.remote_max_retries
     api_ctx.retry_backoff = context.remote_backoff_factor
     api_ctx.add_pip_as_python_dependency = context.add_pip_as_python_dependency
+    api_ctx.use_only_tar_bz2 = context.use_only_tar_bz2
 
 
 def to_package_record_from_subjson(channel, pkg, jsn_string):

--- a/src/py_interface.cpp
+++ b/src/py_interface.cpp
@@ -202,7 +202,8 @@ PYBIND11_MODULE(mamba_api, m)
         .def_readwrite("envs_dirs", &Context::envs_dirs)
         .def_readwrite("pkgs_dirs", &Context::pkgs_dirs)
         .def("set_verbosity", &Context::set_verbosity)
-        .def_readwrite("channels", &Context::channels);
+        .def_readwrite("channels", &Context::channels)
+        .def_readwrite("use_only_tar_bz2", &Context::use_only_tar_bz2);
 
     py::class_<PrefixData>(m, "PrefixData")
         .def(py::init<const std::string&>())

--- a/src/repo.cpp
+++ b/src/repo.cpp
@@ -244,7 +244,8 @@ namespace mamba
         }
 
         LOG_INFO << "loading from json " << m_json_file;
-        int ret = repo_add_conda(m_repo, fp, 0);
+        int flags = Context::instance().use_only_tar_bz2 ? CONDA_ADD_USE_ONLY_TAR_BZ2 : 0;
+        int ret = repo_add_conda(m_repo, fp, flags);
         if (ret != 0)
         {
             throw std::runtime_error("Could not read JSON repodata file (" + m_json_file + ") "


### PR DESCRIPTION
Change for https://github.com/mamba-org/mamba/issues/666.  Will need a new release of libsolv but I'd like for the windows regex fix to be merged before requesting that.

EDIT: Will need to rerun tests after new libsolv is available with the new flag.  Tested this locally already with a locally built copy of libsolv and works as expected.