### PR TITLE
Improve testing of package cache

### DIFF
--- a/src/package_cache.cpp
+++ b/src/package_cache.cpp
@@ -222,7 +222,16 @@ namespace mamba
             }
             if (!extract_dir_valid)
             {
-                remove_or_rename(extract_dir);
+                try
+                {
+                    remove_or_rename(extract_dir);
+                }
+                catch (const std::runtime_error& e)
+                {
+#ifdef UMAMBA_ONLY
+                    throw e;
+#endif
+                }
             }
             else
             {

--- a/src/package_handling.cpp
+++ b/src/package_handling.cpp
@@ -448,7 +448,7 @@ namespace mamba
                 }
 
                 // old packages don't have paths.json with validation information
-                if (p.size_in_bytes != 0 && Context::instance().extra_safety_checks)
+                if (p.size_in_bytes != 0)
                 {
                     bool is_invalid = false;
                     if (p.path_type != PathType::SOFTLINK

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -18,6 +18,8 @@
 
 #include "mamba/context.hpp"
 #include "mamba/util.hpp"
+#include "mamba/output.hpp"
+
 
 namespace mamba
 {
@@ -534,7 +536,7 @@ namespace mamba
             }
             catch (const fs::filesystem_error& e)
             {
-                std::cout << "Caught a filesystem error: " << e.what();
+                LOG_ERROR << "Caught a filesystem error: " << e.what();
                 throw std::runtime_error("Could not remove directory " + path.string());
             }
         }
@@ -546,7 +548,7 @@ namespace mamba
             }
             catch (const fs::filesystem_error& e)
             {
-                std::cout << "Caught a filesystem error: " << e.what();
+                LOG_ERROR << "Caught a filesystem error: " << e.what();
                 throw std::runtime_error("Could not remove file " + path.string());
             }
         }

--- a/test/micromamba/helpers.py
+++ b/test/micromamba/helpers.py
@@ -101,6 +101,11 @@ def get_pkg(n, f=None):
         return Path(os.path.join(root_prefix, "pkgs", n))
 
 
+def get_tarball(n):
+    root_prefix = os.getenv("MAMBA_ROOT_PREFIX")
+    return Path(os.path.join(root_prefix, "pkgs", n + ".tar.bz2"))
+
+
 def get_concrete_pkg_info(env, pkg_name):
     with open(os.path.join(env, "conda-meta", pkg_name + ".json")) as fi:
         return json.load(fi)

--- a/test/micromamba/test_install.py
+++ b/test/micromamba/test_install.py
@@ -103,37 +103,230 @@ class TestLinking:
 
         shutil.rmtree(get_env(env))
 
-    def test_cross_device(self):
-        if platform.system() == "Linux":
-            with open("/tmp/test", "w") as f:
-                f.write("abc")
-            p = Path("/tmp/test")
-            dev_tmp = p.stat().st_dev
+    @pytest.mark.parametrize("allow_softlinks", [True, False])
+    @pytest.mark.parametrize("always_copy", [True, False])
+    def test_cross_device(self, allow_softlinks, always_copy):
+        if platform.system() != "Linux":
+            pytest.skip("o/s is not linux")
 
-            check_file = get_pkg("test.xyz")
-            with open(check_file, "w") as f:
-                f.write("abc")
-            chk_stat = check_file.stat()
-            tmp_stat = p.stat()
+        with open("/tmp/test", "w") as f:
+            f.write("abc")
+        p = Path("/tmp/test")
+        dev_tmp = p.stat().st_dev
 
-            if tmp_stat.st_dev == chk_stat.st_dev:
-                print("tmp is not a different device")
-                return
+        check_file = get_pkg("test.xyz")
+        with open(check_file, "w") as f:
+            f.write("abc")
+        chk_stat = check_file.stat()
+        tmp_stat = p.stat()
 
-            env = "/tmp/testenv"
-            res = create("xtensor", "-p", "/tmp/testenv", "--json", "--always-copy")
-            xf = Path(env + "/include/xtensor/xtensor.hpp")
-            assert xf.exists()
-            stat_xf = xf.stat()
+        os.remove("/tmp/test")
 
-            pkg_name = get_concrete_pkg(res, "xtensor")
-            orig_file_path = get_pkg(pkg_name, "include/xtensor/xtensor.hpp")
+        if tmp_stat.st_dev == chk_stat.st_dev:
+            pytest.skip("/tmp is on the same file system as root_prefix")
 
