### PR TITLE
Parse and use explicit platform specifications.

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -32,7 +32,7 @@ jobs:
     - name: Install dependencies
       shell: pwsh
       run: |
-        conda install clang clang-tools=10.0.1 pre-commit
+        conda install clang clang-tools=11.1.0 pre-commit
     - name: Conda info
       shell: pwsh
       run: |
@@ -41,4 +41,4 @@ jobs:
     - name: Run all linters
       shell: pwsh
       run: |
-        pre-commit run --all-files --verbose
+        pre-commit run --all-files --verbose --show-diff-on-failure

--- a/docs/source/python_api.rst
+++ b/docs/source/python_api.rst
@@ -32,13 +32,12 @@ Here is an example usage of the mamba_api:
         prefix=None,
         repodata_fn="repodata.json",
     ):
-        real_urls = calculate_channel_urls(channel_urls, prepend, platform, use_local)
-        check_whitelist(real_urls)
+        check_whitelist(channel_urls)
 
         dlist = mamba_api.DownloadTargetList()
 
         index = []
-        for idx, url in enumerate(real_urls):
+        for idx, url in enumerate(channel_urls):
             channel = Channel(url)
 
             full_url = channel.url(with_credentials=True) + "/" + repodata_fn

--- a/include/mamba/core/channel.hpp
+++ b/include/mamba/core/channel.hpp
@@ -10,118 +10,69 @@
 #include "mamba/core/validate.hpp"
 
 #include <map>
+#include <optional>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace mamba
 {
     void load_tokens();
 
+    // accessors public
     class Channel
     {
     public:
-        Channel(const std::string& scheme = "",
-                const std::string& auth = "",
-                const std::string& location = "",
-                const std::string& token = "",
-                const std::string& name = "",
-                const std::string& platform = "",
-                const std::string& package_filename = "",
-                const std::string& multi_name = "");
-
-        void set_token(const std::string& token);
         const std::string& scheme() const;
-        const std::string& auth() const;
         const std::string& location() const;
-        const std::string& token() const;
         const std::string& name() const;
-        const std::string& platform() const;
-        const std::string& package_filename() const;
+        const std::vector<std::string>& platforms() const;
+        const std::optional<std::string>& auth() const;
+        const std::optional<std::string>& token() const;
+        const std::optional<std::string>& package_filename() const;
         const std::string& canonical_name() const;
-        const validate::RepoChecker& repo_checker();
+        const validate::RepoChecker& repo_checker() const;
 
         std::string base_url() const;
-        std::string url(bool with_credential = true) const;
-
+        // The pairs consist of (platform,url)
+        std::vector<std::pair<std::string, std::string>> platform_urls(bool with_credential
+                                                                       = true) const;
         std::vector<std::string> urls(bool with_credential = true) const;
-        std::vector<std::string> urls(const std::vector<std::string>& platforms,
-                                      bool with_credential = true) const;
 
-        static Channel make_simple_channel(const Channel& channel_alias,
-                                           const std::string& channel_url,
-                                           const std::string& channel_name = "",
-                                           const std::string& multi_name = "");
-
-        static Channel& make_cached_channel(const std::string& value);
-        static void clear_cache();
-
-    private:
-        using cache_type = std::map<std::string, Channel>;
-        static cache_type& get_cache();
-
-        static Channel from_url(const std::string& url);
-        static Channel from_name(const std::string& name);
-        static Channel from_value(const std::string& value);
-
-        std::string build_url(const std::string& base, bool with_credential) const;
+    protected:
+        Channel(const std::string& scheme,
+                const std::string& location,
+                const std::string& name,
+                const std::optional<std::string>& auth = {},
+                const std::optional<std::string>& token = {},
+                const std::optional<std::string>& package_filename = {},
+                const std::optional<std::string>& canonical_name = {});
 
         std::string m_scheme;
-        std::string m_auth;
         std::string m_location;
-        std::string m_token;
         std::string m_name;
-        std::string m_platform;
-        std::string m_package_filename;
-        mutable std::string m_canonical_name;
-        validate::RepoChecker m_repo_checker;
+        std::vector<std::string> m_platforms;
+        std::optional<std::string> m_auth;
+        std::optional<std::string> m_token;
+        std::optional<std::string> m_package_filename;
+        mutable std::optional<std::string> m_canonical_name;
+        mutable validate::RepoChecker m_repo_checker;
     };
 
-    Channel& make_channel(const std::string& value);
+    // public
+    const Channel& make_channel(const std::string& value);
 
+    // public
     std::vector<std::string> get_channel_urls(const std::vector<std::string>& channel_names,
-                                              const std::vector<std::string>& platforms = {},
                                               bool with_credential = true);
 
+    // public
     std::vector<std::string> calculate_channel_urls(const std::vector<std::string>& channel_names,
                                                     bool append_context_channels = true,
-                                                    const std::string& platform = "",
                                                     bool use_local = false);
 
+    // XXX unused, but should be in python API according to docs
     void check_whitelist(const std::vector<std::string>& urls);
-
-    class ChannelContext
-    {
-    public:
-        using channel_list = std::vector<std::string>;
-        using channel_map = std::map<std::string, Channel>;
-        using multichannel_map = std::map<std::string, std::vector<std::string>>;
-
-        static ChannelContext& instance();
-
-        ChannelContext(const ChannelContext&) = delete;
-        ChannelContext& operator=(const ChannelContext&) = delete;
-        ChannelContext(ChannelContext&&) = delete;
-        ChannelContext& operator=(ChannelContext&&) = delete;
-
-        const Channel& get_channel_alias() const;
-        const channel_map& get_custom_channels() const;
-        const multichannel_map& get_custom_multichannels() const;
-
-        const channel_list& get_whitelist_channels() const;
-
-    private:
-        ChannelContext();
-        ~ChannelContext() = default;
-
-        Channel build_channel_alias();
-        void init_custom_channels();
-
-        Channel m_channel_alias;
-        channel_map m_custom_channels;
-        multichannel_map m_custom_multichannels;
-        channel_list m_whitelist_channels;
-    };
-
 }  // namespace mamba
 
 #endif

--- a/include/mamba/core/channel.hpp
+++ b/include/mamba/core/channel.hpp
@@ -66,11 +66,6 @@ namespace mamba
     std::vector<std::string> get_channel_urls(const std::vector<std::string>& channel_names,
                                               bool with_credential = true);
 
-    // public
-    std::vector<std::string> calculate_channel_urls(const std::vector<std::string>& channel_names,
-                                                    bool append_context_channels = true,
-                                                    bool use_local = false);
-
     // XXX unused, but should be in python API according to docs
     void check_whitelist(const std::vector<std::string>& urls);
 }  // namespace mamba

--- a/include/mamba/core/channel.hpp
+++ b/include/mamba/core/channel.hpp
@@ -34,6 +34,7 @@ namespace mamba
         const validate::RepoChecker& repo_checker() const;
 
         std::string base_url() const;
+        std::string platform_url(std::string platform, bool with_credential = true) const;
         // The pairs consist of (platform,url)
         std::vector<std::pair<std::string, std::string>> platform_urls(bool with_credential
                                                                        = true) const;
@@ -63,8 +64,7 @@ namespace mamba
     const Channel& make_channel(const std::string& value);
 
     // public
-    std::vector<std::string> get_channel_urls(const std::vector<std::string>& channel_names,
-                                              bool with_credential = true);
+    std::vector<const Channel*> get_channels(const std::vector<std::string>& channel_names);
 
     // XXX unused, but should be in python API according to docs
     void check_whitelist(const std::vector<std::string>& urls);

--- a/include/mamba/core/channel_internal.hpp
+++ b/include/mamba/core/channel_internal.hpp
@@ -1,0 +1,91 @@
+// Copyright (c) 2021, QuantStack and Mamba Contributors
+//
+// Distributed under the terms of the BSD 3-Clause License.
+//
+// The full license is in the file LICENSE, distributed with this software.
+
+/** Contains the internal interface within Channel, exposed mainly for testing purposes. **/
+
+#ifndef MAMBA_CORE_CHANNEL_INTERNAL_HPP
+#define MAMBA_CORE_CHANNEL_INTERNAL_HPP
+
+#include <map>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "channel.hpp"
+
+namespace mamba
+{
+    class ChannelInternal : public Channel
+    {
+    public:
+        static Channel make_simple_channel(const Channel& channel_alias,
+                                           const std::string& channel_url,
+                                           const std::string& channel_name = "",
+                                           const std::string& multi_name = "");
+
+        static const Channel& make_cached_channel(const std::string& value);
+
+        static void clear_cache();
+
+    private:
+        ChannelInternal(const std::string& scheme,
+                        const std::string& location,
+                        const std::string& name,
+                        const std::optional<std::string>& auth = {},
+                        const std::optional<std::string>& token = {},
+                        const std::optional<std::string>& package_filename = {},
+                        const std::optional<std::string>& canonical_name = {});
+
+        using cache_type = std::map<std::string, Channel>;
+        static cache_type& get_cache();
+
+        static ChannelInternal from_url(const std::string& url);
+        static ChannelInternal from_name(const std::string& name);
+        static ChannelInternal from_value(const std::string& value);
+        static ChannelInternal from_alias(const std::string& scheme,
+                                          const std::string& location,
+                                          const std::optional<std::string>& auth = {},
+                                          const std::optional<std::string>& token = {});
+        friend class ChannelContext;
+    };
+
+    class ChannelContext
+    {
+    public:
+        using channel_list = std::vector<std::string>;
+        using channel_map = std::map<std::string, Channel>;
+        using multichannel_map = std::map<std::string, std::vector<std::string>>;
+
+        static ChannelContext& instance();
+
+        ChannelContext(const ChannelContext&) = delete;
+        ChannelContext& operator=(const ChannelContext&) = delete;
+        ChannelContext(ChannelContext&&) = delete;
+        ChannelContext& operator=(ChannelContext&&) = delete;
+
+        // internal
+        const Channel& get_channel_alias() const;
+        const channel_map& get_custom_channels() const;
+        const multichannel_map& get_custom_multichannels() const;
+
+        const channel_list& get_whitelist_channels() const;
+
+    private:
+        ChannelContext();
+        ~ChannelContext() = default;
+
+        Channel build_channel_alias();
+        void init_custom_channels();
+
+        Channel m_channel_alias;
+        channel_map m_custom_channels;
+        multichannel_map m_custom_multichannels;
+        channel_list m_whitelist_channels;
+    };
+
+}  // namespace mamba
+
+#endif

--- a/include/mamba/core/subdirdata.hpp
+++ b/include/mamba/core/subdirdata.hpp
@@ -44,7 +44,8 @@ namespace mamba
          */
         MSubdirData(const std::string& name,
                     const std::string& repodata_url,
-                    const std::string& repodata_fn);
+                    const std::string& repodata_fn,
+                    bool is_noarch);
 
         // TODO return seconds as double
         fs::file_time_type::duration check_cache(const fs::path& cache_file,
@@ -84,6 +85,7 @@ namespace mamba
         std::string m_name;
         std::string m_json_fn;
         std::string m_solv_fn;
+        bool m_is_noarch;
         nlohmann::json m_mod_etag;
         std::unique_ptr<TemporaryFile> m_temp_file;
     };

