### PR TITLE
Align all log messages

### DIFF
--- a/include/mamba/util.hpp
+++ b/include/mamba/util.hpp
@@ -261,6 +261,10 @@ namespace mamba
     // Unindent a string literal
     std::string unindent(const char* p);
 
+    std::string prepend(std::string p, const char* start, const char* newline = "");
+
+    std::string prepend(const char* p, const char* start, const char* newline = "");
+
 }  // namespace mamba
 
 #endif  // MAMBA_UTIL_HPP

--- a/src/micromamba/parsers.cpp
+++ b/src/micromamba/parsers.cpp
@@ -306,7 +306,7 @@ check_root_prefix(bool silent)
                 throw std::runtime_error(
                     mamba::concat("Could not use default root prefix ",
                                   default_root_prefix.string(),
-                                  "\nDirectory exists, is not emtpy and not a conda prefix."));
+                                  "\nDirectory exists, is not empty and not a conda prefix."));
             }
         }
         Context::instance().root_prefix = default_root_prefix;

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -675,25 +675,28 @@ namespace mamba
         switch (m_severity)
         {
             case LogSeverity::fatal:
-                std::cerr << termcolor::on_red << "FATAL   " << termcolor::reset << m_stream.str()
-                          << std::endl;
+                std::cerr << termcolor::on_red << "FATAL   " << termcolor::reset
+                          << prepend(m_stream.str(), "", std::string(8, ' ').c_str()) << std::endl;
                 break;
             case LogSeverity::error:
-                std::cerr << termcolor::red << "ERROR   " << termcolor::reset << m_stream.str()
-                          << std::endl;
+                std::cerr << termcolor::red << "ERROR   " << termcolor::reset
+                          << prepend(m_stream.str(), "", std::string(8, ' ').c_str()) << std::endl;
                 break;
             case LogSeverity::warning:
-                std::cerr << termcolor::yellow << "WARNING " << termcolor::reset << m_stream.str()
-                          << std::endl;
+                std::cerr << termcolor::yellow << "WARNING " << termcolor::reset
+                          << prepend(m_stream.str(), "", std::string(8, ' ').c_str()) << std::endl;
                 break;
             case LogSeverity::info:
-                std::cerr << "INFO    " << m_stream.str() << std::endl;
+                std::cerr << "INFO    " << prepend(m_stream.str(), "", std::string(8, ' ').c_str())
+                          << std::endl;
                 break;
             case LogSeverity::debug:
-                std::cerr << "DEBUG   " << m_stream.str() << std::endl;
+                std::cerr << "DEBUG   " << prepend(m_stream.str(), "", std::string(8, ' ').c_str())
+                          << std::endl;
                 break;
             default:
-                std::cerr << "UNKOWN  " << m_stream.str() << std::endl;
+                std::cerr << "UNKOWN  " << prepend(m_stream.str(), "", std::string(8, ' ').c_str())
+                          << std::endl;
                 break;
         }
 

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -577,4 +577,25 @@ namespace mamba
         }
         return result;
     }
+
+    std::string prepend(const char* p, const char* start, const char* newline)
+    {
+        std::string result;
+
+        result += start;
+        while (*p)
+        {
+            result += *p;
+            if (*p++ == '\n')
+            {
+                result += newline;
+            }
+        }
+        return result;
+    }
+
+    std::string prepend(std::string p, const char* start, const char* newline)
+    {
+        return prepend(p.c_str(), start, newline);
+    }
 }  // namespace mamba


### PR DESCRIPTION
Description
---

Left align all log messages.
```
WARNING 'MAMBA_DEFAULT_ROOT_PREFIX' is meant for testing purpose.
        Consider using 'MAMBA_ROOT_PREFIX' instead
WARNING Using default root prefix: "/home/adrien/teeeest/"
WARNING You have not set a $MAMBA_ROOT_PREFIX environment variable.
        To permanently modify the root prefix location, either set the
        MAMBA_ROOT_PREFIX environment variable, or use micromamba
        shell init ... to initialize your shell, then restart or
        source the contents of the shell init script.
ERROR   Error in file "/home/adrien/.condarc" (Skipped)
```
instead of currently
```
WARNING 'MAMBA_DEFAULT_ROOT_PREFIX' is meant for testing purpose.
Consider using 'MAMBA_ROOT_PREFIX' instead
WARNING Using default root prefix: "/home/adrien/teeeest/"
WARNING You have not set a $MAMBA_ROOT_PREFIX environment variable.
To permanently modify the root prefix location, either set the
MAMBA_ROOT_PREFIX environment variable, or use micromamba
shell init ... to initialize your shell, then restart or
source the contents of the shell init script.
ERROR   Error in file "/home/adrien/.condarc" (Skipped)
```