### PR TITLE
support for larger build numbers

### DIFF
--- a/src/link.cpp
+++ b/src/link.cpp
@@ -981,8 +981,8 @@ namespace mamba
 
         auto py_ver_split = split(m_context->python_version, ".");
 
-        if (std::stoi(std::string(py_ver_split[0])) >= 3
-            && std::stoi(std::string(py_ver_split[1])) > 5)
+        if (std::stoull(std::string(py_ver_split[0])) >= 3
+            && std::stoull(std::string(py_ver_split[1])) > 5)
         {
             // activate parallel pyc compilation
             command.push_back("-j0");

--- a/src/package_info.cpp
+++ b/src/package_info.cpp
@@ -107,7 +107,7 @@ namespace mamba
         str = solvable_lookup_str(s, SOLVABLE_BUILDVERSION);
         if (str)
         {
-            n = std::stoi(str);
+            n = std::stoull(str);
             build_number = n;
         }
 


### PR DESCRIPTION
Conda packages with a .dev and timestamp suffix caused an error when the version number parts were converted to an integer (using stoi). Updated to use stoull. 