### PR TITLE
Add a mamba.bat in front of PATH

### DIFF
--- a/mamba/shell_templates/win_redirect/mamba.bat
+++ b/mamba/shell_templates/win_redirect/mamba.bat
@@ -1,0 +1,3 @@
+@REM Copyright (C) 2012 Anaconda, Inc
+@REM SPDX-License-Identifier: BSD-3-Clause
+@CALL "%~dp0..\..\condabin\mamba.bat" %*

--- a/setup.py
+++ b/setup.py
@@ -192,7 +192,9 @@ data_files = [
 ]
 if sys.platform == "win32":
     data_files.append(("condabin", ["mamba/shell_templates/mamba.bat"]),)
-    data_files.append(("Library/bin", ["mamba/shell_templates/win_redirect/mamba.bat"]),)
+    data_files.append(
+        ("Library/bin", ["mamba/shell_templates/win_redirect/mamba.bat"]),
+    )
 
 setup(
     name="mamba",

--- a/setup.py
+++ b/setup.py
@@ -192,6 +192,7 @@ data_files = [
 ]
 if sys.platform == "win32":
     data_files.append(("condabin", ["mamba/shell_templates/mamba.bat"]),)
+    data_files.append(("Library/bin", ["mamba/shell_templates/win_redirect/mamba.bat"]),)
 
 setup(
     name="mamba",


### PR DESCRIPTION
In conda, mamba is found in the following order,

  %PREFIX%\Library\bin\mamba.bat
  %PREFIX%\Scripts\mamba.exe
  %PREFIX%\condabin\mamba.bat

and therefore need a mamba.bat in Libray\bin