### PR TITLE
Improve error handling in C-API

### DIFF
--- a/include/mamba/api/c_api.h
+++ b/include/mamba/api/c_api.h
@@ -12,23 +12,23 @@ extern "C"
 {
 #endif
 
-    void mamba_create();
+    int mamba_create();
 
-    void mamba_install();
+    int mamba_install();
 
-    void mamba_update(int update_all = 0);
+    int mamba_update(int update_all = 0);
 
-    void mamba_remove(int remove_all = 0);
+    int mamba_remove(int remove_all = 0);
 
-    void mamba_list(const char* regex = "");
+    int mamba_list(const char* regex = "");
 
-    void mamba_info();
+    int mamba_info();
 
-    void mamba_config_list();
+    int mamba_config_list();
 
-    void mamba_set_config(const char* name, const char* value);
+    int mamba_set_config(const char* name, const char* value);
 
-    void mamba_clear_config(const char* name);
+    int mamba_clear_config(const char* name);
 
 #ifdef __cplusplus
 }

--- a/src/api/c_api.cpp
+++ b/src/api/c_api.cpp
@@ -20,56 +20,128 @@
 using namespace mamba;
 
 
-void
+int
 mamba_create()
 {
-    create();
+    try
+    {
+        create();
+        return 0;
+    }
+    catch (...)
+    {
+        return 1;
+    }
 }
 
-void
+int
 mamba_install()
 {
-    install();
+    try
+    {
+        install();
+        return 0;
+    }
+    catch (...)
+    {
+        return 1;
+    }
 }
 
-void
+int
 mamba_update(int update_all)
 {
-    update(update_all);
+    try
+    {
+        update(update_all);
+        return 0;
+    }
+    catch (...)
+    {
+        return 1;
+    }
 }
 
-void
+int
 mamba_remove(int remove_all)
 {
-    remove(remove_all);
+    try
+    {
+        remove(remove_all);
+        return 0;
+    }
+    catch (...)
+    {
+        return 1;
+    }
 }
 
-void
+int
 mamba_list(const char* regex)
 {
-    list(regex);
+    try
+    {
+        list(regex);
+        return 0;
+    }
+    catch (...)
+    {
+        return 1;
+    }
 }
 
-void
+int
 mamba_info()
 {
-    info();
+    try
+    {
+        info();
+        return 0;
+    }
+    catch (...)
+    {
+        return 1;
+    }
 }
 
-void
+int
 mamba_config_list()
 {
-    config_list();
+    try
+    {
+        config_list();
+        return 0;
+    }
+    catch (...)
+    {
+        return 1;
+    }
 }
 
-void
+int
 mamba_set_config(const char* name, const char* value)
 {
-    Configuration::instance().at(name).set_yaml_value(value);
+    try
+    {
+        Configuration::instance().at(name).set_yaml_value(value);
+        return 0;
+    }
+    catch (...)
+    {
+        return 1;
+    }
 }
 
-void
+int
 mamba_clear_config(const char* name)
 {
-    Configuration::instance().at(name).clear_values();
+    try
+    {
+        Configuration::instance().at(name).clear_values();
+        return 0;
+    }
+    catch (...)
+    {
+        return 1;
+    }
 }


### PR DESCRIPTION
Description
--

`libmamba` C-API used in interactive shells, such as `rhumba` in R prompt, needs a better error handling to avoid brutal crash of the caller. 

This is a minor effort to return an error C style code instead of throwing:
- catch errors thrown in `libmamba` and add a return code 