-            stat_orig = orig_file_path.stat()
+        env = "/tmp/testenv"
+
+        create_args = ["xtensor", "-p", "/tmp/testenv", "--json"]
+        if allow_softlinks:
+            create_args.append("--allow-softlinks")
+        if always_copy:
+            create_args.append("--always-copy")
+        res = create(*create_args)
+
+        xf = Path(env + "/include/xtensor/xtensor.hpp")
+        assert xf.exists()
+        stat_xf = xf.stat()
+
+        pkg_name = get_concrete_pkg(res, "xtensor")
+        orig_file_path = get_pkg(pkg_name, "include/xtensor/xtensor.hpp")
+
+        stat_orig = orig_file_path.stat()
+        assert stat_orig.st_dev != stat_xf.st_dev and stat_orig.st_ino != stat_xf.st_ino
+        assert xf.is_symlink() == (allow_softlinks and not always_copy)
+
+        shutil.rmtree("/tmp/testenv")
+
+
+class TestPkgCache:
+    def test_extracted_file_deleted(self):
+        ref_env = "x"
+        res = create("xtensor", "-n", ref_env, "--json")
+        xf = get_env(ref_env, "include/xtensor/xtensor.hpp")
+        assert xf.exists()
+        stat_xf = xf.stat()
+
+        pkg_name = get_concrete_pkg(res, "xtensor")
+        orig_file_path = get_pkg(pkg_name, "include/xtensor/xtensor.hpp")
+        stat_orig = orig_file_path.stat()
+
+        assert stat_orig.st_dev == stat_xf.st_dev and stat_orig.st_ino == stat_xf.st_ino
+
+        os.remove(orig_file_path)
+
+        env = "x1"
+        res = create("xtensor", "-n", env, "--json")
+        xf = get_env(env, "include/xtensor/xtensor.hpp")
+        assert xf.exists()
+        stat_xf = xf.stat()
+
+        assert stat_orig.st_dev == stat_xf.st_dev and stat_orig.st_ino != stat_xf.st_ino
+
+        shutil.rmtree(get_env(ref_env))
+        shutil.rmtree(get_env(env))
+
+    @pytest.mark.parametrize("safety_checks", ["disabled", "warn", "enabled"])
+    def test_extracted_file_corrupted(self, safety_checks):
+        ref_env = "x"
+        res = create(
+            "xtensor", "-n", ref_env, "--json", "--safety-checks", safety_checks
+        )
+        xf = get_env(ref_env, "include/xtensor/xtensor.hpp")
+        assert xf.exists()
+        stat_xf = xf.stat()
+
+        pkg_name = get_concrete_pkg(res, "xtensor")
+        orig_file_path = get_pkg(pkg_name, "include/xtensor/xtensor.hpp")
+        stat_orig = orig_file_path.stat()
+
+        assert stat_orig.st_dev == stat_xf.st_dev and stat_orig.st_ino == stat_xf.st_ino
+
+        with open(orig_file_path, "w") as f:
+            f.write("//corruption")
+
+        env = "x1"
+        res = create("xtensor", "-n", env, "--json", "--safety-checks", safety_checks)
+        xf = get_env(env, "include/xtensor/xtensor.hpp")
+        assert xf.exists()
+        stat_xf = xf.stat()
+
+        if safety_checks == "enabled":
             assert (
-                stat_orig.st_dev != stat_xf.st_dev
+                stat_orig.st_dev == stat_xf.st_dev
                 and stat_orig.st_ino != stat_xf.st_ino
             )
-            assert not xf.is_symlink()
+        else:
+            assert (
+                stat_orig.st_dev == stat_xf.st_dev
+                and stat_orig.st_ino == stat_xf.st_ino
+            )
 
