### PR TITLE
Improve configuration

### DIFF
--- a/src/api/c_api.cpp
+++ b/src/api/c_api.cpp
@@ -65,7 +65,7 @@ mamba_config_list()
 void
 mamba_set_config(const char* name, const char* value)
 {
-    Configuration::instance().at(name).set_value(value);
+    Configuration::instance().at(name).set_yaml_value(value);
 }
 
 void

--- a/src/api/clean.cpp
+++ b/src/api/clean.cpp
@@ -18,7 +18,10 @@ namespace mamba
         auto& ctx = Context::instance();
         auto& config = Configuration::instance();
 
-        config.load(MAMBA_ALLOW_FALLBACK_PREFIX | MAMBA_ALLOW_EXISTING_PREFIX);
+        config.at("use_target_prefix_fallback").set_value(true);
+        config.at("target_prefix_checks")
+            .set_value(MAMBA_ALLOW_ROOT_PREFIX | MAMBA_ALLOW_EXISTING_PREFIX);
+        config.load();
 
         bool clean_all = options & MAMBA_CLEAN_ALL;
         bool clean_index = options & MAMBA_CLEAN_INDEX;

--- a/src/api/create.cpp
+++ b/src/api/create.cpp
@@ -18,11 +18,12 @@ namespace mamba
         auto& ctx = Context::instance();
         auto& config = Configuration::instance();
 
-        int target_prefix_checks = MAMBA_NOT_ALLOW_EXISTING_PREFIX | MAMBA_NOT_ALLOW_FALLBACK_PREFIX
-                                   | MAMBA_NOT_ALLOW_MISSING_PREFIX | MAMBA_NOT_ALLOW_NOT_ENV_PREFIX
-                                   | MAMBA_NOT_EXPECT_EXISTING_PREFIX;
-
-        config.load(target_prefix_checks);
+        config.at("use_target_prefix_fallback").set_value(false);
+        config.at("target_prefix_checks")
+            .set_value(MAMBA_NOT_ALLOW_ROOT_PREFIX | MAMBA_NOT_ALLOW_EXISTING_PREFIX
+                       | MAMBA_NOT_ALLOW_MISSING_PREFIX | MAMBA_NOT_ALLOW_NOT_ENV_PREFIX
+                       | MAMBA_NOT_EXPECT_EXISTING_PREFIX);
+        config.load();
 
         auto& create_specs = config.at("specs").value<std::vector<std::string>>();
         auto& use_explicit = config.at("explicit_install").value<bool>();

--- a/src/api/info.cpp
+++ b/src/api/info.cpp
@@ -21,8 +21,11 @@ namespace mamba
     {
         auto& config = Configuration::instance();
 
-        config.load(MAMBA_ALLOW_FALLBACK_PREFIX | MAMBA_ALLOW_EXISTING_PREFIX
-                    | MAMBA_ALLOW_MISSING_PREFIX | MAMBA_ALLOW_NOT_ENV_PREFIX);
+        config.at("use_target_prefix_fallback").set_value(true);
+        config.at("target_prefix_checks")
+            .set_value(MAMBA_ALLOW_ROOT_PREFIX | MAMBA_ALLOW_EXISTING_PREFIX
+                       | MAMBA_ALLOW_MISSING_PREFIX | MAMBA_ALLOW_NOT_ENV_PREFIX);
+        config.load();
 
         detail::print_info();
     }

--- a/src/api/list.cpp
+++ b/src/api/list.cpp
@@ -18,10 +18,13 @@ namespace mamba
     {
         auto& config = Configuration::instance();
 
-        config.at("show_banner").get_wrapped<bool>().set_value(false);
-        config.load(MAMBA_ALLOW_FALLBACK_PREFIX | MAMBA_ALLOW_EXISTING_PREFIX
-                    | MAMBA_ALLOW_MISSING_PREFIX | MAMBA_NOT_ALLOW_NOT_ENV_PREFIX
-                    | MAMBA_EXPECT_EXISTING_PREFIX);
+        config.at("show_banner").set_value(false);
+        config.at("use_target_prefix_fallback").set_value(true);
+        config.at("target_prefix_checks")
+            .set_value(MAMBA_ALLOW_ROOT_PREFIX | MAMBA_ALLOW_EXISTING_PREFIX
+                       | MAMBA_ALLOW_MISSING_PREFIX | MAMBA_NOT_ALLOW_NOT_ENV_PREFIX
+                       | MAMBA_EXPECT_EXISTING_PREFIX);
+        config.load();
 
         detail::list_packages(regex);
     }

