### PR TITLE
Expand user in `--rc-file`

### DIFF
--- a/src/api/configuration.cpp
+++ b/src/api/configuration.cpp
@@ -326,6 +326,7 @@ namespace mamba
                 }
                 for (auto& f : files)
                 {
+                    f = env::expand_user(f);
                     if (!fs::exists(f))
                     {
                         LOG_ERROR << "'rc_file' specified but does not exist at: " << f.string();

--- a/test/micromamba/test_config.py
+++ b/test/micromamba/test_config.py
@@ -163,6 +163,20 @@ class TestConfigSources:
         for (file, tmp_file) in tmpfiles:
             os.rename(tmp_file, file)
 
+    def test_expand_user(self):
+        rc_path = os.path.join(TestConfigSources.root_prefix, random_string() + ".yml")
+        rc_path_short = rc_path.replace(os.path.expanduser("~"), "~")
+
+        os.makedirs(TestConfigSources.root_prefix, exist_ok=True)
+        with open(rc_path, "w") as f:
+            f.write("override_channels_enabled: true")
+
+        res = config("sources", "--rc-file", f"{rc_path_short}")
+        assert (
+            res.strip().splitlines()
+            == f"Configuration files (by precedence order):\n{rc_path_short}".splitlines()
+        )
+
 
 class TestConfigList:
     @pytest.mark.parametrize("rc_flag", ["--no-rc", "--rc-file="])


### PR DESCRIPTION
Description
---

Passing an rc file using `micromamba install xtensor --rc-file="~/myrc.yml"` fails because double-quotes `"` are preventing shell expansion of `~` char.

Expand user in `rc_file` hook
Add test

Closes https://github.com/mamba-org/mamba/issues/967
