### PR TITLE
Use cURL to fetch content trust roles metadata

### DIFF
--- a/include/mamba/core/fetch.hpp
+++ b/include/mamba/core/fetch.hpp
@@ -76,11 +76,6 @@ namespace mamba
             return m_active_logs;
         }
 
-        inline curl_off_t get_downloaded_size() const
-        {
-            return downloaded_size;
-        }
-
         void set_result(CURLcode r);
         bool finalize();
 

--- a/include/mamba/core/fetch.hpp
+++ b/include/mamba/core/fetch.hpp
@@ -45,6 +45,8 @@ namespace mamba
         const std::string& name() const;
 
         void init_curl_target(const std::string& url);
+
+        bool resource_exists();
         bool perform();
         CURL* handle();
 
@@ -64,16 +66,6 @@ namespace mamba
         inline bool ignore_failure() const
         {
             return m_ignore_failure;
-        }
-
-        inline void set_active_logs(bool yes)
-        {
-            m_active_logs = yes;
-        }
-
-        inline bool active_logs() const
-        {
-            return m_active_logs;
         }
 
         void set_result(CURLcode r);
@@ -111,12 +103,13 @@ namespace mamba
 
         bool m_has_progress_bar = false;
         bool m_ignore_failure = false;
-        bool m_active_logs = false;
 
         ProgressProxy m_progress_bar;
 
         char m_errbuf[CURL_ERROR_SIZE];
         std::ofstream m_file;
+
+        static void init_curl_handle(CURL* handle, const std::string& url);
     };
 
     class MultiDownloadTarget

--- a/include/mamba/core/fetch.hpp
+++ b/include/mamba/core/fetch.hpp
@@ -66,6 +66,21 @@ namespace mamba
             return m_ignore_failure;
         }
 
+        inline void set_active_logs(bool yes)
+        {
+            m_active_logs = yes;
+        }
+
+        inline bool active_logs() const
+        {
+            return m_active_logs;
+        }
+
+        inline curl_off_t get_downloaded_size() const
+        {
+            return downloaded_size;
+        }
+
         void set_result(CURLcode r);
         bool finalize();
 
@@ -101,6 +116,7 @@ namespace mamba
 
         bool m_has_progress_bar = false;
         bool m_ignore_failure = false;
+        bool m_active_logs = false;
 
         ProgressProxy m_progress_bar;
 

--- a/include/mamba/core/validate.hpp
+++ b/include/mamba/core/validate.hpp
@@ -151,6 +151,18 @@ namespace validate
 
 
     /**
+     * Error raised when a possible freeze
+     * attack is detected.
+     */
+    class freeze_error : public trust_error
+    {
+    public:
+        freeze_error() noexcept;
+        virtual ~freeze_error() = default;
+    };
+
+
+    /**
      * Error raised when a spec version is either
      * wrong/invalid or not supported by the client.
      */
@@ -159,6 +171,18 @@ namespace validate
     public:
         spec_version_error() noexcept;
         virtual ~spec_version_error() = default;
+    };
+
+
+    /**
+     * Error raised when a role metadata file
+     * fetching process fails.
+     */
+    class fetching_error : public trust_error
+    {
+    public:
+        fetching_error() noexcept;
+        virtual ~fetching_error() = default;
     };
 
 
@@ -452,12 +476,15 @@ namespace validate
     public:
         RepoChecker(const std::string& url, const fs::path& local_trusted_root);
 
-        // Fowarding to a ``RepoIndexChecker`` implementation
+        // Forwarding to a ``RepoIndexChecker`` implementation
         void verify_index(const json& j);
         void verify_index(const fs::path& p);
 
+        std::size_t root_version();
+
     private:
         std::string m_base_url;
+        std::size_t m_root_version = 0;
 
         fs::path m_local_trusted_root;
 
