### PR TITLE
`remove` improvements: orphaned pkgs and console outputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+0.15.0 (TBD)
+============
+
+New features
+- remove orphaned packages such as dependencies of explicitely installed packages (@adriendelsalle) #1040
+- add a diff character before package name in transaction table to improve readability without coloration (@adriendelsalle) #1040
+
 0.14.1 (June 25, 2021)
 ======================
 

--- a/include/mamba/core/solver.hpp
+++ b/include/mamba/core/solver.hpp
@@ -56,6 +56,7 @@ namespace mamba
 
         const std::vector<MatchSpec>& install_specs() const;
         const std::vector<MatchSpec>& remove_specs() const;
+        const std::vector<MatchSpec>& neuter_specs() const;
         const std::vector<MatchSpec>& pinned_specs() const;
 
         operator Solver*();
@@ -71,7 +72,7 @@ namespace mamba
         std::vector<std::pair<int, int>> m_flags;
         std::vector<MatchSpec> m_install_specs;
         std::vector<MatchSpec> m_remove_specs;
-        std::vector<MatchSpec> m_neuter_specs;  // unused for now
+        std::vector<MatchSpec> m_neuter_specs;
         std::vector<MatchSpec> m_pinned_specs;
         bool m_is_solved;
         Solver* m_solver;

--- a/mamba/mamba.py
+++ b/mamba/mamba.py
@@ -239,7 +239,15 @@ def remove(args, parser):
             repos.append(repo)
 
         solver = api.Solver(pool, solver_options)
-        solver.add_jobs(mamba_solve_specs, api.SOLVER_ERASE)
+
+        history = api.History(context.target_prefix)
+        history_map = history.get_requested_specs_map()
+        solver.add_jobs(
+            [ms.conda_build_form() for ms in history_map.values()],
+            api.SOLVER_USERINSTALLED,
+        )
+
+        solver.add_jobs(mamba_solve_specs, api.SOLVER_ERASE | api.SOLVER_CLEANDEPS)
         success = solver.solve()
         if not success:
             print(solver.problems_to_str())

--- a/src/api/remove.cpp
+++ b/src/api/remove.cpp
@@ -74,7 +74,16 @@ namespace mamba
 
             MSolver solver(
                 pool, { { SOLVER_FLAG_ALLOW_DOWNGRADE, 1 }, { SOLVER_FLAG_ALLOW_UNINSTALL, 1 } });
-            solver.add_jobs(specs, SOLVER_ERASE);
+
+            History history(ctx.target_prefix);
+            auto hist_map = history.get_requested_specs_map();
+            std::vector<std::string> keep_specs;
+            for (auto& it : hist_map)
+                keep_specs.push_back(it.second.conda_build_form());
+
+            solver.add_jobs(keep_specs, SOLVER_USERINSTALLED);
+
+            solver.add_jobs(specs, SOLVER_ERASE | SOLVER_CLEANDEPS);
             solver.solve();
 
             const fs::path pkgs_dirs(ctx.root_prefix / "pkgs");

--- a/src/core/solver.cpp
+++ b/src/core/solver.cpp
@@ -155,7 +155,10 @@ namespace mamba
             }
             else if (job_flag & SOLVER_ERASE)
             {
-                m_remove_specs.emplace_back(job);
+                if (((job_flag & SOLVER_USERINSTALLED) ^ SOLVER_USERINSTALLED) == 0)
+                    m_neuter_specs.emplace_back(job);
+                else
+                    m_remove_specs.emplace_back(job);
             }
             if (!ms.channel.empty())
             {
@@ -314,6 +317,11 @@ namespace mamba
     const std::vector<MatchSpec>& MSolver::remove_specs() const
     {
         return m_remove_specs;
+    }
+
+    const std::vector<MatchSpec>& MSolver::neuter_specs() const
+    {
+        return m_neuter_specs;
     }
 
     const std::vector<MatchSpec>& MSolver::pinned_specs() const

--- a/src/core/transaction.cpp
+++ b/src/core/transaction.cpp
@@ -900,7 +900,8 @@ namespace mamba
         std::size_t total_size = 0;
         auto* pool = m_transaction->pool;
 
-        auto format_row = [this, pool, &total_size](rows& r, Solvable* s, printers::format flag) {
+        auto format_row = [this, pool, &total_size](
+                              rows& r, Solvable* s, printers::format flag, std::string diff) {
             std::ptrdiff_t dlsize = solvable_lookup_num(s, SOLVABLE_DOWNLOADSIZE, -1);
             printers::FormattedString dlsize_s;
             if (dlsize != -1)
@@ -932,7 +933,7 @@ namespace mamba
                 }
             }
             printers::FormattedString name;
-            name.s = pool_id2str(pool, s->name);
+            name.s = diff + " " + std::string(pool_id2str(pool, s->name));
             name.flag = flag;
             const char* build_string = solvable_lookup_str(s, SOLVABLE_BUILDFLAVOR);
 
@@ -971,41 +972,44 @@ namespace mamba
 
                 if (filter(s))
                 {
-                    format_row(ignored, s, printers::format::yellow);
+                    format_row(ignored, s, printers::format::yellow, "=");
                     continue;
                 }
                 switch (cls)
                 {
                     case SOLVER_TRANSACTION_UPGRADED:
-                        format_row(upgraded, s, printers::format::red);
+                        format_row(upgraded, s, printers::format::red, "-");
                         format_row(upgraded,
                                    m_transaction->pool->solvables
                                        + transaction_obs_pkg(m_transaction, p),
-                                   printers::format::green);
+                                   printers::format::green,
+                                   "+");
                         break;
                     case SOLVER_TRANSACTION_CHANGED:
                     case SOLVER_TRANSACTION_REINSTALLED:
                         if (cls == SOLVER_TRANSACTION_REINSTALLED && m_force_reinstall == false)
                             break;
 
-                        format_row(changed, s, printers::format::red);
+                        format_row(changed, s, printers::format::red, "-");
                         format_row(changed,
                                    m_transaction->pool->solvables
                                        + transaction_obs_pkg(m_transaction, p),
-                                   printers::format::green);
+                                   printers::format::green,
+                                   "+");
                         break;
                     case SOLVER_TRANSACTION_DOWNGRADED:
