### PR TITLE
[micromamba] Init completion for bash

### DIFF
--- a/include/mamba/api/shell.hpp
+++ b/include/mamba/api/shell.hpp
@@ -15,6 +15,8 @@
 
 namespace mamba
 {
+    void detect_shell(std::string& shell_type);
+
     void shell(const std::string& action,
                std::string& shell_type,
                const std::string& prefix = "",

--- a/src/micromamba/completer.bash
+++ b/src/micromamba/completer.bash
@@ -1,7 +1,10 @@
-#/usr/bin/env bash
+R"MAMBARAW(
+# >>> umamba completion >>>
 _umamba_completions()
 {
   COMPREPLY=($(micromamba completer "${COMP_WORDS[@]:1}"))
 }
 
 complete -F _umamba_completions micromamba
+# <<< umamba completion <<<
+)MAMBARAW"

--- a/src/micromamba/shell.cpp
+++ b/src/micromamba/shell.cpp
@@ -5,6 +5,7 @@
 // The full license is in the file LICENSE, distributed with this software.
 
 #include "common_options.hpp"
+#include "umamba.hpp"
 
 #include "mamba/api/configuration.hpp"
 #include "mamba/api/shell.hpp"
@@ -46,7 +47,8 @@ init_shell_parser(CLI::App* subcom)
                                                       "deactivate",
                                                       "hook",
                                                       "reactivate",
-                                                      "deactivate"
+                                                      "deactivate",
+                                                      "completion"
 #ifdef _WIN32
                                                       ,
                                                       "enable-long-paths-support"
@@ -77,9 +79,45 @@ set_shell_command(CLI::App* subcom)
 
         auto& action = config.at("shell_action").compute().value<std::string>();
         auto& prefix = config.at("shell_prefix").compute().value<std::string>();
-        auto& type = config.at("shell_type").compute().value<std::string>();
+        auto& shell = config.at("shell_type").compute().value<std::string>();
         auto& stack = config.at("shell_stack").compute().value<bool>();
 
-        shell(action, type, prefix, stack);
+        if (action == "completion")
+        {
+            detect_shell(shell);
+
+            if (shell == "bash")
+            {
+                fs::path home = env::home_directory();
+                fs::path bashrc_path
+                    = (on_mac || on_win) ? home / ".bash_profile" : home / ".bashrc";
+                std::regex completion_re("# >>> umamba completion >>>(?:\n|\r\n)?"
+                                         "([\\s\\S]*?)"
+                                         "# <<< umamba completion <<<(?:\n|\r\n)?");
+
+                std::string rc_content = read_contents(bashrc_path, std::ios::in);
+                std::string result = std::regex_replace(
+                    rc_content, completion_re, unindent(umamba_bash_completion));
+
+                if (result.find("# >>> umamba completion >>>") == result.npos)
+                {
+                    std::ofstream rc_file(bashrc_path, std::ios::app | std::ios::binary);
+                    rc_file << std::endl << unindent(umamba_bash_completion);
+                }
+                else
+                {
+                    std::ofstream rc_file(bashrc_path, std::ios::out | std::ios::binary);
+                    rc_file << result;
+                }
+            }
+            else
+            {
+                LOG_ERROR << "Shell auto-completion is not supported in '" << shell << "'";
+                throw std::runtime_error("Shell auto-completion is not supported in '" + shell
+                                         + "'");
+            }
+        }
+        else
+            mamba::shell(action, shell, prefix, stack);
     });
 }

--- a/src/micromamba/umamba.hpp
+++ b/src/micromamba/umamba.hpp
@@ -58,4 +58,11 @@ set_env_command(CLI::App* subcom);
 void
 get_completions(CLI::App* app, int argc, char** argv);
 
+namespace
+{
+    constexpr const char umamba_bash_completion[] =
+#include "./completer.bash"
+        ;
+}
+
 #endif


### PR DESCRIPTION
Description
---

Add a `micromamba shell completion` to init `bash` completion by adding the corresponding block into the user `.bashrc` file