### PR TITLE
[RFC] Add support for UNC file:// urls

### DIFF
--- a/src/fetch.cpp
+++ b/src/fetch.cpp
@@ -35,8 +35,11 @@ namespace mamba
             // a url of type file://hostname/path
             static const std::regex file_host(R"(file://([^/]*)(/.*)?)");
             std::smatch match;
-            if(std::regex_match(m_url, match, file_host)){
-                if(match[1] != "" && match[1] != "localhost" && match[1] != "127.0.0.1" && match[1] != "::1" && !starts_with(match[1].str(), R"(\\))")){
+            if (std::regex_match(m_url, match, file_host))
+            {
+                if (match[1] != "" && match[1] != "localhost" && match[1] != "127.0.0.1"
+                    && match[1] != "::1" && !starts_with(match[1].str(), R"(\\))"))
+                {
                     m_url = "file:////" + std::string(match[1].first, m_url.cend());
                 }
             }

--- a/src/fetch.cpp
+++ b/src/fetch.cpp
@@ -19,31 +19,36 @@ namespace mamba
      * DownloadTarget implementation *
      *********************************/
 
+    std::string unc_url(const std::string& url)
+    {
+        // Replicate UNC behaviour of url_to_path from conda.common.path
+        // We cannot use URLHandler for this since CURL returns an error when asked to parse
+        // a url of type file://hostname/path
+        // Colon character is excluded to make sure we do not match file URLs with absoulute
+        // paths to a windows drive.
+        static const std::regex file_host(R"(file://([^:/]*)(/.*)?)");
+        std::smatch match;
+        if (std::regex_match(url, match, file_host))
+        {
+            if (match[1] != "" && match[1] != "localhost" && match[1] != "127.0.0.1"
+                && match[1] != "::1" && !starts_with(match[1].str(), R"(\\))"))
+            {
+                return "file:////" + std::string(match[1].first, url.cend());
+            }
+        }
+        return url;
+    }
+
     DownloadTarget::DownloadTarget(const std::string& name,
                                    const std::string& url,
                                    const std::string& filename)
         : m_name(name)
         , m_filename(filename)
-        , m_url(url)
+        , m_url(unc_url(url))
     {
         LOG_INFO << "Downloading to filename: " << m_filename;
         m_handle = curl_easy_init();
 
-        {
-            // Replicate UNC behaviour of url_to_path from conda.common.path
-            // We cannot use URLHandler for this since CURL returns an error when asked to parse
-            // a url of type file://hostname/path
-            static const std::regex file_host(R"(file://([^/]*)(/.*)?)");
-            std::smatch match;
-            if (std::regex_match(m_url, match, file_host))
-            {
-                if (match[1] != "" && match[1] != "localhost" && match[1] != "127.0.0.1"
-                    && match[1] != "::1" && !starts_with(match[1].str(), R"(\\))"))
-                {
-                    m_url = "file:////" + std::string(match[1].first, m_url.cend());
-                }
-            }
-        }
         init_curl_target(m_url);
     }
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -18,6 +18,7 @@ set(TEST_SRCS
     test_graph.cpp
     test_pinning.cpp
     test_virtual_packages.cpp
+    test_fetch.cpp
 )
 
 add_executable(test_mamba ${TEST_SRCS})

--- a/test/test_fetch.cpp
+++ b/test/test_fetch.cpp
@@ -1,0 +1,40 @@
+#include <gtest/gtest.h>
+
+#include "mamba/fetch.hpp"
+
+namespace mamba
+{
+    std::string unc_url(const std::string& path);
+
+    TEST(DownloadTarget, unc_url)
+    {
+        {
+            auto out = unc_url("http://example.com/test");
+            EXPECT_EQ(out, "http://example.com/test");
+        }
+        {
+            auto out = unc_url("file://C:/Program\\ (x74)/Users/hello\\ world");
+            EXPECT_EQ(out, "file://C:/Program\\ (x74)/Users/hello\\ world");
+        }
+        {
+            auto out = unc_url("file:///C:/Program\\ (x74)/Users/hello\\ world");
+            EXPECT_EQ(out, "file:///C:/Program\\ (x74)/Users/hello\\ world");
+        }
+        {
+            auto out = unc_url("file:////server/share");
+            EXPECT_EQ(out, "file:////server/share");
+        }
+        {
+            auto out = unc_url("file:///absolute/path");
+            EXPECT_EQ(out, "file:///absolute/path");
+        }
+        {
+            auto out = unc_url("file://server/share");
+            EXPECT_EQ(out, "file:////server/share");
+        }
+        {
+            auto out = unc_url("file://server");
+            EXPECT_EQ(out, "file:////server");
+        }
+    }
+}


### PR DESCRIPTION
Conda and mamba convert `file:////hostname/share` UNC urls to `file://hostname/share` when reading them from e.g. condarc, in conda they are then converted back to UNC urls in the function `url_to_path` which is used by the `LocalFSAdapter`. Implement a similar hack for mamba as discussed in #733.

Note: I have not been able to get the test suite building on my machine, so I have not run the test suite against this change.