### PR TITLE
Refactor `micromamba` config prepend and append sequence

### DIFF
--- a/include/mamba/api/configuration.hpp
+++ b/include/mamba/api/configuration.hpp
@@ -592,6 +592,8 @@ namespace mamba
         self_type& compute(const int options = 0,
                            const ConfigurationLevel& level = ConfigurationLevel::kFile);
 
+        bool is_valid_serialization(const std::string& value) const;
+
         void reset_compute_counter();
 
         void lock();
@@ -814,6 +816,20 @@ namespace mamba
     }
 
     template <class T>
+    bool Configurable<T>::is_valid_serialization(const std::string& value) const
+    {
+        try
+        {
+            detail::Source<T>::deserialize(value);
+            return true;
+        }
+        catch (...)
+        {
+            return false;
+        }
+    }
+
+    template <class T>
     void Configurable<T>::lock()
     {
         m_lock = true;
@@ -1010,6 +1026,8 @@ namespace mamba
 
             virtual bool has_single_op_lifetime() const = 0;
 
+            virtual bool is_valid_serialization(const std::string& value) const = 0;
+
             virtual bool locked() = 0;
 
             virtual void reset_compute_counter() = 0;
@@ -1157,6 +1175,11 @@ namespace mamba
             bool locked()
             {
                 return p_wrapped->locked();
+            }
+
+            bool is_valid_serialization(const std::string& value) const
+            {
+                return p_wrapped->is_valid_serialization(value);
             }
 
             void reset_compute_counter()
@@ -1441,6 +1464,11 @@ namespace mamba
         bool locked()
         {
             return p_impl->locked();
+        }
+
+        bool is_valid_serialization(const std::string& value) const
+        {
+            return p_impl->is_valid_serialization(value);
         }
 
         self_type& set_rc_yaml_value(const YAML::Node& value, const std::string& source)

--- a/include/mamba/api/configuration.hpp
+++ b/include/mamba/api/configuration.hpp
@@ -385,6 +385,8 @@ namespace mamba
                               std::vector<std::string>& source);
 
             static T deserialize(const std::string& value);
+
+            static bool is_sequence();
         };
 
         template <class T>
@@ -401,6 +403,8 @@ namespace mamba
                               std::vector<std::string>& source);
 
             static std::vector<T> deserialize(const std::string& value);
+
+            static bool is_sequence();
         };
 
         template <class T>
@@ -439,6 +443,12 @@ namespace mamba
         }
 
         template <class T>
+        bool Source<T>::is_sequence()
+        {
+            return false;
+        }
+
+        template <class T>
         void Source<std::vector<T>>::merge(const std::map<std::string, std::vector<T>>& values,
                                            const std::vector<std::string>& sources,
                                            std::vector<T>& value,
@@ -467,6 +477,12 @@ namespace mamba
         std::vector<T> Source<std::vector<T>>::deserialize(const std::string& value)
         {
             return YAML::Load("[" + value + "]").as<std::vector<T>>();
+        }
+
+        template <class T>
+        bool Source<std::vector<T>>::is_sequence()
+        {
+            return true;
         }
     }
 
@@ -593,6 +609,8 @@ namespace mamba
                            const ConfigurationLevel& level = ConfigurationLevel::kFile);
 
         bool is_valid_serialization(const std::string& value) const;
+
+        bool is_sequence() const;
 
         void reset_compute_counter();
 
@@ -830,6 +848,12 @@ namespace mamba
     }
 
     template <class T>
