### PR TITLE
Use config api

### DIFF
--- a/include/mamba/api/config.hpp
+++ b/include/mamba/api/config.hpp
@@ -10,7 +10,11 @@
 
 namespace mamba
 {
+    void config_describe();
+
     void config_list();
+
+    void config_sources();
 }
 
 #endif

--- a/include/mamba/api/configuration.hpp
+++ b/include/mamba/api/configuration.hpp
@@ -29,7 +29,9 @@
     if (Configuration::instance().at("print_config_only").value<bool>())                           \
     {                                                                                              \
         Configuration::instance().at("quiet").set_value(true);                                     \
-        std::cout << Configuration::instance().dump(true, true, true) << std::endl;                \
+        int dump_opts                                                                              \
+            = MAMBA_SHOW_CONFIG_VALUES | MAMBA_SHOW_CONFIG_SRCS | MAMBA_SHOW_ALL_CONFIGS;          \
+        std::cout << Configuration::instance().dump(dump_opts) << std::endl;                       \
         exit(0);                                                                                   \
     }
 #define DEBUG_QUIET                                                                                \
@@ -1566,6 +1568,15 @@ namespace mamba
         void check_target_prefix(int options);
     }
 
+
+    int const MAMBA_SHOW_CONFIG_VALUES = 1 << 0;
+    int const MAMBA_SHOW_CONFIG_SRCS = 1 << 1;
+    int const MAMBA_SHOW_CONFIG_DESCS = 1 << 2;
+    int const MAMBA_SHOW_CONFIG_LONG_DESCS = 1 << 3;
+    int const MAMBA_SHOW_CONFIG_GROUPS = 1 << 4;
+    int const MAMBA_SHOW_ALL_CONFIGS = 1 << 5;
+
+
     /*****************
      * Configuration *
      * ***************/
@@ -1606,13 +1617,7 @@ namespace mamba
          */
         void operation_teardown();
 
