### PR TITLE
Improve overrides between target_prefix and env_name

### DIFF
--- a/include/mamba/api/configuration.hpp
+++ b/include/mamba/api/configuration.hpp
@@ -1013,6 +1013,8 @@ namespace mamba
 
             virtual bool cli_configured() const = 0;
 
+            virtual bool api_configured() const = 0;
+
             virtual bool rc_configurable() const = 0;
 
             virtual const std::set<std::string>& needed() const = 0;
@@ -1138,6 +1140,11 @@ namespace mamba
             bool cli_configured() const
             {
                 return p_wrapped->cli_configured();
+            };
+
+            bool api_configured() const
+            {
+                return p_wrapped->api_configured();
             };
 
             bool rc_configurable() const
@@ -1403,6 +1410,11 @@ namespace mamba
         bool cli_configured() const
         {
             return p_impl->cli_configured();
+        };
+
+        bool api_configured() const
+        {
+            return p_impl->api_configured();
         };
 
         bool rc_configurable() const

--- a/src/api/install.cpp
+++ b/src/api/install.cpp
@@ -343,7 +343,7 @@ namespace mamba
         void file_specs_hook(std::vector<std::string>& file_specs)
         {
             auto& config = Configuration::instance();
-            auto& env_name = config.at("env_name");
+            auto& env_name = config.at("spec_file_env_name");
             auto& specs = config.at("specs");
             auto& channels = config.at("channels");
 
@@ -405,10 +405,7 @@ namespace mamba
 
                     if (f["name"])
                     {
-                        if (!env_name.cli_configured())
-                        {
-                            env_name.set_cli_yaml_value(f["name"]);
-                        }
+                        env_name.set_cli_yaml_value(f["name"]);
                     }
                     {
                         LOG_DEBUG << "No env 'name' specified in file: " << file;

--- a/test/micromamba/test_remove.py
+++ b/test/micromamba/test_remove.py
@@ -159,7 +159,7 @@ class TestRemoveConfig:
         else:
             os.environ["CONDA_PREFIX"] = p
 
-        if ((cli_prefix or env_var) and cli_env_name) or not (
+        if (cli_prefix and cli_env_name) or not (
             cli_prefix or cli_env_name or env_var or fallback
         ):
             with pytest.raises(subprocess.CalledProcessError):

--- a/test/micromamba/test_update.py
+++ b/test/micromamba/test_update.py
@@ -216,7 +216,7 @@ class TestUpdateConfig:
     @pytest.mark.parametrize("target_is_root", (False, True))
     @pytest.mark.parametrize("cli_prefix", (False, True))
     @pytest.mark.parametrize("cli_env_name", (False, True))
-    @pytest.mark.parametrize("yaml", (False, True))
+    @pytest.mark.parametrize("yaml_name", (False, True, "prefix"))
     @pytest.mark.parametrize("env_var", (False, True))
     @pytest.mark.parametrize("fallback", (False, True))
     def test_target_prefix(
@@ -225,7 +225,7 @@ class TestUpdateConfig:
         target_is_root,
         cli_prefix,
         cli_env_name,
-        yaml,
+        yaml_name,
         env_var,
         fallback,
     ):
@@ -248,18 +248,29 @@ class TestUpdateConfig:
             p = TestUpdateConfig.prefix
             n = TestUpdateConfig.env_name
 
+        expected_p = p
+
         if cli_prefix:
             cmd += ["-p", p]
 
         if cli_env_name:
             cmd += ["-n", n]
 
-        if yaml:
+        if yaml_name:
             f_name = random_string() + ".yaml"
             spec_file = os.path.join(TestUpdateConfig.prefix, f_name)
 
+            if yaml_name == "prefix":
+                yaml_n = p
+            else:
+                yaml_n = n
+                if not (cli_prefix or cli_env_name or target_is_root):
+                    expected_p = os.path.join(
+                        TestUpdateConfig.root_prefix, "envs", yaml_n
+                    )
+
             file_content = [
-                f"name: {n}",
+                f"name: {yaml_n}",
                 "dependencies: [xtensor]",
             ]
             with open(spec_file, "w") as f:
@@ -275,14 +286,16 @@ class TestUpdateConfig:
         else:
             os.environ["CONDA_PREFIX"] = p
 
-        if ((cli_prefix or env_var) and (cli_env_name or yaml)) or not (
-            cli_prefix or cli_env_name or yaml or env_var or fallback
+        if (
+            (cli_prefix and cli_env_name)
+            or (yaml_name == "prefix")
+            or not (cli_prefix or cli_env_name or yaml_name or env_var or fallback)
         ):
             with pytest.raises(subprocess.CalledProcessError):
                 install(*cmd, "--print-config-only")
         else:
             res = install(*cmd, "--print-config-only")
-            TestUpdateConfig.config_tests(res, root_prefix=r, target_prefix=p)
+            TestUpdateConfig.config_tests(res, root_prefix=r, target_prefix=expected_p)
 
     @pytest.mark.parametrize("cli", (False, True))
     @pytest.mark.parametrize("yaml", (False, True))


### PR DESCRIPTION
Description
---

In the current implementation, `target_prefix` and `env_name` are 2 separate config values and `env_name` is used to set `target_prefix` only when this last config is NOT set (api/cli/env var, since it's not rc configurable). When both are defined, it's considered as an error:
- if `MAMBA_TARGET_PREFIX` env var is set, `micromamba install -n test xtensor` will throw the following error: `Cannot set both prefix and env name`
- same for env name specified in a spec file, but also throw when `target_prefix` is passed through CLI argument using `micromamba` `-p,--prefix` options

It would be better to consider `env_name` as equivalent config as `target_prefix` when not set.
In addition, we still want to throw an error when both are defined from the CLI. At API level, `target_prefix` takes precedence.

This allow a simplification of environment name defined in YAML spec files:
- set `env_name` CLI value with it, if not already configured
- but allow override by `target_prefix` (the check that both `env_name` and `target_prefix` CLI values are not set is done *before* using spec file env name as a fallback)

For convenience, a `spec_file_env_name` config was introduced. But the implementation stay a bit complicated due to a lot of precedence computation between:
- `target_prefix` defined by api/cli/env var
- `env_name`, `spec_file_env_name` defined by api/cli

This PR also add a check on both `env_name` and `spec_file_env_name` to be sure they are names-like (check that they don't contain any filesystem separator) and throw an error if the check fails.

Tests are update to cover all those changes.