+    bool Configurable<T>::is_sequence() const
+    {
+        return detail::Source<T>::is_sequence();
+    }
+
+    template <class T>
     void Configurable<T>::lock()
     {
         m_lock = true;
@@ -1028,6 +1052,8 @@ namespace mamba
 
             virtual bool is_valid_serialization(const std::string& value) const = 0;
 
+            virtual bool is_sequence() const = 0;
+
             virtual bool locked() = 0;
 
             virtual void reset_compute_counter() = 0;
@@ -1180,6 +1206,11 @@ namespace mamba
             bool is_valid_serialization(const std::string& value) const
             {
                 return p_wrapped->is_valid_serialization(value);
+            }
+
+            bool is_sequence() const
+            {
+                return p_wrapped->is_sequence();
             }
 
             void reset_compute_counter()
@@ -1469,6 +1500,11 @@ namespace mamba
         bool is_valid_serialization(const std::string& value) const
         {
             return p_impl->is_valid_serialization(value);
+        }
+
+        bool is_sequence() const
+        {
+            return p_impl->is_sequence();
         }
 
         self_type& set_rc_yaml_value(const YAML::Node& value, const std::string& source)

--- a/src/micromamba/config.cpp
+++ b/src/micromamba/config.cpp
@@ -38,7 +38,7 @@ is_valid_rc_sequence(const std::string& key, const std::string& value)
     try
     {
         auto& c = config.config().at(key);
-        return c.is_valid_serialization(value) && c.rc_configurable();
+        return c.is_valid_serialization(value) && c.rc_configurable() && c.is_sequence();
     }
     catch (const std::out_of_range& e)
     {
@@ -213,7 +213,7 @@ set_config_sequence_command(CLI::App* subcom)
     auto& specs = config.insert(Configurable("config_set_sequence_spec",
                                              std::vector<std::pair<std::string, std::string>>({}))
                                     .group("Output, Prompt and Flow Control")
-                                    .description("Add value to the beginning of a configuration"),
+                                    .description("Add value to a configurable sequence"),
                                 true);
     subcom->add_option("specs", specs.set_cli_config({}), specs.description())->required();
 }
@@ -313,6 +313,8 @@ void
 set_config_prepend_command(CLI::App* subcom)
 {
     set_config_sequence_command(subcom);
+    subcom->get_option("specs")->description(
+        "Add value at the beginning of a configurable sequence");
     subcom->callback([&]() { set_sequence_to_rc(SequenceAddType::kPrepend); });
 }
 
@@ -320,7 +322,7 @@ void
 set_config_append_command(CLI::App* subcom)
 {
     set_config_sequence_command(subcom);
-    subcom->get_option("specs")->description("Add value to the end of a configuration");
+    subcom->get_option("specs")->description("Add value at the end of a configurable sequence");
     subcom->callback([&]() { set_sequence_to_rc(SequenceAddType::kAppend); });
 }
 

--- a/test/micromamba/test_config.py
+++ b/test/micromamba/test_config.py
@@ -500,25 +500,55 @@ class TestConfigModifiers:
         ).splitlines() == ["channels:", "  - flowers"]
 
     def test_file_append_multiple_inputs(self):
+        with open(TestConfigModifiers.home_rc_path, "w") as f:
+            f.write("channels:\n  - foo")
+
+        config(
+            "append",
+            "channels",
+            "condesc,mambesc",
+            "--file",
+            TestConfigModifiers.home_rc_path,
+        )
         assert (
             config(
-                "append",
-                "channels",
-                "condesc",
-                "mambesc",
-                "--file",
-                TestConfigModifiers.home_rc_path,
+                "get", "channels", "--file", TestConfigModifiers.home_rc_path
             ).splitlines()
-            == "Append key is invalid or it's not present in file or more than one key was received".splitlines()
+            == "channels:\n  - foo\n  - condesc\n  - mambesc".splitlines()
+        )
+
+    def test_file_append_multiple_keys(self):
+        with open(TestConfigModifiers.home_rc_path, "w") as f:
+            f.write("channels:\n  - foo\ndefault_channels:\n  - bar")
+
+        config(
+            "append",
+            "channels",
+            "condesc,mambesc",
+            "default_channels",
+            "condescd,mambescd",
+            "--file",
+            TestConfigModifiers.home_rc_path,
+        )
+        assert (
+            config(
+                "get", "channels", "--file", TestConfigModifiers.home_rc_path
+            ).splitlines()
+            == "channels:\n  - foo\n  - condesc\n  - mambesc".splitlines()
+        )
+        assert (
+            config(
+                "get", "default_channels", "--file", TestConfigModifiers.home_rc_path
+            ).splitlines()
+            == "default_channels:\n  - bar\n  - condescd\n  - mambescd".splitlines()
         )
 
     def test_file_append_invalid_input(self):
-        assert (
-            config(
-                "append", "@#A321", "--file", TestConfigModifiers.home_rc_path
-            ).splitlines()
-            == "Append key is invalid or it's not present in file or more than one key was received".splitlines()
-        )
+        with pytest.raises(subprocess.CalledProcessError):
+            config("append", "--file", TestConfigModifiers.home_rc_path)
+
+        with pytest.raises(subprocess.CalledProcessError):
+            config("append", "@#A321", "--file", TestConfigModifiers.home_rc_path)
 
     def test_file_prepend_single_input(self):
         config(
@@ -529,25 +559,55 @@ class TestConfigModifiers:
         ).splitlines() == ["channels:", "  - flowers"]
 
     def test_file_prepend_multiple_inputs(self):
