### PR TITLE
Ultra dry tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -384,7 +384,6 @@ jobs:
           call conda activate mamba-tests
 
           set MAMBA_ROOT_PREFIX=%cd%\mambaroot
-          set MAMBA_DRY_RUN_TESTS=ULTRA_DRY
 
           pytest test/micromamba
 
@@ -423,7 +422,6 @@ jobs:
           conda activate mamba-tests
 
           $env:MAMBA_ROOT_PREFIX = Join-Path -Path $pwd -ChildPath 'mambaroot'
-          $env:MAMBA_DRY_RUN_TESTS='ULTRA_DRY'
 
           pytest test/micromamba
 
@@ -462,6 +460,5 @@ jobs:
           conda activate mamba-tests
 
           export MAMBA_ROOT_PREFIX=~/mambaroot
-          export MAMBA_DRY_RUN_TESTS=ULTRA_DRY
 
           pytest test/micromamba

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -145,7 +145,7 @@ jobs:
           export MAMBA_ROOT_PREFIX=~/mambaroot
           export MAMBA_EXE=$(pwd)/micromamba
           . $MAMBA_ROOT_PREFIX/etc/profile.d/mamba.sh
-          micromamba create -y -p ~/build_env pybind11 libsolv libarchive libcurl nlohmann_json cxx-compiler cmake gtest cpp-filesystem reproc-cpp yaml-cpp cli11 -c conda-forge
+          micromamba create -y -p ~/build_env pybind11 libsolv libarchive libcurl nlohmann_json cxx-compiler cmake gtest cpp-filesystem reproc-cpp yaml-cpp pyyaml cli11 -c conda-forge
         env:
           PYTHON_VERSION: ${{ matrix.python-version }}
       - name: build micromamba
@@ -159,7 +159,7 @@ jobs:
           touch ~/.conda/environments.txt
           mkdir build
           cd build
-          cmake .. -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX -DENABLE_TESTS=OFF -DBUILD_EXE=ON -DBUILD_BINDINGS=OFF
+          cmake .. -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX -DENABLE_TESTS=OFF -DBUILD_EXE=ON -DENABLE_CONTEXT_DEBUG_PRINT=ON -DBUILD_BINDINGS=OFF
           make -j2
       - name: run new micromamba
         shell: bash -l {0}
@@ -209,10 +209,10 @@ jobs:
           eval "$($MAMBA_EXE shell hook -s posix -p ~/mambaroot)"
 
           micromamba activate
-          micromamba install python=3.8 pytest -c conda-forge
+          micromamba install python=3.8 pytest pyyaml -c conda-forge
 
           export TEST_MAMBA_EXE=$(pwd)/build/micromamba
-          pytest test/micromamba -s
+          pytest test/micromamba
 
   mamba_python_tests_win:
     runs-on: ${{ matrix.os }}
@@ -329,7 +329,7 @@ jobs:
           call C:\Users\runneradmin\micromamba\condabin\micromamba.bat activate mamba-test
           mkdir build
           cd build
-          cmake .. -DCMAKE_INSTALL_PREFIX=%CONDA_PREFIX%\Library -DBUILD_EXE=ON -G "Ninja"
+          cmake .. -DCMAKE_INSTALL_PREFIX=%CONDA_PREFIX%\Library -DBUILD_EXE=ON -DENABLE_CONTEXT_DEBUG_PRINT=ON -G "Ninja"
           ninja
           .\micromamba.exe --help
       - name: Install "wheel" in micromamba default env
@@ -375,7 +375,7 @@ jobs:
         run: |
           conda config --add channels conda-forge
           conda config --set channel_priority strict
-          conda create -q -y -n mamba-tests vs2017_win-64 python=$PYTHON_VERSION pip pybind11 libsolv libarchive libcurl nlohmann_json cpp-filesystem conda cmake gtest ninja reproc-cpp yaml-cpp cli11 pytest
+          conda create -q -y -n mamba-tests vs2017_win-64 python=$PYTHON_VERSION pip pybind11 libsolv libarchive libcurl nlohmann_json cpp-filesystem conda cmake gtest ninja reproc-cpp yaml-cpp pyyaml cli11 pytest
         env:
           PYTHON_VERSION: ${{ matrix.python-version }}
       - name: micromamba python based tests
@@ -384,8 +384,9 @@ jobs:
           call conda activate mamba-tests
 
           set MAMBA_ROOT_PREFIX=%cd%\mambaroot
+          set MAMBA_DRY_RUN_TESTS=ULTRA_DRY
 
-          pytest test/micromamba -s
+          pytest test/micromamba
 
   umamba_tests_win_pwsh:
     needs: [umamba_tests_win]
@@ -413,7 +414,7 @@ jobs:
         run: |
           conda config --add channels conda-forge
           conda config --set channel_priority strict
-          conda create -q -y -n mamba-tests vs2017_win-64 python=$PYTHON_VERSION pip pybind11 libsolv libarchive libcurl nlohmann_json cpp-filesystem conda cmake gtest ninja reproc-cpp yaml-cpp cli11 pytest
+          conda create -q -y -n mamba-tests vs2017_win-64 python=$PYTHON_VERSION pip pybind11 libsolv libarchive libcurl nlohmann_json cpp-filesystem conda cmake gtest ninja reproc-cpp yaml-cpp pyyaml cli11 pytest
         env:
           PYTHON_VERSION: ${{ matrix.python-version }}
       - name: micromamba python based tests with pwsh
@@ -422,8 +423,9 @@ jobs:
           conda activate mamba-tests
 
           $env:MAMBA_ROOT_PREFIX = Join-Path -Path $pwd -ChildPath 'mambaroot'
+          $env:MAMBA_DRY_RUN_TESTS='ULTRA_DRY'
 
-          pytest test/micromamba -s
+          pytest test/micromamba
 
   umamba_tests_win_bash:
     needs: [umamba_tests_win]
@@ -451,7 +453,7 @@ jobs:
         run: |
           conda config --add channels conda-forge
           conda config --set channel_priority strict