--- a/include/mamba/core/url.hpp
+++ b/include/mamba/core/url.hpp
@@ -52,11 +52,6 @@ namespace mamba
 
     bool compare_cleaned_url(const std::string& url1, const std::string& url2);
 
-    void split_platform(const std::vector<std::string>& known_platforms,
-                        const std::string& url,
-                        std::string& cleaned_url,
-                        std::string& platform);
-
     bool is_path(const std::string& input);
     std::string path_to_url(const std::string& path);
 

--- a/mamba/mamba_env.py
+++ b/mamba/mamba_env.py
@@ -11,7 +11,6 @@ from conda.base.context import context
 from conda.core.package_cache_data import PackageCacheData
 from conda.core.prefix_data import PrefixData
 from conda.core.solve import get_pinned_specs
-from conda.models.channel import prioritize_channels
 from conda.models.match_spec import MatchSpec
 from conda_env.installers import conda
 
@@ -38,12 +37,10 @@ def mamba_install(prefix, specs, args, env, *_, **kwargs):
         if spec_channel and spec_channel not in channel_urls:
             channel_urls.append(str(spec_channel))
 
-    ordered_channels_dict = prioritize_channels(channel_urls)
-
     pool = api.Pool()
     repos = []
     index = load_channels(
-        pool, tuple(ordered_channels_dict.keys()), repos, prepend=False
+        pool, channel_urls, repos, prepend=False
     )
 
     if not (context.quiet or context.json):

--- a/mamba/mamba_env.py
+++ b/mamba/mamba_env.py
@@ -39,9 +39,7 @@ def mamba_install(prefix, specs, args, env, *_, **kwargs):
 
     pool = api.Pool()
     repos = []
-    index = load_channels(
-        pool, channel_urls, repos, prepend=False
-    )
+    index = load_channels(pool, channel_urls, repos, prepend=False)
 
     if not (context.quiet or context.json):
         print("\n\nLooking for: {}\n\n".format(specs))

--- a/mamba/utils.py
+++ b/mamba/utils.py
@@ -7,6 +7,7 @@ import json
 import os
 import tempfile
 import urllib.parse
+from collections import OrderedDict
 
 from conda._vendor.boltons.setutils import IndexedSet
 from conda.base.constants import ChannelPriority
@@ -21,9 +22,9 @@ from conda.core.link import PrefixSetup, UnlinkLinkTransaction
 from conda.core.prefix_data import PrefixData
 from conda.core.solve import diff_for_unlink_link_precs
 from conda.gateways.connection.session import CondaHttpAuth
-from conda.models.channel import Channel
 from conda.models.prefix_graph import PrefixGraph
 from conda.models.records import PackageRecord
+from conda.models.channel import Channel as CondaChannel
 
 import mamba.mamba_api as api
 
@@ -44,29 +45,37 @@ def get_index(
     prefix=None,
     repodata_fn="repodata.json",
 ):
-    all_urls = []
+    all_channels = []
     if use_local:
-        all_urls.append("local")
-    all_urls.extend(channel_urls)
+        all_channels.append("local")
+    all_channels.extend(channel_urls)
     if prepend:
-        all_urls.extend(context.channels)
-    check_whitelist(all_urls)
+        all_channels.extend(context.channels)
+    check_whitelist(all_channels)
+
+    # Remove duplicates but retain order
+    all_channels = list(OrderedDict.fromkeys(all_channels))
 
     dlist = api.DownloadTargetList()
 
     index = []
 
-    for url in all_urls:
-        at_count = url.count("@")
+    def fixup_channel_spec(spec):
+        at_count = spec.count("@")
         if at_count > 1:
