### PR TITLE
Create behavior with root_prefix

### DIFF
--- a/include/mamba/api/configuration.hpp
+++ b/include/mamba/api/configuration.hpp
@@ -463,14 +463,12 @@ namespace mamba
         kFile = 3
     };
 
-    int const MAMBA_ALLOW_ROOT_PREFIX = 1 << 0;
-    int const MAMBA_ALLOW_EXISTING_PREFIX = 1 << 1;
-    int const MAMBA_ALLOW_FALLBACK_PREFIX = 1 << 2;
-    int const MAMBA_ALLOW_MISSING_PREFIX = 1 << 3;
-    int const MAMBA_ALLOW_NOT_ENV_PREFIX = 1 << 4;
-    int const MAMBA_EXPECT_EXISTING_PREFIX = 1 << 5;
+    int const MAMBA_ALLOW_EXISTING_PREFIX = 1 << 0;
+    int const MAMBA_ALLOW_FALLBACK_PREFIX = 1 << 1;
+    int const MAMBA_ALLOW_MISSING_PREFIX = 1 << 2;
+    int const MAMBA_ALLOW_NOT_ENV_PREFIX = 1 << 3;
+    int const MAMBA_EXPECT_EXISTING_PREFIX = 1 << 4;
 
-    int const MAMBA_NOT_ALLOW_ROOT_PREFIX = 0;
     int const MAMBA_NOT_ALLOW_EXISTING_PREFIX = 0;
     int const MAMBA_NOT_ALLOW_FALLBACK_PREFIX = 0;
     int const MAMBA_NOT_ALLOW_MISSING_PREFIX = 0;

--- a/src/api/clean.cpp
+++ b/src/api/clean.cpp
@@ -18,8 +18,7 @@ namespace mamba
         auto& ctx = Context::instance();
         auto& config = Configuration::instance();
 
-        config.load(MAMBA_ALLOW_ROOT_PREFIX | MAMBA_ALLOW_FALLBACK_PREFIX
-                    | MAMBA_ALLOW_EXISTING_PREFIX);
+        config.load(MAMBA_ALLOW_FALLBACK_PREFIX | MAMBA_ALLOW_EXISTING_PREFIX);
 
         bool clean_all = options & MAMBA_CLEAN_ALL;
         bool clean_index = options & MAMBA_CLEAN_INDEX;

--- a/src/api/configuration.cpp
+++ b/src/api/configuration.cpp
@@ -169,6 +169,17 @@ namespace mamba
                                 (then restart or source the contents of the shell init script))");
             }
 
+            if (!fs::exists(prefix))
+            {
+                fs::create_directories(prefix / "conda-meta");
+                fs::create_directories(prefix / "envs");
+                fs::create_directories(prefix / "pkgs");
+                std::fstream history;
+                history.open(prefix / "conda-meta" / "history", std::fstream::out);
+                history.close();
+            }
+            prefix = fs::weakly_canonical(prefix);
+
             auto& ctx = Context::instance();
             ctx.envs_dirs = { prefix / "envs" };
             ctx.pkgs_dirs = { prefix / "pkgs" };
@@ -215,7 +226,6 @@ namespace mamba
 
             bool allow_fallback = options & MAMBA_ALLOW_FALLBACK_PREFIX;
             bool allow_missing = options & MAMBA_ALLOW_MISSING_PREFIX;
-            bool allow_root = options & MAMBA_ALLOW_ROOT_PREFIX;
             bool allow_not_env = options & MAMBA_ALLOW_NOT_ENV_PREFIX;
             bool allow_existing = options & MAMBA_ALLOW_EXISTING_PREFIX;
             bool expect_existing = options & MAMBA_EXPECT_EXISTING_PREFIX;
@@ -237,12 +247,7 @@ namespace mamba
                     throw std::runtime_error("Aborting.");
                 }
             }
