### PR TITLE
Break some circular deps between Configurables

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -292,7 +292,7 @@ jobs:
           eval "$($MAMBA_EXE shell hook -s posix -p ~/mambaroot)"
 
           micromamba activate
-          micromamba install python=3.8 pytest pyyaml -c conda-forge
+          micromamba install python=3.8 pytest pyyaml pytest-lazy-fixture -c conda-forge
 
           export TEST_MAMBA_EXE=$(pwd)/build/micromamba
           pytest test/micromamba
@@ -508,7 +508,7 @@ jobs:
         run: |
           conda config --add channels conda-forge
           conda config --set channel_priority strict
-          conda create -q -y -n mamba-tests vs2017_win-64 python=$PYTHON_VERSION pip pybind11 libsolv libsodium libarchive "libcurl=7.76.1=*_0" nlohmann_json cpp-filesystem conda cmake gtest gmock ninja reproc-cpp yaml-cpp pyyaml cli11 pytest menuinst
+          conda create -q -y -n mamba-tests vs2017_win-64 python=$PYTHON_VERSION pip pybind11 libsolv libsodium libarchive "libcurl=7.76.1=*_0" nlohmann_json cpp-filesystem conda cmake gtest gmock ninja reproc-cpp yaml-cpp pyyaml cli11 pytest pytest-lazy-fixture menuinst
         env:
           PYTHON_VERSION: ${{ matrix.python-version }}
       - name: micromamba python based tests
@@ -549,7 +549,7 @@ jobs:
         run: |
           conda config --add channels conda-forge
           conda config --set channel_priority strict
-          conda create -q -y -n mamba-tests vs2017_win-64 python=$PYTHON_VERSION pip pybind11 libsolv libsodium libarchive "libcurl=7.76.1=*_0" nlohmann_json cpp-filesystem conda cmake gtest gmock ninja reproc-cpp yaml-cpp pyyaml cli11 pytest menuinst
+          conda create -q -y -n mamba-tests vs2017_win-64 python=$PYTHON_VERSION pip pybind11 libsolv libsodium libarchive "libcurl=7.76.1=*_0" nlohmann_json cpp-filesystem conda cmake gtest gmock ninja reproc-cpp yaml-cpp pyyaml cli11 pytest pytest-lazy-fixture menuinst
         env:
           PYTHON_VERSION: ${{ matrix.python-version }}
       - name: micromamba python based tests with pwsh
@@ -588,7 +588,7 @@ jobs:
         run: |
           conda config --add channels conda-forge
           conda config --set channel_priority strict
-          conda create -q -y -n mamba-tests vs2017_win-64 python=$PYTHON_VERSION pip pybind11 libsolv libsodium libarchive "libcurl=7.76.1=*_0" nlohmann_json cpp-filesystem conda cmake gtest gmock ninja reproc-cpp yaml-cpp pyyaml cli11 pytest menuinst
+          conda create -q -y -n mamba-tests vs2017_win-64 python=$PYTHON_VERSION pip pybind11 libsolv libsodium libarchive "libcurl=7.76.1=*_0" nlohmann_json cpp-filesystem conda cmake gtest gmock ninja reproc-cpp yaml-cpp pyyaml cli11 pytest pytest-lazy-fixture menuinst
         env:
           PYTHON_VERSION: ${{ matrix.python-version }}
       - name: micromamba python based tests

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -22,3 +22,4 @@ dependencies:
   - cli11
   - ccache
   - pytest
+  - pytest-lazy-fixture

--- a/setup.py
+++ b/setup.py
@@ -209,7 +209,7 @@ setup(
     long_description="A (hopefully faster) reimplementation of the slow bits of conda.",
     ext_modules=ext_modules,
     install_requires=[],
-    extras_require={"test": ["pytest"]},
+    extras_require={"test": ["pytest", "pytest-lazy-fixture"]},
     cmdclass={"build_ext": BuildExt},
     data_files=data_files,
     include_package_data=True,

--- a/src/core/channel.cpp
+++ b/src/core/channel.cpp
@@ -65,7 +65,6 @@ namespace mamba
                          PackageCacheData::first_writable().get_pkgs_dir() / "cache"
                              / cache_name_from_url(base_url()))
     {
-        fs::create_directories(m_repo_checker.cache_path());
     }
 
     const std::string& Channel::scheme() const

--- a/src/micromamba/common_options.cpp
+++ b/src/micromamba/common_options.cpp
@@ -17,7 +17,7 @@ init_rc_options(CLI::App* subcom)
     auto& config = Configuration::instance();
     std::string cli_group = "Configuration options";
 
-    auto& rc_files = config.at("rc_file").get_wrapped<std::vector<fs::path>>();
+    auto& rc_files = config.at("rc_files").get_wrapped<std::vector<fs::path>>();
     subcom->add_option("--rc-file", rc_files.set_cli_config({}), rc_files.description())
         ->group(cli_group);
 

--- a/test/micromamba/test_activation.py
+++ b/test/micromamba/test_activation.py
@@ -4,6 +4,7 @@ import shutil
 import string
 import subprocess
 import sys
+import tempfile
 
 import pytest
 
