### PR TITLE
Add experimental artifact verification

### DIFF
--- a/docs/source/developer_zone/build_locally.rst
+++ b/docs/source/developer_zone/build_locally.rst
@@ -88,7 +88,7 @@ To build ``micromamba``, just activate the ``BUILD_EXE`` flag in ``cmake`` comma
     - ``-DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX\\Library`` [win]
 
 | Doing so, you have built the dynamically linked version of ``micromamba``.
-| It's well fitted for development but is not the artefact shipped when installing ``micromamba``.
+| It's well fitted for development but is not the artifact shipped when installing ``micromamba``.
 
 
 Statically linked

--- a/include/mamba/core/channel.hpp
+++ b/include/mamba/core/channel.hpp
@@ -7,6 +7,8 @@
 #ifndef MAMBA_CORE_CHANNEL_HPP
 #define MAMBA_CORE_CHANNEL_HPP
 
+#include "mamba/core/validate.hpp"
+
 #include <map>
 #include <string>
 #include <vector>
@@ -36,6 +38,7 @@ namespace mamba
         const std::string& platform() const;
         const std::string& package_filename() const;
         const std::string& canonical_name() const;
+        const validate::RepoChecker& repo_checker();
 
         std::string base_url() const;
         std::string url(bool with_credential = true) const;
@@ -70,6 +73,7 @@ namespace mamba
         std::string m_platform;
         std::string m_package_filename;
         mutable std::string m_canonical_name;
+        validate::RepoChecker m_repo_checker;
     };
 
     Channel& make_channel(const std::string& value);

--- a/include/mamba/core/context.hpp
+++ b/include/mamba/core/context.hpp
@@ -134,7 +134,7 @@ namespace mamba
 
         VerificationLevel safety_checks = VerificationLevel::kWarn;
         bool extra_safety_checks = false;
-        bool artifact_verif = false;
+        bool verify_artifacts = false;
 
         // debug helpers
         bool keep_temp_files = std::getenv("MAMBA_KEEP_TEMP") ? 1 : 0;

--- a/include/mamba/core/context.hpp
+++ b/include/mamba/core/context.hpp
@@ -134,6 +134,7 @@ namespace mamba
 
         VerificationLevel safety_checks = VerificationLevel::kWarn;
         bool extra_safety_checks = false;
+        bool artifact_verif = false;
 
         // debug helpers
         bool keep_temp_files = std::getenv("MAMBA_KEEP_TEMP") ? 1 : 0;