--- a/src/api/remove.cpp
+++ b/src/api/remove.cpp
@@ -22,7 +22,10 @@ namespace mamba
         auto& ctx = Context::instance();
         auto& config = Configuration::instance();
 
-        config.load(MAMBA_ALLOW_FALLBACK_PREFIX | MAMBA_ALLOW_EXISTING_PREFIX);
+        config.at("use_target_prefix_fallback").set_value(true);
+        config.at("target_prefix_checks")
+            .set_value(MAMBA_ALLOW_ROOT_PREFIX | MAMBA_ALLOW_EXISTING_PREFIX);
+        config.load();
 
         auto remove_specs = config.at("specs").value<std::vector<std::string>>();
 

--- a/src/api/shell.cpp
+++ b/src/api/shell.cpp
@@ -24,9 +24,12 @@ namespace mamba
         auto& ctx = Context::instance();
         auto& config = Configuration::instance();
 
-        config.at("show_banner").get_wrapped<bool>().set_value(false);
-        config.load(MAMBA_ALLOW_FALLBACK_PREFIX | MAMBA_ALLOW_EXISTING_PREFIX
-                    | MAMBA_ALLOW_MISSING_PREFIX);
+        config.at("show_banner").set_value(false);
+        config.at("use_target_prefix_fallback").set_value(true);
+        config.at("target_prefix_checks")
+            .set_value(MAMBA_ALLOW_ROOT_PREFIX | MAMBA_ALLOW_EXISTING_PREFIX
+                       | MAMBA_ALLOW_MISSING_PREFIX);
+        config.load();
 
         std::string shell_prefix = env::expand_user(prefix);
         std::unique_ptr<Activator> activator;

--- a/src/api/update.cpp
+++ b/src/api/update.cpp
@@ -19,7 +19,10 @@ namespace mamba
         auto& ctx = Context::instance();
         auto& config = Configuration::instance();
 
-        config.load(MAMBA_ALLOW_FALLBACK_PREFIX | MAMBA_ALLOW_EXISTING_PREFIX);
+        config.at("use_target_prefix_fallback").set_value(true);
+        config.at("target_prefix_checks")
+            .set_value(MAMBA_ALLOW_ROOT_PREFIX | MAMBA_ALLOW_EXISTING_PREFIX);
+        config.load();
 
         auto update_specs = config.at("specs").value<std::vector<std::string>>();
 

--- a/src/micromamba/clean.cpp
+++ b/src/micromamba/clean.cpp
@@ -22,20 +22,15 @@ init_clean_parser(CLI::App* subcom)
     auto& clean_all = config.insert(
         Configurable("clean_all", false)
             .group("cli")
-            .rc_configurable(false)
             .description("Remove index cache, lock files, unused cache packages, and tarballs"));
-    auto& clean_index = config.insert(Configurable("clean_index_cache", false)
-                                          .group("cli")
-                                          .rc_configurable(false)
-                                          .description("Remove index cache"));
+    auto& clean_index = config.insert(
+        Configurable("clean_index_cache", false).group("cli").description("Remove index cache"));
     auto& clean_pkgs
         = config.insert(Configurable("clean_packages", false)
                             .group("cli")
-                            .rc_configurable(false)
                             .description("Remove unused packages from writable package caches"));
     auto& clean_tarballs = config.insert(Configurable("clean_tarballs", false)
                                              .group("cli")
-                                             .rc_configurable(false)
                                              .description("Remove cached package tarballs"));
 
     subcom->add_flag("-a,--all", clean_all.set_cli_config(0), clean_all.description());

