### PR TITLE
Fix spec files + no_rc

### DIFF
--- a/test/micromamba/helpers.py
+++ b/test/micromamba/helpers.py
@@ -65,9 +65,13 @@ def info(*args):
     return res.decode()
 
 
-def install(*args):
+def install(*args, default_channel=True, no_rc=True):
     umamba = get_umamba()
-    cmd = [umamba, "install", "-y", "--no-rc"] + [arg for arg in args if arg] + channel
+    cmd = [umamba, "install", "-y"] + [arg for arg in args if arg]
+    if default_channel:
+        cmd += channel
+    if no_rc:
+        cmd += ["--no-rc"]
     if use_offline:
         cmd += ["--offline"]
     res = subprocess.check_output(cmd)
@@ -95,9 +99,13 @@ def remove(*args):
     return res.decode()
 
 
-def create(*args):
+def create(*args, default_channel=True, no_rc=True):
     umamba = get_umamba()
-    cmd = [umamba, "create", "-y"] + [arg for arg in args if arg] + channel
+    cmd = [umamba, "create", "-y"] + [arg for arg in args if arg]
+    if default_channel:
+        cmd += channel
+    if no_rc:
+        cmd += ["--no-rc"]
     if use_offline:
         cmd += ["--offline"]
 
@@ -129,12 +137,15 @@ def remove(*args):
         raise (e)
 
 
-def update(*args):
+def update(*args, default_channel=True, no_rc=True):
     umamba = get_umamba()
-    cmd = [umamba, "update", "-y", "--no-rc"] + [arg for arg in args if arg] + channel
+    cmd = [umamba, "update", "-y"] + [arg for arg in args if arg]
     if use_offline:
         cmd += ["--offline"]
-
+    if no_rc:
+        cmd += ["--no-rc"]
+    if default_channel:
+        cmd += channel
     try:
         res = subprocess.check_output(cmd)
         if "--json" in args:

--- a/test/micromamba/test_install.py
+++ b/test/micromamba/test_install.py
@@ -33,6 +33,8 @@ class TestInstall:
         os.makedirs(TestInstall.root_prefix, exist_ok=False)
         install("xtensor", "-n", "base")
         create("xtensor", "-n", TestInstall.env_name)
+        remove("xtensor", "xtl", "-n", "base")
+        remove("xtensor", "xtl", "-n", TestInstall.env_name)
 
     @classmethod
     def teardown_class(cls):
@@ -43,8 +45,8 @@ class TestInstall:
     @classmethod
     def teardown(cls):
         os.environ["MAMBA_ROOT_PREFIX"] = TestInstall.root_prefix
-        remove("xtensor", "xtl", "-n", "base")
-        remove("xtensor", "xtl", "-n", TestInstall.env_name)
+        remove("xtensor", "xtl", "xsimd", "xframe", "-n", "base")
+        remove("xtensor", "xtl", "xsimd", "xframe", "-n", TestInstall.env_name)
 
         res = umamba_list("xtensor", "-n", TestInstall.env_name, "--json")
         assert len(res) == 0
@@ -127,3 +129,65 @@ class TestInstall:
         for l in res["actions"]["LINK"]:
             assert l["channel"].startswith(f"{ca}/conda-forge/")
             assert l["url"].startswith(f"{ca}/conda-forge/")
+
+    @pytest.mark.parametrize("channels", [None, "both", "CLI_only", "file_only"])
+    @pytest.mark.parametrize("env_name", [None, "both", "CLI_only", "file_only"])
+    @pytest.mark.parametrize("specs", ["both", "CLI_only", "file_only"])
+    def test_yaml_spec_file(self, channels, env_name, specs):
+        spec_file_content = []
+        if env_name not in ("CLI_only", None):
+            spec_file_content += [f"name: {TestInstall.env_name}"]
+        if channels not in ("CLI_only", None):
+            spec_file_content += ["channels:", "  - https://repo.mamba.pm/conda-forge"]
+        if specs != "CLI_only":
+            spec_file_content += ["dependencies:", "  - xtensor", "  - xsimd"]
+
+        yaml_spec_file = os.path.join(TestInstall.prefix, "yaml_env.yml")
+        with open(yaml_spec_file, "w") as f:
+            f.write("\n".join(spec_file_content))
+
+        cmd = []
+
+        if specs != "file_only":
+            cmd += ["xframe"]
+
+        if env_name not in ("file_only", None):
+            cmd += [
+                "-n",
+                TestInstall.env_name,
+            ]
+
+        if channels not in ("file_only", None):
+            cmd += ["-c", "https://conda.anaconda.org/conda-forge"]
+
+        cmd += ["-f", yaml_spec_file, "--json"]
+
+        if env_name == "both" or specs == "CLI_only" or channels is None:
+            with pytest.raises(subprocess.CalledProcessError):
+                install(*cmd, default_channel=False)
+        else:
+            res = install(*cmd, default_channel=False)
+
+            assert res["success"]
+            assert not res["dry_run"]
+
+            keys = {"success", "prefix", "actions", "dry_run"}
+            assert keys.issubset(set(res.keys()))
+
+            action_keys = {"LINK", "PREFIX"}
+            assert action_keys.issubset(set(res["actions"].keys()))
+
+            packages = {pkg["name"] for pkg in res["actions"]["LINK"]}
+            expected_packages = ["xtensor", "xtl", "xsimd"]
+            if specs != "file_only":
+                expected_packages.append("xframe")
+            assert set(expected_packages).issubset(packages)
+
+            if channels == "file_only":
+                expected_channel = "https://repo.mamba.pm/conda-forge"
+            else:
+                expected_channel = "https://conda.anaconda.org/conda-forge"
+
+            for l in res["actions"]["LINK"]:
+                assert l["channel"].startswith(expected_channel)
+                assert l["url"].startswith(expected_channel)


### PR DESCRIPTION
Description
---

Spec files are currently considered as rc files.
This causes issue when using the `--no-rc` flag.
- read spec files as CLI configuration
- add tests