@@ -22,15 +23,28 @@ elif platform.system() == "Windows":
     running_os = "win"
 
 
-clean_env = os.environ.copy()
-clean_env = {
-    k: v for k, v in clean_env.items() if not (k.startswith(("CONDA", "MAMBA")))
-}
+@pytest.fixture
+def keep_cache(existing_cache):
+    yield True
 
-path = clean_env.get("PATH")
-elems = path.split(os.pathsep)
-elems = [e for e in elems if not "condabin" in e]
-clean_env["PATH"] = os.pathsep.join(elems)
+
+@pytest.fixture
+def clean_env(keep_cache):
+    clean_env = os.environ.copy()
+    clean_env = {
+        k: v
+        for k, v in clean_env.items()
+        if not k.startswith(("CONDA", "MAMBA"))
+        or (k == "CONDA_PKGS_DIRS" and keep_cache)
+    }
+
+    path = clean_env.get("PATH")
+    elems = path.split(os.pathsep)
+    elems = [e for e in elems if not "condabin" in e]
+    clean_env["PATH"] = os.pathsep.join(elems)
+
+    yield clean_env
+
 
 suffixes = {
     "cmdexe": ".bat",
@@ -76,7 +90,7 @@ def emit_check(cond):
     return cmds.if_(cond).then_(cmds.echo("YES")).else_(cmds.echo("NOPE"))
 
 
-enable_on_os = {
+possible_interpreters = {
     "win": {"powershell", "cmdexe"},
     # 'unix': {'bash', 'zsh', 'xonsh'},
     "unix": {"bash", "zsh", "fish"},
@@ -159,7 +173,7 @@ def call_interpreter(s, tmp_path, interpreter, interactive=False, env=None):
         s = mods
     f = write_script(interpreter, s, tmp_path)
 
-    if interpreter not in enable_on_os[running_os]:
+    if interpreter not in possible_interpreters[running_os]:
         return None, None
 
     if interpreter == "cmdexe":
@@ -187,7 +201,25 @@ def call_interpreter(s, tmp_path, interpreter, interactive=False, env=None):
 
 
 def get_interpreters(exclude=[]):
-    return [x for x in enable_on_os[running_os] if x not in exclude]
+    return [x for x in possible_interpreters[running_os] if x not in exclude]
+
+
+def get_valid_interpreters():
+    valid_interpreters = []
+    s = ["echo 'hello world'"]
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        for interpreter in possible_interpreters[running_os]:
+            try:
+                stdout, _ = call_interpreter(s, tmpdirname, interpreter)
+                assert stdout == "hello world"
+                valid_interpreters.append(interpreter)
+            except:
+                pass
+
+    return valid_interpreters
+
+
+valid_interpreters = get_valid_interpreters()
 
 
 def shvar(v, interpreter):
@@ -205,7 +237,6 @@ class TestActivation:
 
     current_root_prefix = os.environ["MAMBA_ROOT_PREFIX"]
     current_prefix = os.environ["CONDA_PREFIX"]
-    cache = os.path.join(current_root_prefix, "pkgs")
 
     env_name = random_string()
     root_prefix = os.path.expanduser(os.path.join("~", "tmproot" + random_string()))
@@ -217,29 +248,40 @@ class TestActivation:
         root_prefix, *["some_very_long_prefix" for i in range(20)], env_name
     )
 
-    @classmethod
-    def setup_class(cls):
-        os.environ["MAMBA_ROOT_PREFIX"] = cls.root_prefix
-        os.environ["CONDA_PREFIX"] = cls.prefix
+    @staticmethod
+    @pytest.fixture(scope="class")
+    def new_root_prefix(existing_cache):
+        os.environ["MAMBA_ROOT_PREFIX"] = TestActivation.root_prefix
+        os.environ["CONDA_PREFIX"] = TestActivation.prefix
+        create("-n", "base", no_dry_run=True)
+        create("xtensor", "-n", TestActivation.env_name, no_dry_run=True)
 
-    @classmethod
-    def teardown_class(cls):
-        os.environ["MAMBA_ROOT_PREFIX"] = cls.current_root_prefix
-        os.environ["CONDA_PREFIX"] = cls.current_prefix
+        yield
 
-        if os.path.exists(cls.root_prefix):
-            shutil.rmtree(cls.root_prefix)
-        if os.path.exists(cls.other_root_prefix):
-            shutil.rmtree(cls.other_root_prefix)
+        os.environ["MAMBA_ROOT_PREFIX"] = TestActivation.current_root_prefix
+        os.environ["CONDA_PREFIX"] = TestActivation.current_prefix
+
+        if os.path.exists(TestActivation.root_prefix):
+            if platform.system() == "Windows":
+                p = r"\\?\ ".strip() + TestActivation.root_prefix
+            else:
+                p = TestActivation.root_prefix
+            shutil.rmtree(p)
+
+        if os.path.exists(TestActivation.other_root_prefix):
+            if platform.system() == "Windows":
+                p = r"\\?\ ".strip() + TestActivation.other_root_prefix
+            else:
+                p = TestActivation.other_root_prefix
+            shutil.rmtree(p)
 
     @pytest.mark.parametrize("interpreter", get_interpreters())
-    def test_hello_world(self, tmp_path, interpreter):
-        s = ["echo 'hello world'"]
-        stdout, stderr = call_interpreter(s, tmp_path, interpreter)
-        assert stdout == "hello world"
+    def test_shell_init(
+        self, tmp_path, interpreter, clean_shell_files, new_root_prefix
+    ):
+        if interpreter not in valid_interpreters:
+            pytest.skip(f"{interpreter} not available")
 
-    @pytest.mark.parametrize("interpreter", get_interpreters())
-    def test_shell_init(self, tmp_path, interpreter, clean_shell_files):
         cwd = os.getcwd()
         umamba = get_umamba(cwd=cwd)
         env = {"MAMBA_ROOT_PREFIX": self.root_prefix}
@@ -329,7 +371,12 @@ class TestActivation:
                 assert not find_path_in_str(self.root_prefix, x)
 
     @pytest.mark.parametrize("interpreter", get_interpreters())
-    def test_activation(self, tmp_path, interpreter, clean_shell_files):
+    def test_activation(
+        self, tmp_path, interpreter, clean_shell_files, new_root_prefix, clean_env
+    ):
+        if interpreter not in valid_interpreters:
+            pytest.skip(f"{interpreter} not available")
+
         cwd = os.getcwd()
         umamba = get_umamba(cwd=cwd)
 
@@ -363,10 +410,10 @@ class TestActivation:
         if interpreter in ["bash", "zsh", "powershell", "cmdexe"]:
             stdout, stderr = call(evars)
 
-            s = [f"micromamba --help"]
+            s = [f"{umamba} --help"]
             stdout, stderr = call(s)
 
-            s = [f"micromamba activate"] + evars
+            s = ["micromamba activate"] + evars
             stdout, stderr = call(s)
             res = to_dict(stdout)
 
@@ -376,20 +423,20 @@ class TestActivation:
             assert f"CONDA_SHLVL=1" in stdout.splitlines()
 
             # throw with non-existent
-            s = [f"micromamba activate nonexistent"]
+            s = ["micromamba activate nonexistent"]
             if not interpreter == "powershell":
                 with pytest.raises(subprocess.CalledProcessError):
                     stdout, stderr = call(s)
 
-            s1 = [f"micromamba create -n abc"]
-            s2 = [f"micromamba create -n xyz"]
+            s1 = ["micromamba create -n abc"]
+            s2 = ["micromamba create -n xyz"]
             call(s1)
             call(s2)
 
             s = [
-                f"micromamba activate",
-                f"micromamba activate abc",
-                f"micromamba activate xyz",
+                "micromamba activate",
+                "micromamba activate abc",
+                "micromamba activate xyz",
             ] + evars
             stdout, stderr = call(s)
             res = to_dict(stdout)
@@ -401,25 +448,27 @@ class TestActivation:
 
             # long paths
             s = [
-                f"micromamba create -p {TestActivation.long_prefix} xtensor six -y -c conda-forge"
+                f"micromamba create -p {TestActivation.long_prefix} -vvv xtensor six -y -c conda-forge"
             ]
             call(s)
 
             s = [
-                f"micromamba activate",
+                "micromamba activate",
                 f"micromamba activate {TestActivation.long_prefix}",
             ] + evars
             stdout, stderr = call(s)
             res = to_dict(stdout)
+
+            print(res["PATH"])
 
             assert find_path_in_str(str(rp / "condabin"), res["PATH"])
             assert not find_path_in_str(str(rp / "bin"), res["PATH"])
             assert find_path_in_str(TestActivation.long_prefix, res["PATH"])
 
             s = [
-                f"micromamba activate",
-                f"micromamba activate abc",
-                f"micromamba activate xyz --stack",
+                "micromamba activate",
+                "micromamba activate abc",
+                "micromamba activate xyz --stack",
             ] + evars
             stdout, stderr = call(s)
             res = to_dict(stdout)
@@ -429,9 +478,9 @@ class TestActivation:
             assert find_path_in_str(str(rp / "envs" / "xyz"), res["PATH"])
 
             s = [
-                f"micromamba activate",
-                f"micromamba activate abc",
-                f"micromamba activate --stack xyz",
+                "micromamba activate",
+                "micromamba activate abc",
+                "micromamba activate --stack xyz",
             ] + evars
             stdout, stderr = call(s)
             res = to_dict(stdout)

--- a/test/micromamba/test_config.py
+++ b/test/micromamba/test_config.py
@@ -188,21 +188,28 @@ class TestConfigList:
         if rc_flag == "--rc-file=":
             rc_flag += str(rc_file)
 
-        assert config("list", rc_flag).splitlines() == expected[rc_flag].splitlines()
+        assert (
+            config("list", "--no-env", rc_flag).splitlines()
+            == expected[rc_flag].splitlines()
+        )
 
     @pytest.mark.parametrize("source_flag", ["--sources", "-s"])
     def test_list_with_sources(self, rc_file, source_flag):
         home_folder = os.path.expanduser("~")
         src = f"  # '{str(rc_file).replace(home_folder, '~')}'"
         assert (
-            config("list", "--rc-file=" + str(rc_file), source_flag).splitlines()
+            config(
+                "list", "--no-env", "--rc-file=" + str(rc_file), source_flag
+            ).splitlines()
             == f"channels:\n  - channel1{src}\n  - channel2{src}\n".splitlines()
         )
 
     @pytest.mark.parametrize("desc_flag", ["--descriptions", "-d"])
     def test_list_with_descriptions(self, rc_file, desc_flag):
         assert (
-            config("list", "--rc-file=" + str(rc_file), desc_flag).splitlines()
+            config(
+                "list", "--no-env", "--rc-file=" + str(rc_file), desc_flag
+            ).splitlines()
             == f"# channels\n#   Define the list of channels\nchannels:\n"
             "  - channel1\n  - channel2\n".splitlines()
         )
@@ -210,7 +217,9 @@ class TestConfigList:
     @pytest.mark.parametrize("desc_flag", ["--long-descriptions", "-l"])
     def test_list_with_long_descriptions(self, rc_file, desc_flag):
         assert (
-            config("list", "--rc-file=" + str(rc_file), desc_flag).splitlines()
+            config(
+                "list", "--no-env", "--rc-file=" + str(rc_file), desc_flag
+            ).splitlines()
             == f"# channels\n#   The list of channels where the packages will be searched for.\n"
             "#   See also 'channel_priority'.\nchannels:\n  - channel1\n  - channel2\n".splitlines()
         )
@@ -224,7 +233,9 @@ class TestConfigList:
         )
 
         assert (
-            config("list", "--rc-file=" + str(rc_file), "-d", group_flag).splitlines()
+            config(
+                "list", "--no-env", "--rc-file=" + str(rc_file), "-d", group_flag
+            ).splitlines()
             == f"{group}# channels\n#   Define the list of channels\nchannels:\n"
             "  - channel1\n  - channel2\n".splitlines()
         )
@@ -333,7 +344,8 @@ class TestConfigModifiers:
         os.path.join("~", "mamba_spec_files_test_" + random_string())
     )
 