-          conda create -q -y -n mamba-tests vs2017_win-64 python=$PYTHON_VERSION pip pybind11 libsolv libarchive libcurl nlohmann_json cpp-filesystem conda cmake gtest ninja reproc-cpp yaml-cpp cli11 pytest
+          conda create -q -y -n mamba-tests vs2017_win-64 python=$PYTHON_VERSION pip pybind11 libsolv libarchive libcurl nlohmann_json cpp-filesystem conda cmake gtest ninja reproc-cpp yaml-cpp pyyaml cli11 pytest
         env:
           PYTHON_VERSION: ${{ matrix.python-version }}
       - name: micromamba python based tests
@@ -460,5 +462,6 @@ jobs:
           conda activate mamba-tests
 
           export MAMBA_ROOT_PREFIX=~/mambaroot
+          export MAMBA_DRY_RUN_TESTS=ULTRA_DRY
 
-          pytest test/micromamba -s
+          pytest test/micromamba

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -15,5 +15,6 @@ dependencies:
   - cpp-filesystem
   - reproc-cpp
   - yaml-cpp
+  - pyyaml
   - cli11
   - pytest

--- a/include/mamba/api/configuration.hpp
+++ b/include/mamba/api/configuration.hpp
@@ -18,6 +18,33 @@
 #include <functional>
 
 
+#ifdef ENABLE_CONTEXT_DEBUG_PRINT
+#define CONTEXT_DEBUGGING                                                                          \
+    if (Configuration::instance().at("print_context_only").value<bool>())                          \
+    {                                                                                              \
+        Context::instance().debug_print();                                                         \
+        exit(0);                                                                                   \
+    }
+#define CONFIG_DEBUGGING                                                                           \
+    if (Configuration::instance().at("print_config_only").value<bool>())                           \
+    {                                                                                              \
+        Configuration::instance().at("quiet").set_value(true);                                     \
+        std::cout << Configuration::instance().dump(true, true, true) << std::endl;                \
+        exit(0);                                                                                   \
+    }
+#define DEBUG_QUIET                                                                                \
+    if (Configuration::instance().at("print_context_only").compute().value<bool>()                 \
+        || Configuration::instance().at("print_config_only").compute().value<bool>())              \
+    {                                                                                              \
+        Configuration::instance().at("quiet").set_value(true);                                     \
+    }
+#else
+#define CONTEXT_DEBUGGING
+#define CONFIG_DEBUGGING
+#define DEBUG_QUIET
+#endif
+
+
 namespace YAML
 {
     template <>

--- a/src/api/configuration.cpp
+++ b/src/api/configuration.cpp
@@ -731,6 +731,7 @@ namespace mamba
 
     void Configuration::load()
     {
+        DEBUG_QUIET;
         compute_loading_sequence();
         reset_compute_counters();
 
@@ -742,6 +743,7 @@ namespace mamba
         m_load_lock = false;
 
         init_curl_ssl();
+        CONFIG_DEBUGGING;
     }
 
     bool Configuration::is_loading()

--- a/src/api/remove.cpp
+++ b/src/api/remove.cpp
@@ -24,7 +24,9 @@ namespace mamba
 
         config.at("use_target_prefix_fallback").set_value(true);
         config.at("target_prefix_checks")
-            .set_value(MAMBA_ALLOW_ROOT_PREFIX | MAMBA_ALLOW_EXISTING_PREFIX);
+            .set_value(MAMBA_ALLOW_ROOT_PREFIX | MAMBA_ALLOW_EXISTING_PREFIX
+                       | MAMBA_NOT_ALLOW_MISSING_PREFIX | MAMBA_NOT_ALLOW_NOT_ENV_PREFIX
+                       | MAMBA_EXPECT_EXISTING_PREFIX);
         config.load();
 
         auto remove_specs = config.at("specs").value<std::vector<std::string>>();

--- a/src/api/update.cpp
+++ b/src/api/update.cpp
@@ -21,7 +21,9 @@ namespace mamba
 
         config.at("use_target_prefix_fallback").set_value(true);
         config.at("target_prefix_checks")
-            .set_value(MAMBA_ALLOW_ROOT_PREFIX | MAMBA_ALLOW_EXISTING_PREFIX);
+            .set_value(MAMBA_ALLOW_ROOT_PREFIX | MAMBA_ALLOW_EXISTING_PREFIX
+                       | MAMBA_NOT_ALLOW_MISSING_PREFIX | MAMBA_NOT_ALLOW_NOT_ENV_PREFIX
+                       | MAMBA_EXPECT_EXISTING_PREFIX);
         config.load();
 
         auto update_specs = config.at("specs").value<std::vector<std::string>>();

--- a/src/micromamba/common_options.cpp
+++ b/src/micromamba/common_options.cpp
@@ -62,12 +62,15 @@ init_general_options(CLI::App* subcom)
     subcom->add_flag("--dry-run", dry_run.set_cli_config(0), dry_run.description())
         ->group(cli_group);
 
-#ifdef ENABLE_CONTEXT_DEBUGGING
-    static bool debug_context = false;
-    auto& print_context_only = config.insert(Configurable("print_context_only", &debug_context));
+#ifdef ENABLE_CONTEXT_DEBUG_PRINT
+    auto& print_context_only = config.insert(Configurable("print_context_only", false), true);
     subcom
         ->add_flag(
             "--print-context-only", print_context_only.set_cli_config(false), "Debug context")
+        ->group(cli_group);
+
+    auto& print_config_only = config.insert(Configurable("print_config_only", false), true);
+    subcom->add_flag("--print-config-only", print_config_only.set_cli_config(false), "Debug config")
         ->group(cli_group);
 #endif
 }

--- a/src/micromamba/common_options.hpp
+++ b/src/micromamba/common_options.hpp
@@ -15,20 +15,6 @@
 #include <CLI/CLI.hpp>
 #endif
 
-#ifdef ENABLE_CONTEXT_DEBUG_PRINT
-#define CONTEXT_DEBUGGING_SNIPPET                                                                  \
-    if (configuration.at("print_context_only").value<bool>())                                      \
-    {                                                                                              \
-        Context::instance().debug_print();                                                         \
-        exit(0);                                                                                   \
-    }
-#else
-#define CONTEXT_DEBUGGING_SNIPPET
-#endif
-
-#define SET_BOOLEAN_FLAG(NAME)                                                                     \
-    ctx.NAME = create_options.NAME ? ((create_options.NAME == 1) ? true : false) : ctx.NAME;
-
 
 void
 init_rc_options(CLI::App* subcom);

