### PR TITLE
Cache signature metadata

### DIFF
--- a/include/mamba/core/package_info.hpp
+++ b/include/mamba/core/package_info.hpp
@@ -17,6 +17,7 @@ extern "C"
 
 #include <string>
 #include <vector>
+#include <set>
 
 #include "nlohmann/json.hpp"
 
@@ -40,7 +41,8 @@ namespace mamba
                     const std::string build_string,
                     std::size_t build_number);
 
-        nlohmann::json json() const;
+        nlohmann::json json_record() const;
+        nlohmann::json json_signable() const;
         std::string str() const;
         std::string long_str() const;
 
@@ -60,6 +62,9 @@ namespace mamba
         std::string track_features;
         std::vector<std::string> depends;
         std::vector<std::string> constrains;
+        std::string signatures;
+        std::string extra_metadata;
+        std::set<std::string> defaulted_keys;
     };
 }  // namespace mamba
 

--- a/include/mamba/core/validate.hpp
+++ b/include/mamba/core/validate.hpp
@@ -202,6 +202,16 @@ namespace validate
         virtual ~package_error() = default;
     };
 
+    /**
+     * Error raised when signatures threshold
+     * is not met for a trust role.
+     */
+    class role_error : public trust_error
+    {
+    public:
+        role_error() noexcept;
+        virtual ~role_error() = default;
+    };
 
     /**
      * Error raised when an invalid package

--- a/include/mamba/core/validate.hpp
+++ b/include/mamba/core/validate.hpp
@@ -481,8 +481,7 @@ namespace validate
         virtual ~RepoIndexChecker() = default;
         virtual void verify_index(const json& j) const = 0;
         virtual void verify_index(const fs::path& p) const = 0;
-        virtual void verify_package(const fs::path& index_path,
-                                    const std::string& pkg_name) const = 0;
+        virtual void verify_package(const json& signed_data, const json& signatures) const = 0;
 
     protected:
         RepoIndexChecker() = default;
@@ -510,7 +509,7 @@ namespace validate
         // Forwarding to a ``RepoIndexChecker`` implementation
         void verify_index(const json& j) const;
         void verify_index(const fs::path& p) const;
-        void verify_package(const fs::path& index_path, const std::string& pkg_name) const;
+        void verify_package(const json& signed_data, const json& signatures) const;
 
         void generate_index_checker();
 
@@ -746,8 +745,7 @@ namespace validate
 
             void verify_index(const fs::path& p) const override;
             void verify_index(const json& j) const override;
-            void verify_package(const fs::path& index_path,
-                                const std::string& pkg_name) const override;
+            void verify_package(const json& signed_data, const json& signatures) const override;
 
             friend void to_json(json& j, const PkgMgrRole& r);
             friend void from_json(const json& j, PkgMgrRole& r);

--- a/src/core/channel.cpp
+++ b/src/core/channel.cpp
@@ -59,7 +59,7 @@ namespace mamba
         , m_token(token)
         , m_package_filename(package_filename)
         , m_canonical_name(canonical_name)
-        , m_repo_checker(base_url(),
+        , m_repo_checker(rsplit(base_url(), "/", 1).front(),
                          Context::instance().root_prefix / "etc" / "trusted-repos"
                              / cache_name_from_url(base_url()),
                          PackageCacheData::first_writable().get_pkgs_dir() / "cache"

--- a/src/core/query.cpp
+++ b/src/core/query.cpp
@@ -676,15 +676,15 @@ namespace mamba
         j["result"]["pkgs"] = nlohmann::json::array();
         for (size_t i = 0; i < m_pkg_view_list.size(); ++i)
         {
-            j["result"]["pkgs"].push_back(m_pkg_view_list[i]->json());
+            j["result"]["pkgs"].push_back(m_pkg_view_list[i]->json_record());
         }
 
         if (m_type != QueryType::Search && !m_pkg_view_list.empty())
         {
             bool has_root = !m_dep_graph.get_edge_list(0).empty();
             j["result"]["graph_roots"] = nlohmann::json::array();
-            j["result"]["graph_roots"].push_back(has_root ? m_dep_graph.get_node_list()[0].json()
-                                                          : nlohmann::json(m_query));
+            j["result"]["graph_roots"].push_back(
+                has_root ? m_dep_graph.get_node_list()[0].json_record() : nlohmann::json(m_query));
         }
         return j;
     }

--- a/src/core/validate.cpp
+++ b/src/core/validate.cpp
@@ -73,7 +73,12 @@ namespace validate
     }
 
     package_error::package_error() noexcept
-        : trust_error("Invalid package metadata")
+        : trust_error("Invalid package")
+    {
+    }
+
+    role_error::role_error() noexcept
+        : trust_error("Invalid role")
     {
     }
 
@@ -915,7 +920,15 @@ namespace validate
         auto signatures = role.signatures(data);
         auto k = self_keys();
 
-        check_signatures(signed_data, signatures, k);
+        try
+        {
+            check_signatures(signed_data, signatures, k);
+        }
+        catch (const threshold_error& e)
+        {
+            LOG_ERROR << "Validation failed on role '" << type() << "'";
+            throw role_error();
+        }
     }
 
     void RoleBase::check_signatures(const std::string& signed_data,
@@ -960,8 +973,8 @@ namespace validate
 
         if (valid_sig < keyring.threshold)
         {
-            LOG_ERROR << "Threshold of valid signatures for '" << type()
-                      << "' metadata is not met (" << valid_sig << "/" << keyring.threshold << ")";
+            LOG_ERROR << "Threshold of valid signatures is not met (" << valid_sig << "/"
+                      << keyring.threshold << ")";
             throw threshold_error();
         }
     }

--- a/test/test_validate.cpp
+++ b/test/test_validate.cpp
@@ -688,8 +688,7 @@ namespace validate
                     { "op": "replace", "path": "/signed/delegations/root/threshold", "value": 2 }
                     ])"_json;
 
-                EXPECT_THROW(root.update(create_root_update("2.root.json", patch)),
-                             threshold_error);
+                EXPECT_THROW(root.update(create_root_update("2.root.json", patch)), role_error);
             }
 
             TEST_F(RootImplT_v06, expires)
@@ -1740,8 +1739,7 @@ namespace validate
                     { "op": "replace", "path": "/signed/roles/root/threshold", "value": 2 }
                     ])"_json;
 
-                EXPECT_THROW(root.update(create_root_update("2.root.json", patch)),
-                             threshold_error);
+                EXPECT_THROW(root.update(create_root_update("2.root.json", patch)), role_error);
             }
 
             TEST_F(RootImplT_v1, expires)


### PR DESCRIPTION
Description
---

This PR requires `libsolv` modification: https://github.com/openSUSE/libsolv/pull/469/files

- get package metadata from `libsolv` solvable
  - get extra keys/values to patch serialized metadata
  - get signatures
  - avoid parsing error when either `extra_metadata` or `signatures` is empty
- test if deps are found in `libsolv` pool or not
  - allow to know if the serialized metadata used to produced the signature contain the key or not
- add a `json_signable` method to serialize signable package metadata
  - this uses the `extra_metadata` to use for signature reproducibility
- update `RepoIndexChecker` and `RepoChecker` `verify_package` API
  - update `v0.6.0::PkgMgrRole` accordingly
- improve transaction logs for package signatures
- improve errors messages
  - add a `role_error` when verification of a role fails (instead of a `threshold_error`)
  - update tests