### PR TITLE
Trust files strict naming

### DIFF
--- a/include/mamba/core/validate.hpp
+++ b/include/mamba/core/validate.hpp
@@ -229,10 +229,12 @@ namespace validate
         friend void from_json(const json& j, RoleBase* r);
 
     protected:
+        virtual std::string canonicalize(const json& j) const;
+        virtual bool upgradable() const;
+
         SpecVersion major_spec_version() const;
 
         json read_file(const fs::path& p, bool update = false) const;
-        virtual std::string canonicalize(const json& j) const;
 
     private:
         std::string m_internal_type;
@@ -343,6 +345,8 @@ namespace validate
             RootRole();
 
             void load_from_json(const json& j);
+
+            bool upgradable() const override;
 
             std::unique_ptr<RootRoleBase> create_update(const json& j) override;
             std::set<RoleSignature> signatures(const json& j) const;


### PR DESCRIPTION
Description
---

Files should be named using one of the following structures:
 - Trusted (reference) file:
   - FILENAME.EXT
   - svSPEC_VERSION_MAJOR.FILENAME.EXT
 - Update file:
   - VERSION_NUMBER.FILENAME.EXT
   - VERSION_NUMBER.svSPEC_VERSION_MAJOR.FILENAME.EXT

It also enables to warn for possible client update needed when the spec version is not supported but still valid
update and add tests