--- a/src/micromamba/common_options.cpp
+++ b/src/micromamba/common_options.cpp
@@ -14,30 +14,17 @@ using namespace mamba;  // NOLINT(build/namespaces)
 void
 init_rc_options(CLI::App* subcom)
 {
-    auto& ctx = Context::instance();
     auto& config = Configuration::instance();
     std::string cli_group = "Configuration options";
 
-    auto& rc_file = config.insert(Configurable("rc_file", std::string(""))
-                                      .group("cli")
-                                      .rc_configurable(false)
-                                      .set_env_var_name()
-                                      .description("Path to the unique configuration file to use"));
-    subcom->add_option("--rc-file", rc_file.set_cli_config(""), rc_file.description())
+    auto& rc_file = config.at("rc_file").get_wrapped<std::vector<fs::path>>();
+    subcom->add_option("--rc-file", rc_file.set_cli_config({}), rc_file.description())
         ->group(cli_group);
 
-    auto& no_rc = config.insert(Configurable("no_rc", &ctx.no_rc)
-                                    .group("cli")
-                                    .rc_configurable(false)
-                                    .set_env_var_name()
-                                    .description("Disable the use of configuration files"));
+    auto& no_rc = config.at("no_rc").get_wrapped<bool>();
     subcom->add_flag("--no-rc", no_rc.set_cli_config(0), no_rc.description())->group(cli_group);
 
-    auto& no_env = config.insert(Configurable("no_env", &ctx.no_env)
-                                     .group("cli")
-                                     .rc_configurable(false)
-                                     .set_env_var_name()
-                                     .description("Disable the use of environment variables"));
+    auto& no_env = config.at("no_env").get_wrapped<bool>();
     subcom->add_flag("--no-env", no_env.set_cli_config(0), no_env.description())->group(cli_group);
 }
 
@@ -47,57 +34,32 @@ init_general_options(CLI::App* subcom)
 {
     init_rc_options(subcom);
 
-    auto& ctx = Context::instance();
     auto& config = Configuration::instance();
     std::string cli_group = "Global options";
 
-    auto& verbosity = config.insert(
-        Configurable("verbosity", 0)
-            .group("cli")
-            .rc_configurable(false)
-            .set_env_var_name()
-            .description("Set verbosity (higher verbosity with multiple -v, e.g. -vvv)"));
-    subcom->add_flag("-v,--verbose", verbosity.set_cli_config(0), verbosity.description())
+    auto& verbose = config.at("verbose").get_wrapped<std::uint8_t>();
+    subcom
+        ->add_flag("-v,--verbose",
+                   verbose.set_cli_config(0),
+                   "Set verbosity (higher verbosity with multiple -v, e.g. -vvv)")
         ->group(cli_group);
 
-    auto& quiet = config.insert(Configurable("quiet", &ctx.quiet)
-                                    .group("cli")
-                                    .rc_configurable(false)
-                                    .set_env_var_name()
-                                    .description("Set quiet mode (print less output)"));
-    subcom->add_flag("-q,--quiet", quiet.set_cli_config(false), quiet.description())
+    auto& quiet = config.at("quiet").get_wrapped<bool>();
+    subcom->add_flag("-q,--quiet", quiet.set_cli_config(0), quiet.description())->group(cli_group);
+
+    auto& always_yes = config.at("always_yes").get_wrapped<bool>();
+    subcom->add_flag("-y,--yes", always_yes.set_cli_config(0), always_yes.description())
         ->group(cli_group);
 
-    auto& always_yes
-        = config.insert(Configurable("always_yes", &ctx.always_yes)
-                            .group("cli")
-                            .rc_configurable(false)
-                            .set_env_var_name()
-                            .description("Automatically answer yes on prompted questions"));
-    subcom->add_flag("-y,--yes", always_yes.set_cli_config(false), always_yes.description())
+    auto& json = config.at("json").get_wrapped<bool>();
+    subcom->add_flag("--json", json.set_cli_config(0), json.description())->group(cli_group);
+
+    auto& offline = config.at("offline").get_wrapped<bool>();
+    subcom->add_flag("--offline", offline.set_cli_config(0), offline.description())
         ->group(cli_group);
 
-    auto& json = config.insert(Configurable("json", &ctx.json)
-                                   .group("cli")
-                                   .rc_configurable(false)
-                                   .set_env_var_name()
-                                   .description("Report all output as json"));
-    subcom->add_flag("--json", json.set_cli_config(false), json.description())->group(cli_group);
-
-    auto& offline = config.insert(Configurable("offline", &ctx.offline)
-                                      .group("cli")
-                                      .rc_configurable(false)
-                                      .set_env_var_name()
-                                      .description("Force use cached repodata"));
-    subcom->add_flag("--offline", offline.set_cli_config(false), offline.description())
-        ->group(cli_group);
-
-    auto& dry_run = config.insert(Configurable("dry_run", &ctx.dry_run)
-                                      .group("cli")
-                                      .rc_configurable(false)
-                                      .set_env_var_name()
-                                      .description("Only display what would have been done"));
-    subcom->add_flag("--dry-run", dry_run.set_cli_config(false), dry_run.description())
+    auto& dry_run = config.at("dry_run").get_wrapped<bool>();
+    subcom->add_flag("--dry-run", dry_run.set_cli_config(0), dry_run.description())
         ->group(cli_group);
 
 #ifdef ENABLE_CONTEXT_DEBUGGING
@@ -117,13 +79,14 @@ init_prefix_options(CLI::App* subcom)
     std::string cli_group = "Prefix options";
 
     auto& root = config.at("root_prefix").get_wrapped<fs::path>();
-    auto& prefix = config.at("target_prefix").get_wrapped<fs::path>();
-    auto& name = config.at("env_name").get_wrapped<std::string>();
-
     subcom->add_option("-r,--root-prefix", root.set_cli_config(""), root.description())
         ->group(cli_group);
+
+    auto& prefix = config.at("target_prefix").get_wrapped<fs::path>();
     subcom->add_option("-p,--prefix", prefix.set_cli_config(""), prefix.description())
         ->group(cli_group);
+
+    auto& name = config.at("env_name").get_wrapped<std::string>();
     subcom->add_option("-n,--name", name.set_cli_config(""), name.description())->group(cli_group);
 }
 