-    def setup_method(cls):
+    @classmethod
+    def setup(cls):
         # setup for --env
         os.environ["MAMBA_ROOT_PREFIX"] = TestConfigModifiers.root_prefix
         os.environ["CONDA_PREFIX"] = TestConfigModifiers.prefix
@@ -348,7 +360,8 @@ class TestConfigModifiers:
         with open(TestConfigModifiers.home_rc_path, "a"):
             os.utime(TestConfigModifiers.home_rc_path)
 
-    def teardown_method(cls):
+    @classmethod
+    def teardown(cls):
         # teardown for --env
         os.environ["MAMBA_ROOT_PREFIX"] = TestConfigModifiers.root_prefix
         os.environ["CONDA_PREFIX"] = TestConfigModifiers.prefix

--- a/test/micromamba/test_pkg_cache.py
+++ b/test/micromamba/test_pkg_cache.py
@@ -3,6 +3,7 @@ import os
 import platform
 import random
 import shutil
+import stat
 import string
 import subprocess
 from pathlib import Path
@@ -19,8 +20,8 @@ else:
 
 class TestPkgCache:
 
-    current_root_prefix = os.environ["MAMBA_ROOT_PREFIX"]
-    current_prefix = os.environ["CONDA_PREFIX"]
+    current_root_prefix = os.environ.get("MAMBA_ROOT_PREFIX", "")
+    current_prefix = os.environ.get("CONDA_PREFIX", "")
     cache = os.path.join(current_root_prefix, "pkgs")
 
     env_name = random_string()
