### PR TITLE
Add yes and no as additional ways of answering a prompt

### DIFF
--- a/include/mamba/core/output.hpp
+++ b/include/mamba/core/output.hpp
@@ -225,7 +225,9 @@ namespace mamba
 
         static ConsoleStream stream();
         static void print(const std::string_view& str, bool force_print = false);
-        static bool prompt(const std::string_view& message, char fallback = '_', std::istream& input_stream = std::cin);
+        static bool prompt(const std::string_view& message,
+                           char fallback = '_',
+                           std::istream& input_stream = std::cin);
 
         ProgressProxy add_progress_bar(const std::string& name, size_t expected_total = 0);
         void init_multi_progress(ProgressBarMode mode = ProgressBarMode::multi);

--- a/include/mamba/core/output.hpp
+++ b/include/mamba/core/output.hpp
@@ -225,7 +225,7 @@ namespace mamba
 
         static ConsoleStream stream();
         static void print(const std::string_view& str, bool force_print = false);
-        static bool prompt(const std::string_view& message, char fallback = '_');
+        static bool prompt(const std::string_view& message, char fallback = '_', std::istream& input_stream = std::cin);
 
         ProgressProxy add_progress_bar(const std::string& name, size_t expected_total = 0);
         void init_multi_progress(ProgressBarMode mode = ProgressBarMode::multi);

--- a/src/core/output.cpp
+++ b/src/core/output.cpp
@@ -319,7 +319,7 @@ namespace mamba
                 response = std::string(1, fallback);
             }
             if (response.compare("yes") == 0 || 
-		response.compare("Yes") == 0||
+		response.compare("Yes") == 0 ||
 		response.compare("y") == 0 ||
 		response.compare("Y") == 0)
             {

--- a/src/core/output.cpp
+++ b/src/core/output.cpp
@@ -317,11 +317,17 @@ namespace mamba
                 // enter pressed
                 response = std::string(1, fallback);
             }
-            if (response.compare("y") == 0 || response.compare("Y") == 0)
+            if (response.compare("yes") == 0 || 
+		response.compare("Yes") == 0||
+		response.compare("y") == 0 ||
+		response.compare("Y") == 0)
             {
                 return true && !is_sig_interrupted();
             }
-            if (response.compare("n") == 0 || response.compare("N") == 0)
+            if (response.compare("no") == 0 ||
+		response.compare("No") == 0 || 
+		response.compare("n") == 0 || 
+		response.compare("N") == 0)
             {
                 Console::print("Aborted.");
                 return false;

--- a/src/core/output.cpp
+++ b/src/core/output.cpp
@@ -12,6 +12,7 @@
 
 #include <algorithm>
 #include <cstdlib>
+#include <iostream>
 
 #include "mamba/core/output.hpp"
 #include "mamba/core/thread_utils.hpp"
@@ -286,7 +287,7 @@ namespace mamba
         }
     }
 
-    bool Console::prompt(const std::string_view& message, char fallback)
+    bool Console::prompt(const std::string_view& message, char fallback, std::istream& input_stream)
     {
         if (Context::instance().always_yes)
         {
@@ -308,7 +309,7 @@ namespace mamba
                 std::cout << "[y/n] ";
             }
             std::string response;
-            std::getline(std::cin, response);
+            std::getline(input_stream, response);
 #ifdef _WIN32
             response = strip(response);
 #endif

--- a/src/core/output.cpp
+++ b/src/core/output.cpp
@@ -318,17 +318,13 @@ namespace mamba
                 // enter pressed
                 response = std::string(1, fallback);
             }
-            if (response.compare("yes") == 0 || 
-		response.compare("Yes") == 0 ||
-		response.compare("y") == 0 ||
-		response.compare("Y") == 0)
+            if (response.compare("yes") == 0 || response.compare("Yes") == 0
+                || response.compare("y") == 0 || response.compare("Y") == 0)
             {
                 return true && !is_sig_interrupted();
             }
-            if (response.compare("no") == 0 ||
-		response.compare("No") == 0 || 
-		response.compare("n") == 0 || 
-		response.compare("N") == 0)
+            if (response.compare("no") == 0 || response.compare("No") == 0
+                || response.compare("n") == 0 || response.compare("N") == 0)
             {
                 Console::print("Aborted.");
                 return false;

--- a/test/test_cpp.cpp
+++ b/test/test_cpp.cpp
@@ -245,42 +245,41 @@ namespace mamba
         Context::instance().no_progress_bars = false;
     }
 
-    class OutputPromptTests : public testing::TestWithParam<std::tuple<std::string, char, bool>> {};
+    class OutputPromptTests : public testing::TestWithParam<std::tuple<std::string, char, bool>>
+    {
+    };
 
     TEST_P(OutputPromptTests, prompt)
     {
-	auto params = GetParam();
+        auto params = GetParam();
 
-	std::stringstream test_stream;
-	test_stream << std::get<0>(params) << std::endl;
-	EXPECT_EQ(Console::instance().prompt("Test prompt", std::get<1>(params), test_stream), std::get<2>(params));
+        std::stringstream test_stream;
+        test_stream << std::get<0>(params) << std::endl;
+        EXPECT_EQ(Console::instance().prompt("Test prompt", std::get<1>(params), test_stream),
+                  std::get<2>(params));
     }
 
