### PR TITLE
Updates to support arbitrary channel platforms.

### DIFF
--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -20,3 +20,16 @@ dependencies:
   - pyyaml
   - cli11
   - pytest
+    #  - krb5-static
+    #  - libcurl-static 7.76.1 *_0
+    #  - libnghttp2-static
+    #  - libopenssl-static
+    #  - libxml2
+    #  - libsolv-static >=0.7.18
+    #  - libssh2-static
+    #  - lz4-c-static
+    #  - reproc-cpp-static
+    #  - reproc-static
+    #  - yaml-cpp-static
+    #  - xz-static
+    #  - zstd-static

--- a/include/mamba/core/channel.hpp
+++ b/include/mamba/core/channel.hpp
@@ -7,6 +7,7 @@
 #ifndef MAMBA_CORE_CHANNEL_HPP
 #define MAMBA_CORE_CHANNEL_HPP
 
+#include <functional>
 #include <map>
 #include <string>
 #include <vector>
@@ -89,7 +90,7 @@ namespace mamba
     {
     public:
         using channel_list = std::vector<std::string>;
-        using channel_map = std::map<std::string, Channel>;
+        using channel_map = std::map<std::string, Channel, std::less<>>;
         using multichannel_map = std::map<std::string, std::vector<std::string>>;
 
         static ChannelContext& instance();

--- a/include/mamba/core/context.hpp
+++ b/include/mamba/core/context.hpp
@@ -7,6 +7,7 @@
 #ifndef MAMBA_CORE_CONTEXT_HPP
 #define MAMBA_CORE_CONTEXT_HPP
 
+#include <optional>
 #include <map>
 #include <string>
 #include <vector>
@@ -188,6 +189,20 @@ namespace mamba
 
         bool use_only_tar_bz2 = false;
 
+        void set_channel_root_cache(const fs::path& p);
+
+        /**
+         * Resolve a url to the channel base url and the platform.
+         *
+         * Assumes `url` has been sanitized (and does not contain a trailing `/`).
+         *
+         * @param url the url to resolve; it will be overwritten with the base url if it contains a
+         * platform
+         *
+         * @return The platform, if any.
+         */
+        std::optional<std::string> resolve_channel_platform(std::string& url);
+
         static Context& instance();
 
         Context(const Context&) = delete;
@@ -201,6 +216,11 @@ namespace mamba
     private:
         Context();
         ~Context() = default;
+
+        void load_channel_root_cache();
+
+        fs::path channel_root_cache_path = root_prefix / "channels.txt";
+        std::vector<std::string> channel_root_cache;
     };
 }  // namespace mamba
 

--- a/include/mamba/core/fetch.hpp
+++ b/include/mamba/core/fetch.hpp
@@ -33,6 +33,8 @@ namespace mamba
                        const std::string& filename);
         ~DownloadTarget();
 
+        static CURLcode head_request(const std::string& url);
+
         static size_t write_callback(char* ptr, size_t size, size_t nmemb, void* self);
         static size_t header_callback(char* buffer, size_t size, size_t nitems, void* self);
 

--- a/include/mamba/core/fetch.hpp
+++ b/include/mamba/core/fetch.hpp
@@ -33,7 +33,7 @@ namespace mamba
                        const std::string& filename);
         ~DownloadTarget();
 
-        static CURLcode head_request(const std::string& url);
+        static bool resource_exists(const std::string& url);
 
         static size_t write_callback(char* ptr, size_t size, size_t nmemb, void* self);
         static size_t header_callback(char* buffer, size_t size, size_t nitems, void* self);

--- a/include/mamba/core/url.hpp
+++ b/include/mamba/core/url.hpp
@@ -52,11 +52,6 @@ namespace mamba
 
     bool compare_cleaned_url(const std::string& url1, const std::string& url2);
 
-    void split_platform(const std::vector<std::string>& known_platforms,
-                        const std::string& url,
-                        std::string& cleaned_url,
-                        std::string& platform);
-
     bool is_path(const std::string& input);
     std::string path_to_url(const std::string& path);
 

--- a/src/api/configuration.cpp
+++ b/src/api/configuration.cpp
@@ -220,6 +220,7 @@ namespace mamba
             auto& ctx = Context::instance();
             ctx.envs_dirs = { prefix / "envs" };
             ctx.pkgs_dirs = { prefix / "pkgs" };
