### PR TITLE
PGP signature verification

### DIFF
--- a/include/mamba/core/util.hpp
+++ b/include/mamba/core/util.hpp
@@ -298,13 +298,14 @@ namespace mamba
     }
 
     template <size_t S, class B>
-    std::array<unsigned char, S> hex_to_bytes(const B& buffer) noexcept
+    std::array<unsigned char, S> hex_to_bytes(const B& buffer, int& error_code) noexcept
     {
         std::array<unsigned char, S> res{};
         if (buffer.size() != (S * 2))
         {
             LOG_DEBUG << "Wrong size for hexadecimal buffer, expected " << S * 2 << " but is "
                       << buffer.size();
+            error_code = 1;
             return res;
         }
 
@@ -317,6 +318,13 @@ namespace mamba
             ++i;
         }
         return res;
+    }
+
+    template <size_t S, class B>
+    std::array<unsigned char, S> hex_to_bytes(const B& buffer) noexcept
+    {
+        int ec;
+        return hex_to_bytes<S>(buffer, ec);
     }
 
     // get the value corresponding to a key in a JSON object and assign it to target

--- a/include/mamba/core/util.hpp
+++ b/include/mamba/core/util.hpp
@@ -20,6 +20,8 @@
 #include "nlohmann/json.hpp"
 
 #include "mamba_fs.hpp"
+#include "output.hpp"
+
 
 namespace mamba
 {
@@ -256,15 +258,65 @@ namespace mamba
     }
 
     template <class B>
-    inline std::string hex_string(const B& buffer)
+    inline std::string hex_string(const B& buffer, std::size_t size)
     {
         std::ostringstream oss;
         oss << std::hex;
-        for (std::size_t i = 0; i < buffer.size(); ++i)
+        for (std::size_t i = 0; i < size; ++i)
         {
             oss << std::setw(2) << std::setfill('0') << static_cast<int>(buffer[i]);
         }
         return oss.str();
+    }
+
+    template <class B>
+    inline std::string hex_string(const B& buffer)
+    {
+        return hex_string(buffer, buffer.size());
+    }
+
+    template <class B>
+    std::vector<unsigned char> hex_to_bytes(const B& buffer, std::size_t size) noexcept
+    {
+        std::vector<unsigned char> res;
+        if (size % 2 != 0)
+            return res;
+
+        std::string extract;
+        for (auto pos = buffer.cbegin(); pos < buffer.cend(); pos += 2)
+        {
+            extract.assign(pos, pos + 2);
+            res.push_back(std::stoi(extract, nullptr, 16));
+        }
+        return res;
+    }
+
+    template <class B>
+    std::vector<unsigned char> hex_to_bytes(const B& buffer) noexcept
+    {
+        return hex_to_bytes(buffer, buffer.size());
+    }
+
+    template <size_t S, class B>
+    std::array<unsigned char, S> hex_to_bytes(const B& buffer) noexcept
+    {
+        std::array<unsigned char, S> res{};
+        if (buffer.size() != (S * 2))
+        {
+            LOG_DEBUG << "Wrong size for hexadecimal buffer, expected " << S * 2 << " but is "
+                      << buffer.size();
+            return res;
+        }
+
+        std::string extract;
+        std::size_t i = 0;
+        for (auto pos = buffer.cbegin(); pos < buffer.cend(); pos += 2)
+        {
+            extract.assign(pos, pos + 2);
+            res[i] = std::stoi(extract, nullptr, 16);
+            ++i;
+        }
+        return res;
     }
 
     // get the value corresponding to a key in a JSON object and assign it to target

--- a/include/mamba/core/validate.hpp
+++ b/include/mamba/core/validate.hpp
@@ -39,21 +39,17 @@ namespace validate
 
     int sign(const std::string& data, const unsigned char* sk, unsigned char* signature);
 
-    template <class B>
     std::array<unsigned char, MAMBA_ED25519_SIGSIZE_BYTES> ed25519_sig_hex_to_bytes(
-        const B& sig_hex) noexcept
+        const std::string& sig_hex) noexcept;
 
-    {
-        return ::mamba::hex_to_bytes<MAMBA_ED25519_SIGSIZE_BYTES>(sig_hex);
-    }
+    std::array<unsigned char, MAMBA_ED25519_SIGSIZE_BYTES> ed25519_sig_hex_to_bytes(
+        const std::string& sig_hex, int& error_code) noexcept;
 
-    template <class B>
     std::array<unsigned char, MAMBA_ED25519_KEYSIZE_BYTES> ed25519_key_hex_to_bytes(
-        const B& key_hex) noexcept
+        const std::string& key_hex) noexcept;
 
