### PR TITLE
Create base only for `install` operation

### DIFF
--- a/include/mamba/api/configuration.hpp
+++ b/include/mamba/api/configuration.hpp
@@ -1013,6 +1013,8 @@ namespace mamba
 
             virtual bool cli_configured() const = 0;
 
+            virtual bool api_configured() const = 0;
+
             virtual bool rc_configurable() const = 0;
 
             virtual const std::set<std::string>& needed() const = 0;
@@ -1138,6 +1140,11 @@ namespace mamba
             bool cli_configured() const
             {
                 return p_wrapped->cli_configured();
+            };
+
+            bool api_configured() const
+            {
+                return p_wrapped->api_configured();
             };
 
             bool rc_configurable() const
@@ -1403,6 +1410,11 @@ namespace mamba
         bool cli_configured() const
         {
             return p_impl->cli_configured();
+        };
+
+        bool api_configured() const
+        {
+            return p_impl->api_configured();
         };
 
         bool rc_configurable() const

--- a/src/api/configuration.cpp
+++ b/src/api/configuration.cpp
@@ -201,7 +201,7 @@ namespace mamba
                 {
                     if (!(fs::exists(prefix / "pkgs") || fs::exists(prefix / "conda-meta")))
                     {
-                        LOG_ERROR << "Could not use default 'root_prefix' :" << prefix.string();
+                        LOG_ERROR << "Could not use default 'root_prefix': " << prefix.string();
                         LOG_ERROR << "Directory exists, is not empty and not a conda prefix.";
                         exit(1);
                     }
@@ -216,9 +216,12 @@ namespace mamba
                                 (then restart or source the contents of the shell init script))");
             }
 
-            path::touch(prefix / "conda-meta" / "history", true);
-            fs::create_directories(prefix / "envs");
-            fs::create_directories(prefix / "pkgs");
+            if (Configuration::instance().at("create_base").value<bool>())
+            {
+                path::touch(prefix / "conda-meta" / "history", true);
+                fs::create_directories(prefix / "envs");
+                fs::create_directories(prefix / "pkgs");
+            }
 
             prefix = fs::weakly_canonical(prefix);
 
@@ -380,9 +383,14 @@ namespace mamba
         insert(Configurable("root_prefix", &ctx.root_prefix)
                    .group("Basic")
                    .set_env_var_name()
-                   .needs({ "verbose" })
+                   .needs({ "verbose", "create_base" })
                    .description("Path to the root prefix")
                    .set_post_build_hook(detail::root_prefix_hook));
