### PR TITLE
Make 'env update' update packages if they're already installed

### DIFF
--- a/mamba/mamba_env.py
+++ b/mamba/mamba_env.py
@@ -66,8 +66,8 @@ def mamba_install(prefix, specs, args, env, *_, **kwargs):
     # Also pin the Python version if it's installed
     # If python was not specified, check if it is installed.
     # If yes, add the installed python to the specs to prevent updating it.
+    installed_names = [i_rec.name for i_rec in installed_pkg_recs]
     if "python" not in [s.name for s in match_specs]:
-        installed_names = [i_rec.name for i_rec in installed_pkg_recs]
         if "python" in installed_names:
             i = installed_names.index("python")
             version = installed_pkg_recs[i].version

--- a/mamba/mamba_env.py
+++ b/mamba/mamba_env.py
@@ -105,7 +105,11 @@ def mamba_install(prefix, specs, args, env, *_, **kwargs):
     if pinned_specs_info:
         print(f"\n  Pinned packages:\n\n{pinned_specs_info}\n")
 
-    solver.add_jobs(specs, api.SOLVER_INSTALL)
+    install_specs = [s for s in specs if MatchSpec(s).name not in installed_names]
+    solver.add_jobs(install_specs, api.SOLVER_INSTALL)
+
+    update_specs = [s for s in specs if MatchSpec(s).name in installed_names]
+    solver.add_jobs(update_specs, api.SOLVER_UPDATE)
 
     success = solver.solve()
     if not success:

--- a/test/test_all.py
+++ b/test/test_all.py
@@ -55,12 +55,14 @@ def test_env_update(shell_type, tmpdir):
     with Environment(shell_type) as env:
         # first install an older version
         version = "1.25.11"
-        config_a = tmpdir / 'a.yml'
-        config_a.write(f"""
-        dependencies:
-         - python
-         - urllib3={version}
-        """)
+        config_a = tmpdir / "a.yml"
+        config_a.write(
+            f"""
+            dependencies:
+             - python
+             - urllib3={version}
+            """
+        )
         env.mamba(f"env update -q -f {config_a}")
         out = env.execute('python -c "import urllib3; print(urllib3.__version__)"')
 
@@ -68,11 +70,13 @@ def test_env_update(shell_type, tmpdir):
         assert out[-1] == version
 
         # then release the pin
-        config_b = tmpdir / 'b.yml'
-        config_b.write("""
-        dependencies:
-         - urllib3
-        """)
+        config_b = tmpdir / "b.yml"
+        config_b.write(
+            """
+            dependencies:
+             - urllib3
+            """
+        )
         env.mamba(f"env update -q -f {config_b}")
         out = env.execute('python -c "import urllib3; print(urllib3.__version__)"')
         # check that the installed version is newer

--- a/test/test_all.py
+++ b/test/test_all.py
@@ -58,7 +58,8 @@ def test_env_update(shell_type, tmpdir):
         config_a = tmpdir / 'a.yml'
         config_a.write(f"""
         dependencies:
-         - urllib3=={version}
+         - python
+         - urllib3={version}
         """)
         env.mamba(f"env update -q -f {config_a}")
         out = env.execute('python -c "import urllib3; print(urllib3.__version__)"')

--- a/test/test_all.py
+++ b/test/test_all.py
@@ -50,6 +50,35 @@ def test_update(shell_type):
 
 
 @pytest.mark.parametrize("shell_type", platform_shells())
+def test_env_update(shell_type, tmpdir):
+    # check updating a package when a newer version
+    with Environment(shell_type) as env:
+        # first install an older version
+        version = "1.25.11"
+        config_a = tmpdir / 'a.yml'
+        config_a.write(f"""
+        dependencies:
+         - urllib3=={version}
+        """)
+        env.mamba(f"env update -q -f {config_a}")
+        out = env.execute('python -c "import urllib3; print(urllib3.__version__)"')
+
+        # check that the installed version is the old one
+        assert out[-1] == version
+
+        # then release the pin
+        config_b = tmpdir / 'b.yml'
+        config_b.write("""
+        dependencies:
+         - urllib3
+        """)
+        env.mamba(f"env update -q -f {config_b}")
+        out = env.execute('python -c "import urllib3; print(urllib3.__version__)"')
+        # check that the installed version is newer
+        assert StrictVersion(out[-1]) > StrictVersion(version)
+
+
+@pytest.mark.parametrize("shell_type", platform_shells())
 def test_track_features(shell_type):
     with Environment(shell_type) as env:
         # should install CPython since PyPy has track features


### PR DESCRIPTION
This is an attempt to fix #854. The issue appears to be that `api.SOLVER_INSTALL` won't do anything if a package is already installed, so `env update` doesn't update packages.

I've split the install jobs, so that packages newly added still use `api.SOLVER_INSTALL`, but if a package already exists it will instead be updated with `api.SOLVER_UPDATE`. This matches the behavior of `conda env update`.