### PR TITLE
Allow ultra-dry runs on final build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -159,7 +159,7 @@ jobs:
           touch ~/.conda/environments.txt
           mkdir build
           cd build
-          cmake .. -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX -DENABLE_TESTS=OFF -DBUILD_EXE=ON -DENABLE_CONTEXT_DEBUG_PRINT=ON -DBUILD_BINDINGS=OFF
+          cmake .. -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX -DENABLE_TESTS=OFF -DBUILD_EXE=ON -DBUILD_BINDINGS=OFF
           make -j2
       - name: run new micromamba
         shell: bash -l {0}
@@ -329,7 +329,7 @@ jobs:
           call C:\Users\runneradmin\micromamba\condabin\micromamba.bat activate mamba-test
           mkdir build
           cd build
-          cmake .. -DCMAKE_INSTALL_PREFIX=%CONDA_PREFIX%\Library -DBUILD_EXE=ON -DENABLE_CONTEXT_DEBUG_PRINT=ON -G "Ninja"
+          cmake .. -DCMAKE_INSTALL_PREFIX=%CONDA_PREFIX%\Library -DBUILD_EXE=ON -G "Ninja"
           ninja
           .\micromamba.exe --help
       - name: Install "wheel" in micromamba default env

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,14 +58,9 @@ option(BUILD_BINDINGS "" ON)
 option(STATIC_DEPENDENCIES "" OFF)
 option(USE_VENDORED_CLI11 "" OFF)
 option(ENABLE_TESTS "Enable C++ tests for mamba" OFF)
-option(ENABLE_CONTEXT_DEBUG_PRINT "Enable printing the context for debug purposes" OFF)
 
 if (USE_VENDORED_CLI11)
     add_definitions(-DVENDORED_CLI11=1)
-endif()
-
-if (ENABLE_CONTEXT_DEBUG_PRINT)
-    add_definitions(-DENABLE_CONTEXT_DEBUG_PRINT)
 endif()
 
 if (STATIC_DEPENDENCIES)

--- a/include/mamba/api/configuration.hpp
+++ b/include/mamba/api/configuration.hpp
@@ -18,7 +18,6 @@
 #include <functional>
 
 
-#ifdef ENABLE_CONTEXT_DEBUG_PRINT
 #define CONTEXT_DEBUGGING                                                                          \
     if (Configuration::instance().at("print_context_only").value<bool>())                          \
     {                                                                                              \
@@ -34,18 +33,6 @@
         std::cout << Configuration::instance().dump(dump_opts) << std::endl;                       \
         exit(0);                                                                                   \
     }
-#define DEBUG_QUIET                                                                                \
-    if (Configuration::instance().at("print_context_only").compute().value<bool>()                 \
-        || Configuration::instance().at("print_config_only").compute().value<bool>())              \
-    {                                                                                              \
-        Configuration::instance().at("quiet").set_value(true);                                     \
-    }
-#else
-#define CONTEXT_DEBUGGING
-#define CONFIG_DEBUGGING
-#define DEBUG_QUIET
-#endif
-
 
 namespace YAML
 {

--- a/include/mamba/core/context.hpp
+++ b/include/mamba/core/context.hpp
@@ -99,6 +99,7 @@ namespace mamba
         std::string custom_banner = "";
         bool is_micromamba = false;
         bool experimental = false;
+        bool debug = false;
 
         fs::path target_prefix = "";
         // Need to prevent circular imports here (otherwise using env::get())
@@ -194,9 +195,7 @@ namespace mamba
         Context(Context&&) = delete;
         Context& operator=(Context&&) = delete;
 
-#ifdef ENABLE_CONTEXT_DEBUG_PRINT
         const void debug_print();
-#endif
 
     private:
         Context();

--- a/src/core/context.cpp
+++ b/src/core/context.cpp
@@ -99,7 +99,6 @@ namespace mamba
         throw std::runtime_error("Environment name not found " + name);
     }
 
-#ifdef ENABLE_CONTEXT_DEBUG_PRINT
     const void Context::debug_print()
     {
 #define PRINT_CTX(xname) << #xname ": " << xname << "\n"
@@ -144,5 +143,4 @@ namespace mamba
         // clang-format on
 #undef PRINT_CTX
     }
-#endif
 }  // namespace mamba

--- a/src/micromamba/common_options.cpp
+++ b/src/micromamba/common_options.cpp
@@ -66,17 +66,18 @@ init_general_options(CLI::App* subcom)
     subcom->add_flag("--experimental", experimental.set_cli_config(0), experimental.description())
         ->group(cli_group);
 
-#ifdef ENABLE_CONTEXT_DEBUG_PRINT
+    auto& debug = config.at("debug").get_wrapped<bool>();
+    subcom->add_flag("--debug", debug.set_cli_config(false), "Debug mode")->group("");
+
     auto& print_context_only = config.at("print_context_only").get_wrapped<bool>();
     subcom
         ->add_flag(
             "--print-context-only", print_context_only.set_cli_config(false), "Debug context")
-        ->group(cli_group);
+        ->group("");
 
     auto& print_config_only = config.at("print_config_only").get_wrapped<bool>();
     subcom->add_flag("--print-config-only", print_config_only.set_cli_config(false), "Debug config")
-        ->group(cli_group);
-#endif
+        ->group("");
 }
 
 void

--- a/test/micromamba/helpers.py
+++ b/test/micromamba/helpers.py
@@ -64,6 +64,10 @@ def random_string(N=10):
 def shell(*args, cwd=os.getcwd()):
     umamba = get_umamba(cwd=cwd)
     cmd = [umamba, "shell"] + [arg for arg in args if arg]
+
+    if "--print-config-only" in args:
+        cmd += ["--debug"]
+
     res = subprocess.check_output(cmd)
     if "--json" in args:
         try:
@@ -94,6 +98,9 @@ def info(*args):
 def install(*args, default_channel=True, no_rc=True, no_dry_run=False):
     umamba = get_umamba()
     cmd = [umamba, "install", "-y"] + [arg for arg in args if arg]
+
+    if "--print-config-only" in args:
+        cmd += ["--debug"]
     if default_channel:
         cmd += channel
     if no_rc:
@@ -119,6 +126,9 @@ def install(*args, default_channel=True, no_rc=True, no_dry_run=False):
 def create(*args, default_channel=True, no_rc=True, no_dry_run=False, always_yes=True):
     umamba = get_umamba()
     cmd = [umamba, "create"] + [arg for arg in args if arg]
+
+    if "--print-config-only" in args:
+        cmd += ["--debug"]
     if always_yes:
         cmd += ["-y"]
     if default_channel:
@@ -146,6 +156,9 @@ def create(*args, default_channel=True, no_rc=True, no_dry_run=False, always_yes
 def remove(*args, no_dry_run=False):
     umamba = get_umamba()
     cmd = [umamba, "remove", "-y"] + [arg for arg in args if arg]
+
+    if "--print-config-only" in args:
+        cmd += ["--debug"]
     if (dry_run_tests == DryRun.DRY) and "--dry-run" not in args and not no_dry_run:
         cmd += ["--dry-run"]
 


### PR DESCRIPTION
Description
--

Allow ultra-dry runs on final build/executable, removing the necessary CMake `ENABLE_CONTEXT_DEBUG_PRINT` option
Add an extra `debug` Configurable and associated `--debug` CLI flag, required for config and context debug prints
Update CMakeLists, CI scripts and tests