### PR TITLE
The RE recognizing tokens is too narrow

### DIFF
--- a/src/core/url.cpp
+++ b/src/core/url.cpp
@@ -24,7 +24,7 @@ namespace mamba
 
     void split_anaconda_token(const std::string& url, std::string& cleaned_url, std::string& token)
     {
-        std::regex token_re("/t/([a-zA-Z0-9-]*)");
+        std::regex token_re("/t/([^/]*)");
         auto token_begin = std::sregex_iterator(url.begin(), url.end(), token_re);
         if (token_begin != std::sregex_iterator())
         {


### PR DESCRIPTION
When using mamba with tokens sometimes the token part is not recognixed because it contains the '_' char.
This patch enlarge the RE to all chars different from '/'