### PR TITLE
Change pybind11 to a build dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,6 @@
+[build-system]
+build-backend = 'setuptools.build_meta'
+requires = [
+    'setuptools >= 49.2.1',
+    'pybind11 >= 2.2',
+]

--- a/setup.py
+++ b/setup.py
@@ -193,7 +193,7 @@ setup(
     entry_points={"console_scripts": ["mamba = mamba.mamba:main"]},
     long_description="A (hopefully faster) reimplementation of the slow bits of conda.",
     ext_modules=ext_modules,
-    install_requires=["pybind11>=2.2"],
+    install_requires=[],
     extras_require={"test": ["pytest"]},
     cmdclass={"build_ext": BuildExt},
     zip_safe=False,


### PR DESCRIPTION
This closes https://github.com/conda-forge/mamba-feedstock/issues/109

Adding pybind11 to `install_requires` makes it a runtime requirement, so I created a `pyproject.toml` and added it instead as a build requirement.