-        std::string dump(bool show_values = true,
-                         bool show_sources = false,
-                         bool show_defaults = false,
-                         bool show_sections = false,
-                         bool show_desc = false,
-                         bool long_desc = false,
-                         std::vector<std::string> names = {});
+        std::string dump(int opts = MAMBA_SHOW_CONFIG_VALUES, std::vector<std::string> names = {});
 
         template <class T>
         typename detail::cli_config<T>::storage_type& link_cli_option(

--- a/src/api/config.cpp
+++ b/src/api/config.cpp
@@ -9,22 +9,98 @@
 
 namespace mamba
 {
+    void config_describe()
+    {
+        auto& config = Configuration::instance();
+
+        config.at("use_target_prefix_fallback").set_value(true);
+        config.at("show_banner").set_value(false);
+        config.at("target_prefix_checks")
+            .set_value(MAMBA_ALLOW_EXISTING_PREFIX | MAMBA_ALLOW_MISSING_PREFIX
+                       | MAMBA_ALLOW_NOT_ENV_PREFIX | MAMBA_NOT_EXPECT_EXISTING_PREFIX);
+        config.load();
+
+        auto show_group
+            = config.at("show_config_groups").value<bool>() ? MAMBA_SHOW_CONFIG_GROUPS : 0;
+        auto show_long_desc = config.at("show_config_long_descriptions").value<bool>()
+                                  ? MAMBA_SHOW_CONFIG_LONG_DESCS
+                                  : 0;
+        auto specs = config.at("specs").value<std::vector<std::string>>();
+        int dump_opts = MAMBA_SHOW_CONFIG_DESCS | show_long_desc | show_group;
+
+        std::cout << config.dump(dump_opts, specs) << std::endl;
+
+        config.operation_teardown();
+    }
+
     void config_list()
     {
-        // load_configuration(false);
-
         auto& config = Configuration::instance();
-        /*
-                auto& show_sources = config.at("config_show_sources").value<bool>();
-                auto& show_all = config.at("config_show_all").value<bool>();
-                auto& show_groups = config.at("config_show_groups").value<bool>();
-                auto& show_desc = config.at("config_show_descriptions").value<bool>();
-                auto& show_long_desc = config.at("config_show_long_descriptions").value<bool>();
-                auto& specs = config.at("config_specs").value<std::vector<std::string>>();
-                std::cout << config.dump(
-                    true, show_sources, show_all, show_groups, show_desc, show_long_desc, specs)
-                            << std::endl;
-        */
-        std::cout << config.dump(true, true, false, false, false, false, {}) << std::endl;
+
+        config.at("use_target_prefix_fallback").set_value(true);
+        config.at("show_banner").set_value(false);
+        config.at("target_prefix_checks")
+            .set_value(MAMBA_ALLOW_EXISTING_PREFIX | MAMBA_ALLOW_MISSING_PREFIX
+                       | MAMBA_ALLOW_NOT_ENV_PREFIX | MAMBA_NOT_EXPECT_EXISTING_PREFIX);
+        config.load();
+
+        auto show_sources
+            = config.at("show_config_sources").value<bool>() ? MAMBA_SHOW_CONFIG_SRCS : 0;
+        auto show_all = config.at("show_all_configs").value<bool>() ? MAMBA_SHOW_ALL_CONFIGS : 0;
+        auto show_group
+            = config.at("show_config_groups").value<bool>() ? MAMBA_SHOW_CONFIG_GROUPS : 0;
+        auto show_desc
+            = config.at("show_config_descriptions").value<bool>() ? MAMBA_SHOW_CONFIG_DESCS : 0;
+        auto show_long_desc = config.at("show_config_long_descriptions").value<bool>()
+                                  ? MAMBA_SHOW_CONFIG_LONG_DESCS
+                                  : 0;
+        auto specs = config.at("specs").value<std::vector<std::string>>();
+        int dump_opts = MAMBA_SHOW_CONFIG_VALUES | show_sources | show_desc | show_long_desc
+                        | show_group | show_all;
+
+        std::cout << config.dump(dump_opts, specs) << std::endl;
+
+        config.operation_teardown();
+    }
+
+    void config_sources()
+    {
+        auto& config = Configuration::instance();
+
+        config.at("use_target_prefix_fallback").set_value(true);
+        config.at("show_banner").set_value(false);
+        config.at("target_prefix_checks")
+            .set_value(MAMBA_ALLOW_EXISTING_PREFIX | MAMBA_ALLOW_MISSING_PREFIX
+                       | MAMBA_ALLOW_NOT_ENV_PREFIX | MAMBA_NOT_EXPECT_EXISTING_PREFIX);
+        config.load();
+
+        auto& no_rc = config.at("no_rc").value<bool>();
+
+        if (no_rc)
+        {
+            std::cout << "Configuration files disabled by --no-rc flag" << std::endl;
+        }
+        else
+        {
+            std::cout << "Configuration files (by precedence order):" << std::endl;
+
+            auto srcs = config.sources();
+            auto valid_srcs = config.valid_sources();
+
+            for (auto s : srcs)
+            {
+                auto found_s = std::find(valid_srcs.begin(), valid_srcs.end(), s);
+                if (found_s != valid_srcs.end())
+                {
+                    std::cout << env::shrink_user(s).string() << std::endl;
+                }
+                else
+                {
+                    std::cout << env::shrink_user(s).string() + " (invalid)" << std::endl;
+                }
+            }
+        }
+
+        config.operation_teardown();
     }
 }

--- a/src/micromamba/config.cpp
+++ b/src/micromamba/config.cpp
@@ -6,6 +6,7 @@
 
 #include "common_options.hpp"
 
+#include "mamba/api/config.hpp"
 #include "mamba/api/configuration.hpp"
 
 
@@ -16,60 +17,6 @@ init_config_options(CLI::App* subcom)
 {
     init_general_options(subcom);
     init_prefix_options(subcom);
-
-    auto& config = Configuration::instance();
-
-    config.insert(Configurable("config_specs", std::vector<std::string>({}))
-                      .group("cli")
-                      .description("Configurables show"),
-                  true);
-
-    config.insert(Configurable("config_show_long_descriptions", false)
-                      .group("cli")
-                      .description("Display configurables long descriptions"),
-                  true);
-
-    config.insert(Configurable("config_show_groups", false)
-                      .group("cli")
-                      .description("Display configurables groups"),
-                  true);
-}
-
-void
-init_config_list_options(CLI::App* subcom)
-{
-    init_config_options(subcom);
-
-    auto& config = Configuration::instance();
-
-    auto& specs = config.at("config_specs").get_wrapped<std::vector<std::string>>();
-    subcom->add_option("specs", specs.set_cli_config({}), specs.description());
-
-    auto& show_sources
-        = config.insert(Configurable("config_show_sources", false)
-                            .group("cli")
-                            .description("Display all identified configuration sources"));
-    subcom->add_flag("-s,--sources", show_sources.set_cli_config(0), show_sources.description());
-
-    auto& show_all
-        = config.insert(Configurable("config_show_all", false)
-                            .group("cli")
-                            .description("Display all configuration values, including defaults"));
-    subcom->add_flag("-a,--all", show_all.set_cli_config(0), show_all.description());
-
-    auto& show_description = config.insert(Configurable("config_show_descriptions", false)
-                                               .group("cli")
-                                               .description("Display configurables descriptions"));
-    subcom->add_flag(
-        "-d,--descriptions", show_description.set_cli_config(0), show_description.description());
-
-    auto& show_long_description = config.at("config_show_long_descriptions").get_wrapped<bool>();
-    subcom->add_flag("-l,--long-descriptions",
-                     show_long_description.set_cli_config(0),
-                     show_long_description.description());
-
-    auto& show_groups = config.at("config_show_groups").get_wrapped<bool>();
-    subcom->add_flag("-g,--groups", show_groups.set_cli_config(0), show_groups.description());
 }
 
 void
@@ -77,18 +24,36 @@ init_config_describe_options(CLI::App* subcom)
 {
     auto& config = Configuration::instance();
 
-    auto& specs = config.at("config_specs").get_wrapped<std::vector<std::string>>();
+    auto& specs = config.at("specs").get_wrapped<std::vector<std::string>>();
     subcom->add_option("specs", specs.set_cli_config({}), specs.description());
 
-    auto& show_long_description = config.at("config_show_long_descriptions").get_wrapped<bool>();
+    auto& show_long_descriptions = config.at("show_config_long_descriptions").get_wrapped<bool>();
     subcom->add_flag("-l,--long-descriptions",
-                     show_long_description.set_cli_config(0),
-                     show_long_description.description());
+                     show_long_descriptions.set_cli_config(0),
+                     show_long_descriptions.description());
 
-    auto& show_groups = config.at("config_show_groups").get_wrapped<bool>();
+    auto& show_groups = config.at("show_config_groups").get_wrapped<bool>();
     subcom->add_flag("-g,--groups", show_groups.set_cli_config(0), show_groups.description());
 }
 