-            first_at = url.find("@")
-            url = (
-                url[:first_at] + urllib.parse.quote(url[first_at]) + url[first_at + 1 :]
+            first_at = spec.find("@")
+            spec = (
+                spec[:first_at] + urllib.parse.quote(spec[first_at])
+                + spec[first_at + 1 :]
             )
-        channel = Channel(url)
-        for ind, (platform, url) in enumerate(
-                channel.platform_urls(with_credentials=True)
-                ):
+        if platform:
+            spec = spec + "[" + platform + "]"
+        return spec
+
+    all_channels = list(map(fixup_channel_spec, all_channels))
+
+    for channel in api.get_channels(all_channels):
+        for channel_platform, url in channel.platform_urls(with_credentials=True):
             full_url = CondaHttpAuth.add_binstar_token(url + "/" + repodata_fn)
 
             full_path_cache = os.path.join(
@@ -74,13 +83,18 @@ def get_index(
             )
             name = None
             if channel.name:
-                name = channel.name + "/" + platform
+                name = channel.name + "/" + channel_platform
             else:
-                name = channel.urls(with_credential=False)[ind]
-            sd = api.SubdirData(name, full_url, full_path_cache, platform == "noarch")
+                name = channel.platform_url(channel_platform, with_credential=False)
+            sd = api.SubdirData(name, full_url, full_path_cache,
+                                channel_platform == "noarch")
 
             sd.load()
-            index.append((sd, channel))
+            index.append((sd, {
+                "platform": channel_platform,
+                "url": url,
+                "channel": channel
+            }))
             dlist.add(sd)
 
     is_downloaded = dlist.download(True)
@@ -117,31 +131,32 @@ def load_channels(
     subprio_index = len(index)
     if strict_priority:
         # first, count unique channels
-        n_channels = len(set([channel.canonical_name for _, channel in index]))
-        current_channel = index[0][1].canonical_name
+        n_channels = len(set([entry["channel"].canonical_name for _, entry in index]))
+        current_channel = index[0][1]["channel"].canonical_name
         channel_prio = n_channels
 
-    for subdir, chan in index:
+    for subdir, entry in index:
         # add priority here
         if strict_priority:
-            if chan.canonical_name != current_channel:
+            if entry["channel"].canonical_name != current_channel:
                 channel_prio -= 1
-                current_channel = chan.canonical_name
+                current_channel = entry["channel"].canonical_name
             priority = channel_prio
         else:
             priority = 0
         if strict_priority:
-            subpriority = 0 if chan.platform == "noarch" else 1
+            subpriority = 0 if entry["platform"] == "noarch" else 1
         else:
             subpriority = subprio_index
             subprio_index -= 1
 
-        if not subdir.loaded() and chan.platform != "noarch":
+        if not subdir.loaded() and entry["platform"] != "noarch":
             # ignore non-loaded subdir if channel is != noarch
             continue
 
         if context.verbosity != 0:
-            print("Channel: {}, prio: {} : {}".format(chan, priority, subpriority))
+            print("Channel: {}, platform: {}, prio: {} : {}".format(
+                entry["channel"], entry["platform"], priority, subpriority))
             print("Cache path: ", subdir.cache_path())
 
         repo = subdir.create_repo(pool)
@@ -186,12 +201,16 @@ def init_api_context(use_mamba_experimental=False):
     api_ctx.use_only_tar_bz2 = context.use_only_tar_bz2
 
 
-def to_package_record_from_subjson(channel, pkg, jsn_string):
-    channel = channel
-    channel_url = channel.url(with_credentials=True)
+def to_conda_channel(channel, platform):
+    return CondaChannel(channel.scheme, channel.auth, channel.location,
+                        channel.token, channel.name, platform, channel.package_filename)
+
+
+def to_package_record_from_subjson(entry, pkg, jsn_string):
+    channel_url = entry["url"]
     info = json.loads(jsn_string)
     info["fn"] = pkg
-    info["channel"] = channel
+    info["channel"] = to_conda_channel(entry["channel"], entry["platform"])
     info["url"] = join_url(channel_url, pkg)
     package_record = PackageRecord(**info)
     return package_record
@@ -252,8 +271,9 @@ def to_txn(
     final_precs = IndexedSet(prefix_data.iter_records())
 
     lookup_dict = {}
-    for _, c in index:
-        lookup_dict[c.url(with_credentials=False)] = c
+    for _, entry in index:
+        lookup_dict[entry["channel"]
+                    .platform_url(entry["platform"], with_credentials=False)] = entry
 
     for _, pkg in to_unlink:
         for i_rec in installed_pkg_recs:

--- a/mamba/utils.py
+++ b/mamba/utils.py
@@ -285,7 +285,10 @@ def to_txn(
             print("No package record found!")
 
     for c, pkg, jsn_s in to_link:
-        sdir = lookup_dict[split_anaconda_token(remove_auth(c))[0]]
+        key = split_anaconda_token(remove_auth(c))[0]
+        if key not in lookup_dict:
+            raise ValueError("missing key {} in channels: {}".format(key, lookup_dict))
+        sdir = lookup_dict[key]
         rec = to_package_record_from_subjson(sdir, pkg, jsn_s)
         final_precs.add(rec)
         to_link_records.append(rec)

--- a/mamba/utils.py
+++ b/mamba/utils.py
@@ -85,7 +85,7 @@ def get_index(
             if channel.name:
                 name = channel.name + "/" + channel_platform
             else:
-                name = channel.platform_url(channel_platform, with_credential=False)
+                name = channel.platform_url(channel_platform, with_credentials=False)
             sd = api.SubdirData(name, full_url, full_path_cache,
                                 channel_platform == "noarch")
 

--- a/mamba/utils.py
+++ b/mamba/utils.py
@@ -14,17 +14,14 @@ from conda.base.constants import ChannelPriority
 from conda.base.context import context
 from conda.common.serialize import json_dump
 from conda.common.url import join_url, remove_auth, split_anaconda_token
-from conda.core.index import (
-    _supplement_index_with_system,
-    check_whitelist,
-)
+from conda.core.index import _supplement_index_with_system, check_whitelist
 from conda.core.link import PrefixSetup, UnlinkLinkTransaction
 from conda.core.prefix_data import PrefixData
 from conda.core.solve import diff_for_unlink_link_precs
 from conda.gateways.connection.session import CondaHttpAuth
+from conda.models.channel import Channel as CondaChannel
 from conda.models.prefix_graph import PrefixGraph
 from conda.models.records import PackageRecord
-from conda.models.channel import Channel as CondaChannel
 
 import mamba.mamba_api as api
 
@@ -65,7 +62,8 @@ def get_index(
         if at_count > 1:
             first_at = spec.find("@")
             spec = (
-                spec[:first_at] + urllib.parse.quote(spec[first_at])
+                spec[:first_at]
+                + urllib.parse.quote(spec[first_at])
                 + spec[first_at + 1 :]
             )
         if platform:
@@ -86,15 +84,14 @@ def get_index(
                 name = channel.name + "/" + channel_platform
             else:
                 name = channel.platform_url(channel_platform, with_credentials=False)
-            sd = api.SubdirData(name, full_url, full_path_cache,
-                                channel_platform == "noarch")
+            sd = api.SubdirData(
+                name, full_url, full_path_cache, channel_platform == "noarch"
+            )
 
             sd.load()
-            index.append((sd, {
-                "platform": channel_platform,
-                "url": url,
-                "channel": channel
-            }))
+            index.append(
+                (sd, {"platform": channel_platform, "url": url, "channel": channel})
+            )
             dlist.add(sd)
 
     is_downloaded = dlist.download(True)
@@ -155,8 +152,11 @@ def load_channels(
             continue
 
         if context.verbosity != 0:
-            print("Channel: {}, platform: {}, prio: {} : {}".format(
-                entry["channel"], entry["platform"], priority, subpriority))
+            print(
+                "Channel: {}, platform: {}, prio: {} : {}".format(
+                    entry["channel"], entry["platform"], priority, subpriority
+                )
+            )
             print("Cache path: ", subdir.cache_path())
 
         repo = subdir.create_repo(pool)
@@ -202,8 +202,15 @@ def init_api_context(use_mamba_experimental=False):
 
 
 def to_conda_channel(channel, platform):
-    return CondaChannel(channel.scheme, channel.auth, channel.location,
-                        channel.token, channel.name, platform, channel.package_filename)
+    return CondaChannel(
+        channel.scheme,
+        channel.auth,
+        channel.location,
+        channel.token,
+        channel.name,
+        platform,
+        channel.package_filename,
+    )
 
 
 def to_package_record_from_subjson(entry, pkg, jsn_string):
@@ -272,8 +279,9 @@ def to_txn(
 
     lookup_dict = {}
     for _, entry in index:
-        lookup_dict[entry["channel"]
-                    .platform_url(entry["platform"], with_credentials=False)] = entry
+        lookup_dict[
+            entry["channel"].platform_url(entry["platform"], with_credentials=False)
+        ] = entry
 
     for _, pkg in to_unlink:
         for i_rec in installed_pkg_recs:

--- a/mamba/utils.py
+++ b/mamba/utils.py
@@ -64,22 +64,24 @@ def get_index(
                 url[:first_at] + urllib.parse.quote(url[first_at]) + url[first_at + 1 :]
             )
         channel = Channel(url)
-        full_url = CondaHttpAuth.add_binstar_token(
-            channel.url(with_credentials=True) + "/" + repodata_fn
-        )
+        for ind, (platform, url) in enumerate(
+                channel.platform_urls(with_credentials=True)
+                ):
+            full_url = CondaHttpAuth.add_binstar_token(url + "/" + repodata_fn)
 
-        full_path_cache = os.path.join(
-            api.create_cache_dir(), api.cache_fn_url(full_url)
-        )
-        if channel.name:
-            channel_name = channel.name + "/" + channel.subdir
-        else:
-            channel_name = channel.url(with_credentials=False)
-        sd = api.SubdirData(channel_name, full_url, full_path_cache)
+            full_path_cache = os.path.join(
+                api.create_cache_dir(), api.cache_fn_url(full_url)
+            )
+            name = None
+            if channel.name:
+                name = channel.name + "/" + platform
+            else:
+                name = channel.urls(with_credential=False)[ind]
+            sd = api.SubdirData(name, full_url, full_path_cache, platform == "noarch")
 
-        sd.load()
-        index.append((sd, channel))
-        dlist.add(sd)
+            sd.load()
+            index.append((sd, channel))
+            dlist.add(sd)
 
     is_downloaded = dlist.download(True)
 

--- a/mamba/utils.py
+++ b/mamba/utils.py
@@ -285,7 +285,13 @@ def to_txn(
             print("No package record found!")
 
     for c, pkg, jsn_s in to_link:
-        key = split_anaconda_token(remove_auth(c))[0]
+        if c.startswith("file://"):
+            # The conda functions (specifically remove_auth) assume the input
+            # is a url; a file uri on windows with a drive letter messes them
+            # up.
+            key = c
+        else:
+            key = split_anaconda_token(remove_auth(c))[0]
         if key not in lookup_dict:
             raise ValueError("missing key {} in channels: {}".format(key, lookup_dict))
         sdir = lookup_dict[key]

--- a/mamba/utils.py
+++ b/mamba/utils.py
@@ -15,7 +15,6 @@ from conda.common.serialize import json_dump
 from conda.common.url import join_url, remove_auth, split_anaconda_token
 from conda.core.index import (
     _supplement_index_with_system,
-    calculate_channel_urls,
     check_whitelist,
 )
 from conda.core.link import PrefixSetup, UnlinkLinkTransaction
@@ -45,15 +44,19 @@ def get_index(
     prefix=None,
     repodata_fn="repodata.json",
 ):
-
-    real_urls = calculate_channel_urls(channel_urls, prepend, platform, use_local)
-    check_whitelist(real_urls)
+    all_urls = []
+    if use_local:
+        all_urls.append("local")
+    all_urls.extend(channel_urls)
+    if prepend:
+        all_urls.extend(context.channels)
+    check_whitelist(all_urls)
 
     dlist = api.DownloadTargetList()
 
     index = []
 
-    for url in real_urls:
+    for url in all_urls:
         at_count = url.count("@")
         if at_count > 1:
             first_at = url.find("@")

--- a/src/api/install.cpp
+++ b/src/api/install.cpp
@@ -352,32 +352,34 @@ namespace mamba
             load_tokens();
         }
 
-        for (auto& url : channel_urls)
+        for (auto& chan_url : channel_urls)
         {
-            auto& channel = make_channel(url);
-            std::string repodata_full_url = concat(channel.url(true), "/repodata.json");
-
-            auto sdir
-                = std::make_shared<MSubdirData>(concat(channel.name(), "/", channel.platform()),
-                                                repodata_full_url,
-                                                cache_dir / cache_fn_url(repodata_full_url));
-
-            sdir->load();
-            multi_dl.add(sdir->target());
-            subdirs.push_back(sdir);
-            if (ctx.channel_priority == ChannelPriority::kDisabled)
+            auto& channel = make_channel(chan_url);
+            for (auto& [platform, url] : channel.platform_urls(true))
             {
-                priorities.push_back(std::make_pair(0, max_prio--));
-            }
-            else  // Consider 'flexible' and 'strict' the same way
-            {
-                if (channel.name() != prev_channel_name)
+                std::string repodata_full_url = concat(url, "/repodata.json");
+
+                auto sdir
+                    = std::make_shared<MSubdirData>(concat(channel.name(), "/", platform),
+                                                    repodata_full_url,
+                                                    cache_dir / cache_fn_url(repodata_full_url));
+
+                sdir->load();
+                multi_dl.add(sdir->target());
+                subdirs.push_back(sdir);
+                if (ctx.channel_priority == ChannelPriority::kDisabled)
                 {
-                    max_prio--;
-                    prev_channel_name = channel.name();
+                    priorities.push_back(std::make_pair(0, max_prio--));
                 }
-                priorities.push_back(
-                    std::make_pair(max_prio, channel.platform() == "noarch" ? 0 : 1));
+                else  // Consider 'flexible' and 'strict' the same way
+                {
+                    if (channel.name() != prev_channel_name)
+                    {
+                        max_prio--;
+                        prev_channel_name = channel.name();
+                    }
+                    priorities.push_back(std::make_pair(max_prio, platform == "noarch" ? 0 : 1));
+                }
             }
         }
         if (!ctx.offline)

--- a/src/api/install.cpp
+++ b/src/api/install.cpp
@@ -357,20 +357,14 @@ namespace mamba
             load_tokens();
         }
 
-        // Keep track of urls used to ignore duplicates
-        std::set<std::string> visited_urls;
-        for (auto& chan_url : channel_urls)
+        for (auto channel : get_channels(channel_urls))
         {
-            if (visited_urls.count(chan_url) > 0)
-                continue;
-            visited_urls.insert(chan_url);
-            auto& channel = make_channel(chan_url);
-            for (auto& [platform, url] : channel.platform_urls(true))
+            for (auto& [platform, url] : channel->platform_urls(true))
             {
                 std::string repodata_full_url = concat(url, "/repodata.json");
 
                 auto sdir
-                    = std::make_shared<MSubdirData>(concat(channel.name(), "/", platform),
+                    = std::make_shared<MSubdirData>(concat(channel->name(), "/", platform),
                                                     repodata_full_url,
                                                     cache_dir / cache_fn_url(repodata_full_url),
                                                     platform == "noarch");
@@ -384,10 +378,10 @@ namespace mamba
                 }
                 else  // Consider 'flexible' and 'strict' the same way
                 {
-                    if (channel.name() != prev_channel_name)
+                    if (channel->name() != prev_channel_name)
                     {
                         max_prio--;
-                        prev_channel_name = channel.name();
+                        prev_channel_name = channel->name();
                     }
                     priorities.push_back(std::make_pair(max_prio, platform == "noarch" ? 0 : 1));
                 }

--- a/src/api/list.cpp
+++ b/src/api/list.cpp
@@ -105,7 +105,7 @@ namespace mamba
                     }
                     else
                     {
-                        Channel& channel = make_channel(package.second.url);
+                        const Channel& channel = make_channel(package.second.url);
                         formatted_pkgs.channel = channel.name();
                     }
                     packages.push_back(formatted_pkgs);

--- a/src/core/channel.cpp
+++ b/src/core/channel.cpp
@@ -460,7 +460,7 @@ namespace mamba
         }
     }
 
-    static std::string fix_win_path(const std::string& path)
+    std::string fix_win_path(const std::string& path)
     {
 #ifdef _WIN32
         if (starts_with(path, "file:"))
@@ -585,32 +585,6 @@ namespace mamba
             }
         }
         return result;
-    }
-
-    std::vector<std::string> calculate_channel_urls(const std::vector<std::string>& channel_names,
-                                                    bool append_context_channels,
-                                                    bool use_local)
-    {
-        if (append_context_channels || use_local)
-        {
-            const auto& ctx_channels = Context::instance().channels;
-            std::vector<std::string> names;
-            names.reserve(channel_names.size() + 1 + ctx_channels.size());
-            if (use_local)
-            {
-                names.push_back(LOCAL_CHANNELS_NAME);
-            }
-            std::copy(channel_names.begin(), channel_names.end(), std::back_inserter(names));
-            if (append_context_channels)
-            {
-                std::copy(ctx_channels.begin(), ctx_channels.end(), std::back_inserter(names));
-            }
-            return get_channel_urls(names);
-        }
-        else
-        {
-            return get_channel_urls(channel_names);
-        }
     }
 
     void check_whitelist(const std::vector<std::string>& urls)

--- a/src/core/channel.cpp
+++ b/src/core/channel.cpp
@@ -590,8 +590,7 @@ namespace mamba
                 name = name.substr(0, platform_spec_ind);
             }
 
-            auto add_channel = [&](const std::string& name)
-            {
+            auto add_channel = [&](const std::string& name) {
                 auto channel = &make_channel(name + platform_spec);
                 if (added.insert(channel).second)
                 {
@@ -624,20 +623,16 @@ namespace mamba
                            whitelist.end(),
                            accepted_urls.begin(),
                            [](const std::string& url) { return make_channel(url).base_url(); });
-            std::for_each(urls.begin(),
-                          urls.end(),
-                          [&accepted_urls](const std::string& s)
-                          {
-                              auto it = std::find(accepted_urls.begin(),
-                                                  accepted_urls.end(),
-                                                  make_channel(s).base_url());
-                              if (it == accepted_urls.end())
-                              {
-                                  std::ostringstream str;
-                                  str << "Channel " << s << " not allowed";
-                                  throw std::runtime_error(str.str().c_str());
-                              }
-                          });
+            std::for_each(urls.begin(), urls.end(), [&accepted_urls](const std::string& s) {
+                auto it = std::find(
+                    accepted_urls.begin(), accepted_urls.end(), make_channel(s).base_url());
+                if (it == accepted_urls.end())
+                {
+                    std::ostringstream str;
+                    str << "Channel " << s << " not allowed";
+                    throw std::runtime_error(str.str().c_str());
+                }
+            });
         }
     }
 

--- a/src/core/channel.cpp
+++ b/src/core/channel.cpp
@@ -213,7 +213,6 @@ namespace mamba
         }
         base += "/" + name();
 
-        std::vector<std::pair<std::string, std::string>> ret;
         return build_url(*this, base + "/" + platform, with_credential);
     }
 

--- a/src/core/channel.cpp
+++ b/src/core/channel.cpp
@@ -4,6 +4,7 @@
 //
 // The full license is in the file LICENSE, distributed with this software.
 
+#include <cassert>
 #include <iostream>
 #include <regex>
 #include <set>
@@ -12,6 +13,7 @@
 #include <utility>
 
 #include "mamba/core/channel.hpp"
+#include "mamba/core/channel_internal.hpp"
 #include "mamba/core/environment.hpp"
 #include "mamba/core/context.hpp"
 #include "mamba/core/fsutil.hpp"
@@ -35,13 +37,6 @@ namespace mamba
 
         const char LOCAL_CHANNELS_NAME[] = "local";
         const char DEFAULT_CHANNELS_NAME[] = "defaults";
-
-        // ATTENTION names with substrings need to go longer -> smalle
-        // otherwise linux-ppc64 matches for linux-ppc64le etc!
-        const std::vector<std::string> KNOWN_PLATFORMS
-            = { "noarch",       "linux-32",      "linux-64",    "linux-aarch64", "linux-armv6l",
-                "linux-armv7l", "linux-ppc64le", "linux-ppc64", "osx-64",        "osx-arm64",
-                "win-32",       "win-64",        "zos-z" };
     }  // namespace
 
     /**************************
@@ -49,21 +44,20 @@ namespace mamba
      **************************/
 
     Channel::Channel(const std::string& scheme,
-                     const std::string& auth,
                      const std::string& location,
-                     const std::string& token,
                      const std::string& name,
-                     const std::string& platform,
-                     const std::string& package_filename,
-                     const std::string& multi_name)
+                     const std::optional<std::string>& auth,
+                     const std::optional<std::string>& token,
+                     const std::optional<std::string>& package_filename,
+                     const std::optional<std::string>& canonical_name)
         : m_scheme(scheme)
-        , m_auth(auth)
         , m_location(location)
-        , m_token(token)
         , m_name(name)
-        , m_platform(platform)
+        , m_platforms()
+        , m_auth(auth)
+        , m_token(token)
         , m_package_filename(package_filename)
-        , m_canonical_name(multi_name)
+        , m_canonical_name(canonical_name)
         , m_repo_checker(base_url(),
                          Context::instance().root_prefix / "etc" / "trusted-repos"
                              / cache_name_from_url(base_url()),
@@ -73,19 +67,9 @@ namespace mamba
         fs::create_directories(m_repo_checker.cache_path());
     }
 
-    void Channel::set_token(const std::string& token)
-    {
-        m_token = token;
-    }
-
     const std::string& Channel::scheme() const
     {
         return m_scheme;
-    }
-
-    const std::string& Channel::auth() const
-    {
-        return m_auth;
     }
 
     const std::string& Channel::location() const
@@ -93,27 +77,32 @@ namespace mamba
         return m_location;
     }
 
