### PR TITLE
Do not print pinned packages in mamba with JSON output

### DIFF
--- a/mamba/mamba.py
+++ b/mamba/mamba.py
@@ -567,7 +567,7 @@ def install(args, parser, command="install"):
                     "libname VERSION BUILD, for example libblas=*=*mkl\n"
                 )
 
-        if pinned_specs_info:
+        if pinned_specs_info and not (context.quiet or context.json):
             print(f"\nPinned packages:\n{pinned_specs_info}\n")
 
         success = solver.solve()


### PR DESCRIPTION
Description
---

Fix JSON output in mamba: do not print pinned packages when using JSON output

However it looks like other prints could also break the JSON output:
https://github.com/mamba-org/mamba/blob/e45af49eb75cfbb7ecc4c8ff582a6092c4a7ef72/mamba/mamba.py#L575

Closes #1029 