### PR TITLE
Remove target prefix checks for activation

### DIFF
--- a/src/api/shell.cpp
+++ b/src/api/shell.cpp
@@ -25,9 +25,8 @@ namespace mamba
         auto& config = Configuration::instance();
 
         config.at("show_banner").set_value(false);
-        config.at("use_target_prefix_fallback").set_value(true);
-        config.at("target_prefix_checks")
-            .set_value(MAMBA_ALLOW_EXISTING_PREFIX | MAMBA_ALLOW_MISSING_PREFIX);
+        config.at("use_target_prefix_fallback").set_value(false);
+        config.at("target_prefix_checks").set_value(MAMBA_NO_PREFIX_CHECK);
         config.load();
 
         if (shell_type.empty())
@@ -118,8 +117,8 @@ namespace mamba
             }
             if (!fs::exists(shell_prefix))
             {
-                throw std::runtime_error(
-                    "Cannot activate, environment does not exist: " + shell_prefix + "\n");
+                throw std::runtime_error("Cannot activate, prefix does not exist at: "
+                                         + shell_prefix);
             }
 
             std::cout << activator->activate(shell_prefix, stack);

--- a/test/micromamba/helpers.py
+++ b/test/micromamba/helpers.py
@@ -72,6 +72,8 @@ def shell(*args, cwd=os.getcwd()):
         except json.decoder.JSONDecodeError as e:
             print(f"Error when loading JSON output from {res}")
             raise (e)
+    if "--print-config-only" in args:
+        return yaml.load(res, Loader=yaml.FullLoader)
     return res.decode()
 
 

--- a/test/micromamba/test_shell.py
+++ b/test/micromamba/test_shell.py
@@ -161,7 +161,7 @@ class TestShell:
     @pytest.mark.parametrize("prefix_is_root", [False, True])
     @pytest.mark.parametrize("prefix_exists", [False, True])
     @pytest.mark.parametrize(
-        "prefix_type", ["shrinked_prefix", "expanded_prefix" "name"]
+        "prefix_type", ["shrinked_prefix", "expanded_prefix", "name"]
     )
     def test_activate(self, shell_type, prefix_is_root, prefix_exists, prefix_type):
         skip_if_shell_incompat(shell_type)

--- a/test/micromamba/test_shell.py
+++ b/test/micromamba/test_shell.py
@@ -160,18 +160,18 @@ class TestShell:
     @pytest.mark.parametrize("shell_type", ["bash", "posix", "powershell", "cmd.exe"])
     @pytest.mark.parametrize("prefix_is_root", [False, True])
     @pytest.mark.parametrize("prefix_exists", [False, True])
-    @pytest.mark.parametrize("expanded_home", [False, True])
-    @pytest.mark.parametrize("prefix_type", ["prefix", "name"])
-    def test_activate(
-        self, shell_type, prefix_is_root, prefix_exists, prefix_type, expanded_home
-    ):
+    @pytest.mark.parametrize(
+        "prefix_type", ["shrinked_prefix", "expanded_prefix" "name"]
+    )
+    def test_activate(self, shell_type, prefix_is_root, prefix_exists, prefix_type):
         skip_if_shell_incompat(shell_type)
 
         if prefix_exists:
             # Create the environment for this test, so that it exists
             create("-n", TestShell.env_name, "-q", "--offline", no_dry_run=True)
         else:
-            shutil.rmtree(TestShell.root_prefix)
+            if prefix_is_root:
+                shutil.rmtree(TestShell.root_prefix)
 
         if prefix_is_root:
             p = TestShell.root_prefix
@@ -180,19 +180,13 @@ class TestShell:
             p = TestShell.prefix
             n = TestShell.env_name
 
-        if prefix_type == "prefix":
-            if expanded_home:
-                cmd = ("activate", "-s", shell_type, "-p", p)
-            else:
-                cmd = (
-                    "activate",
-                    "-s",
-                    shell_type,
-                    "-p",
-                    p.replace(os.path.expanduser("~"), "~"),
-                )
+        cmd = ["activate", "-s", shell_type, "-p"]
+        if prefix_type == "expanded_prefix":
+            cmd.append(p)
+        elif prefix_type == "shrinked_prefix":
+            cmd.append(p.replace(os.path.expanduser("~"), "~"))
         else:
-            cmd = ("activate", "-s", shell_type, "-p", n)
+            cmd.append(n)
 
         if prefix_exists:
             res = shell(*cmd)

--- a/test/micromamba/test_shell.py
+++ b/test/micromamba/test_shell.py
@@ -7,7 +7,15 @@ from pathlib import Path
 
 import pytest
 