@@ -154,12 +117,7 @@ init_network_options(CLI::App* subcom)
                      local_repodata_ttl.description())
         ->group(cli_group);
 
-    auto& retry_clean_cache
-        = config.insert(Configurable("retry_clean_cache", false)
-                            .group("cli")
-                            .rc_configurable(false)
-                            .set_env_var_name()
-                            .description("If solve fails, try to fetch updated repodata"));
+    auto& retry_clean_cache = config.at("retry_clean_cache").get_wrapped<bool>();
     subcom
         ->add_flag("--retry-clean-cache",
                    retry_clean_cache.set_cli_config(false),
@@ -174,17 +132,18 @@ init_channel_parser(CLI::App* subcom)
     auto& config = Configuration::instance();
 
     auto& channels = config.at("channels").get_wrapped<std::vector<std::string>>();
-    channels.set_post_build_hook(channels_hook);
+    channels.set_post_build_hook(channels_hook).needs({ "override_channels" });
     subcom->add_option("-c,--channel", channels.set_cli_config({}), channels.description())
         ->type_size(1)
         ->allow_extra_args(false);
 
     auto& override_channels = config.insert(Configurable("override_channels", false)
                                                 .group("cli")
-                                                .rc_configurable(false)
                                                 .set_env_var_name()
                                                 .description("Override channels")
-                                                .set_post_build_hook(override_channels_hook));
+                                                .needs({ "override_channels_enabled" })
+                                                .set_post_build_hook(override_channels_hook),
+                                            true);
     subcom->add_flag("--override-channels",
                      override_channels.set_cli_config(false),
                      override_channels.description());
@@ -202,18 +161,18 @@ init_channel_parser(CLI::App* subcom)
     auto& strict_channel_priority
         = config.insert(Configurable("strict_channel_priority", false)
                             .group("cli")
-                            .rc_configurable(false)
                             .description("Enable strict channel priority")
-                            .set_post_build_hook(strict_channel_priority_hook));
+                            .set_post_build_hook(strict_channel_priority_hook),
+                        true);
     subcom->add_flag("--strict-channel-priority",
                      strict_channel_priority.set_cli_config(0),
                      strict_channel_priority.description());
 
     auto& no_channel_priority = config.insert(Configurable("no_channel_priority", false)
                                                   .group("cli")
-                                                  .rc_configurable(false)
                                                   .description("Disable channel priority")
-                                                  .set_post_build_hook(no_channel_priority_hook));
+                                                  .set_post_build_hook(no_channel_priority_hook),
+                                              true);
     subcom->add_flag("--no-channel-priority",
                      no_channel_priority.set_cli_config(0),
                      no_channel_priority.description());