@@ -33,70 +34,73 @@ class TestPkgCache:
     orig_file_path = None
 
     @classmethod
+    @pytest.fixture
+    def cache(cls, existing_cache, test_pkg):
+        cache = Path(os.path.expanduser(os.path.join("~", "cache" + random_string())))
+        os.makedirs(cache)
+        link_dir(cache, existing_cache)
+
+        os.environ["CONDA_PKGS_DIRS"] = str(cache)
+
+        yield cache
+
+        if cache.exists():
+            os.chmod(cache, 0o700)
+            os.chmod(cache / test_pkg, 0o700)
+            os.chmod(cache / test_pkg / xtensor_hpp, 0o700)
+            rmtree(cache)
+
+    @classmethod
+    @pytest.fixture
+    def cached_file(cls, cache, test_pkg):
+        return cache / test_pkg / xtensor_hpp
+
+    @classmethod
     def setup_class(cls):
         os.environ["MAMBA_ROOT_PREFIX"] = TestPkgCache.root_prefix
         os.environ["CONDA_PREFIX"] = TestPkgCache.prefix
-
-        if "CONDA_PKGS_DIRS" in os.environ:
-            os.environ.pop("CONDA_PKGS_DIRS")
 
     @classmethod
     def teardown_class(cls):
         os.environ["MAMBA_ROOT_PREFIX"] = TestPkgCache.current_root_prefix
         os.environ["CONDA_PREFIX"] = TestPkgCache.current_prefix
 