--- a/include/mamba/core/repo.hpp
+++ b/include/mamba/core/repo.hpp
@@ -24,6 +24,10 @@ extern "C"
 
 namespace mamba
 {
+    /**
+     * Represents a channel subdirectory
+     * index.
+     */
     struct RepoMetadata
     {
         std::string url;
@@ -38,19 +42,52 @@ namespace mamba
                && lhs.mod == rhs.mod;
     }
 
+    /**
+     * A wrapper class of libsolv Repo.
+     * Represents a channel subdirectory and
+     * is built using a ready-to-use index/metadata
+     * file (see ``MSubdirData``).
+     */
     class MRepo
     {
     public:
+        /**
+         * Constructor.
+         * @param pool ``libsolv`` pool wrapper
+         * @param prefix_data prefix data
+         */
         MRepo(MPool& pool, const PrefixData& prefix_data);
+
+        /**
+         * Constructor.
+         * @param pool ``libsolv`` pool wrapper
+         * @param name Name of the subdirectory (<channel>/<subdir>)
+         * @param index Path to the index file
+         * @param url Subdirectory URL
+         */
         MRepo(MPool& pool,
               const std::string& name,
               const std::string& filename,
               const std::string& url);
-        MRepo(MPool& pool, const std::string& name, const fs::path& path, const RepoMetadata& meta);
+
+        /**
+         * Constructor.
+         * @param pool ``libsolv`` pool wrapper
+         * @param name Name of the subdirectory (<channel>/<subdir>)
+         * @param index Path to the index file
+         * @param meta Metadata of the repo
+         */
+        MRepo(MPool& pool,
+              const std::string& name,
+              const fs::path& filename,
+              const RepoMetadata& meta);
+
         ~MRepo();
 
         void set_installed();
         void set_priority(int priority, int subpriority);
+
+        const std::string& index_file();
 
         std::string name() const;
         bool write() const;

--- a/include/mamba/core/subdirdata.hpp
+++ b/include/mamba/core/subdirdata.hpp
@@ -28,23 +28,37 @@ namespace decompress
 
 namespace mamba
 {
+    /**
+     * Represents a channel subdirectory (i.e. a platform)
+     * packages index. Handles downloading of the index
+     * from the server and cache generation as well.
+     */
     class MSubdirData
     {
     public:
+        /**
+         * Constructor.
+         * @param name Name of the subdirectory (<channel>/<subdir>)
+         * @param repodata_url URL of the repodata file
+         * @param repodata_fn Local path of the repodata file
+         */
         MSubdirData(const std::string& name,
-                    const std::string& url,
+                    const std::string& repodata_url,
                     const std::string& repodata_fn);
 
         // TODO return seconds as double
         fs::file_time_type::duration check_cache(const fs::path& cache_file,
                                                  const fs::file_time_type::clock::time_point& ref);
+        bool load();
         bool loaded();
+
         bool forbid_cache();
         void clear_cache();
-        bool load();
+
         std::string cache_path() const;
-        DownloadTarget* target();
         const std::string& name() const;
+
+        DownloadTarget* target();
         bool finalize_transfer();
 
         MRepo create_repo(MPool& pool);
@@ -66,7 +80,7 @@ namespace mamba
 
         bool m_loaded;
         bool m_download_complete;
-        std::string m_url;
+        std::string m_repodata_url;
         std::string m_name;
         std::string m_json_fn;
         std::string m_solv_fn;

--- a/include/mamba/core/url.hpp
+++ b/include/mamba/core/url.hpp
@@ -66,6 +66,8 @@ namespace mamba
     std::string unc_url(const std::string& url);
     std::string encode_url(const std::string& url);
     std::string decode_url(const std::string& url);
+    // Only returns a cache name without extension
+    std::string cache_name_from_url(const std::string& url);
 
     class URLHandler
     {

--- a/src/api/configuration.cpp
+++ b/src/api/configuration.cpp
@@ -696,7 +696,7 @@ namespace mamba
                         Spend extra time validating package contents. Currently, runs sha256
                         verification on every file within each package during installation.)")));
 
-        insert(Configurable("artifact_verif", &ctx.artifact_verif)
+        insert(Configurable("verify_artifacts", &ctx.verify_artifacts)
                    .group("Link & Install")
                    .set_rc_configurable()
                    .set_env_var_name()

--- a/src/api/configuration.cpp
+++ b/src/api/configuration.cpp
@@ -696,6 +696,15 @@ namespace mamba
                         Spend extra time validating package contents. Currently, runs sha256
                         verification on every file within each package during installation.)")));
 
+        insert(Configurable("artifact_verif", &ctx.artifact_verif)
+                   .group("Link & Install")
+                   .set_rc_configurable()
+                   .set_env_var_name()
+                   .description("Run verifications on packages signatures")
+                   .long_description(unindent(R"(
+                        Spend extra time validating package contents. It consists of running
+                        cryptographic verifications on channels and packages metadata.)")));
+
         // Output, Prompt and Flow
         insert(Configurable("always_yes", &ctx.always_yes)
                    .group("Output, Prompt and Flow Control")

--- a/src/api/install.cpp
+++ b/src/api/install.cpp
@@ -347,12 +347,12 @@ namespace mamba
         for (auto& url : channel_urls)
         {
             auto& channel = make_channel(url);
-            std::string full_url = concat(channel.url(true), "/repodata.json");
+            std::string repodata_full_url = concat(channel.url(true), "/repodata.json");
 
             auto sdir
                 = std::make_shared<MSubdirData>(concat(channel.name(), "/", channel.platform()),
-                                                full_url,
-                                                cache_dir / cache_fn_url(full_url));
+                                                repodata_full_url,
+                                                cache_dir / cache_fn_url(repodata_full_url));
 
             sdir->load();
             multi_dl.add(sdir->target());

--- a/src/api/list.cpp
+++ b/src/api/list.cpp
@@ -69,7 +69,7 @@ namespace mamba
 
                     if (regex.empty() || std::regex_search(pkg_info.name, spec_pat))
                     {
-                        auto channel = make_channel(pkg_info.url);
+                        auto& channel = make_channel(pkg_info.url);
                         obj["base_url"] = channel.base_url();
                         obj["build_number"] = pkg_info.build_number;
                         obj["build_string"] = pkg_info.build_string;

--- a/src/core/match_spec.cpp
+++ b/src/core/match_spec.cpp
@@ -84,7 +84,7 @@ namespace mamba
                 LOG_INFO << "need to expand path!";
                 spec_str = path_to_url(fs::absolute(env::expand_user(spec_str)));
             }
-            auto parsed_channel = make_channel(spec_str);
+            auto& parsed_channel = make_channel(spec_str);
 
             if (!parsed_channel.platform().empty())
             {

--- a/src/core/repo.cpp
+++ b/src/core/repo.cpp
@@ -30,23 +30,23 @@ namespace mamba
 
     MRepo::MRepo(MPool& pool,
                  const std::string& name,
-                 const fs::path& filename,
+                 const fs::path& index,
                  const RepoMetadata& metadata)
         : m_metadata(metadata)
     {
         m_url = rsplit(metadata.url, "/", 1)[0];
         m_repo = repo_create(pool, m_url.c_str());
-        read_file(filename);
+        read_file(index);
     }
 
     MRepo::MRepo(MPool& pool,
                  const std::string& name,
-                 const std::string& filename,
+                 const std::string& index,
                  const std::string& url)
         : m_url(url)
     {
         m_repo = repo_create(pool, name.c_str());
-        read_file(filename);
+        read_file(index);
     }
 
     MRepo::MRepo(MPool& pool, const PrefixData& prefix_data)
@@ -156,6 +156,11 @@ namespace mamba
     std::size_t MRepo::size() const
     {
         return m_repo->nsolvables;
+    }
+
+    const std::string& MRepo::index_file()
+    {
+        return m_json_file;
     }
 
     bool MRepo::read_file(const std::string& filename)

--- a/src/core/subdirdata.cpp
+++ b/src/core/subdirdata.cpp
@@ -4,12 +4,12 @@
 //
 // The full license is in the file LICENSE, distributed with this software.
 
-#include "openssl/md5.h"
-
 #include "mamba/core/mamba_fs.hpp"
 #include "mamba/core/output.hpp"
 #include "mamba/core/package_cache.hpp"
 #include "mamba/core/subdirdata.hpp"
+#include "mamba/core/url.hpp"
+
 
 namespace decompress
 {
@@ -64,11 +64,11 @@ namespace decompress
 namespace mamba
 {
     MSubdirData::MSubdirData(const std::string& name,
-                             const std::string& url,
+                             const std::string& repodata_url,
                              const std::string& repodata_fn)
         : m_loaded(false)
         , m_download_complete(false)
-        , m_url(url)
+        , m_repodata_url(repodata_url)
         , m_name(name)
         , m_json_fn(repodata_fn)
         , m_solv_fn(repodata_fn.substr(0, repodata_fn.size() - 4) + "solv")
@@ -98,7 +98,7 @@ namespace mamba
 
     bool MSubdirData::forbid_cache()
     {
-        return starts_with(m_url, "file://");
+        return starts_with(m_repodata_url, "file://");
     }
 
     bool MSubdirData::load()
@@ -128,8 +128,8 @@ namespace mamba
                 if ((max_age > cache_age_seconds || Context::instance().offline))
                 {
                     // cache valid!
-                    LOG_INFO << "Using cache " << m_url << " age in seconds: " << cache_age_seconds
-                             << " / " << max_age;
+                    LOG_INFO << "Using cache " << m_repodata_url
+                             << " age in seconds: " << cache_age_seconds << " / " << max_age;
                     std::string prefix = m_name;
                     prefix.resize(PREFIX_LENGTH - 1, ' ');
                     Console::stream() << prefix << " Using cache";
@@ -158,7 +158,7 @@ namespace mamba
         }
         else
         {
-            LOG_INFO << "No cache found " << m_url;
+            LOG_INFO << "No cache found " << m_repodata_url;
             if (!Context::instance().offline || forbid_cache())
             {
                 create_target(m_mod_etag);
@@ -196,7 +196,7 @@ namespace mamba
         if (m_target->result != 0 || m_target->http_status >= 400)
         {
             LOG_INFO << "Unable to retrieve repodata (response: " << m_target->http_status
-                     << ") for " << m_url;
+                     << ") for " << m_repodata_url;
             m_progress_bar.set_postfix(std::to_string(m_target->http_status) + " Failed");
             m_progress_bar.set_full();
             m_progress_bar.mark_as_completed();
@@ -247,24 +247,26 @@ namespace mamba
             return true;
         }
 
-        LOG_INFO << "Finalized transfer: " << m_url;
+        LOG_INFO << "Finalized transfer: " << m_repodata_url;
 
         m_mod_etag.clear();
-        m_mod_etag["_url"] = m_url;
+        m_mod_etag["_url"] = m_repodata_url;
         m_mod_etag["_etag"] = m_target->etag;
         m_mod_etag["_mod"] = m_target->mod;
         m_mod_etag["_cache_control"] = m_target->cache_control;
 
         LOG_INFO << "Opening: " << m_json_fn;
         std::ofstream final_file(m_json_fn);
-        // TODO make sure that cache directory exists!
+
+        create_cache_dir();
+
         if (!final_file.is_open())
         {
             LOG_ERROR << "Could not open file " << m_json_fn;
             exit(1);
         }
 
-        if (ends_with(m_url, ".bz2"))
+        if (ends_with(m_repodata_url, ".bz2"))
         {
             m_progress_bar.set_postfix("Decomp...");
             decompress();
@@ -287,8 +289,8 @@ namespace mamba
 
         if (!temp_file)
         {
-            LOG_ERROR << "Could not write out repodata file " << m_json_fn << ": "
-                      << strerror(errno);
+            LOG_ERROR << "Could not write out repodata file '" << m_json_fn
+                      << "': " << strerror(errno);
             fs::remove(m_json_fn);
             exit(1);
         }
@@ -326,7 +328,7 @@ namespace mamba
     {
         m_temp_file = std::make_unique<TemporaryFile>();
         m_progress_bar = Console::instance().add_progress_bar(m_name);
-        m_target = std::make_unique<DownloadTarget>(m_name, m_url, m_temp_file->path());
+        m_target = std::make_unique<DownloadTarget>(m_name, m_repodata_url, m_temp_file->path());
         m_target->set_progress_bar(m_progress_bar);
         // if we get something _other_ than the noarch, we DO NOT throw if the file
         // can't be retrieved
@@ -405,14 +407,7 @@ namespace mamba
 
     std::string cache_fn_url(const std::string& url)
     {
-        std::vector<unsigned char> hash(MD5_DIGEST_LENGTH);
-        MD5_CTX md5;
-        MD5_Init(&md5);
-        MD5_Update(&md5, url.c_str(), url.size());
-        MD5_Final(hash.data(), &md5);
-
-        std::string hex_digest = hex_string(hash);
-        return hex_digest.substr(0u, 8u) + ".json";
+        return cache_name_from_url(url) + ".json";
     }
 
     std::string create_cache_dir()
@@ -428,7 +423,7 @@ namespace mamba
 
     MRepo MSubdirData::create_repo(MPool& pool)
     {
-        RepoMetadata meta{ m_url,
+        RepoMetadata meta{ m_repodata_url,
                            Context::instance().add_pip_as_python_dependency,
                            m_mod_etag["_etag"],
                            m_mod_etag["_mod"] };

--- a/src/core/transaction.cpp
+++ b/src/core/transaction.cpp
@@ -369,7 +369,8 @@ namespace mamba
 
         if (solver.only_deps == false)
         {
-            auto to_string_vec = [](const std::vector<MatchSpec>& vec) -> std::vector<std::string> {
+            auto to_string_vec = [](const std::vector<MatchSpec>& vec) -> std::vector<std::string>
+            {
                 std::vector<std::string> res;
                 for (const auto& el : vec)
                     res.push_back(el.str());
@@ -705,7 +706,8 @@ namespace mamba
             to_unlink.push_back(solvable_to_json(s));
         }
 
-        auto add_json = [](const auto& jlist, const char* s) {
+        auto add_json = [](const auto& jlist, const char* s)
+        {
             if (!jlist.empty())
             {
                 JsonLogger::instance().json_down(s);
@@ -752,7 +754,7 @@ namespace mamba
             }
 
             auto& ctx = Context::instance();
-            if (ctx.experimental && ctx.artifact_verif)
+            if (ctx.experimental && ctx.verify_artifacts)
             {
                 const auto& repo_checker
                     = Channel::make_cached_channel(mamba_repo->url()).repo_checker();
@@ -900,7 +902,8 @@ namespace mamba
         std::size_t total_size = 0;
         auto* pool = m_transaction->pool;
 
-        auto format_row = [this, pool, &total_size](rows& r, Solvable* s, printers::format flag) {
+        auto format_row = [this, pool, &total_size](rows& r, Solvable* s, printers::format flag)
+        {
             std::ptrdiff_t dlsize = solvable_lookup_num(s, SOLVABLE_DOWNLOADSIZE, -1);
             printers::FormattedString dlsize_s;
             if (dlsize != -1)

--- a/src/core/transaction.cpp
+++ b/src/core/transaction.cpp
@@ -369,8 +369,7 @@ namespace mamba
 
         if (solver.only_deps == false)
         {
-            auto to_string_vec = [](const std::vector<MatchSpec>& vec) -> std::vector<std::string>
-            {
+            auto to_string_vec = [](const std::vector<MatchSpec>& vec) -> std::vector<std::string> {
                 std::vector<std::string> res;
                 for (const auto& el : vec)
                     res.push_back(el.str());
@@ -706,8 +705,7 @@ namespace mamba
             to_unlink.push_back(solvable_to_json(s));
         }
 
-        auto add_json = [](const auto& jlist, const char* s)
-        {
+        auto add_json = [](const auto& jlist, const char* s) {
             if (!jlist.empty())
             {
                 JsonLogger::instance().json_down(s);
@@ -902,8 +900,7 @@ namespace mamba
         std::size_t total_size = 0;
         auto* pool = m_transaction->pool;
 
-        auto format_row = [this, pool, &total_size](rows& r, Solvable* s, printers::format flag)
-        {
+        auto format_row = [this, pool, &total_size](rows& r, Solvable* s, printers::format flag) {
             std::ptrdiff_t dlsize = solvable_lookup_num(s, SOLVABLE_DOWNLOADSIZE, -1);
             printers::FormattedString dlsize_s;
             if (dlsize != -1)

--- a/src/core/transaction.cpp
+++ b/src/core/transaction.cpp
@@ -8,6 +8,8 @@
 #include <stack>
 #include <thread>
 
+#include "mamba/core/channel.hpp"
+#include "mamba/core/context.hpp"
 #include "mamba/core/transaction.hpp"
 #include "mamba/core/link.hpp"
 #include "mamba/core/match_spec.hpp"
@@ -745,7 +747,25 @@ namespace mamba
             }
             if (mamba_repo->url() == "")
             {
+                // TODO: comment which use case it represents
                 continue;
+            }
+
+            auto& ctx = Context::instance();
+            if (ctx.experimental && ctx.artifact_verif)
+            {
+                const auto& repo_checker
+                    = Channel::make_cached_channel(mamba_repo->url()).repo_checker();
+
+                auto pkg_info = PackageInfo(s);
+
+                // TODO: avoid parsing again the index file by storing
+                // keyid/signatures into libsolv Solvable
+                repo_checker.verify_package(fs::path(mamba_repo->index_file()),
+                                            pkg_info.str() + ".tar.bz2");
+
+                LOG_DEBUG << "Package '" << pkg_info.name << "' trusted from channel '"
+                          << mamba_repo->url() << "' metadata";
             }
 
             targets.emplace_back(std::make_unique<PackageDownloadExtractTarget>(s));

--- a/src/core/url.cpp
+++ b/src/core/url.cpp
@@ -4,12 +4,15 @@
 //
 // The full license is in the file LICENSE, distributed with this software.
 
-#include <iostream>
-#include <regex>
-
 #include "mamba/core/mamba_fs.hpp"
 #include "mamba/core/url.hpp"
 #include "mamba/core/util.hpp"
+
+#include "openssl/md5.h"
+
+#include <iostream>
+#include <regex>
+
 
 namespace mamba
 {
@@ -171,6 +174,17 @@ namespace mamba
         throw std::runtime_error("Could not url-unescape string.");
     }
 
+    std::string cache_name_from_url(const std::string& url)
+    {
+        std::vector<unsigned char> hash(MD5_DIGEST_LENGTH);
+        MD5_CTX md5;
+        MD5_Init(&md5);
+        MD5_Update(&md5, url.c_str(), url.size());
+        MD5_Final(hash.data(), &md5);
+
+        std::string hex_digest = hex_string(hash);
+        return hex_digest.substr(0u, 8u);
+    }
 
     URLHandler::URLHandler(const std::string& url)
         : m_url(url)

--- a/src/micromamba/common_options.cpp
+++ b/src/micromamba/common_options.cpp
@@ -327,6 +327,6 @@ init_install_options(CLI::App* subcom)
                     { "enabled", "warn", "disabled" },
                     safety_checks.description());
 
-    auto& av = config.at("artifact_verif").get_wrapped<bool>();
-    subcom->add_flag("--artifact-verif", av.set_cli_config(0), av.description());
+    auto& av = config.at("verify_artifacts").get_wrapped<bool>();
+    subcom->add_flag("--verif-artifacts", av.set_cli_config(0), av.description());
 }

--- a/src/micromamba/common_options.cpp
+++ b/src/micromamba/common_options.cpp
@@ -328,5 +328,5 @@ init_install_options(CLI::App* subcom)
                     safety_checks.description());
 
     auto& av = config.at("verify_artifacts").get_wrapped<bool>();
-    subcom->add_flag("--verif-artifacts", av.set_cli_config(0), av.description());
+    subcom->add_flag("--verify-artifacts", av.set_cli_config(0), av.description());
 }

--- a/src/micromamba/common_options.cpp
+++ b/src/micromamba/common_options.cpp
@@ -326,4 +326,7 @@ init_install_options(CLI::App* subcom)
                     safety_checks.set_cli_config(""),
                     { "enabled", "warn", "disabled" },
                     safety_checks.description());
+
+    auto& av = config.at("artifact_verif").get_wrapped<bool>();
+    subcom->add_flag("--artifact-verif", av.set_cli_config(0), av.description());
 }


### PR DESCRIPTION
Description
---

add `RepoChecker` to Channel
add lazy loading of the `RepoChecker`
add `verify_artifacts` to `Context` and `Configuration`
- add artifact `--verify-artifacts` flag to micromamba CLI, requires `--experimental` to be also set to be effective
- `verify_artifacts` is rc and env var configurable using respectively `verify_artifacts` key and `MAMBA_VERIFY_ARTIFACTS`

get index_file from a `MRepo`
refactor `Channel` to avoid circular dependency in base_url
add cache_name_from_url free function
add index_error to disambiguate with package_error
add `RepoIndexChecker` and `RepoChecker` `verify_package` package to allow verification of a specific package instead of using `verify_index` all the time
implement `verify_package` on v0.6.0 spec `PkgMgr`
define reference and cache path for top-level content trust roles
use cached root metadata if any
add docstrings