+            ctx.set_channel_root_cache(prefix / "channels.txt");
         }
         /*
                 void log_level_hook(LogLevel& lvl)

--- a/src/core/context.cpp
+++ b/src/core/context.cpp
@@ -105,6 +105,7 @@ namespace mamba
 
     void Context::load_channel_root_cache()
     {
+        channel_root_cache.clear();
         if (fs::is_regular_file(channel_root_cache_path))
         {
             std::ifstream file(channel_root_cache_path);

--- a/src/core/context.cpp
+++ b/src/core/context.cpp
@@ -158,8 +158,8 @@ namespace mamba
         // the repodata.json content is invalid json!
         while (true)
         {
-            auto result = DownloadTarget::head_request(std::string(view) + "/channeldata.json");
-            if (result != CURLE_OK)
+            auto exists = DownloadTarget::resource_exists(std::string(view) + "/channeldata.json");
+            if (!exists)
             {
                 auto pos = view.find_last_of('/');
                 if (pos == std::string_view::npos)

--- a/src/core/fetch.cpp
+++ b/src/core/fetch.cpp
@@ -190,6 +190,11 @@ namespace mamba
         }
     }
 
+    static size_t discard(char* ptr, size_t size, size_t nmemb, void*)
+    {
+        return size * nmemb;
+    }
+
     bool DownloadTarget::resource_exists(const std::string& url)
     {
         init_curl_ssl();
@@ -205,6 +210,8 @@ namespace mamba
         // Unfortunately, some servers don't support HEAD, so we will try a GET if the HEAD fails
         // (since HEAD should be pretty quick, and a failing GET should be just as fast).
         curl_easy_setopt(handle, CURLOPT_NOBODY, 0L);
+        // Prevent output of data
+        curl_easy_setopt(handle, CURLOPT_WRITEFUNCTION, &discard);
 
         return curl_easy_perform(handle) == CURLE_OK;
     }

--- a/src/core/match_spec.cpp
+++ b/src/core/match_spec.cpp
@@ -4,6 +4,8 @@
 //
 // The full license is in the file LICENSE, distributed with this software.
 
+#include <cassert>
+
 #include "mamba/core/match_spec.hpp"
 #include "mamba/core/output.hpp"
 #include "mamba/core/url.hpp"
@@ -86,9 +88,10 @@ namespace mamba
             }
             auto parsed_channel = make_channel(spec_str);
 
-            if (!parsed_channel.platform().empty())
+            if (!parsed_channel.package_filename().empty())
             {
                 auto dist = parse_legacy_dist(parsed_channel.package_filename());
+                assert(dist.size() >= 3);
 
                 name = dist[0];
                 version = dist[1];

--- a/src/core/package_handling.cpp
+++ b/src/core/package_handling.cpp
@@ -18,6 +18,8 @@
 #include "mamba/core/util.hpp"
 #include "mamba/core/validate.hpp"
 
+int archive_write_set_format_xar(struct archive*) { return ARCHIVE_FATAL; }
+
 namespace mamba
 {
     class extraction_guard

--- a/src/core/package_handling.cpp
+++ b/src/core/package_handling.cpp
@@ -18,8 +18,6 @@
 #include "mamba/core/util.hpp"
 #include "mamba/core/validate.hpp"
 
-int archive_write_set_format_xar(struct archive*) { return ARCHIVE_FATAL; }
-
 namespace mamba
 {
     class extraction_guard

--- a/src/core/url.cpp
+++ b/src/core/url.cpp
@@ -63,31 +63,6 @@ namespace mamba
         return u1_remaining == u2_remaining;
     }
 
-    void split_platform(const std::vector<std::string>& known_platforms,
-                        const std::string& url,
-                        std::string& cleaned_url,
-                        std::string& platform)
-    {
-        platform = "";
-        size_t pos = std::string::npos;
-        for (auto it = known_platforms.begin(); it != known_platforms.end(); ++it)
-        {
-            pos = url.find(*it);
-            if (pos != std::string::npos)
-            {
-                platform = *it;
-                break;
-            }
-        }
-
-        cleaned_url = url;
-        if (pos != std::string::npos)
-        {
-            cleaned_url.replace(pos - 1, platform.size() + 1, "");
-        }
-        cleaned_url = rstrip(cleaned_url, "/");
-    }
-
     bool is_path(const std::string& input)
     {
         static const std::regex re(R"(\./|\.\.|~|/|[a-zA-Z]:[/\\]|\\\\|//)");

--- a/test/channel_a/channeldata.json
+++ b/test/channel_a/channeldata.json
@@ -1,0 +1,9 @@
+{
+  "channeldata_version": 1,
+  "packages": {},
+  "subdirs": [
+    "noarch",
+    "linux-64",
+    "win-64"
+  ]
+}

--- a/test/channel_b/channeldata.json
+++ b/test/channel_b/channeldata.json
@@ -1,0 +1,9 @@
+{
+  "channeldata_version": 1,
+  "packages": {},
+  "subdirs": [
+    "noarch",
+    "linux-64",
+    "win-64"
+  ]
+}

--- a/test/test_channel.cpp
+++ b/test/test_channel.cpp
@@ -2,6 +2,7 @@
 
 #include "mamba/core/context.hpp"
 #include "mamba/core/channel.hpp"
+#include "mamba/core/context.hpp"
 #include "mamba/core/mamba_fs.hpp"
 #include "mamba/core/url.hpp"
 #include "mamba/core/util.hpp"
@@ -101,25 +102,6 @@ namespace mamba
 #endif
         EXPECT_EQ(c4.name(), "channel_b");
         EXPECT_EQ(c4.platform(), "");
-
-        std::string value5 = "/home/mamba/test/channel_b/" + platform;
-        Channel& c5 = make_channel(value5);
-        EXPECT_EQ(c5.scheme(), "file");
-#ifdef _WIN32
-        EXPECT_EQ(c5.location(), driveletter + ":/home/mamba/test");
-#else
-        EXPECT_EQ(c5.location(), "/home/mamba/test");
-#endif
-        EXPECT_EQ(c5.name(), "channel_b");
-        EXPECT_EQ(c5.platform(), platform);
-
-        std::string value6a = "http://localhost:8000/conda-forge/noarch";
-        Channel& c6a = make_channel(value6a);
-        EXPECT_EQ(c6a.url(false), value6a);
-
-        std::string value6b = "http://localhost:8000/conda_mirror/conda-forge/noarch";
-        Channel& c6b = make_channel(value6b);
-        EXPECT_EQ(c6b.url(false), value6b);
     }
 
     TEST(Channel, urls)
@@ -206,5 +188,23 @@ namespace mamba
         // EXPECT_EQ(chan.url(true),
         // "https://conda.anaconda.org/t/my-12345-token/conda-forge/noarch");
         // EXPECT_EQ(chan.url(false), "https://conda.anaconda.org/conda-forge/noarch");
+    }
+    TEST(Context, resolve_channel_platform)
+    {
+        const std::string expected_channel = "https://conda.anaconda.org/conda-forge";
+        std::string channel = expected_channel + "/linux-64";
+        {
+            auto platform = Context::instance().resolve_channel_platform(channel);
+            EXPECT_EQ(channel, expected_channel);
+            ASSERT_TRUE((bool) platform);
+            EXPECT_EQ(*platform, "linux-64");
+        }
+
+        channel = expected_channel;
+        {
+            auto platform = Context::instance().resolve_channel_platform(channel);
+            EXPECT_EQ(channel, expected_channel);
+            EXPECT_FALSE((bool) platform);
+        }
     }
 }  // namespace mamba

--- a/test/test_url.cpp
+++ b/test/test_url.cpp
@@ -218,27 +218,6 @@ namespace mamba
 #endif
     }
 
-    TEST(url, split_platform)
-    {
-        std::string input = "https://1.2.3.4/t/tk-123/linux-64/path";
-        std::vector<std::string> known_platforms
-            = { "noarch", "linux-32", "linux-64", "linux-aarch64" };
-        std::string cleaned_url, platform;
-        split_platform(known_platforms, input, cleaned_url, platform);
-        EXPECT_EQ(cleaned_url, "https://1.2.3.4/t/tk-123/path");
-        EXPECT_EQ(platform, "linux-64");
-
-        input = "https://1.2.3.4/t/tk-123/linux-ppc64le/path";
-        split_platform(KNOWN_PLATFORMS, input, cleaned_url, platform);
-        EXPECT_EQ(cleaned_url, "https://1.2.3.4/t/tk-123/path");
-        EXPECT_EQ(platform, "linux-ppc64le");
-
-        input = "https://1.2.3.4/t/tk-123/linux-ppc64/path";
-        split_platform(KNOWN_PLATFORMS, input, cleaned_url, platform);
-        EXPECT_EQ(cleaned_url, "https://1.2.3.4/t/tk-123/path");
-        EXPECT_EQ(platform, "linux-ppc64");
-    }
-
     TEST(path, is_path)
     {
         EXPECT_TRUE(is_path("./"));


### PR DESCRIPTION
This closes #794. It removes the list of special/supported platforms, and instead queries the repository with HEAD requests to find the channel root url to determine if a platform is present in the channel url or not. This is cached so it only occurs once per channel root url, assuming that urls won't change from being a channel root to being a platform-specific directory (incredibly unlikely).