+void
+init_config_list_options(CLI::App* subcom)
+{
+    init_config_options(subcom);
+    init_config_describe_options(subcom);
+
+    auto& config = Configuration::instance();
+
+    auto& show_sources = config.at("show_config_sources").get_wrapped<bool>();
+    subcom->add_flag("-s,--sources", show_sources.set_cli_config(0), show_sources.description());
+
+    auto& show_all = config.at("show_all_configs").get_wrapped<bool>();
+    subcom->add_flag("-a,--all", show_all.set_cli_config(0), show_all.description());
+
+    auto& show_descriptions = config.at("show_config_descriptions").get_wrapped<bool>();
+    subcom->add_flag(
+        "-d,--descriptions", show_descriptions.set_cli_config(0), show_descriptions.description());
+}
 
 void
 set_config_list_command(CLI::App* subcom)
@@ -96,24 +61,7 @@ set_config_list_command(CLI::App* subcom)
     init_config_list_options(subcom);
 
     subcom->callback([&]() {
-        auto& config = Configuration::instance();
-
-        config.at("show_banner").set_value(false);
-        config.at("use_target_prefix_fallback").set_value(true);
-        config.at("target_prefix_checks").set_value(MAMBA_ALLOW_EXISTING_PREFIX);
-        config.load();
-
-        auto& show_sources = config.at("config_show_sources").value<bool>();
-        auto& show_all = config.at("config_show_all").value<bool>();
-        auto& show_groups = config.at("config_show_groups").value<bool>();
-        auto& show_desc = config.at("config_show_descriptions").value<bool>();
-        auto& show_long_desc = config.at("config_show_long_descriptions").value<bool>();
-        auto& specs = config.at("config_specs").value<std::vector<std::string>>();
-
-        std::cout << config.dump(
-            true, show_sources, show_all, show_groups, show_desc, show_long_desc, specs)
-                  << std::endl;
-
+        config_list();
         return 0;
     });
 }
