### PR TITLE
Implement RepoChecker interface for a content verification

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,7 +39,7 @@ jobs:
         run: |
           conda config --add channels conda-forge
           conda config --set channel_priority strict
-          conda create -q -y -n mamba-tests python=$PYTHON_VERSION pip pybind11 libsolv libsodium libarchive "libcurl=7.76.1=*_0" nlohmann_json cpp-filesystem conda cxx-compiler cmake gtest reproc-cpp yaml-cpp
+          conda create -q -y -n mamba-tests python=$PYTHON_VERSION pip pybind11 libsolv libsodium libarchive "libcurl=7.76.1=*_0" nlohmann_json cpp-filesystem conda cxx-compiler cmake gtest gmock reproc-cpp yaml-cpp
         env:
           PYTHON_VERSION: ${{ matrix.python-version }}
       - name: Install dependencies
@@ -105,7 +105,7 @@ jobs:
           export MAMBA_ROOT_PREFIX=~/mambaroot
           export MAMBA_EXE=$(pwd)/micromamba
           . $MAMBA_ROOT_PREFIX/etc/profile.d/mamba.sh
-          micromamba create -y -p ~/build_env pybind11 libsolv libsodium libarchive "libcurl=7.76.1=*_0" nlohmann_json cxx-compiler cmake gtest cpp-filesystem reproc-cpp yaml-cpp cli11 -c conda-forge
+          micromamba create -y -p ~/build_env pybind11 libsolv libsodium libarchive "libcurl=7.76.1=*_0" nlohmann_json cxx-compiler cmake gtest gmock cpp-filesystem reproc-cpp yaml-cpp cli11 -c conda-forge
         env:
           PYTHON_VERSION: ${{ matrix.python-version }}
       - name: build tests
@@ -157,7 +157,7 @@ jobs:
           export MAMBA_ROOT_PREFIX=~/mambaroot
           export MAMBA_EXE=$(pwd)/micromamba
           . $MAMBA_ROOT_PREFIX/etc/profile.d/mamba.sh
-          micromamba create -y -p ~/build_env pybind11 libsolv libsodium libarchive "libcurl=7.76.1=*_0" nlohmann_json cxx-compiler cmake gtest cpp-filesystem reproc-cpp yaml-cpp pyyaml cli11 -c conda-forge
+          micromamba create -y -p ~/build_env pybind11 libsolv libsodium libarchive "libcurl=7.76.1=*_0" nlohmann_json cxx-compiler cmake gtest gmock cpp-filesystem reproc-cpp yaml-cpp pyyaml cli11 -c conda-forge
         env:
           PYTHON_VERSION: ${{ matrix.python-version }}
       - name: build micromamba
@@ -251,7 +251,7 @@ jobs:
         run: |
           conda config --add channels conda-forge
           conda config --set channel_priority strict
-          conda install -n base -q -y vs2017_win-64 python=$PYTHON_VERSION pip pybind11 libsolv libsodium libarchive "libcurl=7.76.1=*_0" nlohmann_json cpp-filesystem conda cmake gtest ninja reproc-cpp yaml-cpp cli11
+          conda install -n base -q -y vs2017_win-64 python=$PYTHON_VERSION pip pybind11 libsolv libsodium libarchive "libcurl=7.76.1=*_0" nlohmann_json cpp-filesystem conda cmake gtest gmock ninja reproc-cpp yaml-cpp cli11
         env:
           PYTHON_VERSION: ${{ matrix.python-version }}
       - name: Install dependencies
@@ -296,7 +296,7 @@ jobs:
         run: |
           conda config --add channels conda-forge
           conda config --set channel_priority strict
-          conda create -q -y -n mamba-tests vs2017_win-64 python=$PYTHON_VERSION pip pybind11 libsolv libsodium libarchive "libcurl=7.76.1=*_0" nlohmann_json cpp-filesystem conda cmake gtest ninja reproc-cpp yaml-cpp cli11 pytest
+          conda create -q -y -n mamba-tests vs2017_win-64 python=$PYTHON_VERSION pip pybind11 libsolv libsodium libarchive "libcurl=7.76.1=*_0" nlohmann_json cpp-filesystem conda cmake gtest gmock ninja reproc-cpp yaml-cpp cli11 pytest
         env:
           PYTHON_VERSION: ${{ matrix.python-version }}
       - name: Run C++ tests Windows
@@ -392,7 +392,7 @@ jobs:
         run: |
           conda config --add channels conda-forge
           conda config --set channel_priority strict
-          conda create -q -y -n mamba-tests vs2017_win-64 python=$PYTHON_VERSION pip pybind11 libsolv libsodium libarchive "libcurl=7.76.1=*_0" nlohmann_json cpp-filesystem conda cmake gtest ninja reproc-cpp yaml-cpp pyyaml cli11 pytest
+          conda create -q -y -n mamba-tests vs2017_win-64 python=$PYTHON_VERSION pip pybind11 libsolv libsodium libarchive "libcurl=7.76.1=*_0" nlohmann_json cpp-filesystem conda cmake gtest gmock ninja reproc-cpp yaml-cpp pyyaml cli11 pytest
         env:
           PYTHON_VERSION: ${{ matrix.python-version }}
       - name: micromamba python based tests
