### PR TITLE
Fix implicit conversion of fs::path on windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,6 +73,7 @@ if (ENABLE_CONTEXT_DEBUG_PRINT)
 endif()
 
 add_definitions(-DGHC_WIN_DISABLE_WSTRING_STORAGE_TYPE)
+add_definitions(-DGHC_WIN_DISABLE_AUTO_PREFIXES)
 
 # Dependencies
 # ============

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,6 +72,8 @@ if (ENABLE_CONTEXT_DEBUG_PRINT)
     add_definitions(-DENABLE_CONTEXT_DEBUG_PRINT)
 endif()
 
+add_definitions(-DGHC_WIN_DISABLE_WSTRING_STORAGE_TYPE)
+
 # Dependencies
 # ============
 

--- a/include/mamba/core/environments_manager.hpp
+++ b/include/mamba/core/environments_manager.hpp
@@ -13,6 +13,7 @@
 #include <vector>
 
 #include "environment.hpp"
+#include "fsutil.hpp"
 #include "output.hpp"
 #include "util.hpp"
 
@@ -34,11 +35,11 @@ namespace mamba
             fs::path final_location = fs::absolute(location);
             fs::path folder = final_location.parent_path();
 
-            if (!fs::exists(env_txt_file.parent_path()))
+            if (!fs::exists(env_txt_file))
             {
                 try
                 {
-                    fs::create_directories(env_txt_file.parent_path());
+                    path::touch(env_txt_file, true);
                 }
                 catch (...)
                 {

--- a/setup.py
+++ b/setup.py
@@ -176,6 +176,7 @@ class BuildExt(build_ext):
 
         if sys.platform == "win32":
             self.compiler.macros.append(("REPROCXX_SHARED", 1))
+            self.compiler.macros.append(("GHC_WIN_DISABLE_WSTRING_STORAGE_TYPE", 1))
 
         for ext in self.extensions:
             ext.extra_compile_args = opts

--- a/src/core/shell_init.cpp
+++ b/src/core/shell_init.cpp
@@ -387,7 +387,7 @@ namespace mamba
         else if (shell == "powershell")
         {
             std::stringstream contents;
-            contents << "$Env:MAMBA_EXE=" << exe << "\n";
+            contents << "$Env:MAMBA_EXE='" << exe.native() << "'\n";
             std::string psm1 = mamba_psm1;
             psm1 = psm1.substr(0, psm1.find("## EXPORTS ##"));
             contents << psm1;
@@ -483,8 +483,8 @@ namespace mamba
         out << "#region mamba initialize\n";
         out << "# !! Contents within this block are managed by 'mamba shell init' !!\n";
         out << "$Env:MAMBA_ROOT_PREFIX = " << conda_prefix << "\n";
-        out << "$Env:MAMBA_EXE = " << self_exe << "\n";
-        out << "(& " << self_exe << " 'shell' 'hook' -s 'powershell' -p " << conda_prefix
+        out << "$Env:MAMBA_EXE = '" << self_exe.native() << "'\n";
+        out << "(& '" << self_exe.native() << "' 'shell' 'hook' -s 'powershell' -p " << conda_prefix
             << ") | Out-String | Invoke-Expression\n";
         out << "#endregion\n";
         return out.str();

--- a/test/micromamba/test_shell.py
+++ b/test/micromamba/test_shell.py
@@ -47,8 +47,9 @@ class TestShell:
         res = shell("hook", "-s", shell_type)
 
         mamba_exe = get_umamba()
-        if platform.system() == "Windows":
-            mamba_exe = f"\\\\?\\{mamba_exe}"
+        # suspend long path support on Windows
+        # if platform.system() == "Windows":
+        # mamba_exe = f"\\\\?\\{mamba_exe}"
 
         if shell_type == "powershell":
             umamba = get_umamba()

--- a/test/micromamba/test_shell.py
+++ b/test/micromamba/test_shell.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 import pytest
 
-from .helpers import create, get_env, info, random_string, shell
+from .helpers import create, get_env, get_umamba, info, random_string, shell
 
 
 class TestShell:
@@ -45,7 +45,20 @@ class TestShell:
     )
     def test_hook(self, shell_type):
         res = shell("hook", "-s", shell_type)
-        assert res
+
+        mamba_exe = get_umamba()
+        if platform.system() == "Windows":
+            mamba_exe = f"\\\\?\\{mamba_exe}"
+
+        if shell_type == "powershell":
+            umamba = get_umamba()
+            assert f"$Env:MAMBA_EXE='{mamba_exe}'" in res
+        elif shell_type in ("zsh", "bash", "posix"):
+            assert res.count(mamba_exe) == 5
+        elif shell_type == "xonsh":
+            assert res.count(mamba_exe) == 8
+        elif shell_type == "cmd.exe":
+            assert res
 
     @pytest.mark.parametrize("shell_type", ["bash", "posix", "powershell", "cmd.exe"])
     @pytest.mark.parametrize("root", [False, True])

--- a/test/test_configuration.cpp
+++ b/test/test_configuration.cpp
@@ -61,6 +61,10 @@ namespace mamba
                 mamba::Configuration::instance().load();
             }
 
+            std::string shrink_source(std::size_t position)
+            {
+                return env::shrink_user(config.valid_sources()[position]).string();
+            }
             std::unique_ptr<TemporaryFile> tempfile_ptr
                 = std::make_unique<TemporaryFile>("mambarc", ".yaml");
 
@@ -90,7 +94,7 @@ namespace mamba
                     - test1)");
 
             load_test_config(rc);
