### PR TITLE
improve file urls for window

### DIFF
--- a/mamba/utils.py
+++ b/mamba/utils.py
@@ -236,6 +236,11 @@ def init_api_context(use_mamba_experimental=False):
 
 
 def to_conda_channel(channel, platform):
+    if channel.scheme == "file":
+        return CondaChannel.from_value(
+            channel.platform_url(platform, with_credentials=False)
+        )
+
     return CondaChannel(
         channel.scheme,
         channel.auth,


### PR DESCRIPTION
@afranchuk maybe you can have a quick look at this.
The channel parsing in conda is super weird for Windows `file://` paths. Under some conditions, the `location` is just `c` and the naem is the rest of the path. It's bizarre. I think we shouldn't try to emulate it and just run their parsing over file urls, which is what this PR does. 

If I see correctly, currently `-c local` is broken on Windows.