### PR TITLE
Fix default target prefix

### DIFF
--- a/src/micromamba/clean.cpp
+++ b/src/micromamba/clean.cpp
@@ -53,7 +53,8 @@ set_clean_command(CLI::App* subcom)
     init_clean_parser(subcom);
 
     subcom->callback([&]() {
-        load_configuration();
+        load_configuration(MAMBA_ALLOW_ROOT_PREFIX | MAMBA_ALLOW_FALLBACK_PREFIX
+                           | MAMBA_ALLOW_EXISTING_PREFIX);
 
         auto& ctx = Context::instance();
         auto& config = Configuration::instance();

--- a/src/micromamba/common_options.hpp
+++ b/src/micromamba/common_options.hpp
@@ -56,6 +56,7 @@ override_channels_hook(bool& override_channels);
 int const MAMBA_ALLOW_ROOT_PREFIX = 1 << 0;
 int const MAMBA_ALLOW_EXISTING_PREFIX = 1 << 1;
 int const MAMBA_ALLOW_FALLBACK_PREFIX = 1 << 2;
+int const MAMBA_ALLOW_MISSING_PREFIX = 1 << 3;
 
 void
 check_target_prefix(int options);
@@ -64,6 +65,6 @@ void
 root_prefix_hook(fs::path& prefix);
 
 void
-load_configuration(bool show_banner = true);
+load_configuration(int options, bool show_banner = true);
 
 #endif

--- a/src/micromamba/config.cpp
+++ b/src/micromamba/config.cpp
@@ -100,7 +100,9 @@ set_config_list_command(CLI::App* subcom)
     init_config_list_parser(subcom);
 
     subcom->callback([&]() {
-        load_configuration(false);
+        load_configuration(MAMBA_ALLOW_ROOT_PREFIX | MAMBA_ALLOW_FALLBACK_PREFIX
+                               | MAMBA_ALLOW_EXISTING_PREFIX,
+                           false);
 
         auto& config = Configuration::instance();
 
@@ -125,7 +127,9 @@ set_config_sources_command(CLI::App* subcom)
     init_config_parser(subcom);
 
     subcom->callback([&]() {
-        load_configuration(false);
+        load_configuration(MAMBA_ALLOW_ROOT_PREFIX | MAMBA_ALLOW_FALLBACK_PREFIX
+                               | MAMBA_ALLOW_EXISTING_PREFIX,
+                           false);
 
         auto& config = Configuration::instance();
         auto& no_rc = config.at("no_rc").value<bool>();
@@ -164,7 +168,9 @@ set_config_describe_command(CLI::App* subcom)
     init_config_describe_parser(subcom);
 
     subcom->callback([&]() {
-        load_configuration(false);
+        load_configuration(MAMBA_ALLOW_ROOT_PREFIX | MAMBA_ALLOW_FALLBACK_PREFIX
+                               | MAMBA_ALLOW_EXISTING_PREFIX,
+                           false);
 
         Configuration& config = Configuration::instance();
         auto& show_groups = config.at("config_show_groups").value<bool>();

--- a/src/micromamba/constructor.cpp
+++ b/src/micromamba/constructor.cpp
@@ -49,7 +49,9 @@ set_constructor_command(CLI::App* subcom)
     init_constructor_parser(subcom);
 
     subcom->callback([&]() {
-        load_configuration(false);
+        load_configuration(MAMBA_ALLOW_ROOT_PREFIX | MAMBA_ALLOW_FALLBACK_PREFIX
+                               | MAMBA_ALLOW_EXISTING_PREFIX,
+                           false);
 
         auto& config = Configuration::instance();
         fs::path prefix = config.at("constructor_prefix").value<fs::path>();

--- a/src/micromamba/create.cpp
+++ b/src/micromamba/create.cpp
@@ -19,7 +19,7 @@ set_create_command(CLI::App* subcom)
 
     subcom->callback([&]() {
         parse_file_options();
-        load_configuration();
+        load_configuration(0);
 
         auto& configuration = Configuration::instance();
         auto& specs = configuration.at("specs").value<std::vector<std::string>>();

--- a/src/micromamba/info.cpp
+++ b/src/micromamba/info.cpp
@@ -28,9 +28,8 @@ set_info_command(CLI::App* subcom)
     init_info_parser(subcom);
 
     subcom->callback([&]() {
-        load_configuration();
-        check_target_prefix(MAMBA_ALLOW_ROOT_PREFIX | MAMBA_ALLOW_FALLBACK_PREFIX
-                            | MAMBA_ALLOW_EXISTING_PREFIX);
+        load_configuration(MAMBA_ALLOW_ROOT_PREFIX | MAMBA_ALLOW_FALLBACK_PREFIX
+                           | MAMBA_ALLOW_EXISTING_PREFIX);
 
         auto& ctx = Context::instance();
         std::vector<std::tuple<std::string, std::vector<std::string>>> items;

--- a/src/micromamba/install.cpp
+++ b/src/micromamba/install.cpp
@@ -91,14 +91,12 @@ set_install_command(CLI::App* subcom)
         auto& configuration = Configuration::instance();
 
         parse_file_options();
-        load_configuration();
+        load_configuration(MAMBA_ALLOW_ROOT_PREFIX | MAMBA_ALLOW_FALLBACK_PREFIX
+                           | MAMBA_ALLOW_EXISTING_PREFIX);
 
         auto& specs = configuration.at("specs").value<std::vector<std::string>>();
-
         if (!specs.empty())
         {
-            check_target_prefix(MAMBA_ALLOW_ROOT_PREFIX | MAMBA_ALLOW_FALLBACK_PREFIX
-                                | MAMBA_ALLOW_EXISTING_PREFIX);
             install_specs(specs, false);
         }
         else
@@ -133,8 +131,7 @@ install_specs(const std::vector<std::string>& specs, bool create_env, int solver
 
     if (ctx.target_prefix.empty())
     {
-        throw std::runtime_error(
-            "No active target prefix.\n\nRun $ micromamba activate <PATH_TO_MY_ENV>\nto activate an environment.\n");
+        throw std::runtime_error("No active target prefix");
     }
     if (!fs::exists(ctx.target_prefix) && create_env == false)
     {
@@ -423,8 +420,7 @@ parse_file_options()
                     std::vector<std::string> explicit_specs(file_contents.begin() + i + 1,
                                                             file_contents.end());
 
-                    load_configuration();
-                    check_target_prefix(0);
+                    load_configuration(0);
                     install_explicit_specs(explicit_specs);
                     exit(0);
                 }

--- a/src/micromamba/list.cpp
+++ b/src/micromamba/list.cpp
@@ -31,9 +31,9 @@ set_list_command(CLI::App* subcom)
     init_list_parser(subcom);
 
     subcom->callback([]() {
-        load_configuration(false);
-        check_target_prefix(MAMBA_ALLOW_ROOT_PREFIX | MAMBA_ALLOW_FALLBACK_PREFIX
-                            | MAMBA_ALLOW_EXISTING_PREFIX);
+        load_configuration(MAMBA_ALLOW_ROOT_PREFIX | MAMBA_ALLOW_FALLBACK_PREFIX
+                               | MAMBA_ALLOW_EXISTING_PREFIX,
+                           false);
         auto& config = Configuration::instance();
         auto& regex = config.at("list_regex").value<std::string>();
 

--- a/src/micromamba/main.cpp
+++ b/src/micromamba/main.cpp
@@ -76,12 +76,14 @@ main(int argc, char** argv)
 
     if (app.get_subcommands().size() == 0)
     {
-        load_configuration();
+        load_configuration(MAMBA_ALLOW_ROOT_PREFIX | MAMBA_ALLOW_FALLBACK_PREFIX
+                           | MAMBA_ALLOW_EXISTING_PREFIX | MAMBA_ALLOW_MISSING_PREFIX);
         Console::print(app.help());
     }
     if (app.got_subcommand("config") && app.get_subcommand("config")->get_subcommands().size() == 0)
     {
-        load_configuration();
+        load_configuration(MAMBA_ALLOW_ROOT_PREFIX | MAMBA_ALLOW_FALLBACK_PREFIX
+                           | MAMBA_ALLOW_EXISTING_PREFIX | MAMBA_ALLOW_MISSING_PREFIX);
         Console::print(app.get_subcommand("config")->help());
     }
 

--- a/src/micromamba/remove.cpp
+++ b/src/micromamba/remove.cpp
@@ -41,15 +41,14 @@ set_remove_command(CLI::App* subcom)
     init_remove_parser(subcom);
 
     subcom->callback([&]() {
-        load_configuration();
+        load_configuration(MAMBA_ALLOW_ROOT_PREFIX | MAMBA_ALLOW_FALLBACK_PREFIX
+                           | MAMBA_ALLOW_EXISTING_PREFIX);
 
         auto& config = Configuration::instance();
         auto& specs = config.at("remove_specs").value<std::vector<std::string>>();
 
         if (!specs.empty())
         {
-            check_target_prefix(MAMBA_ALLOW_ROOT_PREFIX | MAMBA_ALLOW_FALLBACK_PREFIX
-                                | MAMBA_ALLOW_EXISTING_PREFIX);
             remove_specs(specs);
         }
         else
@@ -67,7 +66,7 @@ remove_specs(const std::vector<std::string>& specs)
     if (ctx.target_prefix.empty())
     {
         LOG_ERROR << "No active target prefix.";
-        exit(1);
+        throw std::runtime_error("Aborted.");
     }
 
     std::vector<MRepo> repos;

--- a/src/micromamba/shell.cpp
+++ b/src/micromamba/shell.cpp
@@ -78,7 +78,9 @@ set_shell_command(CLI::App* subcom)
         auto& ctx = Context::instance();
         auto& config = Configuration::instance();
 
-        load_configuration(false);
+        load_configuration(MAMBA_ALLOW_ROOT_PREFIX | MAMBA_ALLOW_FALLBACK_PREFIX
+                               | MAMBA_ALLOW_EXISTING_PREFIX | MAMBA_ALLOW_MISSING_PREFIX,
+                           false);
 
         std::unique_ptr<Activator> activator;
         auto& shell_type = config.at("shell_type").value<std::string>();

--- a/src/micromamba/update.cpp
+++ b/src/micromamba/update.cpp
@@ -37,7 +37,8 @@ set_update_command(CLI::App* subcom)
     init_update_parser(subcom);
 
     subcom->callback([&]() {
-        load_configuration();
+        load_configuration(MAMBA_ALLOW_ROOT_PREFIX | MAMBA_ALLOW_FALLBACK_PREFIX
+                           | MAMBA_ALLOW_EXISTING_PREFIX);
 
         auto& ctx = Context::instance();
         auto& config = Configuration::instance();
@@ -61,6 +62,8 @@ set_update_command(CLI::App* subcom)
 
         if (!update_specs.empty())
         {
+            check_target_prefix(MAMBA_ALLOW_ROOT_PREFIX | MAMBA_ALLOW_FALLBACK_PREFIX
+                                | MAMBA_ALLOW_EXISTING_PREFIX);
             install_specs(update_specs, false, SOLVER_UPDATE);
         }
         else

--- a/test/micromamba/helpers.py
+++ b/test/micromamba/helpers.py
@@ -10,6 +10,14 @@ use_offline = False
 channel = ["-c", "conda-forge"]
 
 
+if platform.system() == "Windows":
+    xtensor_hpp = "Library/include/xtensor/xtensor.hpp"
+    xsimd_hpp = "Library/include/xsimd/xsimd.hpp"
+else:
+    xtensor_hpp = "include/xtensor/xtensor.hpp"
+    xsimd_hpp = "include/xsimd/xsimd.hpp"
+
+
 def get_umamba():
     if os.getenv("TEST_MAMBA_EXE"):
         umamba = os.getenv("TEST_MAMBA_EXE")
@@ -59,7 +67,7 @@ def info(*args):
 
 def install(*args):
     umamba = get_umamba()
-    cmd = [umamba, "install"] + [arg for arg in args if arg] + channel
+    cmd = [umamba, "install", "-y", "--no-rc"] + [arg for arg in args if arg] + channel
     if use_offline:
         cmd += ["--offline"]
     res = subprocess.check_output(cmd)
@@ -143,6 +151,19 @@ def update(*args):
     except subprocess.CalledProcessError as e:
         print(f"Error when executing '{' '.join(cmd)}'")
         raise (e)
+
+
+def umamba_list(*args):
+    umamba = get_umamba()
+
+    cmd = [umamba, "list"] + [arg for arg in args if arg]
+    res = subprocess.check_output(cmd)
+
+    if "--json" in args:
+        j = json.loads(res)
+        return j
+
+    return res.decode()
 
 
 def get_concrete_pkg(t, needle):

--- a/test/micromamba/test_create.py
+++ b/test/micromamba/test_create.py
@@ -12,45 +12,89 @@ from .helpers import *
 
 
 class TestCreate:
+
+    current_root_prefix = os.environ["MAMBA_ROOT_PREFIX"]
+    current_prefix = os.environ["CONDA_PREFIX"]
+    cache = os.path.join(current_root_prefix, "pkgs")
+
+    env_name = random_string()
+    root_prefix = os.path.expanduser(os.path.join("~", "tmproot" + random_string()))
+    prefix = os.path.join(root_prefix, "envs", env_name)
+    other_prefix = os.path.expanduser(os.path.join("~", "tmproot" + random_string()))
+
+    @classmethod
+    def setup_class(cls):
+        os.environ["MAMBA_ROOT_PREFIX"] = TestCreate.root_prefix
+        os.environ["CONDA_PREFIX"] = TestCreate.prefix
+
+        # speed-up the tests
+        os.environ["CONDA_PKGS_DIRS"] = TestCreate.cache
+
+    @classmethod
+    def setup(cls):
+        os.makedirs(TestCreate.root_prefix, exist_ok=False)
+
+    @classmethod
+    def teardown_class(cls):
+        os.environ["MAMBA_ROOT_PREFIX"] = TestCreate.current_root_prefix
+        os.environ["CONDA_PREFIX"] = TestCreate.current_prefix
+
+    @classmethod
+    def teardown(cls):
+        os.environ["MAMBA_ROOT_PREFIX"] = TestCreate.root_prefix
+        os.environ["CONDA_PREFIX"] = TestCreate.prefix
+        shutil.rmtree(TestCreate.root_prefix)
+        if Path(TestCreate.other_prefix).exists():
+            shutil.rmtree(TestCreate.other_prefix)
+
+    @pytest.mark.parametrize("root_prefix_env_var", [False, True])
     @pytest.mark.parametrize(
-        "root_prefix,default_root_prefix_not_mamba",
-        [
-            ("", False),
-            ("tmproot" + random_string(), False),
-            ("tmproot" + random_string(), True),
-        ],
+        "env_selector,outside_root_prefix",
+        [("prefix", False), ("prefix", True), ("name", False)],
     )
-    @pytest.mark.parametrize(
-        "cache_prefix", ["", os.path.join(os.environ["MAMBA_ROOT_PREFIX"], "pkgs")]
-    )
-    def test_check_root_prefix(
-        self, root_prefix, default_root_prefix_not_mamba, cache_prefix
-    ):
-        current_root_prefix = os.environ.pop("MAMBA_ROOT_PREFIX")
+    def test_create(self, root_prefix_env_var, env_selector, outside_root_prefix):
+        if not root_prefix_env_var:
+            os.environ.pop("MAMBA_ROOT_PREFIX")
+            cmd = ("-r", TestCreate.root_prefix, "xtensor", "--json")
+        else:
+            cmd = ("xtensor", "--json")
 
-        if root_prefix:
-            abs_root_prefix = os.path.expanduser(os.path.join("~", root_prefix))
-            os.makedirs(abs_root_prefix, exist_ok=True)
-            os.environ["MAMBA_DEFAULT_ROOT_PREFIX"] = abs_root_prefix
-            if default_root_prefix_not_mamba:
-                with open(os.path.join(abs_root_prefix, "some_file"), "w") as f:
-                    f.write("abc")
+        if outside_root_prefix:
+            p = TestCreate.other_prefix
+        else:
+            p = TestCreate.prefix
 
-        if cache_prefix:
-            os.environ["CONDA_PKGS_DIRS"] = os.path.abspath(cache_prefix)
+        if env_selector == "prefix":
+            res = create("-p", p, *cmd)
+        elif env_selector == "name":
+            res = create("-n", TestCreate.env_name, *cmd)
 
-        try:
-            if root_prefix and default_root_prefix_not_mamba:
-                with pytest.raises(subprocess.CalledProcessError):
-                    res = create(
-                        "-n", random_string(), "xtensor", "--json", "--dry-run"
-                    )
-            else:
-                res = create("-n", random_string(), "xtensor", "--json", "--dry-run")
-        finally:  # ensure cleaning
-            os.environ["MAMBA_ROOT_PREFIX"] = current_root_prefix
-            if root_prefix:
-                os.environ.pop("MAMBA_DEFAULT_ROOT_PREFIX")
-                shutil.rmtree(abs_root_prefix)
-            if cache_prefix:
-                os.environ.pop("CONDA_PKGS_DIRS")
+        assert res["success"]
+        assert not res["dry_run"]
+
+        keys = {"success", "prefix", "actions", "dry_run"}
+        assert keys == set(res.keys())
+
+        action_keys = {"LINK", "PREFIX"}
+        assert action_keys == set(res["actions"].keys())
+
+        packages = {pkg["name"] for pkg in res["actions"]["LINK"]}
+        expected_packages = {"xtensor", "xtl"}
+        assert expected_packages.issubset(packages)
+
+        pkg_name = get_concrete_pkg(res, "xtensor")
+        orig_file_path = get_pkg(pkg_name, xtensor_hpp, TestCreate.current_root_prefix)
+        assert orig_file_path.exists()
+
+    @pytest.mark.parametrize("env_selector", ["prefix", "name"])
+    @pytest.mark.parametrize("root_non_empty", [False, True])
+    def test_create_base(self, root_non_empty, env_selector):
+
+        with open(os.path.join(TestCreate.root_prefix, "some_file"), "w") as f:
+            f.write("abc")
+
+        with pytest.raises(subprocess.CalledProcessError):
+            if env_selector == "prefix":
+                create("-p", TestCreate.root_prefix, "xtensor")
+            elif env_selector == "name":
+                create("-n", "base", "xtensor")

--- a/test/micromamba/test_create.py
+++ b/test/micromamba/test_create.py
@@ -73,10 +73,10 @@ class TestCreate:
         assert not res["dry_run"]
 
         keys = {"success", "prefix", "actions", "dry_run"}
-        assert keys == set(res.keys())
+        assert keys.issubset(set(res.keys()))
 
         action_keys = {"LINK", "PREFIX"}
-        assert action_keys == set(res["actions"].keys())
+        assert action_keys.issubset(set(res["actions"].keys()))
 
         packages = {pkg["name"] for pkg in res["actions"]["LINK"]}
         expected_packages = {"xtensor", "xtl"}

--- a/test/micromamba/test_install.py
+++ b/test/micromamba/test_install.py
@@ -89,10 +89,10 @@ class TestInstall:
         assert not res["dry_run"]
         if already_installed:
             keys = {"dry_run", "success", "prefix", "message"}
-            assert keys == set(res.keys())
+            assert keys.issubset(set(res.keys()))
         else:
             keys = {"success", "prefix", "actions", "dry_run"}
-            assert keys == set(res.keys())
+            assert keys.issubset(set(res.keys()))
 
             action_keys = {"LINK", "PREFIX"}
             assert action_keys == set(res["actions"].keys())

--- a/test/micromamba/test_install.py
+++ b/test/micromamba/test_install.py
@@ -11,127 +11,98 @@ import pytest
 
 from .helpers import *
 
-if platform.system() == "Windows":
-    xtensor_hpp = "Library/include/xtensor/xtensor.hpp"
-    xsimd_hpp = "Library/include/xsimd/xsimd.hpp"
-else:
-    xtensor_hpp = "include/xtensor/xtensor.hpp"
-    xsimd_hpp = "include/xsimd/xsimd.hpp"
-
 
 class TestInstall:
-    def test_empty(self):
+
+    current_root_prefix = os.environ["MAMBA_ROOT_PREFIX"]
+    current_prefix = os.environ["CONDA_PREFIX"]
+    cache = os.path.join(current_root_prefix, "pkgs")
+
+    env_name = random_string()
+    root_prefix = os.path.expanduser(os.path.join("~", "tmproot" + random_string()))
+    prefix = os.path.join(root_prefix, "envs", env_name)
+
+    @classmethod
+    def setup_class(cls):
+        os.environ["MAMBA_ROOT_PREFIX"] = TestInstall.root_prefix
+        os.environ["CONDA_PREFIX"] = TestInstall.prefix
+
+        # speed-up the tests
+        os.environ["CONDA_PKGS_DIRS"] = TestInstall.cache
+
+        os.makedirs(TestInstall.root_prefix, exist_ok=False)
+        install("xtensor", "-n", "base")
+        create("xtensor", "-n", TestInstall.env_name)
+
+    @classmethod
+    def teardown_class(cls):
+        os.environ["MAMBA_ROOT_PREFIX"] = TestInstall.current_root_prefix
+        os.environ["CONDA_PREFIX"] = TestInstall.current_prefix
+        shutil.rmtree(TestInstall.root_prefix)
+
+    @classmethod
+    def teardown(cls):
+        os.environ["MAMBA_ROOT_PREFIX"] = TestInstall.root_prefix
+        remove("xtensor", "xtl", "-n", "base")
+        remove("xtensor", "xtl", "-n", TestInstall.env_name)
+
+        res = umamba_list("xtensor", "-n", TestInstall.env_name, "--json")
+        assert len(res) == 0
+
+        os.environ["CONDA_PREFIX"] = TestInstall.prefix
+
+    def test_empty_specs(self):
         assert "Nothing to do." in install().strip()
 
-    def test_already_installed(self):
-        env = random_string()
-        create("-n", env, "xtensor")
-
-        res = install("xtensor", "--json", "--dry-run")
-        keys = {"dry_run", "success", "prefix"}
-        assert keys.issubset(set(res.keys()))
-        assert res["success"]
-
-        shutil.rmtree(get_env(env))
-
-    def test_not_already_installed(self):
-        env = random_string()
-        create("-n", env, "xtensor")
-        res = install("-n", env, "bokeh", "--json", "--dry-run")
-        keys = {"dry_run", "success", "prefix", "actions"}
-        assert keys == set(res.keys())
-        assert res["success"]
-
-        shutil.rmtree(get_env(env))
-
-    def test_dependencies(self):
-        res = create("-n", random_string(), "xtensor", "--json", "--dry-run")
-        keys = {"dry_run", "success", "prefix", "actions"}
-        assert keys.issubset(set(res.keys()))
-        assert res["success"]
-
-        action_keys = {"LINK", "PREFIX"}
-        assert action_keys == set(res["actions"].keys())
-
-        packages = {pkg["name"] for pkg in res["actions"]["LINK"]}
-        expected_packages = {"xtensor", "xtl"}
-        assert expected_packages.issubset(packages)
-
-    @pytest.mark.parametrize(
-        "root_prefix,default_root_prefix_not_mamba",
-        [
-            (os.environ["MAMBA_ROOT_PREFIX"], False),
-            (os.path.expanduser(os.path.join("~", "tmproot" + random_string())), False),
-            (os.path.expanduser(os.path.join("~", "tmproot" + random_string())), True),
-        ],
-    )
-    def test_target_prefix(self, root_prefix, default_root_prefix_not_mamba):
-        env = "installenv" + random_string()
-        current_root_prefix = os.environ.pop("MAMBA_ROOT_PREFIX")
-        if default_root_prefix_not_mamba:
-            os.makedirs(root_prefix, exist_ok=True)
-            with open(os.path.join(root_prefix, "some_file"), "w") as f:
-                f.write("abc")
-
-        try:
-            res = create("-r", root_prefix, "-n", env, "xtensor", "--json")
-            pkg_name = get_concrete_pkg(res, "xtensor")
-            orig_file_path = get_pkg(pkg_name, xtensor_hpp, root_prefix)
-            assert orig_file_path.exists()
-            assert Path(os.path.join(root_prefix, "pkgs", pkg_name)).exists()
-
-            res = install("-r", root_prefix, "-n", env, "-y", "xsimd", "--json")
-            pkg_name = get_concrete_pkg(res, "xsimd")
-            orig_file_path = get_pkg(pkg_name, xsimd_hpp, root_prefix)
-            assert orig_file_path.exists()
-            assert Path(os.path.join(root_prefix, "pkgs", pkg_name)).exists()
-
-        finally:  # ensure cleaning
-            os.environ["MAMBA_ROOT_PREFIX"] = current_root_prefix
-            if current_root_prefix != root_prefix:
-                shutil.rmtree(root_prefix)
-
-    @pytest.mark.parametrize(
-        "root_prefix,default_root_prefix_not_mamba",
-        [
-            (os.environ["MAMBA_ROOT_PREFIX"], False),
-            (os.path.expanduser(os.path.join("~", "tmproot" + random_string())), False),
-            (os.path.expanduser(os.path.join("~", "tmproot" + random_string())), True),
-        ],
-    )
-    @pytest.mark.parametrize("multiple_install", [False, True])
-    def test_root_prefix(
-        self, root_prefix, default_root_prefix_not_mamba, multiple_install
+    @pytest.mark.parametrize("already_installed", [False, True])
+    @pytest.mark.parametrize("root_prefix_env_var", [False, True])
+    @pytest.mark.parametrize("target_is_root", [False, True])
+    @pytest.mark.parametrize("env_selector", ["", "name", "prefix"])
+    def test_install(
+        self, target_is_root, root_prefix_env_var, already_installed, env_selector
     ):
-        current_root_prefix = os.environ.pop("MAMBA_ROOT_PREFIX")
-        os.environ["MAMBA_DEFAULT_ROOT_PREFIX"] = ""
-        if default_root_prefix_not_mamba:
-            os.makedirs(root_prefix, exist_ok=True)
-            with open(os.path.join(root_prefix, "some_file"), "w") as f:
-                f.write("abc")
+        if target_is_root:
+            p = TestInstall.root_prefix
+            n = "base"
+            os.environ["CONDA_PREFIX"] = TestInstall.root_prefix
+        else:
+            p = TestInstall.prefix
+            n = TestInstall.env_name
 
-        try:
-            try:  # Remove packages from root prefix if already installed
-                remove("-r", root_prefix, "-p", root_prefix, "xsimd", "xtensor")
-            except:
-                pass
+        if not root_prefix_env_var:
+            os.environ.pop("MAMBA_ROOT_PREFIX")
+            cmd = ("-r", TestInstall.root_prefix, "xtensor", "--json")
+        else:
+            cmd = "xtensor", "--json"
 
-            create("-r", root_prefix, "-n", "otherenv", "xtensor", "--json")
+        if already_installed:
+            install("xtensor")
 
-            res = install("-r", root_prefix, "-n", "base", "-y", "xtensor", "--json")
+        if env_selector == "prefix":
+            res = install("-p", p, *cmd)
+        elif env_selector == "name":
+            res = install("-n", n, *cmd)
+        else:
+            res = install(*cmd)
+
+        assert res["success"]
+        assert not res["dry_run"]
+        if already_installed:
+            keys = {"dry_run", "success", "prefix", "message"}
+            assert keys == set(res.keys())
+        else:
+            keys = {"success", "prefix", "actions", "dry_run"}
+            assert keys == set(res.keys())
+
+            action_keys = {"LINK", "PREFIX"}
+            assert action_keys == set(res["actions"].keys())
+
+            packages = {pkg["name"] for pkg in res["actions"]["LINK"]}
+            expected_packages = {"xtensor", "xtl"}
+            assert expected_packages.issubset(packages)
+
             pkg_name = get_concrete_pkg(res, "xtensor")
-            orig_file_path = get_pkg(pkg_name, xtensor_hpp, root_prefix)
+            orig_file_path = get_pkg(
+                pkg_name, xtensor_hpp, TestInstall.current_root_prefix
+            )
             assert orig_file_path.exists()
-            assert Path(os.path.join(root_prefix, "pkgs", pkg_name)).exists()
-
-            if multiple_install:
-                res = install("-r", root_prefix, "-n", "base", "-y", "xsimd", "--json")
-                pkg_name = get_concrete_pkg(res, "xsimd")
-                orig_file_path = get_pkg(pkg_name, xsimd_hpp, root_prefix)
-                assert orig_file_path.exists()
-                assert Path(os.path.join(root_prefix, "pkgs", pkg_name)).exists()
-
-        finally:  # ensure cleaning
-            os.environ["MAMBA_ROOT_PREFIX"] = current_root_prefix
-            if current_root_prefix != root_prefix:
-                shutil.rmtree(root_prefix)

--- a/test/micromamba/test_update.py
+++ b/test/micromamba/test_update.py
@@ -9,28 +9,58 @@ from .helpers import *
 
 
 class TestUpdate:
-    def test_update(self):
-        env = "random100"
-        res = create("xtensor=0.18", "-n", env, "--json")
-        old_pkg = get_concrete_pkg(res, "xtensor")
-        pkg_info = get_concrete_pkg_info(get_env(env), old_pkg)
-        old_version = pkg_info["version"]
-        assert old_version.startswith("0.18")
+    env_name = random_string()
+    root_prefix = os.environ["MAMBA_ROOT_PREFIX"]
+    current_prefix = os.environ["CONDA_PREFIX"]
+    prefix = os.path.join(root_prefix, "envs", env_name)
+    old_version = "0.18"
 
-        update_res = update("xtensor", "-n", env, "--json")
-        new_pkg = get_concrete_pkg(update_res, "xtensor")
-        pkg_info = get_concrete_pkg_info(get_env(env), new_pkg)
-        new_version = pkg_info["version"]
+    @classmethod
+    def setup_class(cls):
+        res = create(
+            f"xtensor={TestUpdate.old_version}", "-n", TestUpdate.env_name, "--json"
+        )
+        os.environ["CONDA_PREFIX"] = TestUpdate.prefix
 
-        assert old_pkg != new_pkg
-        assert old_version != new_version
+        pkg = get_concrete_pkg(res, "xtensor")
+        pkg_info = get_concrete_pkg_info(get_env(TestUpdate.env_name), pkg)
+        version = pkg_info["version"]
+        assert version.startswith(TestUpdate.old_version)
+
+    @classmethod
+    def setup(cls):
+        install(
+            f"xtensor={TestUpdate.old_version}", "-n", TestUpdate.env_name, "--json"
+        )
+        res = umamba_list("xtensor", "-n", TestUpdate.env_name, "--json")
+        assert len(res) == 1
+        assert res[0]["version"].startswith(TestUpdate.old_version)
+
+    @classmethod
+    def teardown_class(cls):
+        os.environ["CONDA_PREFIX"] = TestUpdate.current_prefix
+        shutil.rmtree(get_env(TestUpdate.env_name))
+
+    @pytest.mark.parametrize("env_selector", ["", "name", "prefix"])
+    def test_update(self, env_selector):
+
+        if env_selector == "prefix":
+            update_res = update("xtensor", "-p", TestUpdate.prefix, "--json")
+        elif env_selector == "name":
+            update_res = update("xtensor", "-n", TestUpdate.env_name, "--json")
+        else:
+            update_res = update("xtensor", "--json")
+
+        pkg = get_concrete_pkg(update_res, "xtensor")
+        pkg_info = get_concrete_pkg_info(get_env(TestUpdate.env_name), pkg)
+        version = pkg_info["version"]
+
+        assert TestUpdate.old_version != version
 
         # This should do nothing since python is not installed!
-        update_res = update("python", "-n", env, "--json")
+        update_res = update("python", "-n", TestUpdate.env_name, "--json")
 
         # TODO fix this?!
         assert update_res["message"] == "All requested packages already installed"
         assert update_res["success"] == True
         assert "action" not in update_res
-
-        shutil.rmtree(get_env(env))


### PR DESCRIPTION
Description
--

- Fix default target prefix for all micromamba sub commands
- extend tests and improve them by reusing the cache
- also use setup and teardown to improve readability