-
-            if ((prefix == ctx.root_prefix) && !allow_root)
-            {
-                LOG_ERROR << "'root_prefix' not accepted as 'target_prefix'";
-                throw std::runtime_error("Aborting.");
-            }
+            prefix = fs::weakly_canonical(prefix);
 
             if (fs::exists(prefix))
             {

--- a/src/api/configuration.cpp
+++ b/src/api/configuration.cpp
@@ -10,6 +10,7 @@
 
 #include "mamba/core/environment.hpp"
 #include "mamba/core/fetch.hpp"
+#include "mamba/core/fsutil.hpp"
 
 #include <algorithm>
 #include <stdexcept>
@@ -171,12 +172,9 @@ namespace mamba
 
             if (!fs::exists(prefix))
             {
-                fs::create_directories(prefix / "conda-meta");
+                path::touch(prefix / "conda-meta" / "history", true);
                 fs::create_directories(prefix / "envs");
                 fs::create_directories(prefix / "pkgs");
-                std::fstream history;
-                history.open(prefix / "conda-meta" / "history", std::fstream::out);
-                history.close();
             }
             prefix = fs::weakly_canonical(prefix);
 

--- a/src/api/create.cpp
+++ b/src/api/create.cpp
@@ -18,8 +18,7 @@ namespace mamba
         auto& ctx = Context::instance();
         auto& config = Configuration::instance();
 
-        int target_prefix_checks = MAMBA_NOT_ALLOW_ROOT_PREFIX | MAMBA_NOT_ALLOW_EXISTING_PREFIX
-                                   | MAMBA_NOT_ALLOW_FALLBACK_PREFIX
+        int target_prefix_checks = MAMBA_NOT_ALLOW_EXISTING_PREFIX | MAMBA_NOT_ALLOW_FALLBACK_PREFIX
                                    | MAMBA_NOT_ALLOW_MISSING_PREFIX | MAMBA_NOT_ALLOW_NOT_ENV_PREFIX
                                    | MAMBA_NOT_EXPECT_EXISTING_PREFIX;
 

--- a/src/api/info.cpp
+++ b/src/api/info.cpp
@@ -21,9 +21,8 @@ namespace mamba
     {
         auto& config = Configuration::instance();
 
-        config.load(MAMBA_ALLOW_ROOT_PREFIX | MAMBA_ALLOW_FALLBACK_PREFIX
-                    | MAMBA_ALLOW_EXISTING_PREFIX | MAMBA_ALLOW_MISSING_PREFIX
-                    | MAMBA_ALLOW_NOT_ENV_PREFIX);
+        config.load(MAMBA_ALLOW_FALLBACK_PREFIX | MAMBA_ALLOW_EXISTING_PREFIX
+                    | MAMBA_ALLOW_MISSING_PREFIX | MAMBA_ALLOW_NOT_ENV_PREFIX);
 
         detail::print_info();
     }

--- a/src/api/install.cpp
+++ b/src/api/install.cpp
@@ -27,9 +27,9 @@ namespace mamba
     {
         auto& config = Configuration::instance();
 
-        config.load(MAMBA_ALLOW_ROOT_PREFIX | MAMBA_ALLOW_FALLBACK_PREFIX
-                    | MAMBA_ALLOW_EXISTING_PREFIX | MAMBA_NOT_ALLOW_MISSING_PREFIX
-                    | MAMBA_NOT_ALLOW_NOT_ENV_PREFIX | MAMBA_EXPECT_EXISTING_PREFIX);
+        config.load(MAMBA_ALLOW_FALLBACK_PREFIX | MAMBA_ALLOW_EXISTING_PREFIX
+                    | MAMBA_NOT_ALLOW_MISSING_PREFIX | MAMBA_NOT_ALLOW_NOT_ENV_PREFIX
+                    | MAMBA_EXPECT_EXISTING_PREFIX);
 
         auto& install_specs = config.at("specs").value<std::vector<std::string>>();
         auto& use_explicit = config.at("explicit_install").value<bool>();

--- a/src/api/list.cpp
+++ b/src/api/list.cpp
@@ -19,9 +19,9 @@ namespace mamba
         auto& config = Configuration::instance();
 
         config.at("show_banner").get_wrapped<bool>().set_value(false);
-        config.load(MAMBA_ALLOW_ROOT_PREFIX | MAMBA_ALLOW_FALLBACK_PREFIX
-                    | MAMBA_ALLOW_EXISTING_PREFIX | MAMBA_ALLOW_MISSING_PREFIX
-                    | MAMBA_NOT_ALLOW_NOT_ENV_PREFIX | MAMBA_EXPECT_EXISTING_PREFIX);
+        config.load(MAMBA_ALLOW_FALLBACK_PREFIX | MAMBA_ALLOW_EXISTING_PREFIX
+                    | MAMBA_ALLOW_MISSING_PREFIX | MAMBA_NOT_ALLOW_NOT_ENV_PREFIX
+                    | MAMBA_EXPECT_EXISTING_PREFIX);
 
         detail::list_packages(regex);
     }

--- a/src/api/remove.cpp
+++ b/src/api/remove.cpp
@@ -22,8 +22,7 @@ namespace mamba
         auto& ctx = Context::instance();
         auto& config = Configuration::instance();
 
-        config.load(MAMBA_ALLOW_ROOT_PREFIX | MAMBA_ALLOW_FALLBACK_PREFIX
-                    | MAMBA_ALLOW_EXISTING_PREFIX);
+        config.load(MAMBA_ALLOW_FALLBACK_PREFIX | MAMBA_ALLOW_EXISTING_PREFIX);
 
         auto remove_specs = config.at("specs").value<std::vector<std::string>>();
 

--- a/src/api/shell.cpp
+++ b/src/api/shell.cpp
@@ -25,8 +25,8 @@ namespace mamba
         auto& config = Configuration::instance();
 
         config.at("show_banner").get_wrapped<bool>().set_value(false);
-        config.load(MAMBA_ALLOW_ROOT_PREFIX | MAMBA_ALLOW_FALLBACK_PREFIX
-                    | MAMBA_ALLOW_EXISTING_PREFIX | MAMBA_ALLOW_MISSING_PREFIX);
+        config.load(MAMBA_ALLOW_FALLBACK_PREFIX | MAMBA_ALLOW_EXISTING_PREFIX
+                    | MAMBA_ALLOW_MISSING_PREFIX);
 
         std::string shell_prefix = env::expand_user(prefix);
         std::unique_ptr<Activator> activator;

--- a/src/api/update.cpp
+++ b/src/api/update.cpp
@@ -19,8 +19,7 @@ namespace mamba
         auto& ctx = Context::instance();
         auto& config = Configuration::instance();
 
-        config.load(MAMBA_ALLOW_ROOT_PREFIX | MAMBA_ALLOW_FALLBACK_PREFIX
-                    | MAMBA_ALLOW_EXISTING_PREFIX);
+        config.load(MAMBA_ALLOW_FALLBACK_PREFIX | MAMBA_ALLOW_EXISTING_PREFIX);
 
         auto update_specs = config.at("specs").value<std::vector<std::string>>();
 

--- a/src/micromamba/config.cpp
+++ b/src/micromamba/config.cpp
@@ -102,8 +102,7 @@ set_config_list_command(CLI::App* subcom)
         auto& config = Configuration::instance();
 
         config.at("show_banner").get_wrapped<bool>().set_value(false);
-        config.load(MAMBA_ALLOW_ROOT_PREFIX | MAMBA_ALLOW_FALLBACK_PREFIX
-                    | MAMBA_ALLOW_EXISTING_PREFIX);
+        config.load(MAMBA_ALLOW_FALLBACK_PREFIX | MAMBA_ALLOW_EXISTING_PREFIX);
 
         auto& show_sources = config.at("config_show_sources").value<bool>();
         auto& show_all = config.at("config_show_all").value<bool>();
@@ -129,8 +128,7 @@ set_config_sources_command(CLI::App* subcom)
         auto& config = Configuration::instance();
 
         config.at("show_banner").get_wrapped<bool>().set_value(false);
-        config.load(MAMBA_ALLOW_ROOT_PREFIX | MAMBA_ALLOW_FALLBACK_PREFIX
-                    | MAMBA_ALLOW_EXISTING_PREFIX);
+        config.load(MAMBA_ALLOW_FALLBACK_PREFIX | MAMBA_ALLOW_EXISTING_PREFIX);
         auto& no_rc = config.at("no_rc").value<bool>();
 
         if (no_rc)
@@ -170,8 +168,7 @@ set_config_describe_command(CLI::App* subcom)
         auto& config = Configuration::instance();
 
         config.at("show_banner").get_wrapped<bool>().set_value(false);
-        config.load(MAMBA_ALLOW_ROOT_PREFIX | MAMBA_ALLOW_FALLBACK_PREFIX
-                    | MAMBA_ALLOW_EXISTING_PREFIX);
+        config.load(MAMBA_ALLOW_FALLBACK_PREFIX | MAMBA_ALLOW_EXISTING_PREFIX);
 
         auto& show_groups = config.at("config_show_groups").value<bool>();
         auto& show_long_desc = config.at("config_show_long_descriptions").value<bool>();

--- a/src/micromamba/constructor.cpp
+++ b/src/micromamba/constructor.cpp
@@ -67,7 +67,7 @@ construct(const fs::path& prefix, bool extract_conda_pkgs, bool extract_tarball)
     auto& config = Configuration::instance();
 
     config.at("show_banner").get_wrapped<bool>().set_value(false);
-    config.load(MAMBA_ALLOW_ROOT_PREFIX | MAMBA_ALLOW_FALLBACK_PREFIX | MAMBA_ALLOW_EXISTING_PREFIX
+    config.load(MAMBA_ALLOW_FALLBACK_PREFIX | MAMBA_ALLOW_EXISTING_PREFIX
                 | MAMBA_ALLOW_MISSING_PREFIX);
 
     if (extract_conda_pkgs)

--- a/src/micromamba/main.cpp
+++ b/src/micromamba/main.cpp
@@ -46,14 +46,14 @@ main(int argc, char** argv)
 
     if (app.get_subcommands().size() == 0)
     {
-        Configuration::instance().load(MAMBA_ALLOW_ROOT_PREFIX | MAMBA_ALLOW_FALLBACK_PREFIX
-                                       | MAMBA_ALLOW_EXISTING_PREFIX | MAMBA_ALLOW_MISSING_PREFIX);
+        Configuration::instance().load(MAMBA_ALLOW_FALLBACK_PREFIX | MAMBA_ALLOW_EXISTING_PREFIX
+                                       | MAMBA_ALLOW_MISSING_PREFIX);
         Console::print(app.help());
     }
     if (app.got_subcommand("config") && app.get_subcommand("config")->get_subcommands().size() == 0)
     {
-        Configuration::instance().load(MAMBA_ALLOW_ROOT_PREFIX | MAMBA_ALLOW_FALLBACK_PREFIX
-                                       | MAMBA_ALLOW_EXISTING_PREFIX | MAMBA_ALLOW_MISSING_PREFIX);
+        Configuration::instance().load(MAMBA_ALLOW_FALLBACK_PREFIX | MAMBA_ALLOW_EXISTING_PREFIX
+                                       | MAMBA_ALLOW_MISSING_PREFIX);
         Console::print(app.get_subcommand("config")->help());
     }
 

--- a/test/micromamba/test_install.py
+++ b/test/micromamba/test_install.py
@@ -31,9 +31,7 @@ class TestInstall:
         os.environ["CONDA_PKGS_DIRS"] = TestInstall.cache
 
         os.makedirs(TestInstall.root_prefix, exist_ok=False)
-        install("xtensor", "-n", "base", no_dry_run=True)
         create("-n", TestInstall.env_name, "--offline", no_dry_run=True)
-        remove("-n", "base", "-a", no_dry_run=True)
 
     @classmethod
     def teardown_class(cls):
@@ -44,10 +42,18 @@ class TestInstall:
     @classmethod
     def teardown(cls):
         os.environ["MAMBA_ROOT_PREFIX"] = TestInstall.root_prefix
-        remove("-n", "base", "-a", no_dry_run=True)
-        remove(
-            "-n", TestInstall.env_name, "-a", no_dry_run=True,
-        )
+
+        if not Path(TestInstall.root_prefix).exists():
+            os.makedirs(TestInstall.root_prefix, exist_ok=False)
+        else:
+            remove("-n", "base", "-a", no_dry_run=True)
+
+        if not Path(TestInstall.prefix).exists():
+            create("-n", TestInstall.env_name, "--offline", no_dry_run=True)
+        else:
+            remove(
+                "-n", TestInstall.env_name, "-a", no_dry_run=True,
+            )
 
         res = umamba_list("xtensor", "-n", TestInstall.env_name, "--json")
         assert len(res) == 0
@@ -59,12 +65,21 @@ class TestInstall:
 
     @pytest.mark.parametrize("already_installed", [False, True])
     @pytest.mark.parametrize("root_prefix_env_var", [False, True])
-    @pytest.mark.parametrize("target_is_root", [False, True])
+    @pytest.mark.parametrize(
+        "target_is_root,existing_root", [(False, None), (True, False), (True, True)]
+    )
     @pytest.mark.parametrize("env_selector", ["", "name", "prefix"])
     def test_install(
-        self, target_is_root, root_prefix_env_var, already_installed, env_selector
+        self,
+        target_is_root,
+        existing_root,
+        root_prefix_env_var,
+        already_installed,
+        env_selector,
     ):
         if target_is_root:
+            if not existing_root and env_selector:
+                shutil.rmtree(TestInstall.root_prefix)
             p = TestInstall.root_prefix
             n = "base"
             os.environ["CONDA_PREFIX"] = TestInstall.root_prefix
@@ -79,7 +94,7 @@ class TestInstall:
             cmd = "xtensor", "--json"
 
         if already_installed:
-            install("xtensor", no_dry_run=True)
+            install("xtensor", "-r", TestInstall.root_prefix, "-n", n, no_dry_run=True)
 
         if env_selector == "prefix":
             res = install("-p", p, *cmd)
@@ -104,11 +119,12 @@ class TestInstall:
             expected_packages = {"xtensor", "xtl"}
             assert expected_packages.issubset(packages)
 
-            pkg_name = get_concrete_pkg(res, "xtensor")
-            orig_file_path = get_pkg(
-                pkg_name, xtensor_hpp, TestInstall.current_root_prefix
-            )
-            assert orig_file_path.exists()
+            if not dry_run_tests:
+                pkg_name = get_concrete_pkg(res, "xtensor")
+                orig_file_path = get_pkg(
+                    pkg_name, xtensor_hpp, TestInstall.current_root_prefix
+                )
+                assert orig_file_path.exists()
 
     @pytest.mark.parametrize(
         "alias",

--- a/test/test_configuration.cpp
+++ b/test/test_configuration.cpp
@@ -25,10 +25,10 @@ namespace mamba
                     .at("show_banner")
                     .get_wrapped<bool>()
                     .set_value(false);
-                mamba::Configuration::instance().load(
-                    fs::path(unique_location),
-                    MAMBA_ALLOW_EXISTING_PREFIX | MAMBA_ALLOW_FALLBACK_PREFIX
-                        | MAMBA_ALLOW_ROOT_PREFIX | MAMBA_ALLOW_MISSING_PREFIX);
+                mamba::Configuration::instance().load(fs::path(unique_location),
+                                                      MAMBA_ALLOW_EXISTING_PREFIX
+                                                          | MAMBA_ALLOW_FALLBACK_PREFIX
+                                                          | MAMBA_ALLOW_MISSING_PREFIX);
             }
 
             void load_test_config(std::vector<std::string> rcs)
@@ -53,10 +53,10 @@ namespace mamba
                     .at("show_banner")
                     .get_wrapped<bool>()
                     .set_value(false);
-                mamba::Configuration::instance().load(
-                    sources,
-                    MAMBA_ALLOW_EXISTING_PREFIX | MAMBA_ALLOW_FALLBACK_PREFIX
-                        | MAMBA_ALLOW_ROOT_PREFIX | MAMBA_ALLOW_MISSING_PREFIX);
+                mamba::Configuration::instance().load(sources,
+                                                      MAMBA_ALLOW_EXISTING_PREFIX
+                                                          | MAMBA_ALLOW_FALLBACK_PREFIX
+                                                          | MAMBA_ALLOW_MISSING_PREFIX);
             }
 
             std::unique_ptr<TemporaryFile> tempfile_ptr
@@ -68,18 +68,17 @@ namespace mamba
 
         TEST_F(Configuration, target_prefix_options)
         {
-            EXPECT_EQ(!MAMBA_ALLOW_ROOT_PREFIX, 0);
             EXPECT_EQ(!MAMBA_ALLOW_EXISTING_PREFIX, 0);
             EXPECT_EQ(!MAMBA_ALLOW_FALLBACK_PREFIX, 0);
             EXPECT_EQ(!MAMBA_ALLOW_MISSING_PREFIX, 0);
             EXPECT_EQ(!MAMBA_ALLOW_NOT_ENV_PREFIX, 0);
             EXPECT_EQ(!MAMBA_EXPECT_EXISTING_PREFIX, 0);
 
-            EXPECT_EQ(!MAMBA_ALLOW_ROOT_PREFIX, MAMBA_NOT_ALLOW_ROOT_PREFIX);
+            EXPECT_EQ(!MAMBA_ALLOW_EXISTING_PREFIX, MAMBA_NOT_ALLOW_EXISTING_PREFIX);
 
-            EXPECT_EQ(MAMBA_NOT_ALLOW_ROOT_PREFIX | MAMBA_NOT_ALLOW_EXISTING_PREFIX
-                          | MAMBA_NOT_ALLOW_FALLBACK_PREFIX | MAMBA_NOT_ALLOW_MISSING_PREFIX
-                          | MAMBA_NOT_ALLOW_NOT_ENV_PREFIX | MAMBA_NOT_EXPECT_EXISTING_PREFIX,
+            EXPECT_EQ(MAMBA_NOT_ALLOW_EXISTING_PREFIX | MAMBA_NOT_ALLOW_FALLBACK_PREFIX
+                          | MAMBA_NOT_ALLOW_MISSING_PREFIX | MAMBA_NOT_ALLOW_NOT_ENV_PREFIX
+                          | MAMBA_NOT_EXPECT_EXISTING_PREFIX,
                       0);
         }
 


### PR DESCRIPTION
Description
---

This PR is related to the behavior of `create` operation at `root_prefix`.

The current behavior is:
- not allow `target_prefix` to be `root_prefix` in `create` operation
  - a work around is to put some relative `/./` in either the `target_prefix` or the `root_prefix` to cheat. This has to be fixed
  - using `fs::weakly_canonical` only transform into canonical path the existing part of the prefix. The previously mentioned hack still works when appending `/./` to a non-preexisting `root_prefix`
- allow `create` elsewhere
  - even with no specs provided (to get an empty env), will be soonish supported. See #827.

`install` operation is not permitted at a non-existing `target_prefix`.
It's then really difficult to know how to `create`/`install` in `base` env/`root_prefix`.

Proposition
---

I would propose to:
- allow `target_prefix` to be `root_prefix` in `create` op
  - i.e. remove `MAMBA_NOT_ALLOW_ROOT_PREFIX` check (only use for `create`) 
- always create a `root_prefix` structure when the directory doesn't exist, during `root_prefix_hook` (e.g. before `target_prefix` checks)
  - empty `envs` and `pkgs` directories
  - empty `conda-meta/history` file

It will result in:
- `create` in `base` env/`root_prefix` will always throw an `Overwriting root prefix is not permitted` error
  - using `fs::weakly_canonical` will now work because the `root_prefix` is always created *before* `target_prefix` checks 
- `install` in `base` env/`root_prefix` will always be possible, even for a non pre-exisiting `root_prefix`