@@ -520,10 +547,9 @@ namespace validate
 
     namespace v06
     {
-        std::string json_canonicalize(const json& version);
-
         /**
          * ``conda-content-trust`` v0.6.0 specific implementation.
+         * This is a variation of TUF specification.
          */
         class SpecImpl final : public SpecBase
         {
@@ -551,6 +577,10 @@ namespace validate
             RootImpl(const fs::path& p);
             RootImpl(const json& j);
 
+            /**
+             * Return a ``RepoIndexChecker`` implementation (derived class)
+             * from repository base URL.
+             */
             std::unique_ptr<RepoIndexChecker> build_index_checker(
                 const std::string& url) const override;
 
@@ -595,6 +625,10 @@ namespace validate
 
             PkgMgrRole create_pkg_mgr() const;
 
+            /**
+             * Return a ``RepoIndexChecker`` implementation (derived class)
+             * from repository base URL.
+             */
             std::unique_ptr<RepoIndexChecker> build_index_checker(const std::string& url) const;
 
             friend void to_json(json& j, const KeyMgrRole& r);

--- a/src/core/validate.cpp
+++ b/src/core/validate.cpp
@@ -4,8 +4,12 @@
 //
 // The full license is in the file LICENSE, distributed with this software.
 
+#include "mamba/core/environment.hpp"
+#include "mamba/core/fetch.hpp"
+#include "mamba/core/fsutil.hpp"
 #include "mamba/core/validate.hpp"
 #include "mamba/core/output.hpp"
+#include "mamba/core/url.hpp"
 #include "mamba/core/util.hpp"
 
 #include "openssl/md5.h"
@@ -48,6 +52,11 @@ namespace validate
     {
     }
 
+    freeze_error::freeze_error() noexcept
+        : trust_error("Possible freeze attack")
+    {
+    }
+
     role_file_error::role_file_error() noexcept
         : trust_error("Invalid role file")
     {
@@ -55,6 +64,11 @@ namespace validate
 
     spec_version_error::spec_version_error() noexcept
         : trust_error("Unsupported specification version")
+    {
+    }
+
+    fetching_error::fetching_error() noexcept
+        : trust_error("Failed to fetch role metadata")
     {
     }
 
@@ -1136,11 +1150,6 @@ namespace validate
             return unique_sigs;
         }
 
-        std::string json_canonicalize(const json& j)
-        {
-            return j.dump(2);
-        }
-
         bool SpecImpl::upgradable() const
         {
             return true;
@@ -1148,7 +1157,7 @@ namespace validate
 
         std::string SpecImpl::canonicalize(const json& j) const
         {
-            return json_canonicalize(j);
+            return j.dump(2);
         }
 
         RootImpl::RootImpl(const json& j)
@@ -1253,10 +1262,50 @@ namespace validate
         }
 
         std::unique_ptr<RepoIndexChecker> RootImpl::build_index_checker(
-            const std::string& url) const
+            const std::string& base_url) const
         {
-            KeyMgrRole key_mgr(fs::path(url) / "key_mgr.json", all_keys()["key_mgr"], spec_impl());
-            return key_mgr.build_index_checker(url);
+            auto tmp_dir = std::make_unique<mamba::TemporaryDirectory>();
+            auto tmp_dir_path = tmp_dir->path();
+
+            mamba::URLHandler url(base_url + "key_mgr.json");
+            fs::path tmp_file_path = tmp_dir_path / "key_mgr.json";
+
+            auto dl_target
+                = std::make_unique<mamba::DownloadTarget>("key_mgr.json", url.url(), tmp_file_path);
+            dl_target->set_active_logs(false);
+            dl_target->set_ignore_failure(true);
+
+            // perform download
+            auto result = curl_easy_perform(dl_target->handle());
+            dl_target->set_result(result);
+
+            if (result == CURLE_OK)
+            {
+                if (dl_target->finalize())
+                {
+                    LOG_DEBUG << "Content trust: 'key_mgr' role creation for repo '" << base_url
+                              << "'\n"
+                              << dl_target->downloaded_size
+                              << " bytes fetched for file 'key_mgr.json'";
+
+                    KeyMgrRole key_mgr(tmp_file_path, all_keys()["key_mgr"], spec_impl());
+
+                    // TUF spec 5.6.5 - Check for a freeze attack
+                    // 'key_mgr' (equivalent of 'targets') role should not be expired
+                    // https://theupdateframework.github.io/specification/latest/#update-targets
+                    if (key_mgr.expired())
+                    {
+                        LOG_ERROR << "Possible freeze attack of 'key_mgr' metadata.\nExpired: "
+                                  << key_mgr.expires();
+                        throw freeze_error();
+                    }
+
+                    return key_mgr.build_index_checker(base_url);
+                }
+            }
+
+            LOG_ERROR << "Content trust: error while fetching 'key_mgr' metadata.";
+            throw fetching_error();
         }
 
         KeyMgrRole RootImpl::create_key_mgr(const fs::path& p) const
@@ -1582,8 +1631,14 @@ namespace validate
         : m_base_url(url)
         , m_local_trusted_root(local_trusted_root)
     {
+        // TUF spec 5.1 - Record fixed update start time
+        // Expiration computations will be done against
+        // this reference
+        // https://theupdateframework.github.io/specification/latest/#fix-time
+        TimeRef::instance().set_now();
+
         auto root = get_root_role();
-        p_index_checker = root->build_index_checker(fs::path(url));
+        p_index_checker = root->build_index_checker(url);
     };
 
     void RepoChecker::verify_index(const json& j)
@@ -1594,6 +1649,11 @@ namespace validate
     void RepoChecker::verify_index(const fs::path& p)
     {
         p_index_checker->verify_index(p);
+    }
+
+    std::size_t RepoChecker::root_version()
+    {
+        return m_root_version;
     }
 
     std::unique_ptr<RootRole> RepoChecker::get_root_role()
@@ -1615,25 +1675,64 @@ namespace validate
         }
 
         auto update_files = updated_root->possible_update_files();