-    INSTANTIATE_TEST_CASE_P(
-        output,
-        OutputPromptTests,
-        testing::Values(
-            std::make_tuple("y", 'y', true),
-            std::make_tuple("yes", 'y', true),
-            std::make_tuple("Y", 'y', true),
-            std::make_tuple("Yes", 'y', true),
-            std::make_tuple("", 'y', true),
-            std::make_tuple("n", 'y', false),
-            std::make_tuple("no", 'y', false),
-            std::make_tuple("N", 'y', false),
-            std::make_tuple("No", 'y', false),
+    INSTANTIATE_TEST_CASE_P(output,
+                            OutputPromptTests,
+                            testing::Values(std::make_tuple("y", 'y', true),
+                                            std::make_tuple("yes", 'y', true),
+                                            std::make_tuple("Y", 'y', true),
+                                            std::make_tuple("Yes", 'y', true),
+                                            std::make_tuple("", 'y', true),
+                                            std::make_tuple("n", 'y', false),
+                                            std::make_tuple("no", 'y', false),
+                                            std::make_tuple("N", 'y', false),
+                                            std::make_tuple("No", 'y', false),
 
-            std::make_tuple("y", 'n', true),
-            std::make_tuple("yes", 'n', true),
-            std::make_tuple("Y", 'n', true),
-            std::make_tuple("Yes", 'n', true),
-            std::make_tuple("", 'n', false),
-            std::make_tuple("n", 'n', false),
-            std::make_tuple("no", 'n', false),
-            std::make_tuple("N", 'n', false),
-            std::make_tuple("No", 'n', false)
-	)
-    );
+                                            std::make_tuple("y", 'n', true),
+                                            std::make_tuple("yes", 'n', true),
+                                            std::make_tuple("Y", 'n', true),
+                                            std::make_tuple("Yes", 'n', true),
+                                            std::make_tuple("", 'n', false),
+                                            std::make_tuple("n", 'n', false),
+                                            std::make_tuple("no", 'n', false),
+                                            std::make_tuple("N", 'n', false),
+                                            std::make_tuple("No", 'n', false)));
 
     TEST(context, env_name)
     {

--- a/test/test_cpp.cpp
+++ b/test/test_cpp.cpp
@@ -1,5 +1,8 @@
 #include <gtest/gtest.h>
 
+#include <sstream>
+#include <tuple>
+
 #include "mamba/core/context.hpp"
 #include "mamba/core/fsutil.hpp"
 #include "mamba/core/history.hpp"
@@ -241,6 +244,43 @@ namespace mamba
         EXPECT_TRUE(ends_with(output, "conda-forge channel downloaded\n"));
         Context::instance().no_progress_bars = false;
     }
+
+    class OutputPromptTests : public testing::TestWithParam<std::tuple<std::string, char, bool>> {};
+
+    TEST_P(OutputPromptTests, prompt)
+    {
+	auto params = GetParam();
+
+	std::stringstream test_stream;
+	test_stream << std::get<0>(params) << std::endl;
+	EXPECT_EQ(Console::instance().prompt("Test prompt", std::get<1>(params), test_stream), std::get<2>(params));
+    }
+
+    INSTANTIATE_TEST_CASE_P(
+        output,
+        OutputPromptTests,
+        testing::Values(
+            std::make_tuple("y", 'y', true),
+            std::make_tuple("yes", 'y', true),
+            std::make_tuple("Y", 'y', true),
+            std::make_tuple("Yes", 'y', true),
+            std::make_tuple("", 'y', true),
+            std::make_tuple("n", 'y', false),
+            std::make_tuple("no", 'y', false),
+            std::make_tuple("N", 'y', false),
+            std::make_tuple("No", 'y', false),
+
+            std::make_tuple("y", 'n', true),
+            std::make_tuple("yes", 'n', true),
+            std::make_tuple("Y", 'n', true),
+            std::make_tuple("Yes", 'n', true),
+            std::make_tuple("", 'n', false),
+            std::make_tuple("n", 'n', false),
+            std::make_tuple("no", 'n', false),
+            std::make_tuple("N", 'n', false),
+            std::make_tuple("No", 'n', false),
+	)
+    );
 
     TEST(context, env_name)
     {

--- a/test/test_cpp.cpp
+++ b/test/test_cpp.cpp
@@ -278,7 +278,7 @@ namespace mamba
             std::make_tuple("n", 'n', false),
             std::make_tuple("no", 'n', false),
             std::make_tuple("N", 'n', false),
-            std::make_tuple("No", 'n', false),
+            std::make_tuple("No", 'n', false)
 	)
     );
 


### PR DESCRIPTION
Currently Console::prompt only accepts y and n. There has been interest in adding yes and no as alternatives. This would implement issue https://github.com/mamba-org/mamba/issues/977.

Additionally testing was added for Console::prompt. If we do not wish to add yes and no to as possible answers, it may still be worth it to merge the testing code in (with yes and no removed).