### PR TITLE
Add Python bindings for content trust core API

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,10 +3,10 @@ name: CI
 on:
   push:
     branches:
-    - master
+      - master
   pull_request:
     branches:
-    - master
+      - master
 
 jobs:
   mamba_python_tests:
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: [ '3.8' ]
+        python-version: ["3.8"]
 
     steps:
       - uses: actions/checkout@v2
@@ -303,7 +303,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-2016]
-        python-version: [ '3.7' ]
+        python-version: ["3.7"]
 
     steps:
       - uses: actions/checkout@v2
@@ -378,7 +378,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-2016]
-        python-version: [ '3.7' ]
+        python-version: ["3.7"]
 
     steps:
       - uses: actions/checkout@v2
@@ -421,7 +421,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-2016]
-        python-version: [ '3.7' ]
+        python-version: ["3.7"]
 
     steps:
       - uses: actions/checkout@v2
@@ -475,7 +475,7 @@ jobs:
           micromamba create -n testenv python=3.8 wheel -c conda-forge
           micromamba activate testenv
           wheel --help
-      - name: 'Tar files'
+      - name: "Tar files"
         run: tar -cvf umamba.tar build/micromamba.exe
       - uses: actions/upload-artifact@v2
         with:
@@ -489,7 +489,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-2016]
-        python-version: [ '3.7' ]
+        python-version: ["3.7"]
 
     steps:
       - uses: actions/checkout@v2
@@ -530,7 +530,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-2016]
-        python-version: [ '3.7' ]
+        python-version: ["3.7"]
 
     steps:
       - uses: actions/checkout@v2
@@ -569,7 +569,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-2016]
-        python-version: [ '3.7' ]
+        python-version: ["3.7"]
 
     steps:
       - uses: actions/checkout@v2

--- a/include/mamba/core/query.hpp
+++ b/include/mamba/core/query.hpp
@@ -29,7 +29,6 @@ extern "C"
 #include "solv/solver.h"
 }
 
