### PR TITLE
Fix `mamba` not writable cache error

### DIFF
--- a/src/api/configuration.cpp
+++ b/src/api/configuration.cpp
@@ -219,7 +219,15 @@ namespace mamba
 
             auto& ctx = Context::instance();
             ctx.envs_dirs = { prefix / "envs" };
-            ctx.pkgs_dirs = { prefix / "pkgs" };
+
+            if (std::getenv("CONDA_PKGS_DIRS") != nullptr)
+            {
+                ctx.pkgs_dirs = { fs::path(std::getenv("CONDA_PKGS_DIRS")) };
+            }
+            else
+            {
+                ctx.pkgs_dirs = { prefix / "pkgs" };
+            }
         }
         /*
                 void log_level_hook(LogLevel& lvl)

--- a/src/api/install.cpp
+++ b/src/api/install.cpp
@@ -290,15 +290,7 @@ namespace mamba
         auto& no_py_pin = config.at("no_py_pin").value<bool>();
         auto& retry_clean_cache = config.at("retry_clean_cache").value<bool>();
 
-        fs::path pkgs_dirs;
-        if (std::getenv("CONDA_PKGS_DIRS") != nullptr)
-        {
-            pkgs_dirs = fs::path(std::getenv("CONDA_PKGS_DIRS"));
-        }
-        else
-        {
-            pkgs_dirs = ctx.root_prefix / "pkgs";
-        }
+        fs::path pkgs_dirs = ctx.pkgs_dirs.at(0);
 
         if (ctx.target_prefix.empty())
         {

--- a/src/core/channel.cpp
+++ b/src/core/channel.cpp
@@ -17,6 +17,7 @@
 #include "mamba/core/environment.hpp"
 #include "mamba/core/context.hpp"
 #include "mamba/core/fsutil.hpp"
+#include "mamba/core/package_cache.hpp"
 #include "mamba/core/package_handling.hpp"
 #include "mamba/core/url.hpp"
 #include "mamba/core/util.hpp"
@@ -61,7 +62,7 @@ namespace mamba
         , m_repo_checker(base_url(),
                          Context::instance().root_prefix / "etc" / "trusted-repos"
                              / cache_name_from_url(base_url()),
-                         Context::instance().root_prefix / "pkgs" / "cache"
+                         PackageCacheData::first_writable().get_pkgs_dir() / "cache"
                              / cache_name_from_url(base_url()))
     {
         fs::create_directories(m_repo_checker.cache_path());

--- a/test/micromamba/helpers.py
+++ b/test/micromamba/helpers.py
@@ -249,7 +249,9 @@ def get_env(n, f=None):
         return Path(os.path.join(root_prefix, "envs", n))
 
 
-def get_pkg(n, f=None, root_prefix=os.getenv("MAMBA_ROOT_PREFIX")):
+def get_pkg(n, f=None, root_prefix=None):
+    if not root_prefix:
+        root_prefix = os.getenv("MAMBA_ROOT_PREFIX")
     if f:
         return Path(os.path.join(root_prefix, "pkgs", n, f))
     else:

--- a/test/micromamba/test_pkg_cache.py
+++ b/test/micromamba/test_pkg_cache.py
@@ -38,7 +38,7 @@ class TestPkgCache:
         os.environ["CONDA_PREFIX"] = TestPkgCache.prefix
 
         if "CONDA_PKGS_DIRS" in os.environ:
-            os.pop("CONDA_PKGS_DIRS")
+            os.environ.pop("CONDA_PKGS_DIRS")
 
     @classmethod
     def teardown_class(cls):

--- a/test/micromamba/test_pkg_cache.py
+++ b/test/micromamba/test_pkg_cache.py
@@ -18,20 +18,68 @@ else:
 
 
 class TestPkgCache:
-    def test_extracted_file_deleted(self):
-        ref_env = "x"
-        res = create("xtensor", "-n", ref_env, "--json", no_dry_run=True)
-        xf = get_env(ref_env, xtensor_hpp)
+
+    current_root_prefix = os.environ["MAMBA_ROOT_PREFIX"]
+    current_prefix = os.environ["CONDA_PREFIX"]
+    cache = os.path.join(current_root_prefix, "pkgs")
+
+    env_name = random_string()
+    root_prefix = os.path.expanduser(os.path.join("~", "tmproot" + random_string()))
+    prefix = os.path.join(root_prefix, "envs", env_name)
+
+    stat_xf = None
+    stat_orig = None
+    pkg_name = None
+    orig_file_path = None
+
+    @classmethod
+    def setup_class(cls):
+        os.environ["MAMBA_ROOT_PREFIX"] = TestPkgCache.root_prefix
+        os.environ["CONDA_PREFIX"] = TestPkgCache.prefix
+
+        if "CONDA_PKGS_DIRS" in os.environ:
+            os.pop("CONDA_PKGS_DIRS")
+
+    @classmethod
+    def teardown_class(cls):
+        os.environ["MAMBA_ROOT_PREFIX"] = TestPkgCache.current_root_prefix
+        os.environ["CONDA_PREFIX"] = TestPkgCache.current_prefix
+
+    @classmethod
+    def setup(cls):
+        res = create("-n", TestPkgCache.env_name, "xtensor", "--json", no_dry_run=True)
+
+        xf = get_env(TestPkgCache.env_name, xtensor_hpp)
         assert xf.exists()
-        stat_xf = xf.stat()
+        TestPkgCache.stat_xf = xf.stat()
 
-        pkg_name = get_concrete_pkg(res, "xtensor")
-        orig_file_path = get_pkg(pkg_name, xtensor_hpp)
-        stat_orig = orig_file_path.stat()
+        TestPkgCache.pkg_name = get_concrete_pkg(res, "xtensor")
+        TestPkgCache.orig_file_path = get_pkg(TestPkgCache.pkg_name, xtensor_hpp)
+        TestPkgCache.stat_orig = TestPkgCache.orig_file_path.stat()
 
-        assert stat_orig.st_dev == stat_xf.st_dev and stat_orig.st_ino == stat_xf.st_ino
+        assert TestPkgCache.stat_orig.st_dev == TestPkgCache.stat_xf.st_dev
+        assert TestPkgCache.stat_orig.st_ino == TestPkgCache.stat_xf.st_ino
 
-        os.remove(orig_file_path)
+    @classmethod
+    def teardown(cls):
+        if Path(TestPkgCache.root_prefix).exists():
+            shutil.rmtree(os.path.join(TestPkgCache.root_prefix, "envs"))
+
+            extracted_pkg = os.path.join(
+                TestPkgCache.root_prefix, "pkgs", TestPkgCache.pkg_name
+            )
+            if Path(extracted_pkg).exists():
+                shutil.rmtree(extracted_pkg)
+
+            tarball = os.path.join(
+                TestPkgCache.root_prefix, "pkgs", TestPkgCache.pkg_name + ".tar.bz2"
+            )
+            if Path(tarball).exists():
+                os.remove(tarball)
+
+    def test_extracted_file_deleted(self):
+
+        os.remove(TestPkgCache.orig_file_path)
 
         env = "x1"
         res = create("xtensor", "-n", env, "--json", no_dry_run=True)
@@ -39,34 +87,12 @@ class TestPkgCache:
         assert xf.exists()
         stat_xf = xf.stat()
 
-        assert stat_orig.st_dev == stat_xf.st_dev and stat_orig.st_ino != stat_xf.st_ino
-
-        shutil.rmtree(get_env(ref_env))
-        shutil.rmtree(get_env(env))
+        assert TestPkgCache.stat_orig.st_dev == stat_xf.st_dev
+        assert TestPkgCache.stat_orig.st_ino != stat_xf.st_ino
 
     @pytest.mark.parametrize("safety_checks", ["disabled", "warn", "enabled"])
     def test_extracted_file_corrupted(self, safety_checks):
-        ref_env = "x"
-        res = create(
-            "xtensor",
-            "-n",
-            ref_env,
-            "--json",
-            "--safety-checks",
-            safety_checks,
-            no_dry_run=True,
-        )
-        xf = get_env(ref_env, xtensor_hpp)
-        assert xf.exists()
-        stat_xf = xf.stat()
-
-        pkg_name = get_concrete_pkg(res, "xtensor")
-        orig_file_path = get_pkg(pkg_name, xtensor_hpp)
-        stat_orig = orig_file_path.stat()
-
-        assert stat_orig.st_dev == stat_xf.st_dev and stat_orig.st_ino == stat_xf.st_ino
-
-        with open(orig_file_path, "w") as f:
+        with open(TestPkgCache.orig_file_path, "w") as f:
             f.write("//corruption")
 
         env = "x1"
@@ -84,34 +110,14 @@ class TestPkgCache:
         stat_xf = xf.stat()
 
         if safety_checks == "enabled":
-            assert (
-                stat_orig.st_dev == stat_xf.st_dev
-                and stat_orig.st_ino != stat_xf.st_ino
-            )
+            assert TestPkgCache.stat_orig.st_dev == stat_xf.st_dev
+            assert TestPkgCache.stat_orig.st_ino != stat_xf.st_ino
         else:
-            assert (
-                stat_orig.st_dev == stat_xf.st_dev
-                and stat_orig.st_ino == stat_xf.st_ino
-            )
-
-        os.remove(orig_file_path)
-        shutil.rmtree(get_env(ref_env))
-        shutil.rmtree(get_env(env))
+            assert TestPkgCache.stat_orig.st_dev == stat_xf.st_dev
+            assert TestPkgCache.stat_orig.st_ino == stat_xf.st_ino
 
     def test_tarball_deleted(self):
-        ref_env = "x"
-        res = create("xtensor", "-n", ref_env, "--json", no_dry_run=True)
-        xf = get_env(ref_env, xtensor_hpp)
-        assert xf.exists()
-        stat_xf = xf.stat()
-
-        pkg_name = get_concrete_pkg(res, "xtensor")
-        orig_file_path = get_pkg(pkg_name, xtensor_hpp)
-        stat_orig = orig_file_path.stat()
-
-        assert stat_orig.st_dev == stat_xf.st_dev and stat_orig.st_ino == stat_xf.st_ino
-
-        os.remove(get_tarball(pkg_name))
+        os.remove(get_tarball(TestPkgCache.pkg_name))
 
         env = "x1"
         res = create("xtensor", "-n", env, "--json", no_dry_run=True)
@@ -119,29 +125,14 @@ class TestPkgCache:
         assert xf.exists()
         stat_xf = xf.stat()
 
-        assert not get_tarball(pkg_name).exists()
-        assert stat_orig.st_dev == stat_xf.st_dev and stat_orig.st_ino == stat_xf.st_ino
-
-        shutil.rmtree(get_pkg(pkg_name))  # clean for other tests
-        shutil.rmtree(get_env(ref_env))
-        shutil.rmtree(get_env(env))
+        assert not get_tarball(TestPkgCache.pkg_name).exists()
+        assert TestPkgCache.stat_orig.st_dev == stat_xf.st_dev
+        assert TestPkgCache.stat_orig.st_ino == stat_xf.st_ino
 
     def test_tarball_and_extracted_file_deleted(self):
-        ref_env = "x"
-        res = create("xtensor", "-n", ref_env, "--json", no_dry_run=True)
-        xf = get_env(ref_env, xtensor_hpp)
-        assert xf.exists()
-        stat_xf = xf.stat()
-
-        pkg_name = get_concrete_pkg(res, "xtensor")
-        orig_file_path = get_pkg(pkg_name, xtensor_hpp)
-        stat_orig = orig_file_path.stat()
-
-        assert stat_orig.st_dev == stat_xf.st_dev and stat_orig.st_ino == stat_xf.st_ino
-
-        pkg_size = get_tarball(pkg_name).stat().st_size
-        os.remove(orig_file_path)
-        os.remove(get_tarball(pkg_name))
+        pkg_size = get_tarball(TestPkgCache.pkg_name).stat().st_size
+        os.remove(TestPkgCache.orig_file_path)
+        os.remove(get_tarball(TestPkgCache.pkg_name))
 
         env = "x1"
         res = create("xtensor", "-n", env, "--json", no_dry_run=True)
@@ -149,30 +140,16 @@ class TestPkgCache:
         assert xf.exists()
         stat_xf = xf.stat()
 
-        assert get_tarball(pkg_name).exists()
-        assert pkg_size == get_tarball(pkg_name).stat().st_size
-        assert stat_orig.st_dev == stat_xf.st_dev and stat_orig.st_ino != stat_xf.st_ino
-
-        shutil.rmtree(get_env(ref_env))
-        shutil.rmtree(get_env(env))
+        assert get_tarball(TestPkgCache.pkg_name).exists()
+        assert pkg_size == get_tarball(TestPkgCache.pkg_name).stat().st_size
+        assert TestPkgCache.stat_orig.st_dev == stat_xf.st_dev
+        assert TestPkgCache.stat_orig.st_ino != stat_xf.st_ino
 
     def test_tarball_corrupted_and_extracted_file_deleted(self):
-        ref_env = "x"
-        res = create("xtensor", "-n", ref_env, "--json", no_dry_run=True)
-        xf = get_env(ref_env, xtensor_hpp)
-        assert xf.exists()
-        stat_xf = xf.stat()
-
-        pkg_name = get_concrete_pkg(res, "xtensor")
-        orig_file_path = get_pkg(pkg_name, xtensor_hpp)
-        stat_orig = orig_file_path.stat()
-
-        assert stat_orig.st_dev == stat_xf.st_dev and stat_orig.st_ino == stat_xf.st_ino
-
-        pkg_size = get_tarball(pkg_name).stat().st_size
-        os.remove(orig_file_path)
-        os.remove(get_tarball(pkg_name))
-        with open(get_tarball(pkg_name), "w") as f:
+        pkg_size = get_tarball(TestPkgCache.pkg_name).stat().st_size
+        os.remove(TestPkgCache.orig_file_path)
+        os.remove(get_tarball(TestPkgCache.pkg_name))
+        with open(get_tarball(TestPkgCache.pkg_name), "w") as f:
             f.write("")
 
         env = "x1"
@@ -181,35 +158,18 @@ class TestPkgCache:
         assert xf.exists()
         stat_xf = xf.stat()
 
-        assert get_tarball(pkg_name).exists()
-        assert pkg_size == get_tarball(pkg_name).stat().st_size
-        assert stat_orig.st_dev == stat_xf.st_dev and stat_orig.st_ino != stat_xf.st_ino
-
-        shutil.rmtree(get_env(ref_env))
-        shutil.rmtree(get_env(env))
+        assert get_tarball(TestPkgCache.pkg_name).exists()
+        assert pkg_size == get_tarball(TestPkgCache.pkg_name).stat().st_size
+        assert TestPkgCache.stat_orig.st_dev == stat_xf.st_dev
+        assert TestPkgCache.stat_orig.st_ino != stat_xf.st_ino
 
     def test_extracted_file_corrupted_no_perm(self):
-        ref_env = "x"
-        res = create("xtensor", "-n", ref_env, "--json", no_dry_run=True)
-        xf = get_env(ref_env, xtensor_hpp)
-        assert xf.exists()
-        stat_xf = xf.stat()
-
-        pkg_name = get_concrete_pkg(res, "xtensor")
-        orig_file_path = get_pkg(pkg_name, xtensor_hpp)
-        stat_orig = orig_file_path.stat()
-
-        assert stat_orig.st_dev == stat_xf.st_dev and stat_orig.st_ino == stat_xf.st_ino
-
-        with open(orig_file_path, "w") as f:
+        with open(TestPkgCache.orig_file_path, "w") as f:
             f.write("//corruption")
-        os.chmod(get_pkg(pkg_name), 0o500)
+        os.chmod(get_pkg(TestPkgCache.pkg_name), 0o500)
 
         env = "x1"
 
         create("xtensor", "-n", env, "--json", no_dry_run=True)
 
-        os.chmod(get_pkg(pkg_name), 0o755)
-        os.remove(orig_file_path)
-        shutil.rmtree(get_env(ref_env))
-        shutil.rmtree(get_env(env))
+        os.chmod(get_pkg(TestPkgCache.pkg_name), 0o700)


### PR DESCRIPTION
Description
---

Fix `mamba` `runtime_error` when `root_prefix` cache in not writable
Use the first writable cache dir in `Channel` constructor to re-use `Context.pkgs_dirs` filled using `conda` api

The bug has been introduced in https://github.com/mamba-org/mamba/pull/1033, by using `libmamba` `Channel` instead of `conda`'s one.

Closes #1098 