### PR TITLE
Provide long paths support on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,7 +69,6 @@ if (STATIC_DEPENDENCIES)
 endif()
 
 add_definitions(-DGHC_WIN_DISABLE_WSTRING_STORAGE_TYPE)
-add_definitions(-DGHC_WIN_DISABLE_AUTO_PREFIXES)
 
 # Dependencies
 # ============

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -36,6 +36,7 @@ You can try Mamba now by visiting the :ref:`installation page<installation>`!
    user_guide/mamba
    user_guide/micromamba
    user_guide/configuration
+   user_guide/pitfalls
 
 .. toctree::
    :caption: API reference

--- a/docs/source/user_guide/pitfalls.rst
+++ b/docs/source/user_guide/pitfalls.rst
@@ -1,0 +1,46 @@
+.. _pitfalls:
+
+Common pitfalls
+---------------
+
+Using long paths on Windows
+===========================
+
+Windows API historically supports paths up to 260 characters. While it's now possible to used longer ones, there are still limitations related to that.
+
+``libmamba`` internally relies on ``\\?\`` prefixing to handle such paths. If you get error messages advertising such prefix, please have look at the following steps:
+
+
+Long paths support has to be activated
+**************************************
+
+source: Robocorp `troubleshooting documentation <https://robocorp.com/docs/troubleshooting/windows-long-path>`_
+
+1. Open the Local Group Policy Editor application: - Start --> type gpedit.msc --> Enter:
+2. Navigate to Computer Configuration > Administrative Templates > System > Filesystem. On the right, find the "Enable win32 long paths" item and double-click it
+3. Change the setting to Enabled
+4. Exit the Local Group Policy Editor and restart your computer (or sign out and back in) to allow the changes to finish
+
+If the problem persists after those steps, try the following:
+
+1. Open the Registry Editor application: - Start --> type regedit.msc and press Enter:
+2. Navigate to HKEY-LOCAL-MACHINE > SYSTEM > CurrentControlSet > Control > FileSystem. On the right, find the LongPathsEnabled item and double-click it
+3. Change the Value data: to 1
+4. Exit the Registry Editor
+
+
+cmd.exe does not support calls to long prefixes
+***********************************************
+
+While ``cmd.exe`` shell support long paths prefixing for directory operations such as ``dir``, it doesn't allow to call an executable or a batch file located at a long path prefix.
+
+Thus, the following cases will fail:
+
+- completely
+
+  - calling executables located at long prefixes
+  - installation of packages with pre/post linking or activation ``.bat`` scripts
+
+- partially
+
+  - pre-compilation of ``noarch`` packages, with no impact on capability to use the package but removing it will let artifacts (pycache) on the filesystem

--- a/src/core/shell_init.cpp
+++ b/src/core/shell_init.cpp
@@ -267,6 +267,7 @@ namespace mamba
                 size = GetModuleFileNameW(NULL, (wchar_t*) buffer.c_str(), (DWORD) buffer.size());
             } while (new_size == size);
         }
+        buffer.resize(buffer.find(L'\0'));
         return fs::absolute(buffer);
 #elif defined(__APPLE__)
         uint32_t size = PATH_MAX;
@@ -454,6 +455,7 @@ namespace mamba
     std::string get_hook_contents(const std::string& shell)
     {
         fs::path exe = get_self_exe_path();
+
         if (shell == "zsh" || shell == "bash" || shell == "posix")
         {
             std::string contents = mamba_sh;

--- a/test/micromamba/test_activation.py
+++ b/test/micromamba/test_activation.py
@@ -196,6 +196,9 @@ class TestActivation:
         os.path.join("~", "tmproot" + random_string())
     )
     prefix = os.path.join(root_prefix, "envs", env_name)
+    long_prefix = os.path.join(
+        root_prefix, *["some_very_long_prefix" for i in range(20)], env_name
+    )
 
     @classmethod
     def setup_class(cls):
@@ -376,6 +379,23 @@ class TestActivation:
             assert not find_path_in_str(str(rp / "bin"), res["PATH"])
             assert find_path_in_str(str(rp / "envs" / "xyz"), res["PATH"])
             assert not find_path_in_str(str(rp / "envs" / "abc"), res["PATH"])
+
+            # long paths
+            s = [
+                f"micromamba create -p {TestActivation.long_prefix} xtensor six -y -c conda-forge"
+            ]
+            call(s)
+
+            s = [
+                f"micromamba activate",
+                f"micromamba activate {TestActivation.long_prefix}",
+            ] + evars
+            stdout, stderr = call(s)
+            res = to_dict(stdout)
+
+            assert find_path_in_str(str(rp / "condabin"), res["PATH"])
+            assert not find_path_in_str(str(rp / "bin"), res["PATH"])
+            assert find_path_in_str(TestActivation.long_prefix, res["PATH"])
 
             s = [
                 f"micromamba activate",


### PR DESCRIPTION
Description
---

Provide long paths support on Windows

- [x] remove GHC_WIN_DISABLE_AUTO_PREFIXES definition
- [x] fix #857 issue when running cmd.exe subprocesses with long paths
  - add documentation on pitfalls
- [x] fix upstream GHC::filesystem implementation of create_directories
  - see issue gulrak/filesystem#125
  - see PR gulrak/filesystem#126

Related issue https://github.com/mamba-org/mamba/issues/991