### PR TITLE
Add mamba.sh so that reactivating and conda environments work

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -333,6 +333,9 @@ if (NOT (BUILD_EXE AND STATIC_DEPENDENCIES))
             PATTERN "*.hpp"
             PATTERN "*.h")
 
+    install(DIRECTORY "${MAMBA_SRC_DIR}/mamba/shell/"
+            DESTINATION "${CMAKE_INSTALL_PREFIX}/etc/profile.d")
+
     # Makes the project importable from the build directory
     export(EXPORT ${PROJECT_NAME}-targets
            FILE "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Targets.cmake")

--- a/src/mamba/shell/mamba.sh
+++ b/src/mamba/shell/mamba.sh
@@ -1,0 +1,40 @@
+# Copied from conda.sh which is licensed as below
+#
+# Copyright (C) 2012 Anaconda, Inc
+# SPDX-License-Identifier: BSD-3-Clause
+
+mamba() {
+    \local MAMBA_CONDA_EXE_BACKUP=$CONDA_EXE
+    \local MAMBA_EXE=$(\dirname "${CONDA_EXE}")/mamba
+    if [ "$#" -lt 1 ]; then
+        "$MAMBA_EXE" $_CE_M $_CE_CONDA
+    else
+        \local cmd="$1"
+        shift
+        case "$cmd" in
+            activate|deactivate)
+                __conda_activate "$cmd" "$@"
+                ;;
+            install|update|upgrade|remove|uninstall)
+                CONDA_INTERNAL_OLDPATH="${PATH}"
+                __add_sys_prefix_to_path
+                "$MAMBA_EXE" $_CE_M $_CE_CONDA "$cmd" "$@"
+                \local t1=$?
+                PATH="${CONDA_INTERNAL_OLDPATH}"
+                if [ $t1 = 0 ]; then
+                    __conda_reactivate
+                else
+                    return $t1
+                fi
+                ;;
+            *)
+                CONDA_INTERNAL_OLDPATH="${PATH}"
+                __add_sys_prefix_to_path
+                "$MAMBA_EXE" $_CE_M $_CE_CONDA "$cmd" "$@"
+                \local t1=$?
+                PATH="${CONDA_INTERNAL_OLDPATH}"
+                return $t1
+                ;;
+        esac
+    fi
+}


### PR DESCRIPTION
This is very specific to the conda implementation. I think mamba recipe needs to pin conda strictly.
Or we can copy most of `conda.sh` so that `__add_sys_prefix_to_path` and `__conda_activate` are available here.

I didn't add support for `csh`, `fish`, xsh` because I don't use them.

Fixes https://github.com/mamba-org/mamba/issues/1035