@@ -433,7 +433,7 @@ jobs:
         run: |
           conda config --add channels conda-forge
           conda config --set channel_priority strict
-          conda create -q -y -n mamba-tests vs2017_win-64 python=$PYTHON_VERSION pip pybind11 libsolv libsodium libarchive "libcurl=7.76.1=*_0" nlohmann_json cpp-filesystem conda cmake gtest ninja reproc-cpp yaml-cpp pyyaml cli11 pytest
+          conda create -q -y -n mamba-tests vs2017_win-64 python=$PYTHON_VERSION pip pybind11 libsolv libsodium libarchive "libcurl=7.76.1=*_0" nlohmann_json cpp-filesystem conda cmake gtest gmock ninja reproc-cpp yaml-cpp pyyaml cli11 pytest
         env:
           PYTHON_VERSION: ${{ matrix.python-version }}
       - name: micromamba python based tests with pwsh
@@ -472,7 +472,7 @@ jobs:
         run: |
           conda config --add channels conda-forge
           conda config --set channel_priority strict
-          conda create -q -y -n mamba-tests vs2017_win-64 python=$PYTHON_VERSION pip pybind11 libsolv libsodium libarchive "libcurl=7.76.1=*_0" nlohmann_json cpp-filesystem conda cmake gtest ninja reproc-cpp yaml-cpp pyyaml cli11 pytest
+          conda create -q -y -n mamba-tests vs2017_win-64 python=$PYTHON_VERSION pip pybind11 libsolv libsodium libarchive "libcurl=7.76.1=*_0" nlohmann_json cpp-filesystem conda cmake gtest gmock ninja reproc-cpp yaml-cpp pyyaml cli11 pytest
         env:
           PYTHON_VERSION: ${{ matrix.python-version }}
       - name: micromamba python based tests

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ You will additionally need to install cmake and cli11 for micromamba:
 mamba install -c conda-forge cli11 cmake
 ```
 
-For the C++ tests, you need Google Tests installed (e.g. `mamba install gtest`).
+For the C++ tests, you need Google Test and Google Mock installed (e.g. `mamba install gtest gmock`).
 To build the program using CMake, the following lines need to be used:
 
 ```bash

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -13,6 +13,7 @@ dependencies:
   - libcurl 7.76.1 *_0
   - cxx-compiler
   - gtest
+  - gmock
   - cpp-filesystem
   - reproc-cpp
   - yaml-cpp

--- a/include/mamba/core/util.hpp
+++ b/include/mamba/core/util.hpp
@@ -165,6 +165,10 @@ namespace mamba
     bool ends_with(const std::string_view& str, const std::string_view& suffix);
     bool contains(const std::string_view& str, const std::string_view& sub_str);
 
+    bool any_starts_with(const std::vector<std::string_view>& str, const std::string_view& prefix);
+
+    bool starts_with_any(const std::string_view& str, const std::vector<std::string_view>& prefix);
+
     std::string_view strip(const std::string_view& input);
     std::string_view lstrip(const std::string_view& input);
     std::string_view rstrip(const std::string_view& input);

--- a/src/core/util.cpp
+++ b/src/core/util.cpp
@@ -211,6 +211,26 @@ namespace mamba
         return str.size() >= prefix.size() && 0 == str.compare(0, prefix.size(), prefix);
     }
 
+    bool any_starts_with(const std::vector<std::string_view>& str, const std::string_view& prefix)
+    {
+        for (auto& s : str)
+        {
+            if (starts_with(s, prefix))
+                return true;
+        }
+        return false;
+    }
+
+    bool starts_with_any(const std::string_view& str, const std::vector<std::string_view>& prefix)
+    {
+        for (auto& p : prefix)
+        {
+            if (starts_with(str, p))
+                return true;
+        }
+        return false;
+    }
+
     bool contains(const std::string_view& str, const std::string_view& sub_str)
     {
         return str.find(sub_str) != std::string::npos;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,13 +1,6 @@
 cmake_minimum_required(VERSION 3.1)
 
-if(WIN32)
-    find_package(GTest)
-else()
-    add_library(GTest::GTest INTERFACE IMPORTED)
-    target_link_libraries(GTest::GTest INTERFACE gtest)
-    add_library(GTest::Main INTERFACE IMPORTED)
-    target_link_libraries(GTest::Main INTERFACE gtest_main)
-endif()
+find_package(GTest)
 
 include_directories(${GTEST_INCLUDE_DIRS} SYSTEM)
 


### PR DESCRIPTION
Description
---

implement `RepoChecker` workflow
improve compatible or upgrade checks of spec
improve tests using `gmock`, add tests on `RepoChecker` for v0.6.0 spec version using `PkgMgrRole`
update `CMakeLists` to use `gmock` on C++ tests
update CI steps to install `gmock`