-from .helpers import create, get_env, get_umamba, info, random_string, shell
+from .helpers import (
+    MAMBA_NO_PREFIX_CHECK,
+    create,
+    get_env,
+    get_umamba,
+    info,
+    random_string,
+    shell,
+)
 
 
 def skip_if_shell_incompat(shell_type):
@@ -43,12 +51,10 @@ class TestShell:
         os.makedirs(TestShell.root_prefix, exist_ok=False)
 
     @classmethod
-    def teardown_class(cls):
-        os.environ["MAMBA_ROOT_PREFIX"] = TestShell.current_root_prefix
-
-    @classmethod
     def teardown(cls):
         os.environ["MAMBA_ROOT_PREFIX"] = TestShell.root_prefix
+        os.environ["CONDA_PREFIX"] = TestShell.current_prefix
+
         if Path(TestShell.root_prefix).exists():
             shutil.rmtree(TestShell.root_prefix)
 
@@ -152,20 +158,22 @@ class TestShell:
             assert res["actions"]["print"][0] == ""
 
     @pytest.mark.parametrize("shell_type", ["bash", "posix", "powershell", "cmd.exe"])
-    @pytest.mark.parametrize("root", [False, True])
-    @pytest.mark.parametrize("env_exists", [False, True])
+    @pytest.mark.parametrize("prefix_is_root", [False, True])
+    @pytest.mark.parametrize("prefix_exists", [False, True])
     @pytest.mark.parametrize("expanded_home", [False, True])
     @pytest.mark.parametrize("prefix_type", ["prefix", "name"])
-    def test_activate(self, shell_type, root, env_exists, prefix_type, expanded_home):
+    def test_activate(
+        self, shell_type, prefix_is_root, prefix_exists, prefix_type, expanded_home
+    ):
         skip_if_shell_incompat(shell_type)
 
-        if env_exists:
+        if prefix_exists:
             # Create the environment for this test, so that it exists
             create("-n", TestShell.env_name, "-q", "--offline", no_dry_run=True)
         else:
             shutil.rmtree(TestShell.root_prefix)
 
-        if root:
+        if prefix_is_root:
             p = TestShell.root_prefix
             n = "base"
         else:
@@ -184,9 +192,9 @@ class TestShell:
                     p.replace(os.path.expanduser("~"), "~"),
                 )
         else:
-            cmd = ("activate", "-s", shell_type, "-p", p)
+            cmd = ("activate", "-s", shell_type, "-p", n)
 
-        if env_exists:
+        if prefix_exists:
             res = shell(*cmd)
         else:
             with pytest.raises(subprocess.CalledProcessError):
@@ -201,21 +209,31 @@ class TestShell:
             assert f"export CONDA_DEFAULT_ENV='{n}'" in res
             assert f"export CONDA_PROMPT_MODIFIER='({n}) '" in res
 
+    def test_activate_target_prefix_checks(self):
+        """Shell operations have their own 'shel_prefix' Configurable
+        and doesn't use 'target_prefix'."""
+
+        res = shell("activate", "-p", TestShell.root_prefix, "--print-config-only")
+        assert res["target_prefix_checks"] == MAMBA_NO_PREFIX_CHECK
+        assert not res["use_target_prefix_fallback"]
+
     @pytest.mark.parametrize("shell_type", ["bash", "powershell", "cmd.exe"])
     @pytest.mark.parametrize("prefix_selector", [None, "prefix"])
     def test_init(self, shell_type, prefix_selector):
         skip_if_shell_incompat(shell_type)
 
-        if prefix_selector:
-            shell("-y", "init", "-s", shell_type, "-p", TestShell.root_prefix)
-            assert (
-                Path(os.path.join(TestShell.root_prefix, "condabin")).is_dir()
-                or Path(
-                    os.path.join(TestShell.root_prefix, "etc", "profile.d")
-                ).is_dir()
-            )
-        else:
+        if prefix_selector is None:
             with pytest.raises(subprocess.CalledProcessError):
                 shell("-y", "init", "-s", shell_type)
+            return
+
+        shell("-y", "init", "-s", shell_type, "-p", TestShell.root_prefix)
+
+        if shell_type == "bash":
+            assert Path(
+                os.path.join(TestShell.root_prefix, "etc", "profile.d")
+            ).is_dir()
+        else:
+            assert Path(os.path.join(TestShell.root_prefix, "condabin")).is_dir()
 
         shell("init", "-y", "-s", shell_type, "-p", TestShell.current_root_prefix)


### PR DESCRIPTION
Description
---

Shell activate was using `target_prefix` checks even if it uses its own `shell_prefix` Configurable value.
Deactivate `target_prefix` checks for this operation to avoid wrong errors thrown.

improve and clean tests (cc @ashwinvis) 