### PR TITLE
Micromamba only implementations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,10 +64,6 @@ if (USE_VENDORED_CLI11)
     add_definitions(-DVENDORED_CLI11=1)
 endif()
 
-if (BUILD_EXE OR ENABLE_TESTS OR BUILD_SHARED)
-    add_definitions(-DUMAMBA_ONLY)
-endif()
-
 if (ENABLE_CONTEXT_DEBUG_PRINT)
     add_definitions(-DENABLE_CONTEXT_DEBUG_PRINT)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,6 +68,10 @@ if (ENABLE_CONTEXT_DEBUG_PRINT)
     add_definitions(-DENABLE_CONTEXT_DEBUG_PRINT)
 endif()
 
+if (STATIC_DEPENDENCIES)
+    add_definitions(-DUMAMBA_STATIC)
+endif()
+
 add_definitions(-DGHC_WIN_DISABLE_WSTRING_STORAGE_TYPE)
 add_definitions(-DGHC_WIN_DISABLE_AUTO_PREFIXES)
 

--- a/setup.py
+++ b/setup.py
@@ -177,6 +177,7 @@ class BuildExt(build_ext):
         if sys.platform == "win32":
             self.compiler.macros.append(("REPROCXX_SHARED", 1))
             self.compiler.macros.append(("GHC_WIN_DISABLE_WSTRING_STORAGE_TYPE", 1))
+        self.compiler.macros.append(("MAMBA_ONLY", 1))
 
         for ext in self.extensions:
             ext.extra_compile_args = opts

--- a/src/api/configuration.cpp
+++ b/src/api/configuration.cpp
@@ -79,7 +79,9 @@ namespace mamba
                 }
             }
 
+#ifdef UMAMBA_STATIC
             init_curl_ssl();
+#endif
         };
 
         void always_softlink_hook(bool& value)

--- a/src/core/package_cache.cpp
+++ b/src/core/package_cache.cpp
@@ -233,7 +233,7 @@ namespace mamba
                 }
                 catch (const std::runtime_error& e)
                 {
-#ifdef UMAMBA_ONLY
+#ifndef MAMBA_ONLY
                     throw e;
 #endif
                 }

--- a/src/core/prefix_data.cpp
+++ b/src/core/prefix_data.cpp
@@ -31,7 +31,6 @@ namespace mamba
         }
     }
 
-#ifdef UMAMBA_ONLY
     void PrefixData::add_virtual_packages(const std::vector<PackageInfo>& packages)
     {
         for (const auto& pkg : packages)
@@ -41,7 +40,6 @@ namespace mamba
             m_package_records.insert({ pkg.name, std::move(pkg) });
         }
     }
-#endif
 
     const PrefixData::package_map& PrefixData::records() const
     {

--- a/src/micromamba/CMakeLists.txt
+++ b/src/micromamba/CMakeLists.txt
@@ -31,6 +31,8 @@ target_link_libraries(micromamba PRIVATE mamba-static)
 message("Using static dependencies for micromamba: ${STATIC_DEPENDENCIES}")
 
 if (STATIC_DEPENDENCIES AND UNIX)
+    add_definitions(-DUMAMBA_STATIC)
+
     set(MAMBA_DEPENDENCIES_LIBS
         libcurl.a
         libssh2.a

--- a/src/micromamba/CMakeLists.txt
+++ b/src/micromamba/CMakeLists.txt
@@ -31,7 +31,6 @@ target_link_libraries(micromamba PRIVATE mamba-static)
 message("Using static dependencies for micromamba: ${STATIC_DEPENDENCIES}")
 
 if (STATIC_DEPENDENCIES AND UNIX)
-    add_definitions(-DUMAMBA_STATIC)
 
     set(MAMBA_DEPENDENCIES_LIBS
         libcurl.a


### PR DESCRIPTION
Description
--

Add a UMAMBA_STATIC definition to only call init curl ssl in that case
Not throw an error on pkg cache only on mamba, should be thrown using libmamba through rhumba for example.
Remove a guard on `add_virtual_packages`, only called in `install_specs` (not called in mamba)