@@ -223,19 +182,11 @@ void
 channels_hook(std::vector<std::string>& channels)
 {
     auto& config = Configuration::instance();
-
-    // Workaround to silent the hook warning
-    // TODO: resolve configurable deps/workflow to compute only once
-    auto verbosity = MessageLogger::global_log_severity();
-    MessageLogger::global_log_severity() = mamba::LogSeverity::kError;
-    auto& override_channels = config.at("override_channels").compute().value<bool>();
-    MessageLogger::global_log_severity() = verbosity;
+    auto& override_channels = config.at("override_channels").value<bool>();
 
     if (override_channels)
     {
-        channels = config.at("channels")
-                       .compute(ConfigurationLevel::kCli, false)
-                       .value<std::vector<std::string>>();
+        channels = config.at("channels").cli_value<std::vector<std::string>>();
     }
 }
 
@@ -244,8 +195,7 @@ override_channels_hook(bool& value)
 {
     auto& config = Configuration::instance();
     auto& override_channels = config.at("override_channels");
-    auto& override_channels_enabled
-        = config.at("override_channels_enabled").compute().value<bool>();
+    auto& override_channels_enabled = config.at("override_channels_enabled").value<bool>();
 
     if (!override_channels_enabled && override_channels.configured())
     {

--- a/src/micromamba/config.cpp
+++ b/src/micromamba/config.cpp
@@ -21,18 +21,18 @@ init_config_options(CLI::App* subcom)
 
     config.insert(Configurable("config_specs", std::vector<std::string>({}))
                       .group("cli")
-                      .rc_configurable(false)
-                      .description("Configurables show"));
+                      .description("Configurables show"),
+                  true);
 
     config.insert(Configurable("config_show_long_descriptions", false)
                       .group("cli")
-                      .rc_configurable(false)
-                      .description("Display configurables long descriptions"));
+                      .description("Display configurables long descriptions"),
+                  true);
 
     config.insert(Configurable("config_show_groups", false)
                       .group("cli")
-                      .rc_configurable(false)
-                      .description("Display configurables groups"));
+                      .description("Display configurables groups"),
+                  true);
 }
 
 void
@@ -48,20 +48,17 @@ init_config_list_options(CLI::App* subcom)
     auto& show_sources
         = config.insert(Configurable("config_show_sources", false)
                             .group("cli")
-                            .rc_configurable(false)
                             .description("Display all identified configuration sources"));
     subcom->add_flag("-s,--sources", show_sources.set_cli_config(0), show_sources.description());
 
     auto& show_all
         = config.insert(Configurable("config_show_all", false)
                             .group("cli")
-                            .rc_configurable(false)
                             .description("Display all configuration values, including defaults"));
     subcom->add_flag("-a,--all", show_all.set_cli_config(0), show_all.description());
 
     auto& show_description = config.insert(Configurable("config_show_descriptions", false)
                                                .group("cli")
-                                               .rc_configurable(false)
                                                .description("Display configurables descriptions"));
     subcom->add_flag(
         "-d,--descriptions", show_description.set_cli_config(0), show_description.description());
