### PR TITLE
Allow CLI to override spec file env name

### DIFF
--- a/src/micromamba/install.cpp
+++ b/src/micromamba/install.cpp
@@ -382,12 +382,10 @@ parse_file_options()
 
             if (config["name"])
             {
-                if (env_name.cli_configured())
+                if (!env_name.cli_configured())
                 {
-                    throw std::runtime_error(
-                        "Cannot configure environment name in both CLI and file spec");
+                    env_name.set_cli_value(config["name"]);
                 }
-                env_name.set_cli_value(config["name"]);
             }
             {
                 LOG_DEBUG << "No env 'name' specified in file: " << file;

--- a/test/micromamba/test_install.py
+++ b/test/micromamba/test_install.py
@@ -162,17 +162,17 @@ class TestInstall:
 
         cmd += ["-f", yaml_spec_file, "--json"]
 
-        if env_name == "both" or specs == "CLI_only" or channels is None:
+        if specs == "CLI_only" or channels is None:
             with pytest.raises(subprocess.CalledProcessError):
                 install(*cmd, default_channel=False)
         else:
             res = install(*cmd, default_channel=False)
 
-            assert res["success"]
-            assert not res["dry_run"]
-
             keys = {"success", "prefix", "actions", "dry_run"}
             assert keys.issubset(set(res.keys()))
+            assert res["success"]
+            assert not res["dry_run"]
+            assert res["prefix"] == TestInstall.prefix
 
             action_keys = {"LINK", "PREFIX"}
             assert action_keys.issubset(set(res["actions"].keys()))


### PR DESCRIPTION
Description
---

Allow `micromamba` CLI `-n` option to override spec file env name.
Update python based tests accordingly.