@@ -124,39 +72,7 @@ set_config_sources_command(CLI::App* subcom)
     init_config_options(subcom);
 
     subcom->callback([&]() {
-        auto& config = Configuration::instance();
-
-        config.at("show_banner").set_value(false);
-        config.at("use_target_prefix_fallback").set_value(true);
-        config.at("target_prefix_checks").set_value(MAMBA_ALLOW_EXISTING_PREFIX);
-        config.load();
-
-        auto& no_rc = config.at("no_rc").value<bool>();
-
-        if (no_rc)
-        {
-            std::cout << "Configuration files disabled by --no-rc flag" << std::endl;
-        }
-        else
-        {
-            std::cout << "Configuration files (by precedence order):" << std::endl;
-
-            auto srcs = config.sources();
-            auto valid_srcs = config.valid_sources();
-
-            for (auto s : srcs)
-            {
-                auto found_s = std::find(valid_srcs.begin(), valid_srcs.end(), s);
-                if (found_s != valid_srcs.end())
-                {
-                    std::cout << env::shrink_user(s).string() << std::endl;
-                }
-                else
-                {
-                    std::cout << env::shrink_user(s).string() + " (invalid)" << std::endl;
-                }
-            }
-        }
+        config_sources();
         return 0;
     });
 }
@@ -167,20 +83,7 @@ set_config_describe_command(CLI::App* subcom)
     init_config_describe_options(subcom);
 
     subcom->callback([&]() {
-        auto& config = Configuration::instance();
-
-        config.at("show_banner").set_value(false);
-        config.at("use_target_prefix_fallback").set_value(true);
-        config.at("target_prefix_checks").set_value(MAMBA_ALLOW_EXISTING_PREFIX);
-        config.load();
-
-        auto& show_groups = config.at("config_show_groups").value<bool>();
-        auto& show_long_desc = config.at("config_show_long_descriptions").value<bool>();
-        auto& specs = config.at("config_specs").value<std::vector<std::string>>();
-
-        std::cout << config.dump(false, false, true, show_groups, true, show_long_desc, specs)
-                  << std::endl;
-
+        config_describe();
         return 0;
     });
 }

--- a/test/test_configuration.cpp
+++ b/test/test_configuration.cpp
@@ -98,7 +98,8 @@ namespace mamba
             EXPECT_EQ(config.sources().size(), 1);
             EXPECT_EQ(config.valid_sources().size(), 1);
             EXPECT_EQ(config.dump(), "channels:\n  - test1");
-            EXPECT_EQ(config.dump(true, true), "channels:\n  - test1  # '" + src + "'");
+            EXPECT_EQ(config.dump(MAMBA_SHOW_CONFIG_VALUES | MAMBA_SHOW_CONFIG_SRCS),
+                      "channels:\n  - test1  # '" + src + "'");
 
             // Hill-formed config file
             rc = unindent(R"(
@@ -111,7 +112,7 @@ namespace mamba
             EXPECT_EQ(config.sources().size(), 1);
             EXPECT_EQ(config.valid_sources().size(), 0);
             EXPECT_EQ(config.dump(), "");
-            EXPECT_EQ(config.dump(true, true), "");
+            EXPECT_EQ(config.dump(MAMBA_SHOW_CONFIG_VALUES | MAMBA_SHOW_CONFIG_SRCS), "");
         }
 
         TEST_F(Configuration, load_rc_files)
@@ -139,7 +140,7 @@ namespace mamba
                                       - test1
                                       - test2
                                     ssl_verify: <false>)"));
