### PR TITLE
Fix multiple init on cmd.exe

### DIFF
--- a/src/core/shell_init.cpp
+++ b/src/core/shell_init.cpp
@@ -213,13 +213,12 @@ namespace mamba
             std::wstring replace_str(L"__CONDA_REPLACE_ME_123__");
             std::wregex hook_regex(L"(\"[^\"]*?mamba[-_]hook\\.bat\")",
                                    std::regex_constants::icase);
-            prev_value = std::regex_replace(
+            std::wstring replaced_value = std::regex_replace(
                 prev_value, hook_regex, replace_str, std::regex_constants::format_first_only);
 
-            replace_all(prev_value, replace_str, hook_string);
-            std::wstring new_value = prev_value;
+            std::wstring new_value = replaced_value;
 
-            if (new_value.find(hook_string) == new_value.npos)
+            if (replaced_value.find(replace_str) == new_value.npos)
             {
                 if (!new_value.empty())
                 {
@@ -230,6 +229,11 @@ namespace mamba
                     new_value = hook_string;
                 }
             }
+            else
+            {
+                replace_all(new_value, replace_str, hook_string);
+            }
+
             if (new_value != prev_value)
             {
                 std::cout << "Adding to cmd.exe AUTORUN: " << termcolor::green;

--- a/test/micromamba/test_shell.py
+++ b/test/micromamba/test_shell.py
@@ -213,7 +213,10 @@ class TestShell:
 
     @pytest.mark.parametrize("shell_type", ["bash", "powershell", "cmd.exe"])
     @pytest.mark.parametrize("prefix_selector", [None, "prefix"])
-    def test_init(self, shell_type, prefix_selector):
+    @pytest.mark.parametrize(
+        "multiple_time,same_prefix", ((False, None), (True, False), (True, True))
+    )
+    def test_init(self, shell_type, prefix_selector, multiple_time, same_prefix):
         skip_if_shell_incompat(shell_type)
 
         if prefix_selector is None:
@@ -221,7 +224,24 @@ class TestShell:
                 shell("-y", "init", "-s", shell_type)
             return
 
-        shell("-y", "init", "-s", shell_type, "-p", TestShell.root_prefix)
+        res = shell("-y", "init", "-s", shell_type, "-p", TestShell.root_prefix)
+        assert res
+
+        if multiple_time:
+            if same_prefix and shell_type == "cmd.exe":
+                assert (
+                    shell("-y", "init", "-s", shell_type, "-p", TestShell.root_prefix)
+                    == ""
+                )
+            else:
+                assert shell(
+                    "-y",
+                    "init",
+                    "-s",
+                    shell_type,
+                    "-p",
+                    os.path.join(TestShell.root_prefix, random_string()),
+                )
 
         if shell_type == "bash":
             assert Path(


### PR DESCRIPTION
Description
--

Fix multiple shell init on cmd.exe, currently broken:
- root prefix is created
- shell scripts are written
- Windows registry is not updated as expected

Add tests