### PR TITLE
Improve completer sub-command

### DIFF
--- a/include/mamba/core/output.hpp
+++ b/include/mamba/core/output.hpp
@@ -195,6 +195,8 @@ namespace mamba
             std::vector<int> m_padding;
             std::vector<std::vector<FormattedString>> m_table;
         };
+
+        std::ostringstream table_like(const std::vector<std::string>& data, std::size_t max_width);
     }  // namespace printers
 
     // The next two functions / classes were ported from the awesome indicators

--- a/src/core/output.cpp
+++ b/src/core/output.cpp
@@ -235,6 +235,45 @@ namespace mamba
             out << std::flush;
             return out;
         }
+
+        bool string_comparison(const std::string& a, const std::string& b)
+        {
+            return a < b;
+        }
+
+        std::ostringstream table_like(const std::vector<std::string>& data, std::size_t max_width)
+        {
+            int pos = 0;
+            int padding = 3;
+            std::size_t data_max_width = 0;
+            std::ostringstream out;
+
+            for (const auto& d : data)
+                if (d.size() > data_max_width)
+                    data_max_width = d.size();
+
+            max_width -= max_width % (data_max_width + padding);
+            int block_width = padding + data_max_width;
+
+            auto sorted_data = data;
+            std::sort(sorted_data.begin(), sorted_data.end(), string_comparison);
+            for (const auto& d : sorted_data)
+            {
+                int p = block_width - d.size();
+
+                if ((pos + d.size()) < max_width)
+                {
+                    out << d << std::string(p, ' ');
+                    pos += block_width;
+                }
+                else
+                {
+                    out << "\n" << d << std::string(p, ' ');
+                    pos = block_width;
+                }
+            }
+            return out;
+        }
     }  // namespace printers
 
     /*****************

--- a/src/micromamba/CMakeLists.txt
+++ b/src/micromamba/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(MAMBA_EXE
     ${CMAKE_CURRENT_SOURCE_DIR}/src/micromamba/clean.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/micromamba/config.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/micromamba/completer.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/micromamba/constructor.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/micromamba/create.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/micromamba/info.cpp

--- a/src/micromamba/completer.bash
+++ b/src/micromamba/completer.bash
@@ -1,0 +1,7 @@
+#/usr/bin/env bash
+_umamba_completions()
+{
+  COMPREPLY=($(micromamba completer "${COMP_WORDS[@]:1}"))
+}
+
+complete -F _umamba_completions micromamba

--- a/src/micromamba/main.cpp
+++ b/src/micromamba/main.cpp
@@ -13,8 +13,6 @@
 
 #include "mamba/api/configuration.hpp"
 
-#include "completer.cpp"
-
 #include <CLI/CLI.hpp>
 
 
@@ -34,7 +32,7 @@ main(int argc, char** argv)
 
     if (argc >= 2 && strcmp(argv[1], "completer") == 0)
     {
-        get_completions(argc, argv);
+        get_completions(&app, argc, argv);
         exit(0);
     }
 

--- a/src/micromamba/umamba.hpp
+++ b/src/micromamba/umamba.hpp
@@ -55,4 +55,7 @@ set_update_command(CLI::App* subcom);
 void
 set_env_command(CLI::App* subcom);
 
+void
+get_completions(CLI::App* app, int argc, char** argv);
+
 #endif


### PR DESCRIPTION
Description
---

Re-use `micromamba` subcommands by changing their callbacks to generate completer values.
- no need to redefine sub-commands and corresponding flags
- `CLI11` is used to parse the first args, `libmamba` to load the configuration, to be able to detect hill-formed syntaxes
- special handling for env names to produce the list of possible ones

Related to #900 #1076

Examples:
```
$ ./micromamba completer --no
--no-rc      --no-env  
```
```
$ ./micromamba completer install --no
--no-rc                      --no-env                     --no-channel-priority        
--no-pin                     --no-py-pin                  --no-allow-softlinks         
--no-always-softlink         --no-always-copy             --no-extra-safety-checks     
--no-shortcuts
```
```
$ ./micromamba completer install -n      
mamba               mamba-dev           mamba-dev2          mamba-docs          
mamba2              mamba20             mamba30             
```

The following completion doesn't work because `--channel` expect a value:
```
$ ./micromamba completer install --channel --no
```