-            EXPECT_EQ(config.dump(true, true),
+            EXPECT_EQ(config.dump(MAMBA_SHOW_CONFIG_VALUES | MAMBA_SHOW_CONFIG_SRCS),
                       unindent((R"(
                                     channels:
                                       - test1  # ')"
@@ -172,7 +173,7 @@ namespace mamba
                                       - test2
                                       - test3
                                     ssl_verify: <false>)"));
-            EXPECT_EQ(config.dump(true, true),
+            EXPECT_EQ(config.dump(MAMBA_SHOW_CONFIG_VALUES | MAMBA_SHOW_CONFIG_SRCS),
                       unindent((R"(
                                     channels:
                                       - test1  # ')"
@@ -206,7 +207,7 @@ namespace mamba
                                       - test2
                                       - test3
                                     ssl_verify: <false>)"));
-            EXPECT_EQ(config.dump(true, true),
+            EXPECT_EQ(config.dump(MAMBA_SHOW_CONFIG_VALUES | MAMBA_SHOW_CONFIG_SRCS),
                       unindent((R"(
                                     channels:
                                       - test1  # ')"
@@ -254,7 +255,7 @@ namespace mamba
                                 override_channels_enabled: true
                                 allow_softlinks: true)"));
 
-            res = config.dump(true, true);
+            res = config.dump(MAMBA_SHOW_CONFIG_VALUES | MAMBA_SHOW_CONFIG_SRCS);
             EXPECT_EQ(res,
                       unindent((R"(
                                 channels:
@@ -309,7 +310,7 @@ namespace mamba
             ASSERT_EQ(config.valid_sources().size(), 1);
             std::string src1 = shrink_source(0);
 
-            EXPECT_EQ(config.dump(true, true),
+            EXPECT_EQ(config.dump(MAMBA_SHOW_CONFIG_VALUES | MAMBA_SHOW_CONFIG_SRCS),
                       unindent((R"(
                                 channels:
                                   - c90  # 'CONDA_CHANNELS'
@@ -324,7 +325,7 @@ namespace mamba
                 .set_yaml_value("https://my.channel, https://my2.channel")
                 .compute()
                 .set_context();
-            EXPECT_EQ(config.dump(true, true),
+            EXPECT_EQ(config.dump(MAMBA_SHOW_CONFIG_VALUES | MAMBA_SHOW_CONFIG_SRCS),
                       unindent((R"(
                                 channels:
                                   - https://my.channel  # 'API'
@@ -379,7 +380,7 @@ namespace mamba
             ASSERT_EQ(config.valid_sources().size(), 1);
             std::string src1 = shrink_source(0);
 
-            EXPECT_EQ(config.dump(true, true),
+            EXPECT_EQ(config.dump(MAMBA_SHOW_CONFIG_VALUES | MAMBA_SHOW_CONFIG_SRCS),
                       unindent((R"(
                                 default_channels:
                                   - c91  # 'MAMBA_DEFAULT_CHANNELS'
@@ -394,7 +395,7 @@ namespace mamba
                 .set_yaml_value("https://my.channel, https://my2.channel")
                 .compute()
                 .set_context();
-            EXPECT_EQ(config.dump(true, true),
+            EXPECT_EQ(config.dump(MAMBA_SHOW_CONFIG_VALUES | MAMBA_SHOW_CONFIG_SRCS),
                       unindent((R"(
                                 default_channels:
                                   - https://my.channel  # 'API'
@@ -432,11 +433,11 @@ namespace mamba
             ASSERT_EQ(config.valid_sources().size(), 1);
             std::string src1 = shrink_source(0);
 
-            EXPECT_EQ(config.dump(true, true),
+            EXPECT_EQ(config.dump(MAMBA_SHOW_CONFIG_VALUES | MAMBA_SHOW_CONFIG_SRCS),
                       "channel_alias: https://foo.bar  # 'MAMBA_CHANNEL_ALIAS' > '" + src1 + "'");
 
             config.at("channel_alias").set_yaml_value("https://my.channel").compute().set_context();
-            EXPECT_EQ(config.dump(true, true),
+            EXPECT_EQ(config.dump(MAMBA_SHOW_CONFIG_VALUES | MAMBA_SHOW_CONFIG_SRCS),
                       "channel_alias: https://my.channel  # 'API' > 'MAMBA_CHANNEL_ALIAS' > '"
                           + src1 + "'");
             EXPECT_EQ(ctx.channel_alias, config.at("channel_alias").value<std::string>());
@@ -511,11 +512,11 @@ namespace mamba
             ASSERT_EQ(config.valid_sources().size(), 1);
             std::string src1 = shrink_source(0);
 
-            EXPECT_EQ(config.dump(true, true),
+            EXPECT_EQ(config.dump(MAMBA_SHOW_CONFIG_VALUES | MAMBA_SHOW_CONFIG_SRCS),
                       "ssl_verify: /env/bar/baz  # 'MAMBA_SSL_VERIFY' > '" + src1 + "'");
 
             config.at("ssl_verify").set_yaml_value("/new/test").compute().set_context();
-            EXPECT_EQ(config.dump(true, true),
+            EXPECT_EQ(config.dump(MAMBA_SHOW_CONFIG_VALUES | MAMBA_SHOW_CONFIG_SRCS),
                       "ssl_verify: /new/test  # 'API' > 'MAMBA_SSL_VERIFY' > '" + src1 + "'");
 
             env::set("MAMBA_SSL_VERIFY", "");
@@ -537,7 +538,7 @@ namespace mamba
             ASSERT_EQ(config.valid_sources().size(), 1);
             std::string src = shrink_source(0);
 
-            EXPECT_EQ(config.dump(true, true),
+            EXPECT_EQ(config.dump(MAMBA_SHOW_CONFIG_VALUES | MAMBA_SHOW_CONFIG_SRCS),
                       unindent((R"(
                                 cacert_path: /env/ca/baz  # 'MAMBA_CACERT_PATH' > ')"
                                 + src + R"('
@@ -547,7 +548,7 @@ namespace mamba
             EXPECT_EQ(ctx.ssl_verify, "/env/ca/baz");
 
             config.at("cacert_path").set_yaml_value("/new/test").compute().set_context();
-            EXPECT_EQ(config.dump(true, true),
+            EXPECT_EQ(config.dump(MAMBA_SHOW_CONFIG_VALUES | MAMBA_SHOW_CONFIG_SRCS),
                       unindent((R"(
                                 cacert_path: /new/test  # 'API' > 'MAMBA_CACERT_PATH' > ')"
                                 + src + R"('
@@ -557,7 +558,7 @@ namespace mamba
             EXPECT_EQ(ctx.ssl_verify, "/env/ca/baz");
 
             config.at("ssl_verify").compute().set_context();
-            EXPECT_EQ(config.dump(true, true),
+            EXPECT_EQ(config.dump(MAMBA_SHOW_CONFIG_VALUES | MAMBA_SHOW_CONFIG_SRCS),
                       unindent((R"(
                                 cacert_path: /new/test  # 'API' > 'MAMBA_CACERT_PATH' > ')"
                                 + src + R"('
@@ -603,7 +604,8 @@ namespace mamba
         {                                                                                          \
             expected = std::string(#NAME) + ": true  # '" + env_name + "'";                        \
         }                                                                                          \
-        EXPECT_EQ((config.dump(true, true, false, false, false, false, { #NAME })), expected);     \
+        int dump_opts = MAMBA_SHOW_CONFIG_VALUES | MAMBA_SHOW_CONFIG_SRCS;                         \
+        EXPECT_EQ((config.dump(dump_opts, { #NAME })), expected);                                  \
         EXPECT_TRUE(config.at(#NAME).value<bool>());                                               \
         EXPECT_TRUE(CTX);                                                                          \
                                                                                                    \
@@ -617,7 +619,7 @@ namespace mamba
             expected = std::string(#NAME) + ": true  # 'API' > '" + env_name + "'";                \
         }                                                                                          \
         config.at(#NAME).set_yaml_value("true").compute().set_context();                           \
-        EXPECT_EQ((config.dump(true, true, false, false, false, false, { #NAME })), expected);     \
+        EXPECT_EQ((config.dump(dump_opts, { #NAME })), expected);                                  \
         EXPECT_TRUE(config.at(#NAME).value<bool>());                                               \
         EXPECT_TRUE(CTX);                                                                          \
                                                                                                    \
@@ -662,14 +664,14 @@ namespace mamba
             ASSERT_EQ(config.valid_sources().size(), 1);
             std::string src = shrink_source(0);
 
-            EXPECT_EQ(config.dump(true, true),
+            EXPECT_EQ(config.dump(MAMBA_SHOW_CONFIG_VALUES | MAMBA_SHOW_CONFIG_SRCS),
                       "channel_priority: strict  # 'MAMBA_CHANNEL_PRIORITY' > '" + src + "'");
             EXPECT_EQ(config.at("channel_priority").value<ChannelPriority>(),
                       ChannelPriority::kStrict);
             EXPECT_EQ(ctx.channel_priority, ChannelPriority::kStrict);
 
             config.at("channel_priority").set_yaml_value("flexible").compute().set_context();
-            EXPECT_EQ(config.dump(true, true),
+            EXPECT_EQ(config.dump(MAMBA_SHOW_CONFIG_VALUES | MAMBA_SHOW_CONFIG_SRCS),
                       "channel_priority: flexible  # 'API' > 'MAMBA_CHANNEL_PRIORITY' > '" + src
                           + "'");
             EXPECT_EQ(config.at("channel_priority").value<ChannelPriority>(),
@@ -727,7 +729,7 @@ namespace mamba
             ASSERT_EQ(config.valid_sources().size(), 1);
             std::string src1 = shrink_source(0);
 
-            EXPECT_EQ(config.dump(true, true),
+            EXPECT_EQ(config.dump(MAMBA_SHOW_CONFIG_VALUES | MAMBA_SHOW_CONFIG_SRCS),
                       unindent((R"(
                                 pinned_packages:
                                   - mpl=10.2  # 'MAMBA_PINNED_PACKAGES'
@@ -742,7 +744,7 @@ namespace mamba
                 std::vector<std::string>({ "mpl=10.2", "xtensor", "jupyterlab=3", "numpy=1.19" }));
 
             config.at("pinned_packages").set_yaml_value("pytest").compute().set_context();
-            EXPECT_EQ(config.dump(true, true),
+            EXPECT_EQ(config.dump(MAMBA_SHOW_CONFIG_VALUES | MAMBA_SHOW_CONFIG_SRCS),
                       unindent((R"(
                                 pinned_packages:
                                   - pytest  # 'API'
@@ -812,14 +814,14 @@ namespace mamba
             ASSERT_EQ(config.valid_sources().size(), 1);
             std::string src = shrink_source(0);
 
-            EXPECT_EQ(config.dump(true, true),
+            EXPECT_EQ(config.dump(MAMBA_SHOW_CONFIG_VALUES | MAMBA_SHOW_CONFIG_SRCS),
                       "safety_checks: warn  # 'MAMBA_SAFETY_CHECKS' > '" + src + "'");
             EXPECT_EQ(config.at("safety_checks").value<VerificationLevel>(),
                       VerificationLevel::kWarn);
             EXPECT_EQ(ctx.safety_checks, VerificationLevel::kWarn);
 
             config.at("safety_checks").set_yaml_value("disabled").compute().set_context();
-            EXPECT_EQ(config.dump(true, true),
+            EXPECT_EQ(config.dump(MAMBA_SHOW_CONFIG_VALUES | MAMBA_SHOW_CONFIG_SRCS),
                       "safety_checks: disabled  # 'API' > 'MAMBA_SAFETY_CHECKS' > '" + src + "'");
             EXPECT_EQ(config.at("safety_checks").value<VerificationLevel>(),
                       VerificationLevel::kDisabled);


### PR DESCRIPTION
Description
--

The current `config` operation is not totally implementend in `libmamba`.
`micromamba` uses its own and partially duplicated code instead.

This PR finishes the migration from `micromamba` code to `libmamba` for the following operations:
- config list
- config sources
- config describe