### PR TITLE
Add lockfiles for repodata and pkg download

### DIFF
--- a/mamba/mamba.py
+++ b/mamba/mamba.py
@@ -42,10 +42,10 @@ from conda.exceptions import (
     PackagesNotFoundError,
     TooManyArgumentsError,
 )
-from conda.lock import FileLock
 from conda.gateways.disk.create import mkdir_p
 from conda.gateways.disk.delete import delete_trash, path_is_clean, rm_rf
 from conda.gateways.disk.test import is_conda_environment
+from conda.lock import FileLock
 from conda.misc import explicit, touch_nonadmin
 from conda.models.match_spec import MatchSpec
 


### PR DESCRIPTION
Comes from #1104 

---

- [X] Protect repodata cache write and access
- [x] Protect pkg download
- [x] Protect pkg extraction (?)


To force a lock file on repodata cache:

```
mamba clean -i
mamba update --all -y --debug & mamba update --all -y --debug
```

You should see entries like these:

```
Channel: conda-forge[osx-arm64,noarch], platform: noarch, prio: 1 : 0
Cache path:  /Users/jrodriguez/.local/anaconda/envs/mamba-dev/pkgs/cache/ddfd5f96.json
DEBUG conda.lock:__enter__(82): 
LOCKERROR: It looks like conda is already doing something.
The lock ['/Users/jrodriguez/.local/anaconda/envs/mamba-dev/pkgs/cache/ddfd5f96.json.pid11553.conda_lock'] was found. Wait for it to finish before continuing.
If you are sure that conda is not running, remove it and try again.
You can also use: $ conda clean --lock

DEBUG conda.lock:__enter__(83): Sleeping for 1 seconds
DEBUG conda.lock:__enter__(82): 
LOCKERROR: It looks like conda is already doing something.
The lock ['/Users/jrodriguez/.local/anaconda/envs/mamba-dev/pkgs/cache/ddfd5f96.json.pid11553.conda_lock'] was found. Wait for it to finish before continuing.
If you are sure that conda is not running, remove it and try again.
You can also use: $ conda clean --lock
```