### PR TITLE
target prefix fallback is single-op config

### DIFF
--- a/src/api/configuration.cpp
+++ b/src/api/configuration.cpp
@@ -407,6 +407,7 @@ namespace mamba
 
         insert(Configurable("use_target_prefix_fallback", true)
                    .group("Basic")
+                   .set_single_op_lifetime()
                    .description("Fallback to the current target prefix or not"));
 
         insert(Configurable("target_prefix_checks", MAMBA_NO_PREFIX_CHECK)


### PR DESCRIPTION
Description
--

Declare `use_target_prefix_fallback` config as single-op to reset its value at operation teardown.
This will prevent the next operation to use wrong config (instead of explicitly setting it to its default value in each operation)