-    const std::string& Channel::token() const
-    {
-        return m_token;
-    }
-
     const std::string& Channel::name() const
     {
         return m_name;
     }
 
-    const std::string& Channel::platform() const
+    const std::vector<std::string>& Channel::platforms() const
     {
-        return m_platform;
+        return m_platforms;
     }
 
-    const std::string& Channel::package_filename() const
+    const std::optional<std::string>& Channel::auth() const
+    {
+        return m_auth;
+    }
+
+    const std::optional<std::string>& Channel::token() const
+    {
+        return m_token;
+    }
+
+    const std::optional<std::string>& Channel::package_filename() const
     {
         return m_package_filename;
     }
 
-    const validate::RepoChecker& Channel::repo_checker()
+    const validate::RepoChecker& Channel::repo_checker() const
     {
         m_repo_checker.generate_index_checker();
         return m_repo_checker;
@@ -121,7 +110,7 @@ namespace mamba
 
     const std::string& Channel::canonical_name() const
     {
-        if (m_canonical_name == "")
+        if (!m_canonical_name)
         {
             auto it = ChannelContext::instance().get_custom_channels().find(m_name);
             if (it != ChannelContext::instance().get_custom_channels().end())
@@ -141,7 +130,7 @@ namespace mamba
                 m_canonical_name = lstrip(m_location + '/' + m_name, "/");
             }
         }
-        return m_canonical_name;
+        return *m_canonical_name;
     }
 
     std::string Channel::base_url() const
@@ -156,85 +145,69 @@ namespace mamba
         }
     }
 
-    std::string Channel::build_url(const std::string& base, bool with_credential) const
+    static std::string build_url(const Channel& c, const std::string& base, bool with_credential)
     {
-        if (with_credential && auth() != "")
+        if (with_credential && c.auth())
         {
-            return concat(scheme(), "://", auth(), "@", base);
+            return concat(c.scheme(), "://", *c.auth(), "@", base);
         }
         else
         {
-            return concat(scheme(), "://", base);
+            return concat(c.scheme(), "://", base);
         }
     }
 
-    std::string Channel::url(bool with_credential) const
+    static std::optional<std::string> nonempty_str(std::string&& s)
     {
-        std::string base = location();
-        if (with_credential && token() != "")
-        {
-            base += "/t/" + token();
-        }
-        base += "/" + name();
-        if (platform() != "")
-        {
-            base += "/" + platform();
-            if (package_filename() != "")
-            {
-                base += "/" + package_filename();
-            }
-        }
-        else
-        {
-            // TODO: handle unknwon archs that are not "noarch"
-            base += "/noarch";
-        }
-
-        return build_url(base, with_credential);
+        return s.empty() ? std::optional<std::string>() : std::make_optional(s);
     }
 
     std::vector<std::string> Channel::urls(bool with_credential) const
     {
-        return urls(Context::instance().platforms(), with_credential);
-    }
-
-    std::vector<std::string> Channel::urls(const std::vector<std::string>& platforms,
-                                           bool with_credential) const
-    {
-        if (canonical_name() == UNKNOWN_CHANNEL)
-            return make_channel(DEFAULT_CHANNELS_NAME).urls(platforms, with_credential);
-
-        std::string base = with_credential && token() != ""
-                               ? join_url(location(), "t", token(), name())
-                               : join_url(location(), name());
-
-        size_t size = platform() != "" ? (platform() != "noarch" ? 2u : 1u) : platforms.size();
-        std::vector<std::string> res(size);
-        if (platform() != "")
+        if (package_filename())
         {
-            res[0] = build_url(join_url(base, platform()), with_credential);
-            if (size > 1u)
+            std::string base = location();
+            if (with_credential && token())
             {
-                res[1] = build_url(join_url(base, "noarch"), with_credential);
+                base += "/t/" + *token();
             }
+            base += "/" + name();
+            base += "/" + *package_filename();
+            return { { build_url(*this, base, with_credential) } };
         }
         else
         {
-            std::transform(platforms.cbegin(),
-                           platforms.cend(),
-                           res.begin(),
-                           [this, &base, with_credential](const std::string& p) {
-                               return this->build_url(join_url(base, p), with_credential);
-                           });
+            std::vector<std::string> ret;
+            for (auto& [_, v] : platform_urls(with_credential))
+            {
+                ret.emplace_back(v);
+            }
+            return ret;
         }
-
-        return res;
     }
 
-    Channel Channel::make_simple_channel(const Channel& channel_alias,
-                                         const std::string& channel_url,
-                                         const std::string& channel_name,
-                                         const std::string& multi_name)
+    std::vector<std::pair<std::string, std::string>> Channel::platform_urls(
+        bool with_credential) const
+    {
+        std::string base = location();
+        if (with_credential && token())
+        {
+            base += "/t/" + *token();
+        }
+        base += "/" + name();
+
+        std::vector<std::pair<std::string, std::string>> ret;
+        for (const auto& platform : platforms())
+        {
+            ret.emplace_back(platform, build_url(*this, base + "/" + platform, with_credential));
+        }
+        return ret;
+    }
+
+    Channel ChannelInternal::make_simple_channel(const Channel& channel_alias,
+                                                 const std::string& channel_url,
+                                                 const std::string& channel_name,
+                                                 const std::string& multi_name)
     {
         std::string name(channel_name);
         std::string location, scheme, auth, token;
@@ -243,8 +216,8 @@ namespace mamba
         {
             location = channel_alias.location();
             scheme = channel_alias.scheme();
-            auth = channel_alias.auth();
-            token = channel_alias.token();
+            auth = channel_alias.auth().value_or("");
+            token = channel_alias.token().value_or("");
         }
         else if (name == "")
         {
@@ -264,52 +237,70 @@ namespace mamba
             }
         }
         name = name != "" ? strip(name, "/") : strip(channel_url, "/");
-        return Channel(scheme, auth, location, token, name, "", "", multi_name);
+        return ChannelInternal(scheme,
+                               location,
+                               name,
+                               nonempty_str(std::move(auth)),
+                               nonempty_str(std::move(token)),
+                               {},
+                               nonempty_str(std::string(multi_name)));
     }
 
-    Channel& Channel::make_cached_channel(const std::string& value)
+    const Channel& ChannelInternal::make_cached_channel(const std::string& value)
     {
         auto res = get_cache().find(value);
         if (res == get_cache().end())
         {
             auto& ctx = Context::instance();
 
-            auto chan = Channel::from_value(value);
+            auto chan = ChannelInternal::from_value(value);
             auto token_base = concat(chan.scheme(), "://", chan.location());
-            if (chan.token().empty()
-                && ctx.channel_tokens.find(token_base) != ctx.channel_tokens.end())
+            if (!chan.token())
             {
-                chan.set_token(ctx.channel_tokens[token_base]);
+                auto it = ctx.channel_tokens.find(token_base);
+                if (it != ctx.channel_tokens.end())
+                {
+                    chan.m_token = it->second;
+                }
             }
             res = get_cache().insert(std::make_pair(value, std::move(chan))).first;
         }
         return res->second;
     }
 