-            std::string src = tempfile_ptr->path();
+            std::string src = env::shrink_user(tempfile_ptr->path());
 
             EXPECT_EQ(config.sources().size(), 1);
             EXPECT_EQ(config.valid_sources().size(), 1);
@@ -129,8 +133,8 @@ namespace mamba
             ASSERT_EQ(config.sources().size(), 2);
             ASSERT_EQ(config.valid_sources().size(), 2);
 
-            std::string src1 = config.valid_sources()[0];
-            std::string src2 = config.valid_sources()[1];
+            std::string src1 = shrink_source(0);
+            std::string src2 = shrink_source(1);
             EXPECT_EQ(config.dump(), unindent(R"(
                                     channels:
                                       - test1
@@ -160,9 +164,9 @@ namespace mamba
             ASSERT_EQ(config.valid_sources().size(), 3);
 
             // tmp files changed
-            src1 = config.valid_sources()[0];
-            src2 = config.valid_sources()[1];
-            std::string src3 = config.valid_sources()[2];
+            src1 = shrink_source(0);
+            src2 = shrink_source(1);
+            std::string src3 = shrink_source(2);
             EXPECT_EQ(config.dump(), unindent(R"(
                                     channels:
                                       - test1
@@ -194,9 +198,9 @@ namespace mamba
             ASSERT_EQ(config.valid_sources().size(), 3);
 
             // tmp files changed
-            src1 = config.valid_sources()[0];
-            src2 = config.valid_sources()[1];
-            src3 = config.valid_sources()[2];
+            src1 = shrink_source(0);
+            src2 = shrink_source(1);
+            src3 = shrink_source(2);
             EXPECT_EQ(config.dump(), unindent(R"(
                                     channels:
                                       - test1
@@ -238,8 +242,8 @@ namespace mamba
 
             ASSERT_EQ(config.sources().size(), 2);
             ASSERT_EQ(config.valid_sources().size(), 2);
-            std::string src1 = config.valid_sources()[0];
-            std::string src2 = config.valid_sources()[1];
+            std::string src1 = shrink_source(0);
+            std::string src2 = env::shrink_user(shrink_source(1)).string();
 
             std::string res = config.dump();
             // Unexpected/handled keys are dropped
@@ -304,7 +308,7 @@ namespace mamba
 
             ASSERT_EQ(config.sources().size(), 1);
             ASSERT_EQ(config.valid_sources().size(), 1);
-            std::string src1 = config.valid_sources()[0];
+            std::string src1 = shrink_source(0);
 
             EXPECT_EQ(config.dump(true, true),
                       unindent((R"(
@@ -374,7 +378,7 @@ namespace mamba
 
             ASSERT_EQ(config.sources().size(), 1);
             ASSERT_EQ(config.valid_sources().size(), 1);
-            std::string src1 = config.valid_sources()[0];
+            std::string src1 = shrink_source(0);
 
             EXPECT_EQ(config.dump(true, true),
                       unindent((R"(
@@ -427,7 +431,7 @@ namespace mamba
 
             ASSERT_EQ(config.sources().size(), 1);
             ASSERT_EQ(config.valid_sources().size(), 1);
-            std::string src1 = config.valid_sources()[0];
+            std::string src1 = shrink_source(0);
 
             EXPECT_EQ(config.dump(true, true),
                       "channel_alias: https://foo.bar  # 'MAMBA_CHANNEL_ALIAS' > '" + src1 + "'");
@@ -506,7 +510,7 @@ namespace mamba
 
             ASSERT_EQ(config.sources().size(), 1);
             ASSERT_EQ(config.valid_sources().size(), 1);
-            std::string src1 = config.valid_sources()[0];
+            std::string src1 = shrink_source(0);
 
             EXPECT_EQ(config.dump(true, true),
                       "ssl_verify: /env/bar/baz  # 'MAMBA_SSL_VERIFY' > '" + src1 + "'");
@@ -532,7 +536,7 @@ namespace mamba
 
             ASSERT_EQ(config.sources().size(), 1);
             ASSERT_EQ(config.valid_sources().size(), 1);
-            std::string src = config.valid_sources()[0];
+            std::string src = shrink_source(0);
 
             EXPECT_EQ(config.dump(true, true),
                       unindent((R"(
@@ -589,7 +593,7 @@ namespace mamba
                                                                                                    \
         ASSERT_EQ(config.sources().size(), 1);                                                     \
         ASSERT_EQ(config.valid_sources().size(), 1);                                               \
-        std::string src = config.valid_sources()[0];                                               \
+        std::string src = shrink_source(0);                                                        \
                                                                                                    \
         std::string expected;                                                                      \
         if (config.at(#NAME).rc_configurable())                                                    \
@@ -657,7 +661,7 @@ namespace mamba
 
             ASSERT_EQ(config.sources().size(), 1);
             ASSERT_EQ(config.valid_sources().size(), 1);
-            std::string src = config.valid_sources()[0];
+            std::string src = shrink_source(0);
 
             EXPECT_EQ(config.dump(true, true),
                       "channel_priority: strict  # 'MAMBA_CHANNEL_PRIORITY' > '" + src + "'");
@@ -722,7 +726,7 @@ namespace mamba
             load_test_config(rc1);
             ASSERT_EQ(config.sources().size(), 1);
             ASSERT_EQ(config.valid_sources().size(), 1);
-            std::string src1 = config.valid_sources()[0];
+            std::string src1 = shrink_source(0);
 
             EXPECT_EQ(config.dump(true, true),
                       unindent((R"(
@@ -807,7 +811,7 @@ namespace mamba
 
             ASSERT_EQ(config.sources().size(), 1);
             ASSERT_EQ(config.valid_sources().size(), 1);
-            std::string src = config.valid_sources()[0];
+            std::string src = shrink_source(0);
 
             EXPECT_EQ(config.dump(true, true),
                       "safety_checks: warn  # 'MAMBA_SAFETY_CHECKS' > '" + src + "'");


### PR DESCRIPTION
Description
---

`cpp-filesystem` uses native storage since 1.5.0 (see https://github.com/gulrak/filesystem#v150).
We need at least to define the `GHC_WIN_DISABLE_WSTRING_STORAGE_TYPE` to fix compiling issues with newest versions installed using `conda-forge` (and available from today).

I also needed to fix some C++ tests failing on Windows.