### PR TITLE
Improvement: Log actual MD5/Size/SHA256 when we fail to validate

### DIFF
--- a/src/core/transaction.cpp
+++ b/src/core/transaction.cpp
@@ -100,7 +100,7 @@ namespace mamba
         {
             LOG_ERROR << "File not valid: file size doesn't match expectation " << m_tarball_path
                       << "\nExpected: " << m_expected_size
-                      << "\nActual:: " << size_t(m_target->downloaded_size) << "\n";
+                      << "\nActual: " << size_t(m_target->downloaded_size) << "\n";
             m_progress_proxy.mark_as_completed("File size validation error.");
             m_validation_result = SIZE_ERROR;
         }

--- a/src/core/transaction.cpp
+++ b/src/core/transaction.cpp
@@ -103,26 +103,32 @@ namespace mamba
                       << "\nActual: " << size_t(m_target->downloaded_size) << "\n";
             m_progress_proxy.mark_as_completed("File size validation error.");
             m_validation_result = SIZE_ERROR;
+            return;
         }
         interruption_point();
 
-        if (!m_sha256.empty() && !validate::sha256(m_tarball_path, m_sha256))
+        if (!m_sha256.empty())
         {
-            m_validation_result = SHA256_ERROR;
-            m_progress_proxy.mark_as_completed("SHA256 sum validation error.");
-            LOG_ERROR << "File not valid: SHA256 sum doesn't match expectation " << m_tarball_path
-                      << "\nExpected: " << m_sha256
-                      << "\nActual: " << validate::sha256sum(m_tarball_path) << "\n";
+            auto sha256sum = validate::sha256sum(m_tarball_path);
+            if (m_sha256 != sha256sum)
+            {
+                m_validation_result = SHA256_ERROR;
+                m_progress_proxy.mark_as_completed("SHA256 sum validation error.");
+                LOG_ERROR << "File not valid: SHA256 sum doesn't match expectation "
+                          << m_tarball_path << "\nExpected: " << m_sha256
+                          << "\nActual: " << sha256sum << "\n";
+            }
+            return;
         }
-        else
+        if (!m_md5.empty())
         {
-            if (!m_md5.empty() && !validate::md5(m_tarball_path, m_md5))
+            auto md5sum = validate::md5sum(m_tarball_path);
+            if (m_md5 != md5sum)
             {
                 m_validation_result = MD5SUM_ERROR;
                 m_progress_proxy.mark_as_completed("MD5 sum validation error.");
                 LOG_ERROR << "File not valid: MD5 sum doesn't match expectation " << m_tarball_path
-                          << "\nExpected: " << m_md5
-                          << "\nActual: " << validate::md5sum(m_tarball_path) << "\n";
+                          << "\nExpected: " << m_md5 << "\nActual: " << md5sum << "\n";
             }
         }
     }

--- a/src/core/transaction.cpp
+++ b/src/core/transaction.cpp
@@ -99,7 +99,8 @@ namespace mamba
         if (m_expected_size && size_t(m_target->downloaded_size) != m_expected_size)
         {
             LOG_ERROR << "File not valid: file size doesn't match expectation " << m_tarball_path
-                      << "\nExpected: " << m_expected_size << "\n";
+                      << "\nExpected: " << m_expected_size
+                      << "\nActual:: " << size_t(m_target->downloaded_size) << "\n";
             m_progress_proxy.mark_as_completed("File size validation error.");
             m_validation_result = SIZE_ERROR;
         }
@@ -110,7 +111,8 @@ namespace mamba
             m_validation_result = SHA256_ERROR;
             m_progress_proxy.mark_as_completed("SHA256 sum validation error.");
             LOG_ERROR << "File not valid: SHA256 sum doesn't match expectation " << m_tarball_path
-                      << "\nExpected: " << m_sha256 << "\n";
+                      << "\nExpected: " << m_sha256
+                      << "\nActual: " << validate::sha256sum(m_tarball_path) << "\n";
         }
         else
         {
@@ -119,7 +121,8 @@ namespace mamba
                 m_validation_result = MD5SUM_ERROR;
                 m_progress_proxy.mark_as_completed("MD5 sum validation error.");
                 LOG_ERROR << "File not valid: MD5 sum doesn't match expectation " << m_tarball_path
-                          << "\nExpected: " << m_md5 << "\n";
+                          << "\nExpected: " << m_md5
+                          << "\nActual: " << validate::md5sum(m_tarball_path) << "\n";
             }
         }
     }


### PR DESCRIPTION
## Before this PR
Currently when mamba logs the validation error, we only see information about what we expect, with no info on what was expected. Example:
```
ERROR File not valid: file size doesn't match expectation "/tmp/caches/CONDA_PKGS_DIRS/future-0.18.2-py36h5fab9bb_3.tar.bz2"

Expected: 733415
```
or
```
ERROR File not valid: MD5 sum doesn't match expectation "/tmp/caches/CONDA_PKGS_DIRS/pip-21.1.3-py36h06a4308_0.tar.bz2"

Expected: 5ffa50ebfad2aab590348cff27322d32
```
## After this PR
I propose we additionally log the actual value we got, not just the expected value. This should help facilitate debugging issues and help understand what was going on.