-    void Channel::clear_cache()
+    void ChannelInternal::clear_cache()
     {
         get_cache().clear();
     }
 
-    Channel::cache_type& Channel::get_cache()
+    ChannelInternal::ChannelInternal(const std::string& scheme,
+                                     const std::string& location,
+                                     const std::string& name,
+                                     const std::optional<std::string>& auth,
+                                     const std::optional<std::string>& token,
+                                     const std::optional<std::string>& package_filename,
+                                     const std::optional<std::string>& canonical_name)
+        : Channel(scheme, location, name, auth, token, package_filename, canonical_name)
+    {
+    }
+
+    ChannelInternal::cache_type& ChannelInternal::get_cache()
     {
         static cache_type cache;
         return cache;
     }
 
-    void split_conda_url(const std::string& url,
-                         std::string& scheme,
-                         std::string& host,
-                         std::string& port,
-                         std::string& path,
-                         std::string& auth,
-                         std::string& token,
-                         std::string& platform,
-                         std::string& package_name)
+    static void split_conda_url(const std::string& url,
+                                std::string& scheme,
+                                std::string& host,
+                                std::string& port,
+                                std::string& path,
+                                std::string& auth,
+                                std::string& token,
+                                std::string& package_name)
     {
         std::string cleaned_url, extension;
         split_anaconda_token(url, cleaned_url, token);
-        split_platform(KNOWN_PLATFORMS, cleaned_url, cleaned_url, platform);
         split_package_extension(cleaned_url, cleaned_url, extension);
 
         if (extension != "")
@@ -353,10 +344,10 @@ namespace mamba
         std::string m_token;
     };
 
-    channel_configuration read_channel_configuration(const std::string& scheme,
-                                                     const std::string& host,
-                                                     const std::string& port,
-                                                     const std::string& path)
+    static channel_configuration read_channel_configuration(const std::string& scheme,
+                                                            const std::string& host,
+                                                            const std::string& port,
+                                                            const std::string& path)
     {
         std::string spath = std::string(rstrip(path, "/"));
         std::string url
@@ -389,8 +380,8 @@ namespace mamba
                 return channel_configuration(channel.location(),
                                              join_url(channel.name(), subname),
                                              scheme,
-                                             channel.auth(),
-                                             channel.token());
+                                             channel.auth().value_or(""),
+                                             channel.token().value_or(""));
             }
         }
 
@@ -399,7 +390,8 @@ namespace mamba
         if (ca.location() != "" && starts_with(url, ca.location()))
         {
             auto name = std::string(strip(url.replace(0u, ca.location().size(), ""), "/"));
-            return channel_configuration(ca.location(), name, scheme, ca.auth(), ca.token());
+            return channel_configuration(
+                ca.location(), name, scheme, ca.auth().value_or(""), ca.token().value_or(""));
         }
 
         // Case 6: not-otherwise-specified file://-type urls
@@ -415,28 +407,25 @@ namespace mamba
         return channel_configuration(std::string(strip(location, "/")), spath, scheme, "", "");
     }
 
-    Channel Channel::from_url(const std::string& url)
+    ChannelInternal ChannelInternal::from_url(const std::string& url)
     {
-        std::string scheme, host, port, path, auth, token, platform, package_name;
-        split_conda_url(url, scheme, host, port, path, auth, token, platform, package_name);
+        std::string scheme, host, port, path, auth, token, package_name;
+        split_conda_url(url, scheme, host, port, path, auth, token, package_name);
 
         auto config = read_channel_configuration(scheme, host, port, path);
 
-        return Channel(config.m_scheme.size() ? config.m_scheme : "https",
-                       auth.size() ? auth : config.m_auth,
-                       config.m_location,
-                       token.size() ? token : config.m_token,
-                       config.m_name,
-                       platform,
-                       package_name);
+        return ChannelInternal(
+            config.m_scheme.size() ? config.m_scheme : "https",
+            config.m_location,
+            config.m_name,
+            auth.size() ? std::make_optional(auth) : nonempty_str(std::move(config.m_auth)),
+            token.size() ? std::make_optional(token) : nonempty_str(std::move(config.m_token)),
+            nonempty_str(std::move(package_name)));
     }
 
-    Channel Channel::from_name(const std::string& name)
+    ChannelInternal ChannelInternal::from_name(const std::string& name)
     {
-        std::string stripped, platform;
-        split_platform(KNOWN_PLATFORMS, name, stripped, platform);
-
-        std::string tmp_stripped = stripped;
+        std::string tmp_stripped = name;
         const auto& custom_channels = ChannelContext::instance().get_custom_channels();
         auto it_end = custom_channels.end();
         auto it = custom_channels.find(tmp_stripped);
@@ -456,23 +445,22 @@ namespace mamba
 
         if (it != it_end)
         {
-            return Channel(it->second.scheme(),
-                           it->second.auth(),
-                           it->second.location(),
-                           it->second.token(),
-                           stripped,
-                           platform != "" ? platform : it->second.platform(),
-                           it->second.package_filename());
+            return ChannelInternal(it->second.scheme(),
+                                   it->second.location(),
+                                   name,
+                                   it->second.auth(),
+                                   it->second.token(),
+                                   it->second.package_filename());
         }
         else
         {
             const Channel& alias = ChannelContext::instance().get_channel_alias();
-            return Channel(
-                alias.scheme(), alias.auth(), alias.location(), alias.token(), stripped, platform);
+            return ChannelInternal(
+                alias.scheme(), alias.location(), name, alias.auth(), alias.token());
         }
     }
 
-    std::string fix_win_path(const std::string& path)
+    static std::string fix_win_path(const std::string& path)
     {
 #ifdef _WIN32
         if (starts_with(path, "file:"))
@@ -491,62 +479,96 @@ namespace mamba
 #endif
     }
 
-    Channel Channel::from_value(const std::string& value)
+    static std::vector<std::string> take_platforms(std::string& value)
     {
-        if (INVALID_CHANNELS.find(value) != INVALID_CHANNELS.end())
+        std::vector<std::string> platforms;
+        if (!value.empty())
         {
-            return Channel("", "", "", "", UNKNOWN_CHANNEL);
+            if (value[value.size() - 1] == ']')
+            {
+                const auto end_value = value.find_last_of('[');
+                if (end_value != std::string::npos)
+                {
+                    auto ind = end_value + 1;
+                    while (ind < value.size() - 1)
+                    {
+                        auto end = value.find_first_of(", ]", ind);
+                        assert(end != std::string::npos);
+                        platforms.emplace_back(value.substr(ind, end - ind));
+                        ind = end;
+                        while (value[ind] == ',' || value[ind] == ' ')
+                            ind++;
+                    }
+
+                    value.resize(end_value);
+                }
+            }
         }
 
-        if (has_scheme(value))
+        if (platforms.empty())
         {
-            return Channel::from_url(fix_win_path(value));
+            platforms = Context::instance().platforms();
+        }
+        return platforms;
+    }
+
+
+    ChannelInternal ChannelInternal::from_value(const std::string& in_value)
+    {
+        if (INVALID_CHANNELS.count(in_value) > 0)
+        {
+            return ChannelInternal("", "", UNKNOWN_CHANNEL, "");
         }
 
-        if (is_path(value))
-        {
-            return Channel::from_url(path_to_url(value));
-        }
+        std::string value = in_value;
+        auto platforms = take_platforms(value);
 
-        if (is_package_file(value))
-        {
-            return Channel::from_url(fix_win_path(value));
-        }
+        auto chan = has_scheme(value)        ? ChannelInternal::from_url(fix_win_path(value))
+                    : is_path(value)         ? ChannelInternal::from_url(path_to_url(value))
+                    : is_package_file(value) ? ChannelInternal::from_url(fix_win_path(value))
+                                             : ChannelInternal::from_name(value);
 
-        return Channel::from_name(value);
+        chan.m_platforms = std::move(platforms);
+
+        return chan;
+    }
+
+    ChannelInternal ChannelInternal::from_alias(const std::string& scheme,
+                                                const std::string& location,
+                                                const std::optional<std::string>& auth,
+                                                const std::optional<std::string>& token)
+    {
+        return ChannelInternal(scheme, location, "<alias>", auth, token);
     }
 
     /************************************
      * utility functions implementation *
      ************************************/
 
-    Channel& make_channel(const std::string& value)
+    const Channel& make_channel(const std::string& value)
     {
-        return Channel::make_cached_channel(value);
+        return ChannelInternal::make_cached_channel(value);
     }
 
-    void append_channel_urls(const std::string name,
-                             const std::vector<std::string>& platforms,
-                             bool with_credential,
-                             std::vector<std::string>& result,
-                             std::set<std::string>& control)
+    static void append_channel_urls(const std::string name,
+                                    bool with_credential,
+                                    std::vector<std::string>& result,
+                                    std::set<std::string>& control)
     {
         // this checks if the channel is already in our channel_urls list
         bool ret = !control.insert(name).second;
         if (ret)
             return;
 
-        std::vector<std::string> urls = make_channel(name).urls(platforms, with_credential);
+        std::vector<std::string> urls = make_channel(name).urls(with_credential);
         std::copy(urls.begin(), urls.end(), std::back_inserter(result));
     }
 
     std::vector<std::string> get_channel_urls(const std::vector<std::string>& channel_names,
-                                              const std::vector<std::string>& platforms,
                                               bool with_credential)
     {
         std::set<std::string> control;
         std::vector<std::string> result;
-        result.reserve(channel_names.size() * platforms.size());
         for (const auto& name : channel_names)
         {
             auto multi_iter = ChannelContext::instance().get_custom_multichannels().find(name);
@@ -554,12 +576,12 @@ namespace mamba
             {
                 for (const auto& n : multi_iter->second)
                 {
-                    append_channel_urls(n, platforms, with_credential, result, control);
+                    append_channel_urls(n, with_credential, result, control);
                 }
             }
             else
             {
-                append_channel_urls(name, platforms, with_credential, result, control);
+                append_channel_urls(name, with_credential, result, control);
             }
         }
         return result;
@@ -567,14 +589,8 @@ namespace mamba
 
     std::vector<std::string> calculate_channel_urls(const std::vector<std::string>& channel_names,
                                                     bool append_context_channels,
-                                                    const std::string& platform,
                                                     bool use_local)
     {
-        // TODO that doesn't seem very logical
-        std::vector<std::string> platforms = platform.size()
-                                                 ? std::vector<std::string>({ platform, "noarch" })
-                                                 : Context::instance().platforms();
-
         if (append_context_channels || use_local)
         {
             const auto& ctx_channels = Context::instance().channels;
@@ -589,11 +605,11 @@ namespace mamba
             {
                 std::copy(ctx_channels.begin(), ctx_channels.end(), std::back_inserter(names));
             }
-            return get_channel_urls(names, platforms);
+            return get_channel_urls(names);
         }
         else
         {
-            return get_channel_urls(channel_names, platforms);
+            return get_channel_urls(channel_names);
         }
     }
 
@@ -607,16 +623,20 @@ namespace mamba
                            whitelist.end(),
                            accepted_urls.begin(),
                            [](const std::string& url) { return make_channel(url).base_url(); });