-namespace nl = nlohmann;
 
 namespace mamba
 {
@@ -89,7 +88,7 @@ namespace mamba
         std::ostream& table(std::ostream&) const;
         std::ostream& table(std::ostream&, const std::vector<std::string>& fmt) const;
         std::ostream& tree(std::ostream&) const;
-        nl::json json() const;
+        nlohmann::json json() const;
 
         std::ostream& pretty(std::ostream&) const;
 

--- a/include/mamba/core/validate.hpp
+++ b/include/mamba/core/validate.hpp
@@ -36,8 +36,13 @@ namespace validate
     const std::size_t MAMBA_ED25519_SIGSIZE_BYTES = 64;
 
     int generate_ed25519_keypair(unsigned char* pk, unsigned char* sk);
+    std::pair<std::array<unsigned char, MAMBA_ED25519_KEYSIZE_BYTES>,
+              std::array<unsigned char, MAMBA_ED25519_KEYSIZE_BYTES>>
+    generate_ed25519_keypair();
+    std::pair<std::string, std::string> generate_ed25519_keypair_hex();
 
     int sign(const std::string& data, const unsigned char* sk, unsigned char* signature);
+    int sign(const std::string& data, const std::string& sk, std::string& signature);
 
     std::array<unsigned char, MAMBA_ED25519_SIGSIZE_BYTES> ed25519_sig_hex_to_bytes(
         const std::string& sig_hex) noexcept;
@@ -286,6 +291,9 @@ namespace validate
      */
     struct RoleFullKeys
     {
+        RoleFullKeys() = default;
+        RoleFullKeys(const std::map<std::string, Key>& keys_, const std::size_t& threshold_);
+
         std::map<std::string, Key> keys;
         std::size_t threshold;
 
@@ -604,6 +612,8 @@ namespace validate
         public:
             void set_timestamp(const std::string& ts);
 
+            std::string timestamp() const;
+
         protected:
             std::string m_timestamp;
 
@@ -619,11 +629,12 @@ namespace validate
          */
         class RootImpl final
             : public RootRole
-            , protected V06RoleBaseExtension
+            , public V06RoleBaseExtension
         {
         public:
             RootImpl(const fs::path& p);
             RootImpl(const json& j);
+            RootImpl(const std::string& json_str);
 
             /**
              * Return a ``RepoIndexChecker`` implementation (derived class)
@@ -670,6 +681,16 @@ namespace validate
             , public V06RoleBaseExtension
         {
         public:
+            KeyMgrRole(const fs::path& p,
+                       const RoleFullKeys& keys,
+                       const std::shared_ptr<SpecBase> spec);
+            KeyMgrRole(const json& j,
+                       const RoleFullKeys& keys,
+                       const std::shared_ptr<SpecBase> spec);
+            KeyMgrRole(const std::string& json_str,
+                       const RoleFullKeys& keys,
+                       const std::shared_ptr<SpecBase> spec);
+
             // std::set<std::string> roles() const override;
             RoleFullKeys self_keys() const override;
 
@@ -687,12 +708,6 @@ namespace validate
 
         private:
             KeyMgrRole() = delete;
-            KeyMgrRole(const fs::path& p,
-                       const RoleFullKeys& keys,
-                       const std::shared_ptr<SpecBase> spec);
-            KeyMgrRole(const json& j,
-                       const RoleFullKeys& keys,
-                       const std::shared_ptr<SpecBase> spec);
 
             void load_from_json(const json& j);
 
@@ -703,8 +718,6 @@ namespace validate
             std::set<std::string> optionally_defined_roles() const override;
 
             void set_defined_roles(std::map<std::string, RolePubKeys> keys);
-
-            friend class RootImpl;
         };
 
 
@@ -721,8 +734,13 @@ namespace validate
         {
         public:
             PkgMgrRole(const RoleFullKeys& keys, const std::shared_ptr<SpecBase> spec);
-
+            PkgMgrRole(const fs::path& p,
+                       const RoleFullKeys& keys,
+                       const std::shared_ptr<SpecBase> spec);
             PkgMgrRole(const json& j,
+                       const RoleFullKeys& keys,
+                       const std::shared_ptr<SpecBase> spec);
+            PkgMgrRole(const std::string& json_str,
                        const RoleFullKeys& keys,
                        const std::shared_ptr<SpecBase> spec);
 

--- a/src/core/query.cpp
+++ b/src/core/query.cpp
@@ -661,9 +661,9 @@ namespace mamba
         return out;
     }
 
-    nl::json query_result::json() const
+    nlohmann::json query_result::json() const
     {
-        nl::json j;
+        nlohmann::json j;
         std::string query_type = m_type == QueryType::Search
                                      ? "search"
                                      : (m_type == QueryType::Depends ? "depends" : "whoneeds");
@@ -684,7 +684,7 @@ namespace mamba
             bool has_root = !m_dep_graph.get_edge_list(0).empty();
             j["result"]["graph_roots"] = nlohmann::json::array();
             j["result"]["graph_roots"].push_back(has_root ? m_dep_graph.get_node_list()[0].json()
-                                                          : nl::json(m_query));
+                                                          : nlohmann::json(m_query));
         }
         return j;
     }

--- a/test/test_validate.cpp
+++ b/test/test_validate.cpp
@@ -371,6 +371,16 @@ namespace validate
                 EXPECT_EQ(root.version(), 1);
             }
 
+            TEST_F(RootImplT_v06, ctor_from_json_str)
+            {
+                RootImpl root(root1_json.dump());
+
+                EXPECT_EQ(root.type(), "root");
+                EXPECT_EQ(root.file_ext(), "json");
+                EXPECT_EQ(root.spec_version(), SpecImpl("0.6.0"));
+                EXPECT_EQ(root.version(), 1);
+            }
+
             TEST_F(RootImplT_v06, ctor_from_json_pgp_signed)
             {
                 RootImpl root(root1_pgp_json);
@@ -933,6 +943,17 @@ namespace validate
             {
                 RootImpl root(root1_json);
                 auto key_mgr = root.create_key_mgr(key_mgr_json);
+
+                EXPECT_EQ(key_mgr.spec_version(), SpecImpl("0.6.0"));
+                EXPECT_EQ(key_mgr.version(), 1);
+            }
+
+            TEST_F(KeyMgrT_v06, ctor_from_json_str)
+            {
+                RootImpl root(root1_json);
+                auto key_mgr = KeyMgrRole(key_mgr_json.dump(),
+                                          root.all_keys()["key_mgr"],
+                                          std::make_shared<SpecImpl>(SpecImpl()));
 
                 EXPECT_EQ(key_mgr.spec_version(), SpecImpl("0.6.0"));
                 EXPECT_EQ(key_mgr.version(), 1);


### PR DESCRIPTION
Description
---

Add Python bindings for content trust core API
Add overloads and Python bindings to g:
- generate an `ed25519` key pair
- sign data

Add ``PkgMgrRole` and `Key.json_str` bindings
Make `V06RoleBaseExtension` a public base of roles
Add v06 roles constructors using json string
Add tests
Remove `nl` namespace alias to avoid undetected errors in Python bindings