### PR TITLE
Improve solver display of problems

### DIFF
--- a/src/core/solver.cpp
+++ b/src/core/solver.cpp
@@ -328,10 +328,10 @@ namespace mamba
         for (int i = 1; i <= count; i++)
         {
             queue_push(&problem_queue, i);
-            problems << "Problem: " << solver_problem2str(m_solver, i) << "\n";
+            problems << "  - " << solver_problem2str(m_solver, i) << "\n";
         }
         queue_free(&problem_queue);
-        return "Encountered problems while solving.\n" + problems.str();
+        return "Encountered problems while solving:\n" + problems.str();
     }
 
     MSolver::operator Solver*()


### PR DESCRIPTION
Description
---

Have a nicer display of solver problems if some are encountered:
- remove extra newline if only 1 problem encountered
- display problems as a list

before:
```
Encountered problems while solving.
Problem: nothing provides requested xtensora

ERROR   Could not solve for environment specs
```
after:
```
Encountered problems while solving:
- nothing provides requested xtensora
ERROR   Could not solve for environment specs
```