### PR TITLE
Make platform rc configurable

### DIFF
--- a/include/mamba/core/context.hpp
+++ b/include/mamba/core/context.hpp
@@ -17,6 +17,60 @@
 
 namespace mamba
 {
+    namespace
+    {
+// Linux
+#if defined(__linux__)
+#if __x86_64__
+        static const char MAMBA_PLATFORM[] = "linux-64";
+#elif defined(i386)
+        static const char MAMBA_PLATFORM[] = "linux-32";
+// armv6l and armv7l
+#elif defined(__arm__) || defined(__thumb__)
+#ifdef ___ARM_ARCH_6__
+        static const char MAMBA_PLATFORM[] = "linux-armv6l";
+#elif __ARM_ARCH_7__
+        static const char MAMBA_PLATFORM[] = "linux-armv7l";
+#else
+#error "Unknown Linux arm platform"
+#endif
+#elif _M_ARM == 6
+        static const char MAMBA_PLATFORM[] = "linux-armv6l";
+#elif _M_ARM == 7
+        static const char MAMBA_PLATFORM[] = "linux-armv7l";
+// aarch64
+#elif defined(__aarch64__)
+        static const char MAMBA_PLATFORM[] = "linux-aarch64";
+#elif defined(__ppc64__) || defined(__powerpc64__)
+#if (__BYTE_ORDER__ == __ORDER_BIG_ENDIAN__)
+        static const char MAMBA_PLATFORM[] = "linux-ppc64";
+#else
+        static const char MAMBA_PLATFORM[] = "linux-ppc64le";
+#endif
+#elif defined(__s390x__)
+        static const char MAMBA_PLATFORM[] = "linux-s390x";
+#else
+#error "Unknown Linux platform"
+#endif
+// OSX
+#elif defined(__APPLE__) || defined(__MACH__)
+#if __x86_64__
+        static const char MAMBA_PLATFORM[] = "osx-64";
+#elif __arm64__
+        static const char MAMBA_PLATFORM[] = "osx-arm64";
+#else
+#error "Unknown OSX platform"
+#endif
+// Windows
+#elif defined(_WIN64)
+        static const char MAMBA_PLATFORM[] = "win-64";
+#elif defined(_WIN32)
+        static const char MAMBA_PLATFORM[] = "win-32";
+#else
+#error "Unknown platform"
+#endif
+    }  // namespace
+
     enum class VerificationLevel
     {
         kDisabled,
@@ -108,8 +162,9 @@ namespace mamba
 
         void set_verbosity(int lvl);
 
-        static std::string platform();
-        static std::vector<std::string> platforms();
+        std::string host_platform = MAMBA_PLATFORM;
+        std::string platform = MAMBA_PLATFORM;
+        std::vector<std::string> platforms();
 
         std::vector<std::string> channels = {};
         std::vector<std::string> default_channels = {

--- a/src/api/configuration.cpp
+++ b/src/api/configuration.cpp
@@ -424,6 +424,16 @@ namespace mamba
                    .set_post_build_hook(detail::env_name_hook)
                    .description("Name of the target prefix"));
 
+        insert(Configurable("platform", &ctx.platform)
+                   .group("Basic")
+                   .set_rc_configurable()
+                   .set_env_var_name("CONDA_SUBDIR")
+                   .description("The platform description")
+                   .long_description(unindent(R"(
+                        The plaftorm description points what channels
+                        subdir(s) have to fetched for package solving.
+                        This can be 'linux-64' or similar.)")));
+
         insert(Configurable("spec_file_env_name", std::string(""))
                    .group("Basic")
                    .needs({ "file_specs", "root_prefix" })

--- a/src/api/info.cpp
+++ b/src/api/info.cpp
@@ -104,7 +104,7 @@ namespace mamba
 
             items.push_back({ "base environment", { ctx.root_prefix.string() } });
 
-            items.push_back({ "platform", { ctx.platform() } });
+            items.push_back({ "platform", { ctx.platform } });
 
             info_pretty_print(items);
         }

--- a/src/core/context.cpp
+++ b/src/core/context.cpp
@@ -16,59 +16,6 @@
 
 namespace mamba
 {
-    namespace
-    {
-// Linux
-#if defined(__linux__)
-#if __x86_64__
-        static const char MAMBA_PLATFORM[] = "linux-64";
-#elif defined(i386)
-        static const char MAMBA_PLATFORM[] = "linux-32";
-// armv6l and armv7l
-#elif defined(__arm__) || defined(__thumb__)
-#ifdef ___ARM_ARCH_6__
-        static const char MAMBA_PLATFORM[] = "linux-armv6l";
-#elif __ARM_ARCH_7__
-        static const char MAMBA_PLATFORM[] = "linux-armv7l";
-#else
-#error "Unknown Linux arm platform"
-#endif
-#elif _M_ARM == 6
-        static const char MAMBA_PLATFORM[] = "linux-armv6l";
-#elif _M_ARM == 7
-        static const char MAMBA_PLATFORM[] = "linux-armv7l";
-// aarch64
-#elif defined(__aarch64__)
-        static const char MAMBA_PLATFORM[] = "linux-aarch64";
-#elif defined(__ppc64__) || defined(__powerpc64__)
-#if (__BYTE_ORDER__ == __ORDER_BIG_ENDIAN__)
-        static const char MAMBA_PLATFORM[] = "linux-ppc64";
-#else
-        static const char MAMBA_PLATFORM[] = "linux-ppc64le";
-#endif
-#elif defined(__s390x__)
-        static const char MAMBA_PLATFORM[] = "linux-s390x";
-#else
-#error "Unknown Linux platform"
-#endif
-// OSX
-#elif defined(__APPLE__) || defined(__MACH__)
-#if __x86_64__
-        static const char MAMBA_PLATFORM[] = "osx-64";
-#elif __arm64__
-        static const char MAMBA_PLATFORM[] = "osx-arm64";
-#else
-#error "Unknown OSX platform"
-#endif
-// Windows
-#elif defined(_WIN64)
-        static const char MAMBA_PLATFORM[] = "win-64";
-#elif defined(_WIN32)
-        static const char MAMBA_PLATFORM[] = "win-32";
-#else
-#error "Unknown platform"
-#endif
-    }  // namespace
     Context::Context()
     {
         set_verbosity(0);
@@ -101,22 +48,9 @@ namespace mamba
         this->verbosity = lvl;
     }
 
-    std::string Context::platform()
-    {
-        std::string platform = env::get("CONDA_SUBDIR");
-        if (platform.empty())
-        {
-            return MAMBA_PLATFORM;
-        }
-        else
-        {
-            return platform;
-        }
-    }
-
     std::vector<std::string> Context::platforms()
     {
-        return { platform(), "noarch" };
+        return { platform, "noarch" };
     }
 
     std::string env_name(const fs::path& prefix)
@@ -204,7 +138,7 @@ namespace mamba
                   PRINT_CTX_VEC(default_channels)
                   PRINT_CTX_VEC(channels)
                   PRINT_CTX_VEC(pinned_packages)
-                  << "platform: " << platform() << "\n"
+                  << "platform: " << platform << "\n"
                   << ">>> END MAMBA CONTEXT <<< \n"
                   << std::endl;
         // clang-format on

--- a/src/core/virtual_packages.cpp
+++ b/src/core/virtual_packages.cpp
@@ -204,7 +204,7 @@ namespace mamba
             res.build_string = build_string.size() ? build_string : "0";
             res.build_number = 0;
             res.channel = "@";
-            res.subdir = Context::instance().platform();
+            res.subdir = Context::instance().platform;
             res.md5 = "12345678901234567890123456789012";
             res.fn = name;
             return res;
@@ -213,12 +213,12 @@ namespace mamba
         std::vector<PackageInfo> dist_packages()
         {
             std::vector<PackageInfo> res;
-            auto platform = Context::instance().platform();
+            auto platform = Context::instance().platform;
             auto split_platform = split(platform, "-", 1);
 
             if (split_platform.size() != 2)
             {
-                LOG_ERROR << "'CONDA_SUBDIR' is ill-formed, expected <os>-<arch>";
+                LOG_ERROR << "Platform is ill-formed, expected <os>-<arch> in: '" + platform + "'";
                 return res;
             }
             std::string os = split_platform[0];

--- a/test/test_configuration.cpp
+++ b/test/test_configuration.cpp
@@ -571,6 +571,36 @@ namespace mamba
             load_test_config("cacert_path:\nssl_verify: true");  // reset ssl verify to default
         }
 
+        TEST_F(Configuration, platform)
+        {
+            EXPECT_EQ(ctx.platform, ctx.host_platform);
+
+            std::string rc = "platform: mylinux-128";
+            load_test_config(rc);
+            std::string src = shrink_source(0);
+            EXPECT_EQ(config.at("platform").value<std::string>(), "mylinux-128");
+            EXPECT_EQ(ctx.platform, "mylinux-128");
+            EXPECT_EQ(config.dump(MAMBA_SHOW_CONFIG_VALUES | MAMBA_SHOW_CONFIG_SRCS),
+                      unindent((R"(
+                                platform: mylinux-128  # ')"
+                                + src + "'")
+                                   .c_str()));
+
+            env::set("CONDA_SUBDIR", "win-32");
+            load_test_config(rc);
+            src = shrink_source(0);
+            EXPECT_EQ(config.at("platform").value<std::string>(), "win-32");
+            EXPECT_EQ(ctx.platform, "win-32");
+            EXPECT_EQ(config.dump(MAMBA_SHOW_CONFIG_VALUES | MAMBA_SHOW_CONFIG_SRCS),
+                      unindent((R"(
+                                platform: win-32  # 'CONDA_SUBDIR' > ')"
+                                + src + "'")
+                                   .c_str()));
+
+            config.at("platform").clear_values();
+            ctx.platform = ctx.host_platform;
+        }
+
 #define TEST_BOOL_CONFIGURABLE(NAME, CTX)                                                          \
     TEST_F(Configuration, NAME)                                                                    \
     {                                                                                              \

--- a/test/test_virtual_packages.cpp
+++ b/test/test_virtual_packages.cpp
@@ -1,3 +1,4 @@
+#include "mamba/core/context.hpp"
 #include "mamba/core/environment.hpp"
 #include "mamba/core/util.hpp"
 #include "mamba/core/virtual_packages.hpp"
@@ -26,6 +27,7 @@ namespace mamba
         TEST(virtual_packages, dist_packages)
         {
             auto pkgs = detail::dist_packages();
+            auto& ctx = Context::instance();
 
             if (on_win)
             {
@@ -50,7 +52,7 @@ namespace mamba
             EXPECT_EQ(pkgs.back().build_string, "x86_64");
 #endif
 
-            env::set("CONDA_SUBDIR", "osx-arm");
+            ctx.platform = "osx-arm";
             env::set("CONDA_OVERRIDE_OSX", "12.1");
             pkgs = detail::dist_packages();
             ASSERT_EQ(pkgs.size(), 3);
@@ -61,7 +63,7 @@ namespace mamba
             EXPECT_EQ(pkgs[2].build_string, "arm");
 
             env::set("CONDA_OVERRIDE_OSX", "");
-            env::set("CONDA_SUBDIR", "linux-32");
+            ctx.platform = "linux-32";
             env::set("CONDA_OVERRIDE_LINUX", "5.7");
             env::set("CONDA_OVERRIDE_GLIBC", "2.15");
             pkgs = detail::dist_packages();
@@ -76,17 +78,18 @@ namespace mamba
             env::set("CONDA_OVERRIDE_GLIBC", "");
             env::set("CONDA_OVERRIDE_LINUX", "");
 
-            env::set("CONDA_SUBDIR", "lin-850");
+            ctx.platform = "lin-850";
             pkgs = detail::dist_packages();
             ASSERT_EQ(pkgs.size(), 1);
             EXPECT_EQ(pkgs[0].name, "__archspec");
             EXPECT_EQ(pkgs[0].build_string, "850");
             env::set("CONDA_SUBDIR", "");
 
-            env::set("CONDA_SUBDIR", "linux");
+            ctx.platform = "linux";
             pkgs = detail::dist_packages();
             ASSERT_EQ(pkgs.size(), 0);
-            env::set("CONDA_SUBDIR", "");
+
+            ctx.platform = ctx.host_platform;
         }
 
         TEST(virtual_packages, get_virtual_packages)


### PR DESCRIPTION
Description
--

The `platform` is used to get/fetch the packages from channels that correspond to your system.
It's already possible to modify it using `CONDA_SUBDIR` env variable but it could be pretty convenient to have RC configurable. 

For example, ones can then place an rc file in a given env that will act has it was on another platform to install corresponding packages. Pretty convenient when using emulators or interpreted code.

Add tests