### PR TITLE
Improve python auto pinning

### DIFF
--- a/include/mamba/core/solver.hpp
+++ b/include/mamba/core/solver.hpp
@@ -56,6 +56,7 @@ namespace mamba
 
         const std::vector<MatchSpec>& install_specs() const;
         const std::vector<MatchSpec>& remove_specs() const;
+        const std::vector<MatchSpec>& pinned_specs() const;
 
         operator Solver*();
 
@@ -71,6 +72,7 @@ namespace mamba
         std::vector<MatchSpec> m_install_specs;
         std::vector<MatchSpec> m_remove_specs;
         std::vector<MatchSpec> m_neuter_specs;  // unused for now
+        std::vector<MatchSpec> m_pinned_specs;
         bool m_is_solved;
         Solver* m_solver;
         Pool* m_pool;

--- a/mamba/mamba.py
+++ b/mamba/mamba.py
@@ -535,11 +535,12 @@ def install(args, parser, command="install"):
                 if a_pkg in installed_names:
                     solver.add_jobs([a_pkg], api.SOLVER_UPDATE)
 
+        pinned_specs_info = ""
         if python_constraint:
             solver.add_pin(python_constraint)
+            pinned_specs_info += f"  - {python_constraint}"
 
         pinned_specs = get_pinned_specs(context.target_prefix)
-        pinned_specs_info = ""
         if pinned_specs:
             conda_prefix_data = PrefixData(context.target_prefix)
         for s in pinned_specs:
@@ -567,7 +568,7 @@ def install(args, parser, command="install"):
                 )
 
         if pinned_specs_info:
-            print(f"\n  Pinned packages:\n\n{pinned_specs_info}\n")
+            print(f"\nPinned packages:\n{pinned_specs_info}\n")
 
         success = solver.solve()
         if not success:

--- a/src/api/configuration.cpp
+++ b/src/api/configuration.cpp
@@ -634,6 +634,16 @@ namespace mamba
                    .set_env_var_name()
                    .description("Ignore pinned packages"));
 
+        insert(Configurable("no_py_pin", false)
+                   .group("Solver")
+                   .set_rc_configurable()
+                   .set_env_var_name()
+                   .description("Do not automatically pin Python")
+                   .long_description(unindent(R"(
+                        Do not automatically pin Python when not present in
+                        the packages specifications, which is the default
+                        behavior.)")));
+
         insert(Configurable("pinned_packages", &ctx.pinned_packages)
                    .group("Solver")
                    .set_rc_configurable()

--- a/src/api/install.cpp
+++ b/src/api/install.cpp
@@ -285,6 +285,7 @@ namespace mamba
         auto& config = Configuration::instance();
 
         auto& no_pin = config.at("no_pin").value<bool>();
+        auto& no_py_pin = config.at("no_py_pin").value<bool>();
         auto& retry_clean_cache = config.at("retry_clean_cache").value<bool>();
 
         fs::path pkgs_dirs;
@@ -460,10 +461,20 @@ namespace mamba
             solver.add_pins(ctx.pinned_packages);
         }
 
-        auto py_pin = python_pin(prefix_data, specs);
-        if (!py_pin.empty())
+        if (!no_py_pin)
         {
-            solver.add_pin(py_pin);
+            auto py_pin = python_pin(prefix_data, specs);
+            if (!py_pin.empty())
+            {
+                solver.add_pin(py_pin);
+            }
+        }
+        if (!solver.pinned_specs().empty())
+        {
+            std::vector<std::string> pinned_str;
+            for (auto& ms : solver.pinned_specs())
+                pinned_str.push_back("  - " + ms.conda_build_form() + "\n");
+            Console::print("\nPinned packages:\n" + join("", pinned_str));
         }
 
         bool success = solver.solve();

--- a/src/core/pinning.cpp
+++ b/src/core/pinning.cpp
@@ -37,7 +37,7 @@ namespace mamba
 
         std::vector<std::string> elems = split(py_version, ".");
         std::string py_pin = concat("python ", elems[0], ".", elems[1], ".*");
-        LOG_INFO << "Pinning python to " << py_pin;
+        LOG_DEBUG << "Pinning Python to '" << py_pin << "'";
         return py_pin;
     }
 

--- a/src/core/solver.cpp
+++ b/src/core/solver.cpp
@@ -246,6 +246,7 @@ namespace mamba
             LOG_ERROR << "No package can be installed for pin: " << pin;
             exit(1);
         }
+        m_pinned_specs.push_back(ms);
 
         Queue selected_pkgs;
         queue_init(&selected_pkgs);
@@ -313,6 +314,11 @@ namespace mamba
     const std::vector<MatchSpec>& MSolver::remove_specs() const
     {
         return m_remove_specs;
+    }
+
+    const std::vector<MatchSpec>& MSolver::pinned_specs() const
+    {
+        return m_pinned_specs;
     }
 
     bool MSolver::solve()

--- a/src/micromamba/common_options.cpp
+++ b/src/micromamba/common_options.cpp
@@ -301,6 +301,9 @@ init_install_options(CLI::App* subcom)
     auto& no_pin = config.at("no_pin").get_wrapped<bool>();
     subcom->add_flag("--no-pin,!--pin", no_pin.set_cli_config(0), no_pin.description());
 
+    auto& no_py_pin = config.at("no_py_pin").get_wrapped<bool>();
+    subcom->add_flag("--no-py-pin,!--py-pin", no_py_pin.set_cli_config(0), no_py_pin.description());
+
     auto& allow_softlinks = config.at("allow_softlinks").get_wrapped<bool>();
     subcom->add_flag("--allow-softlinks,!--no-allow-softlinks",
                      allow_softlinks.set_cli_config(0),


### PR DESCRIPTION
Description
---

Add console message with pinned packages, including python
- modify `mamba` to include python pin
- add it to `micromamba` to have the exact same display

Add configurable `no_py_pin` to disable python pinning
Add micromamba CLI flags for pinning or not python, `--no-py-pin` and `--py-pin`
Add test

Display of pinned packages is:
```
Pinned packages:
  - python 3.9.*
```

Related to https://github.com/mamba-org/mamba/issues/1002