-    {
-        return ::mamba::hex_to_bytes<MAMBA_ED25519_KEYSIZE_BYTES>(key_hex);
-    }
+    std::array<unsigned char, MAMBA_ED25519_KEYSIZE_BYTES> ed25519_key_hex_to_bytes(
+        const std::string& key_hex, int& error_code) noexcept;
 
     int verify(const unsigned char* data,
                std::size_t data_len,

--- a/include/mamba/core/validate.hpp
+++ b/include/mamba/core/validate.hpp
@@ -7,7 +7,8 @@
 #ifndef MAMBA_CORE_VALIDATE_HPP
 #define MAMBA_CORE_VALIDATE_HPP
 
-#include "mamba_fs.hpp"
+#include "mamba/core/mamba_fs.hpp"
+#include "mamba/core/util.hpp"
 
 #include <nlohmann/json.hpp>
 
@@ -27,18 +28,6 @@ namespace validate
     bool md5(const std::string& path, const std::string& validation);
     bool file_size(const fs::path& path, std::uintmax_t validation);
 
-    int hex2bin(unsigned char* const bin,
-                const size_t bin_maxlen,
-                const char* const hex,
-                const size_t hex_len,
-                const char* const ignore,
-                size_t* const bin_len,
-                const char** const hex_end);
-    char* bin2hex(char* const hex,
-                  const size_t hex_maxlen,
-                  const unsigned char* const bin,
-                  const size_t bin_len);
-
     const std::size_t MAMBA_SHA256_SIZE_HEX = 64;
     const std::size_t MAMBA_SHA256_SIZE_BYTES = 32;
     const std::size_t MAMBA_ED25519_KEYSIZE_HEX = 64;
@@ -50,17 +39,57 @@ namespace validate
 
     int sign(const std::string& data, const unsigned char* sk, unsigned char* signature);
 
+    template <class B>
+    std::array<unsigned char, MAMBA_ED25519_SIGSIZE_BYTES> ed25519_sig_hex_to_bytes(
+        const B& sig_hex) noexcept
+
+    {
+        return ::mamba::hex_to_bytes<MAMBA_ED25519_SIGSIZE_BYTES>(sig_hex);
+    }
+
+    template <class B>
+    std::array<unsigned char, MAMBA_ED25519_KEYSIZE_BYTES> ed25519_key_hex_to_bytes(
+        const B& key_hex) noexcept
+
+    {
+        return ::mamba::hex_to_bytes<MAMBA_ED25519_KEYSIZE_BYTES>(key_hex);
+    }
+
     int verify(const unsigned char* data,
                std::size_t data_len,
-               unsigned char* pk,
-               unsigned char* signature);
-    int verify(const std::string& data, unsigned char* pk, unsigned char* signature);
-    int verify(const std::string& data, const std::string& pk, const std::string& signature);
+               const unsigned char* pk,
+               const unsigned char* signature);
+    int verify(const std::string& data, const unsigned char* pk, const unsigned char* signature);
+    int verify(const std::string& data,
+               const std::string& pk_hex,
+               const std::string& signature_hex);
 
-    int verify_gpg_hashed_msg(const std::string& data, unsigned char* pk, unsigned char* signature);
+    /**
+     * Verify a GPG/PGP signature against the hash of the binary data and
+     * the additional trailer added in V4 signature.
+     * See RFC4880, section 5.2.4 https://datatracker.ietf.org/doc/html/rfc4880#section-5.2.4
+     * This method assumes hash function to be SHA-256
+     */
+    int verify_gpg_hashed_msg(const unsigned char* data,
+                              const unsigned char* pk,
+                              const unsigned char* signature);
+    int verify_gpg_hashed_msg(const std::string& data,
+                              const unsigned char* pk,
+                              const unsigned char* signature);
     int verify_gpg_hashed_msg(const std::string& data,
                               const std::string& pk,
                               const std::string& signature);
+
+    /**
+     * Verify a GPG/PGP signature against the binary data and
+     * the additional trailer added in V4 signature.
+     * See RFC4880, section 5.2.4 https://datatracker.ietf.org/doc/html/rfc4880#section-5.2.4
+     * This method assumes hash function to be SHA-256
+     */
+    int verify_gpg(const std::string& data,
+                   const std::string& gpg_v4_trailer,
+                   const std::string& pk,
+                   const std::string& signature);
 
     class trust_error : public std::exception
     {

--- a/test/test_validate.cpp
+++ b/test/test_validate.cpp
@@ -99,6 +99,24 @@ namespace validate
             EXPECT_EQ(verify("Some text.", pk_hex, signature_hex), 1);
         }
 
+        TEST_F(VerifyMsg, wrong_signature)
+        {
+            mamba::MessageLogger::global_log_severity() = mamba::LogSeverity::kDebug;
+            auto pk_hex = ::mamba::hex_string(pk, MAMBA_ED25519_KEYSIZE_BYTES);
+
+            EXPECT_EQ(verify("Some text.", pk_hex, "signature_hex"), 0);
+            mamba::MessageLogger::global_log_severity() = mamba::LogSeverity::kInfo;
+        }
+
+        TEST_F(VerifyMsg, wrong_public_key)
+        {
+            mamba::MessageLogger::global_log_severity() = mamba::LogSeverity::kDebug;
+            auto signature_hex = ::mamba::hex_string(signature, MAMBA_ED25519_SIGSIZE_BYTES);
+
+            EXPECT_EQ(verify("Some text.", "pk_hex", signature_hex), 0);
+            mamba::MessageLogger::global_log_severity() = mamba::LogSeverity::kInfo;
+        }
+
         class VerifyGPGMsg : public ::testing::Test
         {  // Using test/data/2.root.json from conda-content-trust
         protected:


### PR DESCRIPTION
Description
---

use a C++ style for nicer converters `hex2bin` and `bin2hex`
provide both `std::array` and `std::vector` storage for compile time known sizes (ED25519 keys and signature sizes, SHA256 size)
implement PGP verification using trailer as described in [RFC4880](https://datatracker.ietf.org/doc/html/rfc4880#section-5.2.4), stored as `other_headers` in v0.6 spec version of content trust.
add and refactor tests