### PR TITLE
Enable PGP signatures

### DIFF
--- a/include/mamba/core/validate.hpp
+++ b/include/mamba/core/validate.hpp
@@ -145,15 +145,11 @@ namespace validate
         }
     };
 
-    struct GPGKey : public Key
-    {
-        std::string other_headers = "";
-    };
-
     struct RoleSignature
     {
         std::string keyid = "";
         std::string sig = "";
+        std::string pgp_trailer = "";
     };
 
     bool operator<(const RoleSignature& rs1, const RoleSignature& rs2);
@@ -236,6 +232,7 @@ namespace validate
         SpecVersion major_spec_version() const;
 
         json read_file(const fs::path& p, bool update = false) const;
+        virtual std::string canonicalize(const json& j) const;
 
     private:
         std::string m_internal_type;
@@ -349,6 +346,8 @@ namespace validate
 
             std::unique_ptr<RootRoleBase> create_update(const json& j) override;
             std::set<RoleSignature> signatures(const json& j) const;
+
+            std::string canonicalize(const json& j) const override;
 
             std::map<std::string, RolePubKeys> m_delegations;
         };

--- a/test/validation_data/1.sv0.6.root.json
+++ b/test/validation_data/1.sv0.6.root.json
@@ -1,0 +1,29 @@
+{
+  "signatures": {
+    "2b920f88531576643ada0a632915d1dcdd377557647093f29cbe251ba8c33724": {
+      "other_headers": "04001608001d1621040673d781a8b80bcb7b002040ac7bc8bcf821360d050260a52453",
+      "signature": "d891de3fc102a2ff7b96559ff2f4d81a8e25b5d51a44e10a9fbc5bdc3febf22120582f30e26f6dfe9450ca8100566af7cbc286bf7f52c700d074acd3d4a01603"
+    }
+  },
+  "signed": {
+    "delegations": {
+      "key_mgr": {
+        "pubkeys": [
+          "013ddd714962866d12ba5bae273f14d48c89cf0773dee2dbf6d4561e521c83f7"
+        ],
+        "threshold": 1
+      },
+      "root": {
+        "pubkeys": [
+          "2b920f88531576643ada0a632915d1dcdd377557647093f29cbe251ba8c33724"
+        ],
+        "threshold": 1
+      }
+    },
+    "expiration": "2022-05-19T14:44:35Z",
+    "metadata_spec_version": "0.6.0",
+    "timestamp": "2021-05-19T14:44:35Z",
+    "type": "root",
+    "version": 1
+  }
+}


### PR DESCRIPTION
Description
---

Add JSON `canonicalize` virtual method
- v0.6 uses 2 spaces indentation
- v1 uses no indentation

Use updated role `canonicalize` method to compute verifications
- if update consists in moving from a spec version to another, you need to dump JSON with the new format

Handle PGP trailer from and to JSON files
Test root role v0.6 loading from file with PGP signature (w/ trailer)
Add and update tests