### PR TITLE
[micromamba] Missing flexible channel priority in CLI

### DIFF
--- a/src/micromamba/common_options.cpp
+++ b/src/micromamba/common_options.cpp
@@ -161,7 +161,7 @@ init_channel_parser(CLI::App* subcom)
         ->add_option("--channel-priority",
                      channel_priority.set_cli_config(""),
                      channel_priority.description())
-        ->check(CLI::IsMember(std::set<std::string>({ "strict", "disabled" })));
+        ->check(CLI::IsMember(std::set<std::string>({ "strict", "flexible", "disabled" })));
 
     auto& channel_alias = config.at("channel_alias").get_wrapped<std::string>();
     subcom->add_option(

--- a/test/micromamba/test_install.py
+++ b/test/micromamba/test_install.py
@@ -310,13 +310,10 @@ class TestInstall:
             expected_priority = "strict"
 
         if (
-            (priority == "flexible")
-            or (
-                (priority is not None)
-                and (
-                    (no_priority and priority != "disabled")
-                    or (strict_priority and priority != "strict")
-                )
+            (priority is not None)
+            and (
+                (no_priority and priority != "disabled")
+                or (strict_priority and priority != "strict")
             )
             or (no_priority and strict_priority)
         ):


### PR DESCRIPTION
Description
---

Fix missing flexible channel priority in `micromamba` CLI: add value in `IsMember` check.