### PR TITLE
Enable ultra-dry C++ tests

### DIFF
--- a/src/api/configuration.cpp
+++ b/src/api/configuration.cpp
@@ -600,6 +600,17 @@ namespace mamba
                    .set_env_var_name()
                    .description("Report all output as json"));
 
+#ifdef ENABLE_CONTEXT_DEBUG_PRINT
+        insert(Configurable("print_config_only", false)
+                   .group("Output, Prompt and Flow Control")
+                   .description("Print the config after loading. Allow ultra-dry runs"));
+
+        insert(
+            Configurable("print_context_only", false)
+                .group("Output, Prompt and Flow Control")
+                .description("Print the context after loading the config. Allow ultra-dry runs"));
+#endif
+
         insert(Configurable("show_banner", true)
                    .group("Output, Prompt and Flow Control")
                    .needs({ "quiet", "json" })

--- a/src/micromamba/common_options.cpp
+++ b/src/micromamba/common_options.cpp
@@ -67,13 +67,13 @@ init_general_options(CLI::App* subcom)
         ->group(cli_group);
 
 #ifdef ENABLE_CONTEXT_DEBUG_PRINT
-    auto& print_context_only = config.insert(Configurable("print_context_only", false), true);
+    auto& print_context_only = config.at("print_context_only").get_wrapped<bool>();
     subcom
         ->add_flag(
             "--print-context-only", print_context_only.set_cli_config(false), "Debug context")
         ->group(cli_group);
 
-    auto& print_config_only = config.insert(Configurable("print_config_only", false), true);
+    auto& print_config_only = config.at("print_config_only").get_wrapped<bool>();
     subcom->add_flag("--print-config-only", print_config_only.set_cli_config(false), "Debug config")
         ->group(cli_group);
 #endif


### PR DESCRIPTION
Description
--

Move the configurables `print_config_only` and `print_context_only` from `micromamba` to `libmamba` to enable C++ ultra-dry tests.

C++ tests are already unit testing config options but it could be convenient to have those dumps to add some integration tests.

It's also annoying in dev mode to get errors on config load in C++ tests when build with the same command as micromamba executable for python test suite.