+        auto tmp_dir = std::make_unique<mamba::TemporaryDirectory>();
+        auto tmp_dir_path = tmp_dir->path();
+
         // do chained updates
         while (true)
         {
-            fs::path p = "";
+            fs::path tmp_file_path;
+
             // Update from the most recent spec supported by this client
             for (auto& f : update_files)
             {
-                if (fs::exists(f))
+                mamba::URLHandler url(m_base_url + f.string());
+                tmp_file_path = tmp_dir_path / f;
+
+                auto dl_target
+                    = std::make_unique<mamba::DownloadTarget>(f.string(), url.url(), tmp_file_path);
+                dl_target->set_active_logs(false);
+                dl_target->set_ignore_failure(true);
+
+                // perform download
+                auto result = curl_easy_perform(dl_target->handle());
+                dl_target->set_result(result);
+
+                if (result == CURLE_OK)
                 {
-                    p = f;
-                    break;
+                    if (dl_target->finalize())
+                    {
+                        LOG_DEBUG << "Content trust: 'root' role update for repo '" << m_base_url
+                                  << "'\n"
+                                  << dl_target->get_downloaded_size() << " bytes fetched for file '"
+                                  << f.string() << "'";
+                        break;
+                    }
+                }
+                else
+                {
+                    tmp_file_path = "";
                 }
             }
 
-            if (p.empty())
+            if (tmp_file_path.empty())
                 break;
 
-            updated_root = updated_root->update(p);
+            updated_root = updated_root->update(tmp_file_path);
             update_files = updated_root->possible_update_files();
+        }
+
+        m_root_version = updated_root->version();
+        LOG_DEBUG << "Content trust: latest 'root' metadata has version " << m_root_version;
+
+        // TUF spec 5.3.10 - Check for a freeze attack
+        // Updated 'root' role should not be expired
+        // https://theupdateframework.github.io/specification/latest/#update-root
+        if (updated_root->expired())
+        {
+            LOG_ERROR << "Possible freeze attack of 'root' metadata.\nExpired: "
+                      << updated_root->expires();
+            throw freeze_error();
         }
 
         return updated_root;

--- a/src/core/validate.cpp
+++ b/src/core/validate.cpp
@@ -1704,7 +1704,7 @@ namespace validate
                     {
                         LOG_DEBUG << "Content trust: 'root' role update for repo '" << m_base_url
                                   << "'\n"
-                                  << dl_target->get_downloaded_size() << " bytes fetched for file '"
+                                  << dl_target->downloaded_size << " bytes fetched for file '"
                                   << f.string() << "'";
                         break;
                     }


### PR DESCRIPTION
Description
---

Fetch content trust roles metadata using `cURL`
Check for freeze attack on `root` or `pkg_mgr` metadata
Add capability to silent logs on `DownloadTarget` (also move a log from constructor to `perform`)
Add `fetch_error` and `freeze_error`
add C++ tests