-            std::for_each(urls.begin(), urls.end(), [&accepted_urls](const std::string& s) {
-                auto it = std::find(
-                    accepted_urls.begin(), accepted_urls.end(), make_channel(s).base_url());
-                if (it == accepted_urls.end())
-                {
-                    std::ostringstream str;
-                    str << "Channel " << s << " not allowed";
-                    throw std::runtime_error(str.str().c_str());
-                }
-            });
+            std::for_each(urls.begin(),
+                          urls.end(),
+                          [&accepted_urls](const std::string& s)
+                          {
+                              auto it = std::find(accepted_urls.begin(),
+                                                  accepted_urls.end(),
+                                                  make_channel(s).base_url());
+                              if (it == accepted_urls.end())
+                              {
+                                  std::ostringstream str;
+                                  str << "Channel " << s << " not allowed";
+                                  throw std::runtime_error(str.str().c_str());
+                              }
+                          });
         }
     }
 
@@ -665,7 +685,8 @@ namespace mamba
         std::string alias = ctx.channel_alias;
         std::string location, scheme, auth, token;
         split_scheme_auth_token(alias, location, scheme, auth, token);
-        return Channel(scheme, auth, location, token);
+        return ChannelInternal::from_alias(
+            scheme, location, nonempty_str(std::move(auth)), nonempty_str(std::move(token)));
     }
 
     void ChannelContext::init_custom_channels()
@@ -680,8 +701,8 @@ namespace mamba
         auto name_iter = default_names.begin();
         for (auto& url : default_channels)
         {
-            auto channel
-                = Channel::make_simple_channel(m_channel_alias, url, "", DEFAULT_CHANNELS_NAME);
+            auto channel = ChannelInternal::make_simple_channel(
+                m_channel_alias, url, "", DEFAULT_CHANNELS_NAME);
             std::string name = channel.name();
             auto res = m_custom_channels.emplace(std::move(name), std::move(channel));
             *name_iter++ = res.first->first;
@@ -701,8 +722,8 @@ namespace mamba
             if (fs::is_directory(p))
             {
                 std::string url = path_to_url(p);
-                auto channel
-                    = Channel::make_simple_channel(m_channel_alias, url, "", LOCAL_CHANNELS_NAME);
+                auto channel = ChannelInternal::make_simple_channel(
+                    m_channel_alias, url, "", LOCAL_CHANNELS_NAME);
                 std::string name = channel.name();
                 auto res = m_custom_channels.emplace(std::move(name), std::move(channel));
                 local_names.push_back(res.first->first);
@@ -718,7 +739,8 @@ namespace mamba
         for (auto& ch : DEFAULT_CUSTOM_CHANNELS)
         {
             m_custom_channels.emplace(
-                ch.first, Channel::make_simple_channel(m_channel_alias, ch.second, ch.first));
+                ch.first,
+                ChannelInternal::make_simple_channel(m_channel_alias, ch.second, ch.first));
         }
     }
 

--- a/src/core/match_spec.cpp
+++ b/src/core/match_spec.cpp
@@ -86,24 +86,26 @@ namespace mamba
             }
             auto& parsed_channel = make_channel(spec_str);
 
-            if (!parsed_channel.platform().empty())
+            if (parsed_channel.package_filename())
             {
-                auto dist = parse_legacy_dist(parsed_channel.package_filename());
+                auto dist = parse_legacy_dist(*parsed_channel.package_filename());
 
                 name = dist[0];
                 version = dist[1];
                 build = dist[2];
 
                 channel = parsed_channel.canonical_name();
-                subdir = parsed_channel.platform();
-                fn = parsed_channel.package_filename();
+                // TODO how to handle this with multiple platforms?
+                // subdir = parsed_channel.platforms();
+                fn = *parsed_channel.package_filename();
                 url = spec_str;
                 is_file = true;
             }
             return;
         }
 