--- a/test/micromamba/helpers.py
+++ b/test/micromamba/helpers.py
@@ -4,16 +4,38 @@ import platform
 import random
 import string
 import subprocess
+from enum import Enum
 from pathlib import Path
+
+import yaml
+
+
+class DryRun(Enum):
+    OFF = "OFF"
+    DRY = "DRY"
+    ULTRA_DRY = "ULTRA_DRY"
+
 
 use_offline = False
 channel = ["-c", "conda-forge"]
-dry_run_tests = (
-    True
-    if "MAMBA_DRY_RUN_TESTS" in os.environ and os.environ["MAMBA_DRY_RUN_TESTS"] == "ON"
-    else False
+dry_run_tests = DryRun(
+    os.environ["MAMBA_DRY_RUN_TESTS"]
+    if ("MAMBA_DRY_RUN_TESTS" in os.environ)
+    else "OFF"
 )
 
+MAMBA_NO_PREFIX_CHECK = 1 << 0
+MAMBA_ALLOW_ROOT_PREFIX = 1 << 1
+MAMBA_ALLOW_EXISTING_PREFIX = 1 << 2
+MAMBA_ALLOW_MISSING_PREFIX = 1 << 3
+MAMBA_ALLOW_NOT_ENV_PREFIX = 1 << 4
+MAMBA_EXPECT_EXISTING_PREFIX = 1 << 5
+
+MAMBA_NOT_ALLOW_ROOT_PREFIX = 0
+MAMBA_NOT_ALLOW_EXISTING_PREFIX = 0
+MAMBA_NOT_ALLOW_MISSING_PREFIX = 0
+MAMBA_NOT_ALLOW_NOT_ENV_PREFIX = 0
+MAMBA_NOT_EXPECT_EXISTING_PREFIX = 0
 
 if platform.system() == "Windows":
     xtensor_hpp = "Library/include/xtensor/xtensor.hpp"
@@ -78,7 +100,7 @@ def install(*args, default_channel=True, no_rc=True, no_dry_run=False):
         cmd += ["--no-rc"]
     if use_offline:
         cmd += ["--offline"]
-    if dry_run_tests and "--dry-run" not in args and not no_dry_run:
+    if (dry_run_tests == DryRun.DRY) and "--dry-run" not in args and not no_dry_run:
         cmd += ["--dry-run"]
 
     res = subprocess.check_output(cmd)
@@ -89,20 +111,8 @@ def install(*args, default_channel=True, no_rc=True, no_dry_run=False):
         except:
             print(res.decode())
             return
-    return res.decode()
-
-
-def remove(*args):
-    umamba = get_umamba()
-    cmd = [umamba, "remove"] + [arg for arg in args if arg]
-    res = subprocess.check_output(cmd)
-    if "--json" in args:
-        try:
-            j = json.loads(res)
-            return j
-        except:
-            print(res.decode())
-            return
+    if "--print-config-only" in args:
+        return yaml.load(res, Loader=yaml.FullLoader)
     return res.decode()
 
 
@@ -117,7 +127,7 @@ def create(*args, default_channel=True, no_rc=True, no_dry_run=False, always_yes
         cmd += ["--no-rc"]
     if use_offline:
         cmd += ["--offline"]
-    if dry_run_tests and "--dry-run" not in args and not no_dry_run:
+    if (dry_run_tests == DryRun.DRY) and "--dry-run" not in args and not no_dry_run:
         cmd += ["--dry-run"]
 
     try:
@@ -125,8 +135,9 @@ def create(*args, default_channel=True, no_rc=True, no_dry_run=False, always_yes
         if "--json" in args:
             j = json.loads(res)
             return j
+        if "--print-config-only" in args:
+            return yaml.load(res, Loader=yaml.FullLoader)
         return res.decode()
-
     except subprocess.CalledProcessError as e:
         print(f"Error when executing '{' '.join(cmd)}'")
         raise (e)
@@ -135,7 +146,7 @@ def create(*args, default_channel=True, no_rc=True, no_dry_run=False, always_yes
 def remove(*args, no_dry_run=False):
     umamba = get_umamba()
     cmd = [umamba, "remove", "-y"] + [arg for arg in args if arg]
-    if dry_run_tests and "--dry-run" not in args and not no_dry_run:
+    if (dry_run_tests == DryRun.DRY) and "--dry-run" not in args and not no_dry_run:
         cmd += ["--dry-run"]
 
     try:
@@ -143,8 +154,9 @@ def remove(*args, no_dry_run=False):
         if "--json" in args:
             j = json.loads(res)
             return j
+        if "--print-config-only" in args:
+            return yaml.load(res, Loader=yaml.FullLoader)
         return res.decode()
-
     except subprocess.CalledProcessError as e:
         print(f"Error when executing '{' '.join(cmd)}'")
         raise (e)
@@ -159,7 +171,7 @@ def update(*args, default_channel=True, no_rc=True, no_dry_run=False):
         cmd += ["--no-rc"]
     if default_channel:
         cmd += channel
-    if dry_run_tests and "--dry-run" not in args and not no_dry_run:
+    if (dry_run_tests == DryRun.DRY) and "--dry-run" not in args and not no_dry_run:
         cmd += ["--dry-run"]
 
     try:

--- a/test/micromamba/test_info.py
+++ b/test/micromamba/test_info.py
@@ -29,7 +29,7 @@ class TestInfo:
         os.environ["CONDA_PKGS_DIRS"] = TestInfo.cache
 
         os.makedirs(TestInfo.root_prefix, exist_ok=False)
-        create("xtensor", "-n", TestInfo.env_name, "--offline", no_dry_run=True)
+        create("-n", TestInfo.env_name, "--offline", no_dry_run=True)
 
     @classmethod
     def teardown_class(cls):

--- a/test/micromamba/test_install.py
+++ b/test/micromamba/test_install.py
@@ -12,6 +12,7 @@ import pytest
 from .helpers import *
 
 
+@pytest.mark.skipif(dry_run_tests == DryRun.ULTRA_DRY, reason="Running ultra dry tests")
 class TestInstall:
 
     current_root_prefix = os.environ["MAMBA_ROOT_PREFIX"]
@@ -104,7 +105,7 @@ class TestInstall:
             res = install(*cmd)
 
         assert res["success"]
-        assert res["dry_run"] == dry_run_tests
+        assert res["dry_run"] == (dry_run_tests == DryRun.DRY)
         if already_installed:
             keys = {"dry_run", "success", "prefix", "message"}
             assert keys.issubset(set(res.keys()))
@@ -188,7 +189,7 @@ class TestInstall:
             keys = {"success", "prefix", "actions", "dry_run"}
             assert keys.issubset(set(res.keys()))
             assert res["success"]
-            assert res["dry_run"] == dry_run_tests
+            assert res["dry_run"] == (dry_run_tests == DryRun.DRY)
             assert res["prefix"] == TestInstall.prefix
 
             action_keys = {"LINK", "PREFIX"}
@@ -265,10 +266,272 @@ class TestInstall:
         res = install(*cmd, "--json", default_channel=True)
 
         assert res["success"]
-        assert res["dry_run"] == dry_run_tests
+        assert res["dry_run"] == (dry_run_tests == DryRun.DRY)
 
         packages = {pkg["name"] for pkg in res["actions"]["LINK"]}
         expected_packages = ["xtensor", "xtl", "xsimd"]
         if f_count == 2:
             expected_packages += ["python", "wheel"]
         assert set(expected_packages).issubset(packages)
+
+
+class TestInstallConfig:
+
+    current_root_prefix = os.environ["MAMBA_ROOT_PREFIX"]
+    current_prefix = os.environ["CONDA_PREFIX"]
+
+    env_name = random_string()
+    root_prefix = os.path.expanduser(os.path.join("~", "tmproot" + random_string()))
+    prefix = os.path.join(root_prefix, "envs", env_name)
+
+    @classmethod
+    def setup_class(cls):
+        os.environ["MAMBA_ROOT_PREFIX"] = TestInstallConfig.root_prefix
+        os.environ["CONDA_PREFIX"] = TestInstallConfig.prefix
+
+        os.makedirs(TestInstallConfig.root_prefix, exist_ok=False)
+        create("-n", TestInstallConfig.env_name, "--offline", no_dry_run=True)
+
+        # TODO: remove that when https://github.com/mamba-org/mamba/pull/836 will be merge
+        os.makedirs(
+            os.path.join(TestInstallConfig.root_prefix, "conda-meta"), exist_ok=False
+        )
+
+    @classmethod
+    def teardown(cls):
+        os.environ["MAMBA_ROOT_PREFIX"] = TestInstallConfig.root_prefix
+        os.environ["CONDA_PREFIX"] = TestInstallConfig.prefix
+
+        for v in ("CONDA_CHANNELS", "MAMBA_TARGET_PREFIX"):
+            if v in os.environ:
+                os.environ.pop(v)
+
+    @classmethod
+    def teardown_class(cls):
+        os.environ["MAMBA_ROOT_PREFIX"] = TestInstallConfig.current_root_prefix
+        os.environ["CONDA_PREFIX"] = TestInstallConfig.current_prefix
+
+        shutil.rmtree(TestInstallConfig.root_prefix)
+
+    @classmethod
+    def common_tests(cls, res, root_prefix=root_prefix, target_prefix=prefix):
+        assert res["root_prefix"] == root_prefix
+        assert res["target_prefix"] == target_prefix
+        assert res["use_target_prefix_fallback"]
+        checks = (
+            MAMBA_ALLOW_ROOT_PREFIX
+            | MAMBA_ALLOW_EXISTING_PREFIX
+            | MAMBA_NOT_ALLOW_MISSING_PREFIX
+            | MAMBA_NOT_ALLOW_NOT_ENV_PREFIX
+            | MAMBA_EXPECT_EXISTING_PREFIX
+        )
+        assert res["target_prefix_checks"] == checks
+
+    @pytest.mark.parametrize(
+        "source,file_type",
+        [
+            ("cli_only", None),
+            ("spec_file_only", "classic"),
+            ("spec_file_only", "explicit"),
+            ("spec_file_only", "yaml"),
+            ("both", "classic"),
+            ("both", "explicit"),
+            ("both", "yaml"),
+        ],
+    )
+    def test_specs(self, source, file_type):
+        cmd = []
+        specs = []
+
+        if source in ("cli_only", "both"):
+            specs = ["xframe", "xtl"]
+            cmd = list(specs)
+
+        if source in ("spec_file_only", "both"):
+            f_name = random_string()
+            spec_file = os.path.join(TestInstallConfig.root_prefix, f_name)
+
+            if file_type == "classic":
+                file_content = ["xtensor >0.20", "xsimd"]
+                specs += file_content
+            elif file_type == "explicit":
+                explicit_specs = [
+                    "https://conda.anaconda.org/conda-forge/linux-64/xtensor-0.21.5-hc9558a2_0.tar.bz2#d330e02e5ed58330638a24601b7e4887",
+                    "https://conda.anaconda.org/conda-forge/linux-64/xsimd-7.4.8-hc9558a2_0.tar.bz2#32d5b7ad7d6511f1faacf87e53a63e5f",
+                ]
+                file_content = ["@EXPLICIT"] + explicit_specs
+                specs = explicit_specs
+            else:  # yaml
+                spec_file += ".yaml"
+                file_content = ["dependencies:", "  - xtensor >0.20", "  - xsimd"]
+                specs += ["xtensor >0.20", "xsimd"]
+
+            with open(spec_file, "w") as f:
+                f.write("\n".join(file_content))
+
+            cmd += ["-f", spec_file]
+
+        res = install(*cmd, "--print-config-only")
+
+        TestInstallConfig.common_tests(res)
+        assert res["env_name"] == ""
+        assert res["specs"] == specs
+
+    @pytest.mark.parametrize("root_prefix", (None, "env_var", "cli"))
+    @pytest.mark.parametrize("target_is_root", (False, True))
+    @pytest.mark.parametrize("cli_prefix", (False, True))
+    @pytest.mark.parametrize("cli_env_name", (False, True))
+    @pytest.mark.parametrize("yaml", (False, True))
+    @pytest.mark.parametrize("env_var", (False, True))
+    @pytest.mark.parametrize("fallback", (False, True))
+    def test_target_prefix(
+        self,
+        root_prefix,
+        target_is_root,
+        cli_prefix,
+        cli_env_name,
+        yaml,
+        env_var,
+        fallback,
+    ):
+        cmd = []
+
+        if root_prefix in (None, "cli"):
+            os.environ["MAMBA_DEFAULT_ROOT_PREFIX"] = os.environ.pop(
+                "MAMBA_ROOT_PREFIX"
+            )
+
+        if root_prefix == "cli":
+            cmd += ["-r", TestInstallConfig.root_prefix]
+
+        r = TestInstallConfig.root_prefix
+
+        if target_is_root:
+            p = r
+            n = "base"
+        else:
+            p = TestInstallConfig.prefix
+            n = TestInstallConfig.env_name
+
+        if cli_prefix:
+            cmd += ["-p", p]
+
+        if cli_env_name:
+            cmd += ["-n", n]
+
+        if yaml:
+            f_name = random_string() + ".yaml"
+            spec_file = os.path.join(TestInstallConfig.prefix, f_name)
+
+            file_content = [
+                f"name: {n}",
+                "dependencies: [xtensor]",
+            ]
+            with open(spec_file, "w") as f:
+                f.write("\n".join(file_content))
+
+            cmd += ["-f", spec_file]
+
+        if env_var:
+            os.environ["MAMBA_TARGET_PREFIX"] = p
+
+        if not fallback:
+            os.environ.pop("CONDA_PREFIX")
+        else:
+            os.environ["CONDA_PREFIX"] = p
+
+        if ((cli_prefix or env_var) and (cli_env_name or yaml)) or not (
+            cli_prefix or cli_env_name or yaml or env_var or fallback
+        ):
+            with pytest.raises(subprocess.CalledProcessError):
+                install(*cmd, "--print-config-only")
+        else:
+            res = install(*cmd, "--print-config-only")
+            TestInstallConfig.common_tests(res, root_prefix=r, target_prefix=p)
+
+    @pytest.mark.parametrize("cli", (False, True))
+    @pytest.mark.parametrize("yaml", (False, True))
+    @pytest.mark.parametrize("env_var", (False, True))
+    @pytest.mark.parametrize("rc_file", (False, True))
+    def test_channels(self, cli, yaml, env_var, rc_file):
+        cmd = []
+        expected_channels = []
+
+        if cli:
+            cmd += ["-c", "cli"]
+            expected_channels += ["cli"]
+
+        if yaml:
+            f_name = random_string() + ".yaml"
+            spec_file = os.path.join(TestInstallConfig.prefix, f_name)
+
+            file_content = [
+                "channels: [yaml]",
+                "dependencies: [xtensor]",
+            ]
+            with open(spec_file, "w") as f:
+                f.write("\n".join(file_content))
+
+            cmd += ["-f", spec_file]
+            expected_channels += ["yaml"]
+
+        if env_var:
+            os.environ["CONDA_CHANNELS"] = "env_var"
+            expected_channels += ["env_var"]
+
+        if rc_file:
+            f_name = random_string() + ".yaml"
+            rc_file = os.path.join(TestInstallConfig.prefix, f_name)
+
+            file_content = ["channels: [rc]"]
+            with open(rc_file, "w") as f:
+                f.write("\n".join(file_content))
+
+            cmd += ["--rc-file", rc_file]
+            expected_channels += ["rc"]
+
+        res = install(
+            *cmd, "--print-config-only", no_rc=not rc_file, default_channel=False
+        )
+        TestInstallConfig.common_tests(res)
+        if expected_channels:
+            assert res["channels"] == expected_channels
+        else:
+            assert res["channels"] is None
+
+    @pytest.mark.parametrize("type", ("yaml", "classic", "explicit"))
+    def test_multiple_spec_files(self, type):
+        cmd = []
+        specs = ["xtensor", "xsimd"]
+        explicit_specs = [
+            "https://conda.anaconda.org/conda-forge/linux-64/xtensor-0.21.5-hc9558a2_0.tar.bz2#d330e02e5ed58330638a24601b7e4887",
+            "https://conda.anaconda.org/conda-forge/linux-64/xsimd-7.4.8-hc9558a2_0.tar.bz2#32d5b7ad7d6511f1faacf87e53a63e5f",
+        ]
+
+        for i in range(2):
+            f_name = random_string()
+            file = os.path.join(TestInstallConfig.prefix, f_name)
+
+            if type == "yaml":
+                file += ".yaml"
+                file_content = [f"dependencies: [{specs[i]}]"]
+            elif type == "classic":
+                file_content = [specs[i]]
+                expected_specs = specs
+            else:  # explicit
+                file_content = ["@EXPLICIT", explicit_specs[i]]
+
+            with open(file, "w") as f:
+                f.write("\n".join(file_content))
+
+            cmd += ["-f", file]
+
+        if type == "yaml":
+            with pytest.raises(subprocess.CalledProcessError):
+                install(*cmd, "--print-config-only")
+        else:
+            res = install(*cmd, "--print-config-only")
+            if type == "classic":
+                assert res["specs"] == specs
+            else:  # explicit
+                assert res["specs"] == [explicit_specs[0]]

--- a/test/micromamba/test_remove.py
+++ b/test/micromamba/test_remove.py
@@ -11,6 +11,7 @@ import pytest
 from .helpers import *
 
 
+@pytest.mark.skipif(dry_run_tests == DryRun.ULTRA_DRY, reason="Running ultra dry tests")
 class TestRemove:
     env_name = random_string()
     root_prefix = os.environ["MAMBA_ROOT_PREFIX"]
@@ -24,7 +25,7 @@ class TestRemove:
 
     @classmethod
     def setup(cls):
-        if not dry_run_tests:
+        if dry_run_tests == DryRun.OFF:
             install("xtensor", "-n", TestRemove.env_name)
         res = umamba_list("xtensor", "-n", TestRemove.env_name, "--json")
         assert len(res) == 1
@@ -32,7 +33,7 @@ class TestRemove:
     @classmethod
     def teardown_class(cls):
         os.environ["CONDA_PREFIX"] = TestRemove.current_prefix
-        if not dry_run_tests:
+        if dry_run_tests == DryRun.OFF:
             shutil.rmtree(get_env(TestRemove.env_name))
 
     @pytest.mark.parametrize("env_selector", ["", "name", "prefix"])
@@ -50,3 +51,117 @@ class TestRemove:
         assert len(res["actions"]["UNLINK"]) == 1
         assert res["actions"]["UNLINK"][0]["name"] == "xtensor"
         assert res["actions"]["PREFIX"] == TestRemove.prefix
+
+
+class TestRemoveConfig:
+
+    current_root_prefix = os.environ["MAMBA_ROOT_PREFIX"]
+    current_prefix = os.environ["CONDA_PREFIX"]
+
+    env_name = random_string()
+    root_prefix = os.path.expanduser(os.path.join("~", "tmproot" + random_string()))
+    prefix = os.path.join(root_prefix, "envs", env_name)
+
+    @classmethod
+    def setup_class(cls):
+        os.environ["MAMBA_ROOT_PREFIX"] = TestRemoveConfig.root_prefix
+        os.environ["CONDA_PREFIX"] = TestRemoveConfig.prefix
+
+        os.makedirs(TestRemoveConfig.root_prefix, exist_ok=False)
+        create("-n", TestRemoveConfig.env_name, "--offline", no_dry_run=True)
+
+        # TODO: remove that when https://github.com/mamba-org/mamba/pull/836 will be merge
+        os.makedirs(
+            os.path.join(TestRemoveConfig.root_prefix, "conda-meta"), exist_ok=False
+        )
+
+    @classmethod
+    def teardown(cls):
+        os.environ["MAMBA_ROOT_PREFIX"] = TestRemoveConfig.root_prefix
+        os.environ["CONDA_PREFIX"] = TestRemoveConfig.prefix
+
+        for v in ("CONDA_CHANNELS", "MAMBA_TARGET_PREFIX"):
+            if v in os.environ:
+                os.environ.pop(v)
+
+    @classmethod
+    def teardown_class(cls):
+        os.environ["MAMBA_ROOT_PREFIX"] = TestRemoveConfig.current_root_prefix
+        os.environ["CONDA_PREFIX"] = TestRemoveConfig.current_prefix
+
+        shutil.rmtree(TestRemoveConfig.root_prefix)
+
+    @classmethod
+    def common_tests(cls, res, root_prefix=root_prefix, target_prefix=prefix):
+        assert res["root_prefix"] == root_prefix
+        assert res["target_prefix"] == target_prefix
+        assert res["use_target_prefix_fallback"]
+        checks = (
+            MAMBA_ALLOW_ROOT_PREFIX
+            | MAMBA_ALLOW_EXISTING_PREFIX
+            | MAMBA_NOT_ALLOW_MISSING_PREFIX
+            | MAMBA_NOT_ALLOW_NOT_ENV_PREFIX
+            | MAMBA_EXPECT_EXISTING_PREFIX
+        )
+        assert res["target_prefix_checks"] == checks
+
+    def test_specs(self):
+        specs = ["xframe", "xtl"]
+        cmd = list(specs)
+
+        res = remove(*cmd, "--print-config-only")
+
+        TestRemoveConfig.common_tests(res)
+        assert res["env_name"] == ""
+        assert res["specs"] == specs
+
+    @pytest.mark.parametrize("root_prefix", (None, "env_var", "cli"))
+    @pytest.mark.parametrize("target_is_root", (False, True))
+    @pytest.mark.parametrize("cli_prefix", (False, True))
+    @pytest.mark.parametrize("cli_env_name", (False, True))
+    @pytest.mark.parametrize("env_var", (False, True))
+    @pytest.mark.parametrize("fallback", (False, True))
+    def test_target_prefix(
+        self, root_prefix, target_is_root, cli_prefix, cli_env_name, env_var, fallback,
+    ):
+        cmd = []
+
+        if root_prefix in (None, "cli"):
+            os.environ["MAMBA_DEFAULT_ROOT_PREFIX"] = os.environ.pop(
+                "MAMBA_ROOT_PREFIX"
+            )
+
+        if root_prefix == "cli":
+            cmd += ["-r", TestRemoveConfig.root_prefix]
+
+        r = TestRemoveConfig.root_prefix
+
+        if target_is_root:
+            p = r
+            n = "base"
+        else:
+            p = TestRemoveConfig.prefix
+            n = TestRemoveConfig.env_name
+
+        if cli_prefix:
+            cmd += ["-p", p]
+
+        if cli_env_name:
+            cmd += ["-n", n]
+
+        if env_var:
+            os.environ["MAMBA_TARGET_PREFIX"] = p
+
+        if not fallback:
+            os.environ.pop("CONDA_PREFIX")
+        else:
+            os.environ["CONDA_PREFIX"] = p
+
+        if ((cli_prefix or env_var) and cli_env_name) or not (
+            cli_prefix or cli_env_name or env_var or fallback
+        ):
+            with pytest.raises(subprocess.CalledProcessError):
+                remove(*cmd, "--print-config-only")
+        else:
+            res = remove(*cmd, "--print-config-only")
+            TestRemoveConfig.common_tests(res, root_prefix=r, target_prefix=p)

--- a/test/micromamba/test_update.py
+++ b/test/micromamba/test_update.py
@@ -8,6 +8,7 @@ import pytest
 from .helpers import *
 
 
+@pytest.mark.skipif(dry_run_tests == DryRun.ULTRA_DRY, reason="Running ultra dry tests")
 class TestUpdate:
 
     current_root_prefix = os.environ["MAMBA_ROOT_PREFIX"]
@@ -39,7 +40,7 @@ class TestUpdate:
 
     @classmethod
     def setup(cls):
-        if not dry_run_tests:
+        if dry_run_tests == DryRun.OFF:
             install(
                 f"xtensor={TestUpdate.old_version}",
                 "-n",
@@ -72,7 +73,7 @@ class TestUpdate:
         ][0]
         assert TestUpdate.old_version != xtensor_link["version"]
 
-        if not dry_run_tests:
+        if dry_run_tests == DryRun.OFF:
             pkg = get_concrete_pkg(update_res, "xtensor")
             pkg_info = get_concrete_pkg_info(get_env(TestUpdate.env_name), pkg)
             version = pkg_info["version"]
@@ -155,7 +156,7 @@ class TestUpdate:
             res = update(*cmd, default_channel=False)
 
             assert res["success"]
-            assert res["dry_run"] == dry_run_tests
+            assert res["dry_run"] == (dry_run_tests == DryRun.DRY)
             assert res["prefix"] == TestUpdate.prefix
 
             if channels is None:
@@ -175,7 +176,7 @@ class TestUpdate:
                 ][0]
                 assert TestUpdate.old_version != xtensor_link["version"]
 
-                if not dry_run_tests:
+                if dry_run_tests == DryRun.OFF:
                     pkg = get_concrete_pkg(res, "xtensor")
                     pkg_info = get_concrete_pkg_info(get_env(TestUpdate.env_name), pkg)
                     version = pkg_info["version"]
@@ -217,7 +218,7 @@ class TestUpdate:
         res = install(*cmd, "--json", default_channel=True)
 
         assert res["success"]
-        assert res["dry_run"] == dry_run_tests
+        assert res["dry_run"] == (dry_run_tests == DryRun.DRY)
 
         packages = {pkg["name"] for pkg in res["actions"]["LINK"]}
         expected_packages = ["xtensor", "xtl"]
@@ -225,3 +226,265 @@ class TestUpdate:
 
         packages = {pkg["name"] for pkg in res["actions"]["UNLINK"]}
         assert set(expected_packages).issubset(packages)
+
+
+class TestUpdateConfig:
+
+    current_root_prefix = os.environ["MAMBA_ROOT_PREFIX"]
+    current_prefix = os.environ["CONDA_PREFIX"]
+
+    env_name = random_string()
+    root_prefix = os.path.expanduser(os.path.join("~", "tmproot" + random_string()))
+    prefix = os.path.join(root_prefix, "envs", env_name)
+
+    @classmethod
+    def setup_class(cls):
+        os.environ["MAMBA_ROOT_PREFIX"] = TestUpdateConfig.root_prefix
+        os.environ["CONDA_PREFIX"] = TestUpdateConfig.prefix
+
+        os.makedirs(TestUpdateConfig.root_prefix, exist_ok=False)
+        create("-n", TestUpdateConfig.env_name, "--offline", no_dry_run=True)
+
+        # TODO: remove that when https://github.com/mamba-org/mamba/pull/836 will be merge
+        os.makedirs(
+            os.path.join(TestUpdateConfig.root_prefix, "conda-meta"), exist_ok=False
+        )
+
+    @classmethod
+    def teardown(cls):
+        os.environ["MAMBA_ROOT_PREFIX"] = TestUpdateConfig.root_prefix
+        os.environ["CONDA_PREFIX"] = TestUpdateConfig.prefix
+
+        for v in ("CONDA_CHANNELS", "MAMBA_TARGET_PREFIX"):
+            if v in os.environ:
+                os.environ.pop(v)
+
+    @classmethod
+    def teardown_class(cls):
+        os.environ["MAMBA_ROOT_PREFIX"] = TestUpdateConfig.current_root_prefix
+        os.environ["CONDA_PREFIX"] = TestUpdateConfig.current_prefix
+
+        shutil.rmtree(TestUpdateConfig.root_prefix)
+
+    @classmethod
+    def common_tests(cls, res, root_prefix=root_prefix, target_prefix=prefix):
+        assert res["root_prefix"] == root_prefix
+        assert res["target_prefix"] == target_prefix
+        assert res["use_target_prefix_fallback"]
+        checks = (
+            MAMBA_ALLOW_ROOT_PREFIX
+            | MAMBA_ALLOW_EXISTING_PREFIX
+            | MAMBA_NOT_ALLOW_MISSING_PREFIX
+            | MAMBA_NOT_ALLOW_NOT_ENV_PREFIX
+            | MAMBA_EXPECT_EXISTING_PREFIX
+        )
+        assert res["target_prefix_checks"] == checks
+
+    @pytest.mark.parametrize(
+        "source,file_type",
+        [
+            ("cli_only", None),
+            ("spec_file_only", "classic"),
+            ("spec_file_only", "explicit"),
+            ("spec_file_only", "yaml"),
+            ("both", "classic"),
+            ("both", "explicit"),
+            ("both", "yaml"),
+        ],
+    )
+    def test_specs(self, source, file_type):
+        cmd = []
+        specs = []
+
+        if source in ("cli_only", "both"):
+            specs = ["xframe", "xtl"]
+            cmd = list(specs)
+
+        if source in ("spec_file_only", "both"):
+            f_name = random_string()
+            spec_file = os.path.join(TestUpdateConfig.root_prefix, f_name)
+
+            if file_type == "classic":
+                file_content = ["xtensor >0.20", "xsimd"]
+                specs += file_content
+            elif file_type == "explicit":
+                explicit_specs = [
+                    "https://conda.anaconda.org/conda-forge/linux-64/xtensor-0.21.5-hc9558a2_0.tar.bz2#d330e02e5ed58330638a24601b7e4887",
+                    "https://conda.anaconda.org/conda-forge/linux-64/xsimd-7.4.8-hc9558a2_0.tar.bz2#32d5b7ad7d6511f1faacf87e53a63e5f",
+                ]
+                file_content = ["@EXPLICIT"] + explicit_specs
+                specs = explicit_specs
+            else:  # yaml
+                spec_file += ".yaml"
+                file_content = ["dependencies:", "  - xtensor >0.20", "  - xsimd"]
+                specs += ["xtensor >0.20", "xsimd"]
+
+            with open(spec_file, "w") as f:
+                f.write("\n".join(file_content))
+
+            cmd += ["-f", spec_file]
+
+        res = install(*cmd, "--print-config-only")
+
+        TestUpdateConfig.common_tests(res)
+        assert res["env_name"] == ""
+        assert res["specs"] == specs
+
+    @pytest.mark.parametrize("root_prefix", (None, "env_var", "cli"))
+    @pytest.mark.parametrize("target_is_root", (False, True))
+    @pytest.mark.parametrize("cli_prefix", (False, True))
+    @pytest.mark.parametrize("cli_env_name", (False, True))
+    @pytest.mark.parametrize("yaml", (False, True))
+    @pytest.mark.parametrize("env_var", (False, True))
+    @pytest.mark.parametrize("fallback", (False, True))
+    def test_target_prefix(
+        self,
+        root_prefix,
+        target_is_root,
+        cli_prefix,
+        cli_env_name,
+        yaml,
+        env_var,
+        fallback,
+    ):
+        cmd = []
+
+        if root_prefix in (None, "cli"):
+            os.environ["MAMBA_DEFAULT_ROOT_PREFIX"] = os.environ.pop(
+                "MAMBA_ROOT_PREFIX"
+            )
+
+        if root_prefix == "cli":
+            cmd += ["-r", TestUpdateConfig.root_prefix]
+
+        r = TestUpdateConfig.root_prefix
+
+        if target_is_root:
+            p = r
+            n = "base"
+        else:
+            p = TestUpdateConfig.prefix
+            n = TestUpdateConfig.env_name
+
+        if cli_prefix:
+            cmd += ["-p", p]
+
+        if cli_env_name:
+            cmd += ["-n", n]
+
+        if yaml:
+            f_name = random_string() + ".yaml"
+            spec_file = os.path.join(TestUpdateConfig.prefix, f_name)
+
+            file_content = [
+                f"name: {n}",
+                "dependencies: [xtensor]",
+            ]
+            with open(spec_file, "w") as f:
+                f.write("\n".join(file_content))
+
+            cmd += ["-f", spec_file]
+
+        if env_var:
+            os.environ["MAMBA_TARGET_PREFIX"] = p
+
+        if not fallback:
+            os.environ.pop("CONDA_PREFIX")
+        else:
+            os.environ["CONDA_PREFIX"] = p
+
+        if ((cli_prefix or env_var) and (cli_env_name or yaml)) or not (
+            cli_prefix or cli_env_name or yaml or env_var or fallback
+        ):
+            with pytest.raises(subprocess.CalledProcessError):
+                install(*cmd, "--print-config-only")
+        else:
+            res = install(*cmd, "--print-config-only")
+            TestUpdateConfig.common_tests(res, root_prefix=r, target_prefix=p)
+
+    @pytest.mark.parametrize("cli", (False, True))
+    @pytest.mark.parametrize("yaml", (False, True))
+    @pytest.mark.parametrize("env_var", (False, True))
+    @pytest.mark.parametrize("rc_file", (False, True))
+    def test_channels(self, cli, yaml, env_var, rc_file):
+        cmd = []
+        expected_channels = []
+
+        if cli:
+            cmd += ["-c", "cli"]
+            expected_channels += ["cli"]
+
+        if yaml:
+            f_name = random_string() + ".yaml"
+            spec_file = os.path.join(TestUpdateConfig.prefix, f_name)
+
+            file_content = [
+                "channels: [yaml]",
+                "dependencies: [xtensor]",
+            ]
+            with open(spec_file, "w") as f:
+                f.write("\n".join(file_content))
+
+            cmd += ["-f", spec_file]
+            expected_channels += ["yaml"]
+
+        if env_var:
+            os.environ["CONDA_CHANNELS"] = "env_var"
+            expected_channels += ["env_var"]
+
+        if rc_file:
+            f_name = random_string() + ".yaml"
+            rc_file = os.path.join(TestUpdateConfig.prefix, f_name)
+
+            file_content = ["channels: [rc]"]
+            with open(rc_file, "w") as f:
+                f.write("\n".join(file_content))
+
+            cmd += ["--rc-file", rc_file]
+            expected_channels += ["rc"]
+
+        res = install(
+            *cmd, "--print-config-only", no_rc=not rc_file, default_channel=False
+        )
+        TestUpdateConfig.common_tests(res)
+        if expected_channels:
+            assert res["channels"] == expected_channels
+        else:
+            assert res["channels"] is None
+
+    @pytest.mark.parametrize("type", ("yaml", "classic", "explicit"))
+    def test_multiple_spec_files(self, type):
+        cmd = []
+        specs = ["xtensor", "xsimd"]
+        explicit_specs = [
+            "https://conda.anaconda.org/conda-forge/linux-64/xtensor-0.21.5-hc9558a2_0.tar.bz2#d330e02e5ed58330638a24601b7e4887",
+            "https://conda.anaconda.org/conda-forge/linux-64/xsimd-7.4.8-hc9558a2_0.tar.bz2#32d5b7ad7d6511f1faacf87e53a63e5f",
+        ]
+
+        for i in range(2):
+            f_name = random_string()
+            file = os.path.join(TestUpdateConfig.prefix, f_name)
+
+            if type == "yaml":
+                file += ".yaml"
+                file_content = [f"dependencies: [{specs[i]}]"]
+            elif type == "classic":
+                file_content = [specs[i]]
+                expected_specs = specs
+            else:  # explicit
+                file_content = ["@EXPLICIT", explicit_specs[i]]
+
+            with open(file, "w") as f:
+                f.write("\n".join(file_content))
+
+            cmd += ["-f", file]
+
+        if type == "yaml":
+            with pytest.raises(subprocess.CalledProcessError):
+                install(*cmd, "--print-config-only")
+        else:
+            res = install(*cmd, "--print-config-only")
+            if type == "classic":
+                assert res["specs"] == specs
+            else:  # explicit
+                assert res["specs"] == [explicit_specs[0]]


### PR DESCRIPTION
Description
---

Create ultra dry tests to fasten CI.
Uses `Configuration` status after being loaded instead of `dry_run`/`--dry-run` that still requires fetching the repodata.json and running the solver.