### PR TITLE
Regression: activation check path

### DIFF
--- a/src/api/shell.cpp
+++ b/src/api/shell.cpp
@@ -116,6 +116,11 @@ namespace mamba
             {
                 shell_prefix = ctx.root_prefix / "envs" / shell_prefix;
             }
+            if (!fs::exists(shell_prefix))
+            {
+                throw std::runtime_error(
+                    "Cannot activate, environment does not exist: " + shell_prefix + "\n");
+            }
 
             std::cout << activator->activate(shell_prefix, stack);
         }

--- a/test/micromamba/test_shell.py
+++ b/test/micromamba/test_shell.py
@@ -12,16 +12,11 @@ from .helpers import create, get_env, get_umamba, info, random_string, shell
 
 def skip_if_shell_incompat(shell_type):
     """Skip test if ``shell_type`` is incompatible with the platform"""
+    plat_system = platform.system()
     if (
-        (platform.system() == "Linux" and shell_type not in ("bash", "posix"))
-        or (
-            platform.system() == "Windows"
-            and shell_type not in ("cmd.exe", "powershell")
-        )
-        or (
-            platform.system() == "Darwin"
-            and shell_type not in ("zsh", "bash", "posix")
-        )
+        (plat_system == "Linux" and shell_type not in ("bash", "posix"))
+        or (plat_system == "Windows" and shell_type not in ("cmd.exe", "powershell"))
+        or (plat_system == "Darwin" and shell_type not in ("zsh", "bash", "posix"))
     ):
         pytest.skip("Incompatible shell/OS")
 

--- a/test/micromamba/test_shell.py
+++ b/test/micromamba/test_shell.py
@@ -158,7 +158,7 @@ class TestShell:
     def test_activate(self, shell_type, root, env_exists, prefix_type, expanded_home):
         skip_if_shell_incompat(shell_type)
 
-        if not root and env_exists:
+        if not root and not env_exists:
             create("-n", TestShell.env_name, "-q", "--offline", no_dry_run=True)
 
         if prefix_type == "prefix":


### PR DESCRIPTION
- Fix regression: check path exists before activating
- Add test: activating non-existent env

Closes #682, again!
