### PR TITLE
Improve config lifetime

### DIFF
--- a/src/api/clean.cpp
+++ b/src/api/clean.cpp
@@ -235,5 +235,7 @@ namespace mamba
                 }
             }
         }
+
+        config.operation_teardown();
     }
 }  // mamba

--- a/src/api/configuration.cpp
+++ b/src/api/configuration.cpp
@@ -355,6 +355,7 @@ namespace mamba
                             "use_target_prefix_fallback",
                             "verbose",
                             "always_yes" })
+                   .set_single_op_lifetime()
                    .description("Path to the target prefix")
                    .set_post_build_hook(detail::target_prefix_hook));
 
@@ -371,6 +372,7 @@ namespace mamba
         insert(Configurable("env_name", std::string(""))
                    .group("Basic")
                    .needs({ "file_specs" })
+                   .set_single_op_lifetime()
                    .description("Name of the target prefix"));
 
         insert(Configurable("specs", std::vector<std::string>({}))
@@ -604,6 +606,7 @@ namespace mamba
                    .group("Output, Prompt and Flow Control")
                    .needs({ "quiet", "json" })
                    .set_post_build_hook(detail::show_banner_hook)
+                   .set_single_op_lifetime()
                    .description("Show the banner"));
 
         insert(Configurable("quiet", &ctx.quiet)
@@ -812,6 +815,29 @@ namespace mamba
         for (auto& c : m_config)
         {
             c.second.clear_rc_values();
+        }
+    }
+
+    void Configuration::clear_cli_values()
+    {
+        for (auto& c : m_config)
+        {
+            c.second.clear_cli_value();
+        }
+    }
+
+    void Configuration::operation_teardown()
+    {
+        for (auto& c : m_config)
+        {
+            if (c.second.has_single_op_lifetime())
+            {
+                c.second.clear_values();
+            }
+            else
+            {
+                c.second.clear_cli_value();
+            }
         }
     }
 

--- a/src/api/create.cpp
+++ b/src/api/create.cpp
@@ -69,5 +69,7 @@ namespace mamba
         {
             detail::create_empty_target(ctx.target_prefix);
         }
+
+        config.operation_teardown();
     }
 }

--- a/src/api/info.cpp
+++ b/src/api/info.cpp
@@ -28,6 +28,8 @@ namespace mamba
         config.load();
 
         detail::print_info();
+
+        config.operation_teardown();
     }
 
     std::string version()

--- a/src/api/install.cpp
+++ b/src/api/install.cpp
@@ -51,6 +51,8 @@ namespace mamba
         {
             Console::print("Nothing to do.");
         }
+
+        config.operation_teardown();
     }
 
     int RETRY_SUBDIR_FETCH = 1 << 0;

--- a/src/api/list.cpp
+++ b/src/api/list.cpp
@@ -26,6 +26,8 @@ namespace mamba
         config.load();
 
         detail::list_packages(regex);
+
+        config.operation_teardown();
     }
 
     namespace detail

--- a/src/api/remove.cpp
+++ b/src/api/remove.cpp
@@ -49,6 +49,8 @@ namespace mamba
         {
             Console::print("Nothing to do.");
         }
+
+        config.operation_teardown();
     }
 
     namespace detail

--- a/src/api/shell.cpp
+++ b/src/api/shell.cpp
@@ -126,6 +126,7 @@ namespace mamba
         {
             throw std::runtime_error("Need an action (activate, deactivate or hook)");
         }
-    }
 
+        config.operation_teardown();
+    }
 }  // mamba

--- a/src/api/update.cpp
+++ b/src/api/update.cpp
@@ -50,5 +50,7 @@ namespace mamba
         {
             Console::print("Nothing to do.");
         }
+
+        config.operation_teardown();
     }
 }


### PR DESCRIPTION
Description
--

In contexts where `libmamba` is used in interactive shells, such as `rhumba` in R prompt, multiple operations may occurs one after the other without configuration reset.
This issue was never faced in `micromamba` because the CLI exposes calls to single operation:
- rc files and environment variables are parsed/read each time
- CLI or API configs have single-operation lifetime by construction

We have to refine this behavior to:
- clear CLI config after each operation
- also clear API config of some `Configurable` to avoid memory effect
  - calling `install` after `config_list` should still display the banner by default for example
  - are concerned : `show_banner`, `env_name` and `target_prefix`
- store the default value at construction time to use it each time the value is computed from all configured sources
  - avoid a memory effect since we didn't kept track of this value

Details:
- add single operation config flag for `Configurable`
- add an operation teardown for `Configuration`
- use it in all ops of high level API