### PR TITLE
Fix activate command example in "How to use mamba" docs

### DIFF
--- a/docs/source/how_to_use.md
+++ b/docs/source/how_to_use.md
@@ -30,6 +30,6 @@ jupyter lab               # this will start up jupyter lab and open a browser
 Once an environment is activated, `mamba install` can be used to install further packages into the environment.
 
 ```
-mamba activate myjlabenv
+conda activate myjlabenv
 mamba install bqplot  # now you can use bqplot in myjlabenv
 ```


### PR DESCRIPTION
In docs section ["how to use"](https://mamba.readthedocs.io/en/latest/how_to_use.html), an example is given with the erroneous command:

    mamba activate myjlabenv

Now fixed to:

    conda activate myjlabenv

since the one exception (when using mamba as a drop-in replacement for conda) is that [you should still use conda for activation and deactivation](https://mamba.readthedocs.io/en/latest/getting_started.html).