@@ -101,8 +98,11 @@ set_config_list_command(CLI::App* subcom)
     subcom->callback([&]() {
         auto& config = Configuration::instance();
 
-        config.at("show_banner").get_wrapped<bool>().set_value(false);
-        config.load(MAMBA_ALLOW_FALLBACK_PREFIX | MAMBA_ALLOW_EXISTING_PREFIX);
+        config.at("show_banner").set_value(false);
+        config.at("use_target_prefix_fallback").set_value(true);
+        config.at("target_prefix_checks")
+            .set_value(MAMBA_ALLOW_ROOT_PREFIX | MAMBA_ALLOW_EXISTING_PREFIX);
+        config.load();
 
         auto& show_sources = config.at("config_show_sources").value<bool>();
         auto& show_all = config.at("config_show_all").value<bool>();
@@ -127,8 +127,12 @@ set_config_sources_command(CLI::App* subcom)
     subcom->callback([&]() {
         auto& config = Configuration::instance();
 
-        config.at("show_banner").get_wrapped<bool>().set_value(false);
-        config.load(MAMBA_ALLOW_FALLBACK_PREFIX | MAMBA_ALLOW_EXISTING_PREFIX);
+        config.at("show_banner").set_value(false);
+        config.at("use_target_prefix_fallback").set_value(true);
+        config.at("target_prefix_checks")
+            .set_value(MAMBA_ALLOW_ROOT_PREFIX | MAMBA_ALLOW_EXISTING_PREFIX);
+        config.load();
+
         auto& no_rc = config.at("no_rc").value<bool>();
 
         if (no_rc)
@@ -167,8 +171,11 @@ set_config_describe_command(CLI::App* subcom)
     subcom->callback([&]() {
         auto& config = Configuration::instance();
 
-        config.at("show_banner").get_wrapped<bool>().set_value(false);
-        config.load(MAMBA_ALLOW_FALLBACK_PREFIX | MAMBA_ALLOW_EXISTING_PREFIX);
+        config.at("show_banner").set_value(false);
+        config.at("use_target_prefix_fallback").set_value(true);
+        config.at("target_prefix_checks")
+            .set_value(MAMBA_ALLOW_ROOT_PREFIX | MAMBA_ALLOW_EXISTING_PREFIX);
+        config.load();
 
         auto& show_groups = config.at("config_show_groups").value<bool>();
         auto& show_long_desc = config.at("config_show_long_descriptions").value<bool>();

--- a/src/micromamba/constructor.cpp
+++ b/src/micromamba/constructor.cpp
@@ -22,7 +22,6 @@ init_constructor_parser(CLI::App* subcom)
 
     auto& prefix = config.insert(Configurable("constructor_prefix", fs::path(""))
                                      .group("cli")
-                                     .rc_configurable(false)
                                      .description("Extract the conda pkgs in <prefix>/pkgs"));
 
     subcom->add_option("-p,--prefix", prefix.set_cli_config(""), prefix.description());
@@ -30,7 +29,6 @@ init_constructor_parser(CLI::App* subcom)
     auto& extract_conda_pkgs
         = config.insert(Configurable("constructor_extract_conda_pkgs", false)
                             .group("cli")
-                            .rc_configurable(false)
                             .description("Extract the conda pkgs in <prefix>/pkgs"));
     subcom->add_flag("--extract-conda-pkgs",
                      extract_conda_pkgs.set_cli_config(0),
@@ -38,7 +36,6 @@ init_constructor_parser(CLI::App* subcom)
 
     auto& extract_tarball = config.insert(Configurable("constructor_extract_tarball", false)
                                               .group("cli")
-                                              .rc_configurable(false)
                                               .description("Extract given tarball into prefix"));
     subcom->add_flag(
         "--extract-tarball", extract_tarball.set_cli_config(0), extract_tarball.description());
@@ -66,9 +63,12 @@ construct(const fs::path& prefix, bool extract_conda_pkgs, bool extract_tarball)
 {
     auto& config = Configuration::instance();
 
-    config.at("show_banner").get_wrapped<bool>().set_value(false);
-    config.load(MAMBA_ALLOW_FALLBACK_PREFIX | MAMBA_ALLOW_EXISTING_PREFIX
-                | MAMBA_ALLOW_MISSING_PREFIX);
+    config.at("show_banner").set_value(false);
+    config.at("use_target_prefix_fallback").set_value(true);
+    config.at("target_prefix_checks")
+        .set_value(MAMBA_ALLOW_ROOT_PREFIX | MAMBA_ALLOW_EXISTING_PREFIX
+                   | MAMBA_ALLOW_MISSING_PREFIX);
+    config.load();
 
     if (extract_conda_pkgs)
     {

--- a/src/micromamba/list.cpp
+++ b/src/micromamba/list.cpp
@@ -23,7 +23,6 @@ init_list_parser(CLI::App* subcom)
     auto& regex
         = config.insert(Configurable("list_regex", std::string(""))
                             .group("cli")
-                            .rc_configurable(false)
                             .description("List only packages matching a regular expression"));
     subcom->add_option("regex", regex.set_cli_config(""), regex.description());
 }
@@ -35,7 +34,7 @@ set_list_command(CLI::App* subcom)
 
     subcom->callback([]() {
         auto& config = Configuration::instance();
-        auto& regex = config.at("list_regex").value<std::string>();
+        auto& regex = config.at("list_regex").compute().value<std::string>();
 
         list(regex);
     });

--- a/src/micromamba/main.cpp
+++ b/src/micromamba/main.cpp
@@ -46,14 +46,12 @@ main(int argc, char** argv)
 
     if (app.get_subcommands().size() == 0)
     {
-        Configuration::instance().load(MAMBA_ALLOW_FALLBACK_PREFIX | MAMBA_ALLOW_EXISTING_PREFIX
-                                       | MAMBA_ALLOW_MISSING_PREFIX);
+        Configuration::instance().load();
         Console::print(app.help());
     }
     if (app.got_subcommand("config") && app.get_subcommand("config")->get_subcommands().size() == 0)
     {
-        Configuration::instance().load(MAMBA_ALLOW_FALLBACK_PREFIX | MAMBA_ALLOW_EXISTING_PREFIX
-                                       | MAMBA_ALLOW_MISSING_PREFIX);
+        Configuration::instance().load();
         Console::print(app.get_subcommand("config")->help());
     }
 

--- a/src/micromamba/remove.cpp
+++ b/src/micromamba/remove.cpp
@@ -25,7 +25,6 @@ init_remove_parser(CLI::App* subcom)
 
     auto& remove_all = config.insert(Configurable("remove_all", false)
                                          .group("cli")
-                                         .rc_configurable(false)
                                          .description("Remove all packages in the environment"));
     subcom->add_flag("-a, --all", remove_all.set_cli_config(0), remove_all.description());
 }

--- a/src/micromamba/shell.cpp
+++ b/src/micromamba/shell.cpp
@@ -19,10 +19,8 @@ init_shell_parser(CLI::App* subcom)
 
     auto& config = Configuration::instance();
 
-    auto& shell_type = config.insert(Configurable("shell_type", std::string(""))
-                                         .group("cli")
-                                         .rc_configurable(false)
-                                         .description("A shell type"));
+    auto& shell_type = config.insert(
+        Configurable("shell_type", std::string("")).group("cli").description("A shell type"));
     subcom->add_set("-s,--shell",
                     shell_type.set_cli_config(""),
                     { "bash", "posix", "powershell", "cmd.exe", "xonsh", "zsh" },
@@ -30,7 +28,6 @@ init_shell_parser(CLI::App* subcom)
 
     auto& stack = config.insert(Configurable("shell_stack", false)
                                     .group("cli")
-                                    .rc_configurable(false)
                                     .description("Stack the environment being activated")
                                     .long_description(unindent(R"(
                        Stack the environment being activated on top of the
@@ -43,7 +40,6 @@ init_shell_parser(CLI::App* subcom)
 
     auto& action = config.insert(Configurable("shell_action", std::string(""))
                                      .group("cli")
-                                     .rc_configurable(false)
                                      .description("The action to complete"));
     subcom->add_set("action",
                     action.set_cli_config(""),
@@ -53,7 +49,6 @@ init_shell_parser(CLI::App* subcom)
     auto& prefix = config.insert(
         Configurable("shell_prefix", std::string(""))
             .group("cli")
-            .rc_configurable(false)
             .description("The root prefix to configure (for init and hook), and the prefix "
                          "to activate for activate, either by name or by path"));
     subcom->add_option("-p,--prefix", prefix.set_cli_config(""), prefix.description());

--- a/src/micromamba/update.cpp
+++ b/src/micromamba/update.cpp
@@ -21,7 +21,6 @@ init_update_parser(CLI::App* subcom)
 
     auto& update_all = config.insert(Configurable("update_all", false)
                                          .group("cli")
-                                         .rc_configurable(false)
                                          .description("Update all packages in the environment"));
 
     subcom->get_option("specs")->description("Specs to update in the environment");

--- a/test/micromamba/helpers.py
+++ b/test/micromamba/helpers.py
@@ -106,9 +106,11 @@ def remove(*args):
     return res.decode()
 
 
-def create(*args, default_channel=True, no_rc=True, no_dry_run=False):
+def create(*args, default_channel=True, no_rc=True, no_dry_run=False, always_yes=True):
     umamba = get_umamba()
-    cmd = [umamba, "create", "-y"] + [arg for arg in args if arg]
+    cmd = [umamba, "create"] + [arg for arg in args if arg]
+    if always_yes:
+        cmd += ["-y"]
     if default_channel:
         cmd += channel
     if no_rc:

--- a/test/micromamba/test_config.py
+++ b/test/micromamba/test_config.py
@@ -252,6 +252,9 @@ class TestConfigList:
             f.write("offline: true")
 
         try:
+            if "MAMBA_OFFLINE" in os.environ:
+                os.environ.pop("MAMBA_OFFLINE")
+
             assert (
                 config("list", "offline", f"--rc-file={rc_file}", "-s").splitlines()
                 == f"offline: true  # '{short_rc_file}'".splitlines()


### PR DESCRIPTION
Description
---

The current `Configuration` and `Configurable` implementation have some issues:
- a lot of `Configurable` are loaded multiple times
  - some hooks/callbacks relies on other `Configurable` values
  - loading sequence is not ensured so we compute value multiple times to "be sure" it's done
  - since hooks/callbacks can modify values, it could lead to different results
- there is no way to specify what has to be computed before a given `Configurable`
  - specifying the loading sequence at a single place would not take into account `Configurable` added in the CLI (`micromamba`)
  - each `Configurable` has to handle what needs to be computed before and maybe also what should be computed right after
- a `Configurable` value can be get without computing it
  - the value is the result of the merge operation between all existing sources (possible sources are: rc file, env var, cli and api)
  - the value before computing is the init value, either a snapshot of the referenced value of the `Context`, or the init value hard-coded a `Configurable` declaration

What this PR does
---

- add loading sequence computation
  - add capability to declare `needed` and `implied` `Configurable` from a given one
    - `needed` are computed before the current `Configurable`
    - `implied` are computed right after the current `Configurable`
  - throw when circular deps are detected
- compute each configurable once using the loading sequence
- normalize the `ConfigurableInterface` API
  - rename `set_value` and `set_cli_value` to resp. `set_yaml_value` and `set_cli_yaml_value`
  - overload `set_yaml_value` and `set_cli_yaml_value` with both `std::string` and `YAML::Node`
  - add templated `set_value` and `set_cli_value` methods
- throw error when using a config value that was never computed
- add explicit multiple declaration for inserting a `Configurable` with an already used name
  - useful for some config declared in `micromamba`, with same code re-used in multiple commands
  - when explicitly allowed, keep the current behavior: return the already declared `Configurable` else throw an error
- throw error when computing a config multiple times during the loading sequence
  - force clean dev of hook/callbacks
- clean `Configuration.load` arguments
  - create a `target_prefix_checks` `Configurable` to store the checks to perform
    - create `MAMBA_NO_PREFIX_CHECK` and use it as default value for `target_prefix_checks`
  - make the `rc_file` one capable to handle multiple rc files using `std::vector<fs::path>`
- make `Configurable` not rc configurable by default
  - rename `Configurable.rc_configurable(bool)` to `Configurable.set_rc_configurable` to be more explicit
    - there is no case where we set it to false since the default value is now false
  - add `rc_file` to needed configs when rc configurable
- add `no_env` to needed configs when environment variable is associated to the `Configurable`
- log a fatal error when a bad cast of  `Configurable` occurs (`get_wrapped<T>`/`as<T>` methods)

Room for improvement
---

Some configs create circular dependencies:
- `always_yes`: `rc_file` -> `target_prefix` (may prompt) -> `always_yes` (rc configurable) -> `rc_file`
- `no_env`: `no_env` (rc configurable) -> `rc_file` (env configurable) -> `no_env`

And others to keep a nice display:
- `show_banner`: loaded before any message logged, to prevent stderr to appear before stdout
- `quiet` and `json` are then also needed, but we break there dependencies to `rc_file` to avoid logging some messages during rc files opening or prefix checks

Those 5 configs are currently handled by exception to the general rule, loading twice:
- at the beginning of the loading sequence
- right after loading rc values, if any 

This way of doing generate some special behaviors and will need to the well documented:
- `quiet`: rc value(s) do not affect banner display (only API, CLI or env var)
  - n.b. a similar corner case will be encountered when adding a `log_level`, rc configurable config
- `always_yes`: rc value(s) do not affect `target_prefix` confirmation of overwrite that may be prompted in `create` operation (only API, CLI or env var)
  - we should think about moving the `target_prefix_checks_hook` after `rc_file_hook` to avoid that behavior

*EDIT*
`target_prefix_checks` was split into 2 pieces:
- `use_target_prefix_fallback` that is set before loading the configuration and computed before `target_prefix` (used in `target_prefix_hook`)
- `target_prefix_checks` that only performs checks, after loading rc configs to be sure `always_yes` set in rc config is respected
  - no more changing the `target_prefix` in the corresponding hook

Tests have been added