-        auto extract_kv = [&spec_str](const std::string& kv_string, auto& map) {
+        auto extract_kv = [&spec_str](const std::string& kv_string, auto& map)
+        {
             static std::regex kv_re("([a-zA-Z0-9_-]+?)=([\"\']?)([^\'\"]*?)(\\2)(?:[\'\", ]|$)");
             std::cmatch kv_match;
             const char* text_iter = kv_string.c_str();

--- a/src/core/match_spec.cpp
+++ b/src/core/match_spec.cpp
@@ -104,8 +104,7 @@ namespace mamba
             return;
         }
 
-        auto extract_kv = [&spec_str](const std::string& kv_string, auto& map)
-        {
+        auto extract_kv = [&spec_str](const std::string& kv_string, auto& map) {
             static std::regex kv_re("([a-zA-Z0-9_-]+?)=([\"\']?)([^\'\"]*?)(\\2)(?:[\'\", ]|$)");
             std::cmatch kv_match;
             const char* text_iter = kv_string.c_str();

--- a/src/core/solver.cpp
+++ b/src/core/solver.cpp
@@ -41,8 +41,15 @@ namespace mamba
         // bioconda-experimental etc) Note: s->repo->name is the URL of the repo
         // TODO maybe better to check all repos, select pointers, and compare the
         // pointer (s->repo == ptr?)
-        Channel& chan = make_channel(s->repo->name);
-        return chan.url(false).find(channel) != std::string::npos;
+        const Channel& chan = make_channel(s->repo->name);
+        for (const auto& url : chan.urls(false))
+        {
+            if (url.find(channel) != std::string::npos)
+            {
+                return true;
+            }
+        }
+        return false;
     }
 
     void MSolver::add_channel_specific_job(const MatchSpec& ms, int job_flag)

--- a/src/core/subdirdata.cpp
+++ b/src/core/subdirdata.cpp
@@ -65,13 +65,15 @@ namespace mamba
 {
     MSubdirData::MSubdirData(const std::string& name,
                              const std::string& repodata_url,
-                             const std::string& repodata_fn)
+                             const std::string& repodata_fn,
+                             bool is_noarch)
         : m_loaded(false)
         , m_download_complete(false)
         , m_repodata_url(repodata_url)
         , m_name(name)
         , m_json_fn(repodata_fn)
         , m_solv_fn(repodata_fn.substr(0, repodata_fn.size() - 4) + "solv")
+        , m_is_noarch(is_noarch)
     {
     }
 
@@ -332,7 +334,7 @@ namespace mamba
         m_target->set_progress_bar(m_progress_bar);
         // if we get something _other_ than the noarch, we DO NOT throw if the file
         // can't be retrieved
-        if (!ends_with(m_name, "/noarch"))
+        if (!m_is_noarch)
         {
             m_target->set_ignore_failure(true);
         }
@@ -358,7 +360,8 @@ namespace mamba
         // "_mod": "Sat, 04 Apr 2020 03:29:49 GMT",
         // "_cache_control": "public, max-age=1200"
 
-        auto extract_subjson = [](std::ifstream& s) {
+        auto extract_subjson = [](std::ifstream& s)
+        {
             char next;
             std::string result;
             bool escaped = false;

--- a/src/core/subdirdata.cpp
+++ b/src/core/subdirdata.cpp
@@ -360,8 +360,7 @@ namespace mamba
         // "_mod": "Sat, 04 Apr 2020 03:29:49 GMT",
         // "_cache_control": "public, max-age=1200"
 
-        auto extract_subjson = [](std::ifstream& s)
-        {
+        auto extract_subjson = [](std::ifstream& s) {
             char next;
             std::string result;
             bool escaped = false;

--- a/src/core/transaction.cpp
+++ b/src/core/transaction.cpp
@@ -369,8 +369,7 @@ namespace mamba
 
         if (solver.only_deps == false)
         {
-            auto to_string_vec = [](const std::vector<MatchSpec>& vec) -> std::vector<std::string>
-            {
+            auto to_string_vec = [](const std::vector<MatchSpec>& vec) -> std::vector<std::string> {
                 std::vector<std::string> res;
                 for (const auto& el : vec)
                     res.push_back(el.str());
@@ -706,8 +705,7 @@ namespace mamba
             to_unlink.push_back(solvable_to_json(s));
         }
 
-        auto add_json = [](const auto& jlist, const char* s)
-        {
+        auto add_json = [](const auto& jlist, const char* s) {
             if (!jlist.empty())
             {
                 JsonLogger::instance().json_down(s);

--- a/src/core/transaction.cpp
+++ b/src/core/transaction.cpp
@@ -369,7 +369,8 @@ namespace mamba
 
         if (solver.only_deps == false)
         {
-            auto to_string_vec = [](const std::vector<MatchSpec>& vec) -> std::vector<std::string> {
+            auto to_string_vec = [](const std::vector<MatchSpec>& vec) -> std::vector<std::string>
+            {
                 std::vector<std::string> res;
                 for (const auto& el : vec)
                     res.push_back(el.str());
@@ -705,7 +706,8 @@ namespace mamba
             to_unlink.push_back(solvable_to_json(s));
         }
 
-        auto add_json = [](const auto& jlist, const char* s) {
+        auto add_json = [](const auto& jlist, const char* s)
+        {
             if (!jlist.empty())
             {
                 JsonLogger::instance().json_down(s);
@@ -754,8 +756,7 @@ namespace mamba
             auto& ctx = Context::instance();
             if (ctx.experimental && ctx.verify_artifacts)
             {
-                const auto& repo_checker
-                    = Channel::make_cached_channel(mamba_repo->url()).repo_checker();
+                const auto& repo_checker = make_channel(mamba_repo->url()).repo_checker();
 
                 auto pkg_info = PackageInfo(s);
 

--- a/src/core/url.cpp
+++ b/src/core/url.cpp
@@ -66,31 +66,6 @@ namespace mamba
         return u1_remaining == u2_remaining;
     }
 
-    void split_platform(const std::vector<std::string>& known_platforms,
-                        const std::string& url,
-                        std::string& cleaned_url,
-                        std::string& platform)
-    {
-        platform = "";
-        size_t pos = std::string::npos;
-        for (auto it = known_platforms.begin(); it != known_platforms.end(); ++it)
-        {
-            pos = url.find(*it);
-            if (pos != std::string::npos)
-            {
-                platform = *it;
-                break;
-            }
-        }
-
-        cleaned_url = url;
-        if (pos != std::string::npos)
-        {
-            cleaned_url.replace(pos - 1, platform.size() + 1, "");
-        }
-        cleaned_url = rstrip(cleaned_url, "/");
-    }
-
     bool is_path(const std::string& input)
     {
         static const std::regex re(R"(\./|\.\.|~|/|[a-zA-Z]:[/\\]|\\\\|//)");

--- a/src/mamba/py_interface.cpp
+++ b/src/mamba/py_interface.cpp
@@ -258,7 +258,6 @@ PYBIND11_MODULE(mamba_api, m)
              });
 
     m.def("get_channel_urls", &get_channel_urls);
-    m.def("calculate_channel_urls", &calculate_channel_urls);
 
     m.def("transmute", &transmute);
 

--- a/src/mamba/py_interface.cpp
+++ b/src/mamba/py_interface.cpp
@@ -39,9 +39,9 @@ PYBIND11_MODULE(mamba_api, m)
 
     py::class_<fs::path>(m, "Path")
         .def(py::init<std::string>())
-        .def("__repr__",
-             [](fs::path& self) -> std::string
-             { return std::string("fs::path[") + std::string(self) + "]"; });
+        .def("__repr__", [](fs::path& self) -> std::string {
+            return std::string("fs::path[") + std::string(self) + "]";
+        });
     py::implicitly_convertible<std::string, fs::path>();
 
     py::register_exception<mamba_error>(m, "MambaNativeException");
@@ -74,9 +74,9 @@ PYBIND11_MODULE(mamba_api, m)
         .def("print", &MTransaction::print)
         .def("fetch_extract_packages", &MTransaction::fetch_extract_packages)
         .def("prompt", &MTransaction::prompt)
-        .def("execute",
-             [](MTransaction& self, PrefixData& target_prefix) -> bool
-             { return self.execute(target_prefix); });
+        .def("execute", [](MTransaction& self, PrefixData& target_prefix) -> bool {
+            return self.execute(target_prefix);
+        });
 
     py::class_<MSolver>(m, "Solver")
         .def(py::init<MPool&, std::vector<std::pair<int, int>>>())
@@ -116,8 +116,7 @@ PYBIND11_MODULE(mamba_api, m)
         .def("find",
              [](const Query& q,
                 const std::string& query,
-                const query::RESULT_FORMAT format) -> std::string
-             {
+                const query::RESULT_FORMAT format) -> std::string {
                  std::stringstream res_stream;
                  switch (format)
                  {
@@ -133,8 +132,7 @@ PYBIND11_MODULE(mamba_api, m)
         .def("whoneeds",
              [](const Query& q,
                 const std::string& query,
-                const query::RESULT_FORMAT format) -> std::string
-             {
+                const query::RESULT_FORMAT format) -> std::string {
                  // QueryResult res = q.whoneeds(query, tree);
                  std::stringstream res_stream;
                  query_result res = q.whoneeds(query, (format == query::TREE));
@@ -156,8 +154,7 @@ PYBIND11_MODULE(mamba_api, m)
         .def("depends",
              [](const Query& q,
                 const std::string& query,
-                const query::RESULT_FORMAT format) -> std::string
-             {
+                const query::RESULT_FORMAT format) -> std::string {
                  query_result res = q.depends(query, (format == query::TREE));
                  std::stringstream res_stream;
                  switch (format)
@@ -232,8 +229,8 @@ PYBIND11_MODULE(mamba_api, m)
         .def_readwrite("name", &PackageInfo::name);
 
     py::class_<Channel, std::unique_ptr<Channel, py::nodelete>>(m, "Channel")
-        .def(py::init([](const std::string& value)
-                      { return const_cast<Channel*>(&make_channel(value)); }))
+        .def(py::init(
+            [](const std::string& value) { return const_cast<Channel*>(&make_channel(value)); }))
         .def_property_readonly("scheme", &Channel::scheme)
         .def_property_readonly("location", &Channel::location)
         .def_property_readonly("name", &Channel::name)
@@ -244,23 +241,24 @@ PYBIND11_MODULE(mamba_api, m)
         .def_property_readonly("canonical_name", &Channel::canonical_name)
         .def("urls", &Channel::urls, py::arg("with_credentials") = true)
         .def("platform_urls", &Channel::platform_urls, py::arg("with_credentials") = true)
-        .def("platform_url", &Channel::platform_url, py::arg("platform"), py::arg("with_credentials") = true)
-        .def("__repr__",
-             [](const Channel& c)
-             {
-                 auto s = c.name();
-                 s += "[";
-                 bool first = true;
-                 for (const auto& platform : c.platforms())
-                 {
-                     if (!first)
-                         s += ",";
-                     s += platform;
-                     first = false;
-                 }
-                 s += "]";
-                 return s;
-             });
+        .def("platform_url",
+             &Channel::platform_url,
+             py::arg("platform"),
+             py::arg("with_credentials") = true)
+        .def("__repr__", [](const Channel& c) {
+            auto s = c.name();
+            s += "[";
+            bool first = true;
+            for (const auto& platform : c.platforms())
+            {
+                if (!first)
+                    s += ",";
+                s += platform;
+                first = false;
+            }
+            s += "]";
+            return s;
+        });
 
     m.def("get_channels", &get_channels);
 

--- a/src/mamba/py_interface.cpp
+++ b/src/mamba/py_interface.cpp
@@ -177,7 +177,7 @@ PYBIND11_MODULE(mamba_api, m)
              });
 
     py::class_<MSubdirData>(m, "SubdirData")
-        .def(py::init<const std::string&, const std::string&, const std::string&>())
+        .def(py::init<const std::string&, const std::string&, const std::string&, bool>())
         .def("create_repo", &MSubdirData::create_repo)
         .def("load", &MSubdirData::load)
         .def("loaded", &MSubdirData::loaded)
@@ -240,6 +240,7 @@ PYBIND11_MODULE(mamba_api, m)
         .def_property_readonly("platforms", &Channel::platforms)
         .def_property_readonly("canonical_name", &Channel::canonical_name)
         .def("urls", &Channel::urls, py::arg("with_credentials") = true)
+        .def("platform_urls", &Channel::platform_urls, py::arg("with_credentials") = true)
         .def("__repr__",
              [](const Channel& c)
              {

--- a/src/mamba/py_interface.cpp
+++ b/src/mamba/py_interface.cpp
@@ -237,10 +237,14 @@ PYBIND11_MODULE(mamba_api, m)
         .def_property_readonly("scheme", &Channel::scheme)
         .def_property_readonly("location", &Channel::location)
         .def_property_readonly("name", &Channel::name)
+        .def_property_readonly("auth", &Channel::auth)
+        .def_property_readonly("token", &Channel::token)
+        .def_property_readonly("package_filename", &Channel::package_filename)
         .def_property_readonly("platforms", &Channel::platforms)
         .def_property_readonly("canonical_name", &Channel::canonical_name)
         .def("urls", &Channel::urls, py::arg("with_credentials") = true)
         .def("platform_urls", &Channel::platform_urls, py::arg("with_credentials") = true)
+        .def("platform_url", &Channel::platform_url, py::arg("platform"), py::arg("with_credentials") = true)
         .def("__repr__",
              [](const Channel& c)
              {
@@ -258,7 +262,7 @@ PYBIND11_MODULE(mamba_api, m)
                  return s;
              });
 
-    m.def("get_channel_urls", &get_channel_urls);
+    m.def("get_channels", &get_channels);
 
     m.def("transmute", &transmute);
 

--- a/test/micromamba/test_linking.py
+++ b/test/micromamba/test_linking.py
@@ -100,9 +100,9 @@ class TestLinking:
 
         create_args = ["xtensor", "-p", "/tmp/testenv", "--json"]
         if allow_softlinks:
-            create_args.append("--allow-softlinks", no_dry_run=True)
+            create_args.append("--allow-softlinks")
         if always_copy:
-            create_args.append("--always-copy", no_dry_run=True)
+            create_args.append("--always-copy")
         res = create(*create_args, no_dry_run=True)
 
         xf = Path(env) / xtensor_hpp

--- a/test/test_channel.cpp
+++ b/test/test_channel.cpp
@@ -145,44 +145,6 @@ namespace mamba
                                              "https://conda.anaconda.org/conda-forge/noarch" }));
     }
 
-    TEST(Channel, calculate_channel_urls)
-    {
-        std::vector<std::string> urls = { "conda-forge", "defaults" };
-        std::vector<std::string> res = calculate_channel_urls(urls, true);
-        EXPECT_EQ(res.size(), on_win ? 8u : 6u);
-        EXPECT_EQ(res[0], "https://conda.anaconda.org/conda-forge/" + platform);
-        EXPECT_EQ(res[1], "https://conda.anaconda.org/conda-forge/noarch");
-        EXPECT_EQ(res[2], "https://repo.anaconda.com/pkgs/main/" + platform);
-        EXPECT_EQ(res[3], "https://repo.anaconda.com/pkgs/main/noarch");
-        EXPECT_EQ(res[4], "https://repo.anaconda.com/pkgs/r/" + platform);
-        EXPECT_EQ(res[5], "https://repo.anaconda.com/pkgs/r/noarch");
-
-        std::vector<std::string> res2 = calculate_channel_urls(urls, false);
-        EXPECT_EQ(res2.size(), on_win ? 8u : 6u);
-        EXPECT_EQ(res2[0], res[0]);
-        EXPECT_EQ(res2[1], res[1]);
-        EXPECT_EQ(res2[2], res[2]);
-        EXPECT_EQ(res2[3], res[3]);
-        EXPECT_EQ(res2[4], res[4]);
-        EXPECT_EQ(res2[5], res[5]);
-
-#ifdef _WIN32
-        EXPECT_EQ(res[6], "https://repo.anaconda.com/pkgs/msys2/" + platform);
-        EXPECT_EQ(res[7], "https://repo.anaconda.com/pkgs/msys2/noarch");
-        EXPECT_EQ(res2[6], res[6]);
-        EXPECT_EQ(res2[7], res[7]);
-#endif
-
-        std::vector<std::string> local_urls = { "./channel_b", "./channel_a" };
-        std::vector<std::string> local_res = calculate_channel_urls(local_urls, false);
-        std::string current_dir = path_to_url(fs::current_path().string()) + '/';
-        EXPECT_EQ(local_res.size(), 4u);
-        EXPECT_EQ(local_res[0], current_dir + "channel_b/" + platform);
-        EXPECT_EQ(local_res[1], current_dir + "channel_b/noarch");
-        EXPECT_EQ(local_res[2], current_dir + "channel_a/" + platform);
-        EXPECT_EQ(local_res[3], current_dir + "channel_a/noarch");
-    }
-
     TEST(Channel, add_token)
     {
         auto& ctx = Context::instance();

--- a/test/test_channel.cpp
+++ b/test/test_channel.cpp
@@ -2,6 +2,7 @@
 
 #include "mamba/core/context.hpp"
 #include "mamba/core/channel.hpp"
+#include "mamba/core/channel_internal.hpp"
 #include "mamba/core/mamba_fs.hpp"
 #include "mamba/core/url.hpp"
 #include "mamba/core/util.hpp"
@@ -43,8 +44,8 @@ namespace mamba
         const auto& ch = ChannelContext::instance().get_channel_alias();
         EXPECT_EQ(ch.scheme(), "https");
         EXPECT_EQ(ch.location(), "conda.anaconda.org");
-        EXPECT_EQ(ch.name(), "");
-        EXPECT_EQ(ch.canonical_name(), "");
+        EXPECT_EQ(ch.name(), "<alias>");
+        EXPECT_EQ(ch.canonical_name(), "<alias>");
 
         const auto& custom = ChannelContext::instance().get_custom_channels();
 
@@ -70,28 +71,28 @@ namespace mamba
     TEST(Channel, make_channel)
     {
         std::string value = "conda-forge";
-        Channel& c = make_channel(value);
+        const Channel& c = make_channel(value);
         EXPECT_EQ(c.scheme(), "https");
         EXPECT_EQ(c.location(), "conda.anaconda.org");
         EXPECT_EQ(c.name(), "conda-forge");
-        EXPECT_EQ(c.platform(), "");
+        EXPECT_EQ(c.platforms(), std::vector<std::string>({ platform, "noarch" }));
 
-        std::string value2 = "https://repo.anaconda.com/pkgs/main/" + platform;
-        Channel& c2 = make_channel(value2);
+        std::string value2 = "https://repo.anaconda.com/pkgs/main[" + platform + "]";
+        const Channel& c2 = make_channel(value2);
         EXPECT_EQ(c2.scheme(), "https");
         EXPECT_EQ(c2.location(), "repo.anaconda.com");
         EXPECT_EQ(c2.name(), "pkgs/main");
-        EXPECT_EQ(c2.platform(), platform);
+        EXPECT_EQ(c2.platforms(), std::vector<std::string>({ platform }));
 
-        std::string value3 = "https://conda.anaconda.org/conda-forge/" + platform;
-        Channel& c3 = make_channel(value3);
+        std::string value3 = "https://conda.anaconda.org/conda-forge[" + platform + "]";
+        const Channel& c3 = make_channel(value3);
         EXPECT_EQ(c3.scheme(), c.scheme());
         EXPECT_EQ(c3.location(), c.location());
         EXPECT_EQ(c3.name(), c.name());
-        EXPECT_EQ(c3.platform(), platform);
+        EXPECT_EQ(c3.platforms(), std::vector<std::string>({ platform }));
 
         std::string value4 = "/home/mamba/test/channel_b";
-        Channel& c4 = make_channel(value4);
+        const Channel& c4 = make_channel(value4);
         EXPECT_EQ(c4.scheme(), "file");
 #ifdef _WIN32
         std::string driveletter = fs::absolute(fs::path("/")).string().substr(0, 1);
@@ -100,10 +101,10 @@ namespace mamba
         EXPECT_EQ(c4.location(), "/home/mamba/test");
 #endif
         EXPECT_EQ(c4.name(), "channel_b");
-        EXPECT_EQ(c4.platform(), "");
+        EXPECT_EQ(c4.platforms(), std::vector<std::string>({ platform, "noarch" }));
 
-        std::string value5 = "/home/mamba/test/channel_b/" + platform;
-        Channel& c5 = make_channel(value5);
+        std::string value5 = "/home/mamba/test/channel_b[" + platform + "]";
+        const Channel& c5 = make_channel(value5);
         EXPECT_EQ(c5.scheme(), "file");
 #ifdef _WIN32
         EXPECT_EQ(c5.location(), driveletter + ":/home/mamba/test");
@@ -111,35 +112,37 @@ namespace mamba
         EXPECT_EQ(c5.location(), "/home/mamba/test");
 #endif
         EXPECT_EQ(c5.name(), "channel_b");
-        EXPECT_EQ(c5.platform(), platform);
+        EXPECT_EQ(c5.platforms(), std::vector<std::string>({ platform }));
 
-        std::string value6a = "http://localhost:8000/conda-forge/noarch";
-        Channel& c6a = make_channel(value6a);
-        EXPECT_EQ(c6a.url(false), value6a);
+        std::string value6a = "http://localhost:8000/conda-forge[noarch]";
+        const Channel& c6a = make_channel(value6a);
+        EXPECT_EQ(c6a.urls(false),
+                  std::vector<std::string>({ "http://localhost:8000/conda-forge/noarch" }));
 
-        std::string value6b = "http://localhost:8000/conda_mirror/conda-forge/noarch";
-        Channel& c6b = make_channel(value6b);
-        EXPECT_EQ(c6b.url(false), value6b);
+        std::string value6b = "http://localhost:8000/conda_mirror/conda-forge[noarch]";
+        const Channel& c6b = make_channel(value6b);
+        EXPECT_EQ(
+            c6b.urls(false),
+            std::vector<std::string>({ "http://localhost:8000/conda_mirror/conda-forge/noarch" }));
+
+        std::string value7 = "conda-forge[noarch,arbitrary]";
+        const Channel& c7 = make_channel(value7);
+        EXPECT_EQ(c7.platforms(), std::vector<std::string>({ "noarch", "arbitrary" }));
     }
 
     TEST(Channel, urls)
     {
-        std::string value = "https://conda.anaconda.org/conda-forge/linux-64";
-        std::vector<std::string> platforms = { "win-64", "noarch" };
+        std::string value = "https://conda.anaconda.org/conda-forge[noarch,win-64,arbitrary]";
+        const Channel& c = make_channel(value);
+        EXPECT_EQ(c.urls(),
+                  std::vector<std::string>({ "https://conda.anaconda.org/conda-forge/noarch",
+                                             "https://conda.anaconda.org/conda-forge/win-64",
+                                             "https://conda.anaconda.org/conda-forge/arbitrary" }));
 
-        Channel& c = make_channel(value);
-        std::vector<std::string> urls = c.urls(platforms);
-        EXPECT_EQ(urls[0], value);
-        EXPECT_EQ(urls[1], "https://conda.anaconda.org/conda-forge/noarch");
-
-        std::vector<std::string> urls10 = c.urls();
-        EXPECT_EQ(urls[0], urls10[0]);
-        EXPECT_EQ(urls[1], urls10[1]);
-
-        Channel& c1 = make_channel("https://conda.anaconda.org/conda-forge");
-        std::vector<std::string> urls2 = c1.urls(platforms);
-        EXPECT_EQ(urls2[0], "https://conda.anaconda.org/conda-forge/win-64");
-        EXPECT_EQ(urls2[1], "https://conda.anaconda.org/conda-forge/noarch");
+        const Channel& c1 = make_channel("https://conda.anaconda.org/conda-forge");
+        EXPECT_EQ(c1.urls(),
+                  std::vector<std::string>({ "https://conda.anaconda.org/conda-forge/" + platform,
+                                             "https://conda.anaconda.org/conda-forge/noarch" }));
     }
 
     TEST(Channel, calculate_channel_urls)
@@ -185,12 +188,15 @@ namespace mamba
         auto& ctx = Context::instance();
         ctx.channel_tokens["https://conda.anaconda.org"] = "my-12345-token";
 
-        Channel::clear_cache();
+        ChannelInternal::clear_cache();
 
-        auto& chan = make_channel("conda-forge");
+        const auto& chan = make_channel("conda-forge[noarch]");
         EXPECT_EQ(chan.token(), "my-12345-token");
-        EXPECT_EQ(chan.url(true), "https://conda.anaconda.org/t/my-12345-token/conda-forge/noarch");
-        EXPECT_EQ(chan.url(false), "https://conda.anaconda.org/conda-forge/noarch");
+        EXPECT_EQ(chan.urls(true),
+                  std::vector<std::string>{
+                      { "https://conda.anaconda.org/t/my-12345-token/conda-forge/noarch" } });
+        EXPECT_EQ(chan.urls(false),
+                  std::vector<std::string>{ { "https://conda.anaconda.org/conda-forge/noarch" } });
     }
 
     TEST(Channel, load_tokens)
@@ -201,7 +207,7 @@ namespace mamba
 
         // Channel::clear_cache();
 
-        // auto& chan = make_channel("conda-forge");
+        // const auto& chan = make_channel("conda-forge");
         // EXPECT_EQ(chan.token(), "my-12345-token");
         // EXPECT_EQ(chan.url(true),
         // "https://conda.anaconda.org/t/my-12345-token/conda-forge/noarch");

--- a/test/test_transfer.cpp
+++ b/test/test_transfer.cpp
@@ -11,8 +11,10 @@ namespace mamba
         Context::instance().quiet = true;
         {
             mamba::MultiDownloadTarget multi_dl;
-            mamba::MSubdirData cf(
-                "conda-forge/linux-64", "file:///nonexistent/repodata.json", "/tmp/zyx.json");
+            mamba::MSubdirData cf("conda-forge/linux-64",
+                                  "file:///nonexistent/repodata.json",
+                                  "/tmp/zyx.json",
+                                  false);
             cf.load();
             multi_dl.add(cf.target());
 
@@ -27,7 +29,7 @@ namespace mamba
         {
             mamba::MultiDownloadTarget multi_dl;
             mamba::MSubdirData cf(
-                "conda-forge/noarch", "file:///nonexistent/repodata.json", "/tmp/zyx.json");
+                "conda-forge/noarch", "file:///nonexistent/repodata.json", "/tmp/zyx.json", true);
             cf.load();
             multi_dl.add(cf.target());
             EXPECT_THROW(multi_dl.download(true), std::runtime_error);

--- a/test/test_url.cpp
+++ b/test/test_url.cpp
@@ -227,27 +227,6 @@ namespace mamba
 #endif
     }
 
-    TEST(url, split_platform)
-    {
-        std::string input = "https://1.2.3.4/t/tk-123/linux-64/path";
-        std::vector<std::string> known_platforms
-            = { "noarch", "linux-32", "linux-64", "linux-aarch64" };
-        std::string cleaned_url, platform;
-        split_platform(known_platforms, input, cleaned_url, platform);
-        EXPECT_EQ(cleaned_url, "https://1.2.3.4/t/tk-123/path");
-        EXPECT_EQ(platform, "linux-64");
-
-        input = "https://1.2.3.4/t/tk-123/linux-ppc64le/path";
-        split_platform(KNOWN_PLATFORMS, input, cleaned_url, platform);
-        EXPECT_EQ(cleaned_url, "https://1.2.3.4/t/tk-123/path");
-        EXPECT_EQ(platform, "linux-ppc64le");
-
-        input = "https://1.2.3.4/t/tk-123/linux-ppc64/path";
-        split_platform(KNOWN_PLATFORMS, input, cleaned_url, platform);
-        EXPECT_EQ(cleaned_url, "https://1.2.3.4/t/tk-123/path");
-        EXPECT_EQ(platform, "linux-ppc64");
-    }
-
     TEST(path, is_path)
     {
         EXPECT_TRUE(is_path("./"));


### PR DESCRIPTION
Rather than trying to figure out whether a channel string/url contains a platform, we instead make platform specification explicit with `CHANNEL[PLATFORM1,PLATFORM2,...]`.

There is a refactor of the channel class here to hide implementation details/functions which are only relevant for testing.

This is a rework related to discussion at #934, and will close #794.

Note that this introduces breaking CLI changes as well as breaking Python API changes (the `Channel` class is improved), so these should be noted in the changelog.