-    @classmethod
-    def setup(cls):
-        res = create("-n", TestPkgCache.env_name, "xtensor", "--json", no_dry_run=True)
+        if "CONDA_PKGS_DIRS" in os.environ:
+            os.environ.pop("CONDA_PKGS_DIRS")
 
-        xf = get_env(TestPkgCache.env_name, xtensor_hpp)
-        assert xf.exists()
-        TestPkgCache.stat_xf = xf.stat()
-
-        TestPkgCache.pkg_name = get_concrete_pkg(res, "xtensor")
-        TestPkgCache.orig_file_path = get_pkg(TestPkgCache.pkg_name, xtensor_hpp)
-        TestPkgCache.stat_orig = TestPkgCache.orig_file_path.stat()
-
-        assert TestPkgCache.stat_orig.st_dev == TestPkgCache.stat_xf.st_dev
-        assert TestPkgCache.stat_orig.st_ino == TestPkgCache.stat_xf.st_ino
+        if Path(TestPkgCache.root_prefix).exists():
+            rmtree(TestPkgCache.root_prefix)
 
     @classmethod
     def teardown(cls):
-        if Path(TestPkgCache.root_prefix).exists():
-            shutil.rmtree(os.path.join(TestPkgCache.root_prefix, "envs"))
+        envs_dir = os.path.join(TestPkgCache.root_prefix, "envs")
+        if Path(envs_dir).exists():
+            rmtree(envs_dir)
 
-            extracted_pkg = os.path.join(
-                TestPkgCache.root_prefix, "pkgs", TestPkgCache.pkg_name
-            )
-            if Path(extracted_pkg).exists():
-                shutil.rmtree(extracted_pkg)
-
-            tarball = os.path.join(
-                TestPkgCache.root_prefix, "pkgs", TestPkgCache.pkg_name + ".tar.bz2"
-            )
-            if Path(tarball).exists():
-                os.remove(tarball)
-
-    def test_extracted_file_deleted(self):
-
-        os.remove(TestPkgCache.orig_file_path)
+    def test_extracted_file_deleted(self, cached_file):
+        old_ino = cached_file.stat().st_ino
+        os.remove(cached_file)
 
         env = "x1"
-        res = create("xtensor", "-n", env, "--json", no_dry_run=True)
-        xf = get_env(env, xtensor_hpp)
-        assert xf.exists()
-        stat_xf = xf.stat()
+        create("xtensor", "-n", env, "--json", no_dry_run=True)
 
-        assert TestPkgCache.stat_orig.st_dev == stat_xf.st_dev
-        assert TestPkgCache.stat_orig.st_ino != stat_xf.st_ino
+        linked_file = get_env(env, xtensor_hpp)
+        assert linked_file.exists()
+        linked_file_stats = linked_file.stat()
+
+        assert cached_file.stat().st_dev == linked_file_stats.st_dev
+        assert cached_file.stat().st_ino == linked_file_stats.st_ino
+        assert old_ino != linked_file_stats.st_ino
 
     @pytest.mark.parametrize("safety_checks", ["disabled", "warn", "enabled"])
-    def test_extracted_file_corrupted(self, safety_checks):
-        with open(TestPkgCache.orig_file_path, "w") as f:
+    def test_extracted_file_corrupted(self, safety_checks, cached_file):
+        old_ino = cached_file.stat().st_ino
+
+        with open(cached_file, "w") as f:
             f.write("//corruption")
 
         env = "x1"