-                        format_row(downgraded, s, printers::format::red);
+                        format_row(downgraded, s, printers::format::red, "-");
                         format_row(downgraded,
                                    m_transaction->pool->solvables
                                        + transaction_obs_pkg(m_transaction, p),
-                                   printers::format::green);
+                                   printers::format::green,
+                                   "+");
                         break;
                     case SOLVER_TRANSACTION_ERASE:
-                        format_row(erased, s, printers::format::red);
+                        format_row(erased, s, printers::format::red, "-");
                         break;
                     case SOLVER_TRANSACTION_INSTALL:
-                        format_row(installed, s, printers::format::green);
+                        format_row(installed, s, printers::format::green, "+");
                         break;
                     case SOLVER_TRANSACTION_IGNORE:
                         break;

--- a/src/mamba/py_interface.cpp
+++ b/src/mamba/py_interface.cpp
@@ -90,6 +90,15 @@ PYBIND11_MODULE(mamba_api, m)
         .def("problems_to_str", &MSolver::problems_to_str)
         .def("solve", &MSolver::solve);
 
+    py::class_<History>(m, "History")
+        .def(py::init<const std::string&>())
+        .def("get_requested_specs_map", &History::get_requested_specs_map);
+
+    py::class_<MatchSpec>(m, "MatchSpec")
+        .def(py::init<>())
+        .def(py::init<const std::string&>())
+        .def("conda_build_form", &MatchSpec::conda_build_form);
+
     /*py::class_<Query>(m, "Query")
         .def(py::init<MPool&>())
         .def("find", &Query::find)


### PR DESCRIPTION
Description
---

Remove orphaned packages as default behavior:
- use history file to get information about previous user specs
  - use `libsolv` `SOLVER_USERINSTALLED` to freeze specs
- use `libsolv` `SOLVER_CLEANDEPS` as an additional flag to `SOLVER_ERASE` for `remove` specs

Removing `wget` in a fresh env where only `python` and `wget` were previously installed gives:
```
  Removing specs:

   - wget


  Package         Version  Build          Channel                                                                         Size
────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
  Remove:
────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

  -gettext       0.19.8.1  h0b5b191_1005  repo.mamba.pm/conda-forge/linux-64/gettext-0.19.8.1-h0b5b191_1005.tar.bz2     Cached
  -libidn2          2.3.1  h7f98852_0     repo.mamba.pm/conda-forge/linux-64/libidn2-2.3.1-h7f98852_0.tar.bz2           Cached
  -libunistring    0.9.10  h14c3975_0     repo.mamba.pm/conda-forge/linux-64/libunistring-0.9.10-h14c3975_0.tar.bz2     Cached
  -wget            1.20.1  h22169c7_0     repo.mamba.pm/conda-forge/linux-64/wget-1.20.1-h22169c7_0.tar.bz2             Cached
```

Closes #31 
Closes #1037 

---

Add git diff like chars for installed, removed and skipped pkgs:
- `+` when installing
- `-` when removing
- `=` when skipping

It will give an additional visual help when copy/pasting or redirecting the stream, losing the coloration (resp. green, red and yellow):
```
  Package   Version  Build       Channel                                                                     Size
───────────────────────────────────────────────────────────────────────────────────────────────────────────────────
  Install:
───────────────────────────────────────────────────────────────────────────────────────────────────────────────────

  +xframe     0.3.0  h0efe328_1  repo.mamba.pm/conda-forge/linux-64                                        Cached

  Downgrade:
───────────────────────────────────────────────────────────────────────────────────────────────────────────────────

  -xtensor  0.23.10  h4bd325d_0  repo.mamba.pm/conda-forge/linux-64/xtensor-0.23.10-h4bd325d_0.tar.bz2     Cached
  +xtensor  0.21.10  h0efe328_0  repo.mamba.pm/conda-forge/linux-64                                        Cached
  -xtl        0.7.2  h4bd325d_1  repo.mamba.pm/conda-forge/linux-64/xtl-0.7.2-h4bd325d_1.tar.bz2           Cached
  +xtl       0.6.23  h4bd325d_1  repo.mamba.pm/conda-forge/linux-64                                        Cached
```

Closes #297