+        with open(TestConfigModifiers.home_rc_path, "w") as f:
+            f.write("channels:\n  - foo")
+
+        config(
+            "prepend",
+            "channels",
+            "condesc,mambesc",
+            "--file",
+            TestConfigModifiers.home_rc_path,
+        )
         assert (
             config(
-                "prepend",
-                "channels",
-                "condesc",
-                "mambesc",
-                "--file",
-                TestConfigModifiers.home_rc_path,
+                "get", "channels", "--file", TestConfigModifiers.home_rc_path
             ).splitlines()
-            == "Prepend key is invalid or it's not present in file or more than one key was received".splitlines()
+            == "channels:\n  - condesc\n  - mambesc\n  - foo".splitlines()
+        )
+
+    def test_file_prepend_multiple_keys(self):
+        with open(TestConfigModifiers.home_rc_path, "w") as f:
+            f.write("channels:\n  - foo\ndefault_channels:\n  - bar")
+
+        config(
+            "prepend",
+            "channels",
+            "condesc,mambesc",
+            "default_channels",
+            "condescd,mambescd",
+            "--file",
+            TestConfigModifiers.home_rc_path,
+        )
+        assert (
+            config(
+                "get", "channels", "--file", TestConfigModifiers.home_rc_path
+            ).splitlines()
+            == "channels:\n  - condesc\n  - mambesc\n  - foo".splitlines()
+        )
+        assert (
+            config(
+                "get", "default_channels", "--file", TestConfigModifiers.home_rc_path
+            ).splitlines()
+            == "default_channels:\n  - condescd\n  - mambescd\n  - bar".splitlines()
         )
 
     def test_file_prepend_invalid_input(self):
-        assert (
-            config(
-                "prepend", "@#A321", "--file", TestConfigModifiers.home_rc_path
-            ).splitlines()
-            == "Prepend key is invalid or it's not present in file or more than one key was received".splitlines()
-        )
+        with pytest.raises(subprocess.CalledProcessError):
+            config("prepend", "--file", TestConfigModifiers.home_rc_path)
+
+        with pytest.raises(subprocess.CalledProcessError):
+            config("prepend", "@#A321", "--file", TestConfigModifiers.home_rc_path)
 
     def test_file_append_and_prepend_inputs(self):
         config(

--- a/test/micromamba/test_config.py
+++ b/test/micromamba/test_config.py
@@ -550,6 +550,20 @@ class TestConfigModifiers:
         with pytest.raises(subprocess.CalledProcessError):
             config("append", "@#A321", "--file", TestConfigModifiers.home_rc_path)
 
+        with pytest.raises(subprocess.CalledProcessError):
+            config("append", "json", "true", "--file", TestConfigModifiers.home_rc_path)
+
+        with pytest.raises(subprocess.CalledProcessError):
+            config(
+                "append",
+                "channels",
+                "foo,bar",
+                "json",
+                "true",
+                "--file",
+                TestConfigModifiers.home_rc_path,
+            )
+
     def test_file_prepend_single_input(self):
         config(
             "prepend", "channels", "flowers", "--file", TestConfigModifiers.home_rc_path
@@ -608,6 +622,22 @@ class TestConfigModifiers:
 
         with pytest.raises(subprocess.CalledProcessError):
             config("prepend", "@#A321", "--file", TestConfigModifiers.home_rc_path)
+
+        with pytest.raises(subprocess.CalledProcessError):
+            config(
+                "prepend", "json", "true", "--file", TestConfigModifiers.home_rc_path
+            )
+
+        with pytest.raises(subprocess.CalledProcessError):
+            config(
+                "prepend",
+                "channels",
+                "foo,bar",
+                "json",
+                "true",
+                "--file",
+                TestConfigModifiers.home_rc_path,
+            )
 
     def test_file_append_and_prepend_inputs(self):
         config(


### PR DESCRIPTION
Description
---

refactor `micromamba` config prepend and append sequence
add capability to define multiple key/val pairs
catch empty args or no values passed cases
check if keys match rc configurables configs
define config append or prepend spec as required
update and add tests

cc @marimeireles 

Closes #1019
Closes #1020 
Closes #1021