### PR TITLE
Conda root prefix

### DIFF
--- a/include/mamba/api/c_api.h
+++ b/include/mamba/api/c_api.h
@@ -32,6 +32,8 @@ extern "C"
 
     int mamba_clear_config(const char* name);
 
+    int mamba_use_conda_root_prefix(int force = 0);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/mamba/api/configuration.hpp
+++ b/include/mamba/api/configuration.hpp
@@ -1747,6 +1747,8 @@ namespace mamba
         auto& config = at(name).get_wrapped<T>();
         return config.set_cli_config(init);
     }
+
+    void use_conda_root_prefix(bool force = false);
 }
 
 #endif  // MAMBA_CONFIG_HPP

--- a/src/api/c_api.cpp
+++ b/src/api/c_api.cpp
@@ -169,3 +169,18 @@ mamba_clear_config(const char* name)
         return 1;
     }
 }
+
+int
+mamba_use_conda_root_prefix(int force)
+{
+    try
+    {
+        use_conda_root_prefix(force);
+        return 0;
+    }
+    catch (...)
+    {
+        Configuration::instance().operation_teardown();
+        return 1;
+    }
+}


### PR DESCRIPTION
Description
---

Improve interoperability with `conda` by adding a free-function to set `MAMBA_ROOT_PREFIX` using `conda config --show root_prefix --json` output.
Expose it through the C-API.