### PR TITLE
More selective root prefix warnings

### DIFF
--- a/test/micromamba/test_install.py
+++ b/test/micromamba/test_install.py
@@ -46,7 +46,7 @@ class TestInstall:
             if v in os.environ:
                 os.environ.pop(v)
 
-        if Path(TestInstall.root_prefix).exists():
+        if Path(os.path.join(TestInstall.root_prefix, "conda-meta")).exists():
             remove("-n", "base", "-a", no_dry_run=True)
 
         if not Path(TestInstall.prefix).exists():


### PR DESCRIPTION
Description
--

Only warn about using default root prefix when using env name. That prevent from warning when passing a full target prefix
Only create base when target prefix is root prefix and create base is required (for install op)