### PR TITLE
cURL lazy init

### DIFF
--- a/include/mamba/core/context.hpp
+++ b/include/mamba/core/context.hpp
@@ -140,6 +140,7 @@ namespace mamba
 
         bool change_ps1 = true;
 
+        bool curl_initialized = false;
         int connect_timeout_secs = 10;
         // int read_timeout_secs = 60;
         int retry_timeout = 2;  // seconds

--- a/src/api/configuration.cpp
+++ b/src/api/configuration.cpp
@@ -46,42 +46,9 @@ namespace mamba
             {
                 if (value.empty() || (value == "true") || (value == "1") || (value == "<true>"))
                 {
-                    if (on_linux)
-                    {
-                        std::array<std::string, 6> cert_locations{
-                            "/etc/ssl/certs/ca-certificates.crt",  // Debian/Ubuntu/Gentoo etc.
-                            "/etc/pki/tls/certs/ca-bundle.crt",    // Fedora/RHEL 6
-                            "/etc/ssl/ca-bundle.pem",              // OpenSUSE
-                            "/etc/pki/tls/cacert.pem",             // OpenELEC
-                            "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem",  // CentOS/RHEL 7
-                            "/etc/ssl/cert.pem",                                  // Alpine Linux
-                        };
-                        bool found = false;
-
-                        for (const auto& loc : cert_locations)
-                        {
-                            if (fs::exists(loc))
-                            {
-                                value = loc;
-                                found = true;
-                            }
-                        }
-                        if (!found)
-                        {
-                            LOG_ERROR << "ssl_verify is enabled but no ca certificates found";
-                            throw std::runtime_error("No CA certificates found.");
-                        }
-                    }
-                    else
-                    {
-                        value = "<system>";
-                    }
+                    value = "<system>";
                 }
             }
-
-#ifdef UMAMBA_STATIC
-            init_curl_ssl();
-#endif
         };
 
         void always_softlink_hook(bool& value)

--- a/src/core/fetch.cpp
+++ b/src/core/fetch.cpp
@@ -201,24 +201,27 @@ namespace mamba
         }
 
         std::string& ssl_verify = Context::instance().ssl_verify;
-        if (ssl_verify == "<false>")
+        if (ssl_verify.size())
         {
-            curl_easy_setopt(m_handle, CURLOPT_SSL_VERIFYPEER, 0L);
-            curl_easy_setopt(m_handle, CURLOPT_SSL_VERIFYHOST, 0L);
-        }
-        else if (ssl_verify == "<system>")
-        {
-            curl_easy_setopt(m_handle, CURLOPT_CAINFO, nullptr);
-        }
-        else
-        {
-            if (!fs::exists(ssl_verify))
+            if (ssl_verify == "<false>")
             {
-                throw std::runtime_error("ssl_verify does not contain a valid file path.");
+                curl_easy_setopt(m_handle, CURLOPT_SSL_VERIFYPEER, 0L);
+                curl_easy_setopt(m_handle, CURLOPT_SSL_VERIFYHOST, 0L);
+            }
+            else if (ssl_verify == "<system>")
+            {
+                curl_easy_setopt(m_handle, CURLOPT_CAINFO, nullptr);
             }
             else
             {
-                curl_easy_setopt(m_handle, CURLOPT_CAINFO, ssl_verify.c_str());
+                if (!fs::exists(ssl_verify))
+                {
+                    throw std::runtime_error("ssl_verify does not contain a valid file path.");
+                }
+                else
+                {
+                    curl_easy_setopt(m_handle, CURLOPT_CAINFO, ssl_verify.c_str());
+                }
             }
         }
     }

--- a/test/test_configuration.cpp
+++ b/test/test_configuration.cpp
@@ -445,35 +445,25 @@ namespace mamba
             env::set("MAMBA_CHANNEL_ALIAS", "");
         }
 
-#define EXPECT_CA_EQUAL(CA)                                                                        \
-    if (on_linux)                                                                                  \
-    {                                                                                              \
-        EXPECT_TRUE(starts_with(CA, "/etc/"));                                                     \
-    }                                                                                              \
-    else                                                                                           \
-    {                                                                                              \
-        EXPECT_EQ(CA, "<system>");                                                                 \
-    }
-
         TEST_F(Configuration, ssl_verify)
         {
             // Default empty string value
             ctx.ssl_verify = "";
             std::string rc = "";
             load_test_config(rc);
-            EXPECT_CA_EQUAL(ctx.ssl_verify);
+            EXPECT_EQ(ctx.ssl_verify, "<system>");
 
             rc = "ssl_verify: true";
             load_test_config(rc);
-            EXPECT_CA_EQUAL(ctx.ssl_verify);
+            EXPECT_EQ(ctx.ssl_verify, "<system>");
 
             rc = "ssl_verify: <true>";
             load_test_config(rc);
-            EXPECT_CA_EQUAL(ctx.ssl_verify);
+            EXPECT_EQ(ctx.ssl_verify, "<system>");
 
             rc = "ssl_verify: 1";
             load_test_config(rc);
-            EXPECT_CA_EQUAL(ctx.ssl_verify);
+            EXPECT_EQ(ctx.ssl_verify, "<system>");
 
             rc = "ssl_verify: 10";
             load_test_config(rc);
@@ -498,8 +488,8 @@ namespace mamba
             std::string rc1 = "ssl_verify: true";
             std::string rc2 = "ssl_verify: false";
             load_test_config({ rc1, rc2 });
-            EXPECT_CA_EQUAL(config.at("ssl_verify").value<std::string>());
-            EXPECT_CA_EQUAL(ctx.ssl_verify);
+            EXPECT_EQ(config.at("ssl_verify").value<std::string>(), "<system>");
+            EXPECT_EQ(ctx.ssl_verify, "<system>");
 
             load_test_config({ rc2, rc1 });
             EXPECT_EQ(config.at("ssl_verify").value<std::string>(), "<false>");


### PR DESCRIPTION
Description
--

Lazy loading of cURL allow to search for system CA certificates on linux only at first download init.
It prevent from errors in offline mode but also in operation that don't require download.

Skip cURL SSL init when `ssl_verify` is set to false (`<false>`).