### PR TITLE
Fix clean operation

### DIFF
--- a/src/api/clean.cpp
+++ b/src/api/clean.cpp
@@ -19,7 +19,6 @@ namespace mamba
         auto& config = Configuration::instance();
 
         config.at("use_target_prefix_fallback").set_value(true);
-        config.at("target_prefix_checks").set_value(MAMBA_ALLOW_EXISTING_PREFIX);
         config.load();
 
         bool clean_all = options & MAMBA_CLEAN_ALL;

--- a/src/api/configuration.cpp
+++ b/src/api/configuration.cpp
@@ -413,6 +413,7 @@ namespace mamba
                    .group("Basic")
                    .needs({ "target_prefix", "rc_file" })
                    .description("The type of checks performed on the target prefix")
+                   .set_single_op_lifetime()
                    .set_post_build_hook(detail::target_prefix_checks_hook));
 
         insert(Configurable("env_name", std::string(""))

--- a/src/micromamba/clean.cpp
+++ b/src/micromamba/clean.cpp
@@ -49,13 +49,13 @@ set_clean_command(CLI::App* subcom)
         auto& config = Configuration::instance();
         int options = 0;
 
-        if (config.at("clean_all").value<bool>())
+        if (config.at("clean_all").compute().value<bool>())
             options = options | MAMBA_CLEAN_ALL;
-        if (config.at("clean_index_cache").value<bool>())
+        if (config.at("clean_index_cache").compute().value<bool>())
             options = options | MAMBA_CLEAN_INDEX;
-        if (config.at("clean_packages").value<bool>())
+        if (config.at("clean_packages").compute().value<bool>())
             options = options | MAMBA_CLEAN_PKGS;
-        if (config.at("clean_tarballs").value<bool>())
+        if (config.at("clean_tarballs").compute().value<bool>())
             options = options | MAMBA_CLEAN_TARBALLS;
 
         clean(options);


### PR DESCRIPTION
Description
---

Fix use of config value before computing it, preventing flags to work.
Remove target prefix checks since target prefix is not necesseray.