### PR TITLE
Add experimental mode

### DIFF
--- a/include/mamba/core/context.hpp
+++ b/include/mamba/core/context.hpp
@@ -44,6 +44,7 @@ namespace mamba
         std::string current_command = "mamba";
         std::string custom_banner = "";
         bool is_micromamba = false;
+        bool experimental = false;
 
         fs::path target_prefix = "";
         // Need to prevent circular imports here (otherwise using env::get())

--- a/src/api/configuration.cpp
+++ b/src/api/configuration.cpp
@@ -332,6 +332,12 @@ namespace mamba
                 config.at("json").compute(MAMBA_CONF_FORCE_COMPUTE).set_context();
             }
         }
+
+        void experimental_hook(bool& value)
+        {
+            if (value)
+                LOG_WARNING << "Experimental mode enabled";
+        }
     }
 
     Configuration::Configuration()
@@ -387,6 +393,16 @@ namespace mamba
                    .group("Basic")
                    .needs({ "file_specs" })  // explicit file specs overwrite current specs
                    .description("Packages specification"));
+
+        insert(Configurable("experimental", &ctx.experimental)
+                   .group("Basic")
+                   .description("Enable experimental features")
+                   .set_rc_configurable()
+                   .set_env_var_name()
+                   .long_description(unindent(R"(
+                        Enable experimental features that may be still.
+                        under active development and not stable yet.)"))
+                   .set_post_build_hook(detail::experimental_hook));
 
         // Channels
         insert(Configurable("channels", &ctx.channels)

--- a/src/micromamba/common_options.cpp
+++ b/src/micromamba/common_options.cpp
@@ -62,6 +62,10 @@ init_general_options(CLI::App* subcom)
     subcom->add_flag("--dry-run", dry_run.set_cli_config(0), dry_run.description())
         ->group(cli_group);
 
+    auto& experimental = config.at("experimental").get_wrapped<bool>();
+    subcom->add_flag("--experimental", experimental.set_cli_config(0), experimental.description())
+        ->group(cli_group);
+
 #ifdef ENABLE_CONTEXT_DEBUG_PRINT
     auto& print_context_only = config.insert(Configurable("print_context_only", false), true);
     subcom


### PR DESCRIPTION
Description
--

Add an experimental mode:
- add flag to the `Context` (low level/core api)
- add the correspond `Configurable` (high level api)
  - make it rc/env_var configurable
  - emit a log warning when activated
- add flag to `micromamba` CLI