### PR TITLE
Add --channel-alias option to umamba CLI

### DIFF
--- a/src/micromamba/common_options.cpp
+++ b/src/micromamba/common_options.cpp
@@ -236,6 +236,10 @@ init_channel_parser(CLI::App* subcom)
                     { "strict", "disabled" },
                     channel_priority.description());
 
+    auto& channel_alias = config.at("channel_alias").get_wrapped<std::string>();
+    subcom->add_option(
+        "--channel-alias", channel_alias.set_cli_config(""), channel_alias.description());
+
     auto& strict_channel_priority
         = config.insert(Configurable("strict_channel_priority", false)
                             .group("cli")

--- a/test/micromamba/test_create.py
+++ b/test/micromamba/test_create.py
@@ -98,3 +98,32 @@ class TestCreate:
                 create("-p", TestCreate.root_prefix, "xtensor")
             elif env_selector == "name":
                 create("-n", "base", "xtensor")
+
+    @pytest.mark.parametrize(
+        "alias",
+        [
+            "",
+            "https://conda.anaconda.org/",
+            "https://repo.mamba.pm/",
+            "https://repo.mamba.pm",
+        ],
+    )
+    def test_channel_alias(self, alias):
+        if alias:
+            res = create(
+                "-n",
+                TestCreate.env_name,
+                "xtensor",
+                "--json",
+                "--dry-run",
+                "--channel-alias",
+                alias,
+            )
+            ca = alias.rstrip("/")
+        else:
+            res = create("-n", TestCreate.env_name, "xtensor", "--json", "--dry-run")
+            ca = "https://conda.anaconda.org"
+
+        for l in res["actions"]["LINK"]:
+            assert l["channel"].startswith(f"{ca}/conda-forge/")
+            assert l["url"].startswith(f"{ca}/conda-forge/")

--- a/test/micromamba/test_install.py
+++ b/test/micromamba/test_install.py
@@ -106,3 +106,24 @@ class TestInstall:
                 pkg_name, xtensor_hpp, TestInstall.current_root_prefix
             )
             assert orig_file_path.exists()
+
+    @pytest.mark.parametrize(
+        "alias",
+        [
+            "",
+            "https://conda.anaconda.org/",
+            "https://repo.mamba.pm/",
+            "https://repo.mamba.pm",
+        ],
+    )
+    def test_channel_alias(self, alias):
+        if alias:
+            res = install("xtensor", "--json", "--dry-run", "--channel-alias", alias)
+            ca = alias.rstrip("/")
+        else:
+            res = install("xtensor", "--json", "--dry-run")
+            ca = "https://conda.anaconda.org"
+
+        for l in res["actions"]["LINK"]:
+            assert l["channel"].startswith(f"{ca}/conda-forge/")
+            assert l["url"].startswith(f"{ca}/conda-forge/")

--- a/test/micromamba/test_update.py
+++ b/test/micromamba/test_update.py
@@ -64,3 +64,32 @@ class TestUpdate:
         assert update_res["message"] == "All requested packages already installed"
         assert update_res["success"] == True
         assert "action" not in update_res
+
+    @pytest.mark.parametrize(
+        "alias",
+        [
+            "",
+            "https://conda.anaconda.org/",
+            "https://repo.mamba.pm/",
+            "https://repo.mamba.pm",
+        ],
+    )
+    def test_channel_alias(self, alias):
+        if alias:
+            res = update(
+                "-n",
+                TestUpdate.env_name,
+                "xtensor",
+                "--json",
+                "--dry-run",
+                "--channel-alias",
+                alias,
+            )
+            ca = alias.rstrip("/")
+        else:
+            res = update("-n", TestUpdate.env_name, "xtensor", "--json", "--dry-run")
+            ca = "https://conda.anaconda.org"
+
+        for l in res["actions"]["LINK"]:
+            assert l["channel"].startswith(f"{ca}/conda-forge/")
+            assert l["url"].startswith(f"{ca}/conda-forge/")


### PR DESCRIPTION
Description
---

Add --channel-alias option to umamba CLI: in `install`, `create` and `update` sub commands
Add python tests