### PR TITLE
change token regex and add test

### DIFF
--- a/include/mamba/core/util.hpp
+++ b/include/mamba/core/util.hpp
@@ -43,7 +43,9 @@ namespace mamba
 #error "no supported OS detected"
 #endif
 
-    const static std::regex token_re("/t/([a-zA-Z0-9-]*)");
+    // usernames on anaconda.org can have a underscore, which influences the
+    // first two characters
+    const static std::regex token_re("/t/([a-zA-Z0-9-_]{0,2}[a-zA-Z0-9-]*)");
     const static std::regex http_basicauth_re("://([^\\s]+):([^\\s]+)@");
 
     class mamba_error : public std::runtime_error

--- a/test/test_url.cpp
+++ b/test/test_url.cpp
@@ -204,12 +204,19 @@ namespace mamba
     TEST(url, split_scheme_auth_token)
     {
         std::string input = "https://u:p@conda.io/t/x1029384756/more/path";
+        std::string input2 = "https://u:p@conda.io/t/a_-12345-absdj12345-xyxyxyx/more/path";
         std::string remaining_url, scheme, auth, token;
         split_scheme_auth_token(input, remaining_url, scheme, auth, token);
         EXPECT_EQ(remaining_url, "conda.io/more/path");
         EXPECT_EQ(scheme, "https");
         EXPECT_EQ(auth, "u:p");
         EXPECT_EQ(token, "x1029384756");
+
+        split_scheme_auth_token(input2, remaining_url, scheme, auth, token);
+        EXPECT_EQ(remaining_url, "conda.io/more/path");
+        EXPECT_EQ(scheme, "https");
+        EXPECT_EQ(auth, "u:p");
+        EXPECT_EQ(token, "a_-12345-absdj12345-xyxyxyx");
 
 #ifdef _WIN32
         split_scheme_auth_token(


### PR DESCRIPTION
This fixes anaconda token detection for usernames with an underscore. 

cc @chenghlee @asterbini