+
+        insert(Configurable("create_base", false)
+                   .group("Basic")
+                   .set_single_op_lifetime()
+                   .description("Define if base environment will be initialized empty"));
 
         insert(Configurable("target_prefix", &ctx.target_prefix)
                    .group("Basic")

--- a/src/api/install.cpp
+++ b/src/api/install.cpp
@@ -343,7 +343,7 @@ namespace mamba
         void file_specs_hook(std::vector<std::string>& file_specs)
         {
             auto& config = Configuration::instance();
-            auto& env_name = config.at("env_name");
+            auto& env_name = config.at("spec_file_env_name");
             auto& specs = config.at("specs");
             auto& channels = config.at("channels");
 
@@ -405,10 +405,7 @@ namespace mamba
 
                     if (f["name"])
                     {
-                        if (!env_name.cli_configured())
-                        {
-                            env_name.set_cli_yaml_value(f["name"]);
-                        }
+                        env_name.set_cli_yaml_value(f["name"]);
                     }
                     {
                         LOG_DEBUG << "No env 'name' specified in file: " << file;

--- a/src/api/install.cpp
+++ b/src/api/install.cpp
@@ -27,6 +27,7 @@ namespace mamba
     {
         auto& config = Configuration::instance();
 
+        config.at("create_base").set_value(true);
         config.at("use_target_prefix_fallback").set_value(true);
         config.at("target_prefix_checks")
             .set_value(MAMBA_ALLOW_EXISTING_PREFIX | MAMBA_NOT_ALLOW_MISSING_PREFIX

--- a/src/core/shell_init.cpp
+++ b/src/core/shell_init.cpp
@@ -512,14 +512,6 @@ namespace mamba
     void init_root_prefix(const std::string& shell, const fs::path& root_prefix)
     {
         Context::instance().root_prefix = root_prefix;
-        if (fs::exists(root_prefix))
-        {
-            if (!Console::prompt("Prefix at " + root_prefix.string()
-                                 + " already exists, use as root prefix?"))
-            {
-                exit(0);
-            }
-        }
 
         if (shell == "zsh" || shell == "bash" || shell == "posix")
         {

--- a/test/micromamba/test_remove.py
+++ b/test/micromamba/test_remove.py
@@ -159,7 +159,7 @@ class TestRemoveConfig:
         else:
             os.environ["CONDA_PREFIX"] = p
 
-        if ((cli_prefix or env_var) and cli_env_name) or not (
+        if (cli_prefix and cli_env_name) or not (
             cli_prefix or cli_env_name or env_var or fallback
         ):
             with pytest.raises(subprocess.CalledProcessError):

--- a/test/micromamba/test_remove.py
+++ b/test/micromamba/test_remove.py
@@ -29,6 +29,7 @@ class TestRemove:
         # speed-up the tests
         os.environ["CONDA_PKGS_DIRS"] = TestRemove.cache
 
+        create("-n", "base", no_dry_run=True)
         create("xtensor", "-n", TestRemove.env_name, no_dry_run=True)
 
     @classmethod
@@ -75,7 +76,7 @@ class TestRemoveConfig:
         os.environ["MAMBA_ROOT_PREFIX"] = TestRemoveConfig.root_prefix
         os.environ["CONDA_PREFIX"] = TestRemoveConfig.prefix
 
-        os.makedirs(TestRemoveConfig.root_prefix, exist_ok=False)
+        create("-n", "base", no_dry_run=True)
         create("-n", TestRemoveConfig.env_name, "--offline", no_dry_run=True)
 
     @classmethod

--- a/test/micromamba/test_update.py
+++ b/test/micromamba/test_update.py
@@ -216,7 +216,7 @@ class TestUpdateConfig:
     @pytest.mark.parametrize("target_is_root", (False, True))
     @pytest.mark.parametrize("cli_prefix", (False, True))
     @pytest.mark.parametrize("cli_env_name", (False, True))
-    @pytest.mark.parametrize("yaml", (False, True))
+    @pytest.mark.parametrize("yaml_name", (False, True, "prefix"))
     @pytest.mark.parametrize("env_var", (False, True))
     @pytest.mark.parametrize("fallback", (False, True))
     def test_target_prefix(
@@ -225,7 +225,7 @@ class TestUpdateConfig:
         target_is_root,
         cli_prefix,
         cli_env_name,
-        yaml,
+        yaml_name,
         env_var,
         fallback,
     ):
@@ -248,18 +248,29 @@ class TestUpdateConfig:
             p = TestUpdateConfig.prefix
             n = TestUpdateConfig.env_name
 
+        expected_p = p
+
         if cli_prefix:
             cmd += ["-p", p]
 
         if cli_env_name:
             cmd += ["-n", n]
 
-        if yaml:
+        if yaml_name:
             f_name = random_string() + ".yaml"
             spec_file = os.path.join(TestUpdateConfig.prefix, f_name)
 
+            if yaml_name == "prefix":
+                yaml_n = p
+            else:
+                yaml_n = n
+                if not (cli_prefix or cli_env_name or target_is_root):
+                    expected_p = os.path.join(
+                        TestUpdateConfig.root_prefix, "envs", yaml_n
+                    )
+
             file_content = [
-                f"name: {n}",
+                f"name: {yaml_n}",
                 "dependencies: [xtensor]",
             ]
             with open(spec_file, "w") as f:
@@ -275,14 +286,16 @@ class TestUpdateConfig:
         else:
             os.environ["CONDA_PREFIX"] = p
 
-        if ((cli_prefix or env_var) and (cli_env_name or yaml)) or not (
-            cli_prefix or cli_env_name or yaml or env_var or fallback
+        if (
+            (cli_prefix and cli_env_name)
+            or (yaml_name == "prefix")
+            or not (cli_prefix or cli_env_name or yaml_name or env_var or fallback)
         ):
             with pytest.raises(subprocess.CalledProcessError):
                 install(*cmd, "--print-config-only")
         else:
             res = install(*cmd, "--print-config-only")
-            TestUpdateConfig.config_tests(res, root_prefix=r, target_prefix=p)
+            TestUpdateConfig.config_tests(res, root_prefix=r, target_prefix=expected_p)
 
     @pytest.mark.parametrize("cli", (False, True))
     @pytest.mark.parametrize("yaml", (False, True))


### PR DESCRIPTION
Description
---

Current implementation initializes `base` in `root_prefix_hook`, which is always called when loading the configuration, even for operations that won't require `root_prefix` to exist.
It leads to directories created at default/fallback `$home/micromamba` path when calling `micromamba info` or even `micromamba --help`, which is not great.

Use a more selective, single-operation, `create_base` config enabled only for `install` operation.
It preserves the behavior of ready-to-use `base` env (no errors thrown when trying to install in base for example) without polluting the host unnecessarily.