-            shutil.rmtree("/tmp/testenv")
+        os.remove(orig_file_path)
+        shutil.rmtree(get_env(ref_env))
+        shutil.rmtree(get_env(env))
+
+    def test_tarball_deleted(self):
+        ref_env = "x"
+        res = create("xtensor", "-n", ref_env, "--json")
+        xf = get_env(ref_env, "include/xtensor/xtensor.hpp")
+        assert xf.exists()
+        stat_xf = xf.stat()
+
+        pkg_name = get_concrete_pkg(res, "xtensor")
+        orig_file_path = get_pkg(pkg_name, "include/xtensor/xtensor.hpp")
+        stat_orig = orig_file_path.stat()
+
+        assert stat_orig.st_dev == stat_xf.st_dev and stat_orig.st_ino == stat_xf.st_ino
+
+        os.remove(get_tarball(pkg_name))
+
+        env = "x1"
+        res = create("xtensor", "-n", env, "--json")
+        xf = get_env(env, "include/xtensor/xtensor.hpp")
+        assert xf.exists()
+        stat_xf = xf.stat()
+
+        assert not get_tarball(pkg_name).exists()
+        assert stat_orig.st_dev == stat_xf.st_dev and stat_orig.st_ino == stat_xf.st_ino
+
+        shutil.rmtree(get_pkg(pkg_name))  # clean for other tests
+        shutil.rmtree(get_env(ref_env))
+        shutil.rmtree(get_env(env))
+
+    def test_tarball_and_extracted_file_deleted(self):
+        ref_env = "x"
+        res = create("xtensor", "-n", ref_env, "--json")
+        xf = get_env(ref_env, "include/xtensor/xtensor.hpp")
+        assert xf.exists()
+        stat_xf = xf.stat()
+
+        pkg_name = get_concrete_pkg(res, "xtensor")
+        orig_file_path = get_pkg(pkg_name, "include/xtensor/xtensor.hpp")
+        stat_orig = orig_file_path.stat()
+
+        assert stat_orig.st_dev == stat_xf.st_dev and stat_orig.st_ino == stat_xf.st_ino
+
+        pkg_size = get_tarball(pkg_name).stat().st_size
+        os.remove(orig_file_path)
+        os.remove(get_tarball(pkg_name))
+
+        env = "x1"
+        res = create("xtensor", "-n", env, "--json")
+        xf = get_env(env, "include/xtensor/xtensor.hpp")
+        assert xf.exists()
+        stat_xf = xf.stat()
+
+        assert get_tarball(pkg_name).exists()
+        assert pkg_size == get_tarball(pkg_name).stat().st_size
+        assert stat_orig.st_dev == stat_xf.st_dev and stat_orig.st_ino != stat_xf.st_ino
+
+        shutil.rmtree(get_env(ref_env))
+        shutil.rmtree(get_env(env))
+
+    def test_tarball_corrupted_and_extracted_file_deleted(self):
+        ref_env = "x"
+        res = create("xtensor", "-n", ref_env, "--json")
+        xf = get_env(ref_env, "include/xtensor/xtensor.hpp")
+        assert xf.exists()
+        stat_xf = xf.stat()
+
+        pkg_name = get_concrete_pkg(res, "xtensor")
+        orig_file_path = get_pkg(pkg_name, "include/xtensor/xtensor.hpp")
+        stat_orig = orig_file_path.stat()
+
+        assert stat_orig.st_dev == stat_xf.st_dev and stat_orig.st_ino == stat_xf.st_ino
+
+        pkg_size = get_tarball(pkg_name).stat().st_size
+        os.remove(orig_file_path)
+        os.remove(get_tarball(pkg_name))
+        with open(get_tarball(pkg_name), "w") as f:
+            f.write("")
+
+        env = "x1"
+        res = create("xtensor", "-n", env, "--json")
+        xf = get_env(env, "include/xtensor/xtensor.hpp")
+        assert xf.exists()
+        stat_xf = xf.stat()
+
+        assert get_tarball(pkg_name).exists()
+        assert pkg_size == get_tarball(pkg_name).stat().st_size
+        assert stat_orig.st_dev == stat_xf.st_dev and stat_orig.st_ino != stat_xf.st_ino
+
+        shutil.rmtree(get_env(ref_env))
+        shutil.rmtree(get_env(env))
+
+    def test_extracted_file_corrupted_no_perm(self):
+        ref_env = "x"
+        res = create("xtensor", "-n", ref_env, "--json")
+        xf = get_env(ref_env, "include/xtensor/xtensor.hpp")
+        assert xf.exists()
+        stat_xf = xf.stat()
+
+        pkg_name = get_concrete_pkg(res, "xtensor")
+        orig_file_path = get_pkg(pkg_name, "include/xtensor/xtensor.hpp")
+        stat_orig = orig_file_path.stat()
+
+        assert stat_orig.st_dev == stat_xf.st_dev and stat_orig.st_ino == stat_xf.st_ino
+
+        with open(orig_file_path, "w") as f:
+            f.write("//corruption")
+        os.chmod(get_pkg(pkg_name), 0o500)
+
+        env = "x1"
+
+        create("xtensor", "-n", env, "--json")
+
+        os.chmod(get_pkg(pkg_name), 0o755)
+        os.remove(orig_file_path)
+        shutil.rmtree(get_env(ref_env))
+        shutil.rmtree(get_env(env))


### PR DESCRIPTION
Description
---

Details:
- add tests on package cache
- throw an error when cache in not writable only in `micromamba` (passthrough on `mamba` to let `conda` handle the case)
- always check that files sizes match and warn if not