### PR TITLE
C-API to set CLI config

### DIFF
--- a/include/mamba/api/c_api.h
+++ b/include/mamba/api/c_api.h
@@ -26,6 +26,8 @@ extern "C"
 
     int mamba_config_list();
 
+    int mamba_set_cli_config(const char* name, const char* value);
+
     int mamba_set_config(const char* name, const char* value);
 
     int mamba_clear_config(const char* name);

--- a/src/api/c_api.cpp
+++ b/src/api/c_api.cpp
@@ -119,6 +119,20 @@ mamba_config_list()
 }
 
 int
+mamba_set_cli_config(const char* name, const char* value)
+{
+    try
+    {
+        Configuration::instance().at(name).set_cli_yaml_value(value);
+        return 0;
+    }
+    catch (...)
+    {
+        return 1;
+    }
+}
+
+int
 mamba_set_config(const char* name, const char* value)
 {
     try

--- a/src/api/configuration.cpp
+++ b/src/api/configuration.cpp
@@ -378,6 +378,7 @@ namespace mamba
         insert(Configurable("specs", std::vector<std::string>({}))
                    .group("Basic")
                    .needs({ "file_specs" })  // explicit file specs overwrite current specs
+                   .set_single_op_lifetime()
                    .description("Packages specification"));
 
         insert(Configurable("experimental", &ctx.experimental)


### PR DESCRIPTION
Description
--

Add a C-API to set CLI config values.

Since the lifetime of a CLI config value is limited to a single operation, it's pretty convenient to use it on purpose vs setting at API level which may persist.

Also set `specs` as a single operation config.