-        res = create(
+        create(
             "xtensor",
             "-n",
             env,
@@ -105,71 +109,282 @@ class TestPkgCache:
             safety_checks,
             no_dry_run=True,
         )
-        xf = get_env(env, xtensor_hpp)
-        assert xf.exists()
-        stat_xf = xf.stat()
+
+        linked_file = get_env(env, xtensor_hpp)
+        assert linked_file.exists()
+        linked_file_stats = linked_file.stat()
+
+        assert cached_file.stat().st_dev == linked_file_stats.st_dev
+        assert cached_file.stat().st_ino == linked_file_stats.st_ino
 
         if safety_checks == "enabled":
-            assert TestPkgCache.stat_orig.st_dev == stat_xf.st_dev
-            assert TestPkgCache.stat_orig.st_ino != stat_xf.st_ino
+            assert old_ino != linked_file_stats.st_ino
         else:
-            assert TestPkgCache.stat_orig.st_dev == stat_xf.st_dev
-            assert TestPkgCache.stat_orig.st_ino == stat_xf.st_ino
+            assert old_ino == linked_file_stats.st_ino
 
-    def test_tarball_deleted(self):
-        os.remove(get_tarball(TestPkgCache.pkg_name))
-
-        env = "x1"
-        res = create("xtensor", "-n", env, "--json", no_dry_run=True)
-        xf = get_env(env, xtensor_hpp)
-        assert xf.exists()
-        stat_xf = xf.stat()
-
-        assert not get_tarball(TestPkgCache.pkg_name).exists()
-        assert TestPkgCache.stat_orig.st_dev == stat_xf.st_dev
-        assert TestPkgCache.stat_orig.st_ino == stat_xf.st_ino
-
-    def test_tarball_and_extracted_file_deleted(self):
-        pkg_size = get_tarball(TestPkgCache.pkg_name).stat().st_size
-        os.remove(TestPkgCache.orig_file_path)
-        os.remove(get_tarball(TestPkgCache.pkg_name))
+    def test_tarball_deleted(self, cached_file, test_pkg, cache):
+        tarball = cache / Path(str(test_pkg) + ".tar.bz2")
+        os.remove(tarball)
 
         env = "x1"
-        res = create("xtensor", "-n", env, "--json", no_dry_run=True)
-        xf = get_env(env, xtensor_hpp)
-        assert xf.exists()
-        stat_xf = xf.stat()
+        create("xtensor", "-n", env, "--json", no_dry_run=True)
 
-        assert get_tarball(TestPkgCache.pkg_name).exists()
-        assert pkg_size == get_tarball(TestPkgCache.pkg_name).stat().st_size
-        assert TestPkgCache.stat_orig.st_dev == stat_xf.st_dev
-        assert TestPkgCache.stat_orig.st_ino != stat_xf.st_ino
+        linked_file = get_env(env, xtensor_hpp)
+        assert linked_file.exists()
+        linked_file_stats = linked_file.stat()
 
-    def test_tarball_corrupted_and_extracted_file_deleted(self):
-        pkg_size = get_tarball(TestPkgCache.pkg_name).stat().st_size
-        os.remove(TestPkgCache.orig_file_path)
-        os.remove(get_tarball(TestPkgCache.pkg_name))
-        with open(get_tarball(TestPkgCache.pkg_name), "w") as f:
+        assert not (tarball).exists()
+        assert cached_file.stat().st_dev == linked_file_stats.st_dev
+        assert cached_file.stat().st_ino == linked_file_stats.st_ino
+
+    def test_tarball_and_extracted_file_deleted(self, cache, test_pkg, cached_file):
+        tarball = cache / Path(str(test_pkg) + ".tar.bz2")
+        tarball_size = tarball.stat().st_size
+        old_ino = cached_file.stat().st_ino
+        os.remove(cached_file)
+        os.remove(tarball)
+
+        env = "x1"
+        create("xtensor", "-n", env, "--json", no_dry_run=True)
+
+        linked_file = get_env(env, xtensor_hpp)
+        assert linked_file.exists()
+        linked_file_stats = linked_file.stat()
+
+        assert tarball.exists()
+        assert tarball_size == tarball.stat().st_size
+        assert cached_file.stat().st_dev == linked_file_stats.st_dev
+        assert cached_file.stat().st_ino == linked_file_stats.st_ino
+        assert old_ino != linked_file_stats.st_ino
+
+    def test_tarball_corrupted_and_extracted_file_deleted(
+        self, cache, test_pkg, cached_file
+    ):
+        tarball = cache / Path(str(test_pkg) + ".tar.bz2")
+        tarball_size = tarball.stat().st_size
+        old_ino = cached_file.stat().st_ino
+        os.remove(cached_file)
+        os.remove(tarball)
+        with open(tarball, "w") as f:
             f.write("")
 
         env = "x1"
-        res = create("xtensor", "-n", env, "--json", no_dry_run=True)
-        xf = get_env(env, xtensor_hpp)
-        assert xf.exists()
-        stat_xf = xf.stat()
-
-        assert get_tarball(TestPkgCache.pkg_name).exists()
-        assert pkg_size == get_tarball(TestPkgCache.pkg_name).stat().st_size
-        assert TestPkgCache.stat_orig.st_dev == stat_xf.st_dev
-        assert TestPkgCache.stat_orig.st_ino != stat_xf.st_ino
-
-    def test_extracted_file_corrupted_no_perm(self):
-        with open(TestPkgCache.orig_file_path, "w") as f:
-            f.write("//corruption")
-        os.chmod(get_pkg(TestPkgCache.pkg_name), 0o500)
-
-        env = "x1"
-
         create("xtensor", "-n", env, "--json", no_dry_run=True)
 
-        os.chmod(get_pkg(TestPkgCache.pkg_name), 0o700)
+        linked_file = get_env(env, xtensor_hpp)
+        assert linked_file.exists()
+        linked_file_stats = linked_file.stat()
+
+        assert tarball.exists()
+        assert tarball_size == tarball.stat().st_size
+        assert cached_file.stat().st_dev == linked_file_stats.st_dev
+        assert cached_file.stat().st_ino == linked_file_stats.st_ino
+        assert old_ino != linked_file_stats.st_ino
+
+    def test_extracted_file_corrupted_no_perm(self, cache, cached_file, test_pkg):
+        with open(cached_file, "w") as f:
+            f.write("//corruption")
+        recursive_chmod(cache / test_pkg, 0o500)
+
+        env = "x1"
+        cmd_args = ("xtensor", "-n", env, "--json", "-vv")
+
+        create(*cmd_args, no_dry_run=True)
+
+
+class TestMultiplePkgCaches:
+
+    current_root_prefix = os.environ.get("MAMBA_ROOT_PREFIX", "")
+    current_prefix = os.environ.get("CONDA_PREFIX", "")
+    cache = os.path.join(current_root_prefix, "pkgs")
+
+    env_name = random_string()
+    root_prefix = os.path.expanduser(os.path.join("~", "tmproot" + random_string()))
+    prefix = os.path.join(root_prefix, "envs", env_name)
+
+    @staticmethod
+    @pytest.fixture
+    def cache1(existing_cache, first_cache_is_writable):
+        cache = Path(os.path.expanduser(os.path.join("~", "cache" + random_string())))
+        os.makedirs(cache)
+
+        if first_cache_is_writable:
+            link_dir(cache, existing_cache)
+        else:
+            recursive_chmod(cache, 0o500)
+
+        yield cache
+
+        if cache.exists():
+            rmtree(cache)
+
+    @staticmethod
+    @pytest.fixture
+    def cache2(existing_cache, first_cache_is_writable):
+        cache = Path(os.path.expanduser(os.path.join("~", "cache" + random_string())))
+        os.makedirs(cache)
+        link_dir(cache, existing_cache)
+
+        yield cache
+
+        if cache.exists():
+            rmtree(cache)
+
+    @staticmethod
+    @pytest.fixture
+    def used_cache(cache1, cache2, first_cache_is_writable):
+        if first_cache_is_writable:
+            yield cache1
+        else:
+            yield cache2
+
+    @staticmethod
+    @pytest.fixture
+    def unused_cache(cache1, cache2, first_cache_is_writable):
+        if first_cache_is_writable:
+            yield cache2
+        else:
+            yield cache1
+
+    @classmethod
+    def setup_class(cls):
+        os.environ["MAMBA_ROOT_PREFIX"] = TestMultiplePkgCaches.root_prefix
+        os.environ["CONDA_PREFIX"] = TestMultiplePkgCaches.prefix
+        if "CONDA_PKGS_DIRS" in os.environ:
+            os.environ.pop("CONDA_PKGS_DIRS")
+
+    @classmethod
+    def teardown_class(cls):
+        os.environ["MAMBA_ROOT_PREFIX"] = TestMultiplePkgCaches.current_root_prefix
+        os.environ["CONDA_PREFIX"] = TestMultiplePkgCaches.current_prefix
+
+        if Path(TestMultiplePkgCaches.root_prefix).exists():
+            rmtree(TestMultiplePkgCaches.root_prefix)
+
+    @classmethod
+    def teardown(cls):
+        if "CONDA_PKGS_DIRS" in os.environ:
+            os.environ.pop("CONDA_PKGS_DIRS")
+
+    @pytest.mark.parametrize("cache", (pytest.lazy_fixture(("cache1", "cache2"))))
+    def test_different_caches(self, cache):
+        os.environ["CONDA_PKGS_DIRS"] = f"{cache}"
+
+        env_name = TestMultiplePkgCaches.env_name
+        res = create("-n", env_name, "xtensor", "-v", "--json", no_dry_run=True)
+
+        linked_file = get_env(env_name, xtensor_hpp)
+        assert linked_file.exists()
+
+        pkg_name = get_concrete_pkg(res, "xtensor")
+        cache_file = cache / pkg_name / xtensor_hpp
+
+        assert cache_file.exists()
+
+        assert linked_file.stat().st_dev == cache_file.stat().st_dev
+        assert linked_file.stat().st_ino == cache_file.stat().st_ino
+
+    @pytest.mark.parametrize("first_is_writable", (False, True))
+    def test_first_writable(
+        self, first_is_writable, cache1, cache2, used_cache, unused_cache
+    ):
+        os.environ["CONDA_PKGS_DIRS"] = f"{cache1},{cache2}"
+        env_name = TestMultiplePkgCaches.env_name
+
+        res = create("-n", env_name, "xtensor", "--json", no_dry_run=True,)
+
+        linked_file = get_env(env_name, xtensor_hpp)
+        assert linked_file.exists()
+
+        pkg_name = get_concrete_pkg(res, "xtensor")
+        cache_file = used_cache / pkg_name / xtensor_hpp
+
+        assert cache_file.exists()
+
+        assert linked_file.stat().st_dev == cache_file.stat().st_dev
+        assert linked_file.stat().st_ino == cache_file.stat().st_ino
+
+    def test_extracted_tarball_only_in_non_writable_cache(
+        self, cache1, cache2, test_pkg, repodata_files
+    ):
+        tarball = cache1 / Path(str(test_pkg) + ".tar.bz2")
+        rmtree(tarball)
+        # this will chmod 700 the hardlinks and have to be done before chmod cache1
+        rmtree(cache2)
+        recursive_chmod(cache1, 0o500)
+
+        os.environ["CONDA_PKGS_DIRS"] = f"{cache1},{cache2}"
+        env_name = TestMultiplePkgCaches.env_name
+
+        create("-n", env_name, "xtensor", "--json", no_dry_run=True)
+
+        linked_file = get_env(env_name, xtensor_hpp)
+        assert linked_file.exists()
+
+        non_writable_cache_file = cache1 / test_pkg / xtensor_hpp
+        writable_cache_file = cache2 / test_pkg / xtensor_hpp
+
+        # check repodata files
+        for f in repodata_files:
+            for ext in ["json", "solv"]:
+                assert (cache1 / "cache" / (f + "." + ext)).exists()
+                assert not (cache2 / "cache" / (f + "." + ext)).exists()
+
+        # check tarballs
+        assert not (cache1 / Path(str(test_pkg) + ".tar.bz2")).exists()
+        assert not (cache2 / Path(str(test_pkg) + ".tar.bz2")).exists()
+
+        # check extracted files
+        assert non_writable_cache_file.exists()
+        assert not writable_cache_file.exists()
+
+        # check linked files
+        assert linked_file.stat().st_dev == non_writable_cache_file.stat().st_dev
+        assert linked_file.stat().st_ino == non_writable_cache_file.stat().st_ino
+
+    def test_expired_but_valid_repodata_in_non_writable_cache(
+        self, cache1, cache2, test_pkg, repodata_files
+    ):
+        rmtree(cache2)
+        recursive_chmod(cache1, 0o500)
+
+        os.environ["CONDA_PKGS_DIRS"] = f"{cache1},{cache2}"
+        env_name = TestMultiplePkgCaches.env_name
+
+        create(
+            "-n",
+            env_name,
+            "xtensor",
+            "-vv",
+            "--json",
+            "--repodata-ttl=0",
+            no_dry_run=True,
+        )
+
+        linked_file = get_env(env_name, xtensor_hpp)
+        assert linked_file.exists()
+
+        non_writable_cache_file = cache1 / test_pkg / xtensor_hpp
+        writable_cache_file = cache2 / test_pkg / xtensor_hpp
+
+        # check repodata files
+        for f in repodata_files:
+            for ext in ["json", "solv"]:
+                assert (cache1 / "cache" / (f + "." + ext)).exists()
+                assert (cache2 / "cache" / (f + "." + ext)).exists()
+
+        # check tarballs
+        assert (cache1 / Path(str(test_pkg) + ".tar.bz2")).exists()
+        assert not (cache2 / Path(str(test_pkg) + ".tar.bz2")).exists()
+
+        # check extracted dir
+        assert (cache1 / test_pkg).exists()
+        assert not (cache2 / test_pkg).exists()
+
+        # check extracted files
+        assert non_writable_cache_file.exists()
+        assert not writable_cache_file.exists()
+
+        # check linked files
+        assert linked_file.stat().st_dev == non_writable_cache_file.stat().st_dev
+        assert linked_file.stat().st_ino == non_writable_cache_file.stat().st_ino

--- a/test/micromamba/test_virtual_pkgs.py
+++ b/test/micromamba/test_virtual_pkgs.py
@@ -11,33 +11,6 @@ from .helpers import create, get_env, info, random_string
 
 
 class TestVirtualPkgs:
-
-    current_root_prefix = os.environ["MAMBA_ROOT_PREFIX"]
-    current_prefix = os.environ["CONDA_PREFIX"]
-    cache = os.path.join(current_root_prefix, "pkgs")
-
-    env_name = random_string()
-    root_prefix = os.path.expanduser(os.path.join("~", "tmproot" + random_string()))
-    prefix = os.path.join(root_prefix, "envs", env_name)
-    user_config = os.path.expanduser(os.path.join("~", ".mambarc"))
-
-    @classmethod
-    def setup_class(cls):
-        os.environ["MAMBA_ROOT_PREFIX"] = TestVirtualPkgs.root_prefix
-        os.environ["CONDA_PREFIX"] = TestVirtualPkgs.prefix
-
-        # speed-up the tests
-        os.environ["CONDA_PKGS_DIRS"] = TestVirtualPkgs.cache
-
-        os.makedirs(TestVirtualPkgs.root_prefix, exist_ok=False)
-        create("xtensor", "-n", TestVirtualPkgs.env_name, "--offline", no_dry_run=True)
-
-    @classmethod
-    def teardown_class(cls):
-        os.environ["MAMBA_ROOT_PREFIX"] = TestVirtualPkgs.current_root_prefix
-        os.environ["CONDA_PREFIX"] = TestVirtualPkgs.current_prefix
-        shutil.rmtree(TestVirtualPkgs.root_prefix)
-
     def test_virtual_packages(self):
 
         infos = info()


### PR DESCRIPTION
Description
---

- use a 2 step loading of configuration
  - first step after `root_prefix` computation
  - second step after `target_prefix` computation
  - enable to break circular dependencies between `Configurable`s
    - especially `envs_dirs`->`rc_file` (rc configurable)->`target_prefix`->`envs_dirs` 
- add enumeration `RCConfigLevel` to define `Configurable` computation step of rc values
  - add `level` arg in `rc_configurable` to set loading step (default: `kTargetPrefix`)
- refactor code to cache yaml values already read from 1st step
- use multiple `MAMBARC` and `CONDARC` env vars, both related to `rc_files`
- rename  `rc_file` configurable `rc_files` to reflect its nature (vector)
- add `envs_dirs` and `pkgs_dirs` `Configurable` and associated hooks to be able to set multiple directories for both
  - for now it's not guaranteed the first writable value will be picked, the behavior is unchanged
  - final implementations will come in separate PRs
    - multiple pkgs caches already started: https://github.com/mamba-org/mamba/pull/1109