### PR TITLE
Implements support for fish shell

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -274,11 +274,16 @@ jobs:
           then
             exit 1;
           fi
-      - name: install zsh and xonsh
+      - name: install zsh, xonsh and fish in linux
         if: matrix.os == 'ubuntu-latest'
         shell: bash -l -eo pipefail {0}
         run: |
-          sudo apt-get install zsh xonsh -y
+          sudo apt-get install zsh xonsh fish -y
+      - name: install fish in mac
+        if: matrix.os == 'macos-latest'
+        shell: bash -l -eo pipefail {0}
+        run: |
+          brew install fish
       - name: micromamba python based tests
         shell: bash -l -eo pipefail {0}
         run: |

--- a/data/mamba.fish
+++ b/data/mamba.fish
@@ -1,0 +1,174 @@
+R"MAMBARAW(
+
+if not set -q MAMBA_SHLVL
+  set -gx MAMBA_SHLVL "0"
+  set -gx PATH $MAMBA_ROOT_PREFIX/condabin $PATH
+end
+
+if not set -q MAMBA_NO_PROMPT
+  function __mamba_add_prompt
+    if set -q MAMBA_PROMPT_MODIFIER
+      set_color -o green
+      echo -n $MAMBA_PROMPT_MODIFIER
+      set_color normal
+    end
+  end
+
+  if functions -q fish_prompt
+      if not functions -q __fish_prompt_orig
+          functions -c fish_prompt __fish_prompt_orig
+      end
+      functions -e fish_prompt
+  else
+      function __fish_prompt_orig
+      end
+  end
+
+  function return_last_status
+    return $argv
+  end
+
+  function fish_prompt
+    set -l last_status $status
+    if set -q MAMBA_LEFT_PROMPT
+        __mamba_add_prompt
+    end
+    return_last_status $last_status
+    __fish_prompt_orig
+  end
+
+  if functions -q fish_right_prompt
+      if not functions -q __fish_right_prompt_orig
+          functions -c fish_right_prompt __fish_right_prompt_orig
+      end
+      functions -e fish_right_prompt
+  else
+      function __fish_right_prompt_orig
+      end
+  end
+
+  function fish_right_prompt
+    if not set -q MAMBA_LEFT_PROMPT
+        __mamba_add_prompt
+    end
+    __fish_right_prompt_orig
+  end
+end
+
+
+function __mamba_add_sys_prefix_to_path
+  test -z "$MAMBA_ROOT_PREFIX" && return
+
+  set -gx MAMBA_INTERNAL_OLDPATH $PATH
+  if test -n "$WINDIR"
+    set -gx -p PATH "$MAMBA_ROOT_PREFIX/bin"
+    set -gx -p PATH "$MAMBA_ROOT_PREFIX/Scripts"
+    set -gx -p PATH "$MAMBA_ROOT_PREFIX/Library/bin"
+    set -gx -p PATH "$MAMBA_ROOT_PREFIX/Library/usr/bin"
+    set -gx -p PATH "$MAMBA_ROOT_PREFIX/Library/mingw-w64/bin"
+    set -gx -p PATH "$MAMBA_ROOT_PREFIX"
+  else
+    set -gx -p PATH "$MAMBA_ROOT_PREFIX/bin"
+  end
+end
+
+function micromamba --inherit-variable MAMBA_EXE
+  if [ (count $argv) -lt 1 ]
+    eval $MAMBA_EXE
+  else
+    set -l cmd $argv[1]
+    set -e argv[1]
+    __mamba_add_sys_prefix_to_path
+    switch $cmd
+      case activate deactivate
+        $MAMBA_EXE shell -s fish $cmd $argv | source || return $status
+        return
+      case install update upgrade remove uninstall
+        eval $MAMBA_EXE $cmd $argv || return $status
+        set -l script (eval $MAMBA_EXE shell -s fish reactivate) || return $status
+        eval $script || return $status
+      case '*'
+        eval $MAMBA_EXE $cmd $argv || return $status
+    end
+    set ret $status
+    set -gx PATH $MAMBA_INTERNAL_OLDPATH
+    return $ret
+  end
+end
+
+
+
+# Autocompletions below
+
+function __fish_mamba_env_commands
+  string replace -r '.*_([a-z]+)\.py$' '$1' $MAMBA_ROOT_PREFIX/lib/python*/site-packages/conda_env/cli/main_*.py
+end
+
+function __fish_mamba_envs
+  micromamba env list | tail -n +11 | cut -d' ' -f3
+end
+
+function __fish_mamba_packages
+  micromamba list | awk 'NR > 3 {print $1}'
+end
+
+function __fish_mamba_universial_optspecs
+    string join \n 'h/help' 'a-version' 'b-rc-file' \
+                   'c-no-rc' 'd-no-env' 'v/verbose' \
+                   'q/quiet' 'y/yes' 'e-json' 'f-offline' \
+                   'g-dry-run' 'i-experimental' 'r/root-prefix' \
+                   'p/prefix' 'n/name'
+end
+
+function __fish_mamba_needs_command
+    # Figure out if the current invocation already has a command.
+    set -l argv (commandline -opc)
+    set -e argv[1]
+    argparse -s (__fish_mamba_universial_optspecs) -- $argv 2>/dev/null
+    or return 0
+    if set -q argv[1]
+      echo $argv[1]
+      return 1
+    end
+    return 0
+end
+
+function __fish_mamba_using_command
+    set -l cmd (__fish_mamba_needs_command)
+    test -z "$cmd"
+    and return 1
+    contains -- $cmd $argv
+    and return 0
+end
+
+
+# Conda commands
+complete -x -c micromamba -n '__fish_mamba_needs_command' -a shell       -d 'Generate shell init scripts'
+complete -x -c micromamba -n '__fish_mamba_needs_command' -a create      -d 'Create new environment'
+complete -x -c micromamba -n '__fish_mamba_needs_command' -a install     -d 'Install packages in active environment'
+complete -x -c micromamba -n '__fish_mamba_needs_command' -a update      -d 'Update packages in active environment'
+complete -x -c micromamba -n '__fish_mamba_needs_command' -a remove      -d 'Remove packages from active environment'
+complete -x -c micromamba -n '__fish_mamba_needs_command' -a list        -d 'List packages in active environment'
+complete -x -c micromamba -n '__fish_mamba_needs_command' -a clean       -d 'Clean package cache'
+complete -x -c micromamba -n '__fish_mamba_needs_command' -a config      -d 'Configuration of micromamba'
+complete -x -c micromamba -n '__fish_mamba_needs_command' -a info        -d 'Information about micromamba'
+complete -x -c micromamba -n '__fish_mamba_needs_command' -a constructor -d 'Commands to support using micromamba in constructor'
+complete -x -c micromamba -n '__fish_mamba_needs_command' -a env         -d 'List environments'
+# Commands after hook
+complete -x -c micromamba -n '__fish_mamba_needs_command' -a activate    -d 'Commands to support using micromamba in constructor'
+complete -x -c micromamba -n '__fish_mamba_needs_command' -a deactivate  -d 'List environments'
+
+# subcommands
+complete -x -c micromamba -n '__fish_mamba_using_command env' -a 'list'  -d 'List known environments'
+
+# Commands that need environment as parameter
+complete -x -c micromamba -n '__fish_mamba_using_command activate' -a '(__fish_mamba_envs)'
+
+# Commands that need package as parameter
+complete -x -c micromamba -n '__fish_mamba_using_command remove' -a '(__fish_mamba_packages)'
+complete -x -c micromamba -n '__fish_mamba_using_command uninstall' -a '(__fish_mamba_packages)'
+complete -x -c micromamba -n '__fish_mamba_using_command upgrade' -a '(__fish_mamba_packages)'
+complete -x -c micromamba -n '__fish_mamba_using_command update' -a '(__fish_mamba_packages)'
+
+)MAMBARAW"
+

--- a/data/mamba.fish
+++ b/data/mamba.fish
@@ -171,4 +171,3 @@ complete -x -c micromamba -n '__fish_mamba_using_command upgrade' -a '(__fish_ma
 complete -x -c micromamba -n '__fish_mamba_using_command update' -a '(__fish_mamba_packages)'
 
 )MAMBARAW"
-

--- a/include/mamba/core/activation.hpp
+++ b/include/mamba/core/activation.hpp
@@ -166,6 +166,23 @@ namespace mamba
         std::string hook_postamble() override;
         fs::path hook_source_path() override;
     };
+
+    class FishActivator : public Activator
+    {
+    public:
+        FishActivator() = default;
+        virtual ~FishActivator() = default;
+
+        std::string script(const EnvironmentTransform& env_transform) override;
+        std::pair<std::string, std::string> update_prompt(
+            const std::string& conda_prompt_modifier) override;
+        std::string shell_extension() override;
+        std::string shell() override;
+
+        std::string hook_preamble() override;
+        std::string hook_postamble() override;
+        fs::path hook_source_path() override;
+    };
 }  // namespace mamba
 
 #endif

--- a/src/api/shell.cpp
+++ b/src/api/shell.cpp
@@ -73,6 +73,10 @@ namespace mamba
         {
             activator = std::make_unique<mamba::XonshActivator>();
         }
+        else if (shell_type == "fish")
+        {
+            activator = std::make_unique<mamba::FishActivator>();
+        }
         else
         {
             LOG_ERROR << "Not handled 'shell_type': " << shell_type;

--- a/src/core/activation.cpp
+++ b/src/core/activation.cpp
@@ -1033,4 +1033,72 @@ namespace mamba
 
         return out.str();
     }
+
+    std::string FishActivator::shell_extension()
+    {
+        return ".fish";
+    }
+
+    std::string FishActivator::shell()
+    {
+        return "fish";
+    }
+
+    std::string FishActivator::hook_preamble()
+    {
+        return "";
+    }
+
+    std::string FishActivator::hook_postamble()
+    {
+        return "";
+    }
+
+    fs::path FishActivator::hook_source_path()
+    {
+        return Context::instance().root_prefix / "etc" / "fish" / "conf.d" / "mamba.fish";
+    }
+
+    std::pair<std::string, std::string> FishActivator::update_prompt(
+        const std::string& conda_prompt_modifier)
+    {
+        return { "", "" };
+    }
+
+    std::string FishActivator::script(const EnvironmentTransform& env_transform)
+    {
+        std::stringstream out;
+
+        if (!env_transform.export_path.empty())
+        {
+            out << "set -gx PATH \"" << env_transform.export_path << "\"\n";
+        }
+
+        for (const fs::path& ds : env_transform.deactivate_scripts)
+        {
+            out << "source " << ds << "\n";
+        }
+
+        for (const std::string& uvar : env_transform.unset_vars)
+        {
+            out << "set -e " << uvar << "\n";
+        }
+
+        for (const auto& [skey, svar] : env_transform.set_vars)
+        {
+            out << "set " << skey << " \"" << svar << "\"\n";
+        }
+
+        for (const auto& [ekey, evar] : env_transform.export_vars)
+        {
+            out << "set -gx " << ekey << " \"" << evar << "\"\n";
+        }
+
+        for (const fs::path& p : env_transform.activate_scripts)
+        {
+            out << "source " << p << "\n";
+        }
+
+        return out.str();
+    }
 }  // namespace mamba

--- a/src/core/shell_init.cpp
+++ b/src/core/shell_init.cpp
@@ -51,6 +51,9 @@ namespace mamba
         constexpr const char mamba_xsh[] =
 #include "../data/mamba.xsh"
             ;
+        constexpr const char mamba_fish[] =
+#include "../data/mamba.fish"
+            ;
 
         std::regex CONDA_INITIALIZE_RE_BLOCK("# >>> mamba initialize >>>(?:\n|\r\n)?"
                                              "([\\s\\S]*?)"
@@ -84,6 +87,10 @@ namespace mamba
         if (contains(parent_process_name, "powershell"))
         {
             return "powershell";
+        }
+        if (contains(parent_process_name, "fish"))
+        {
+            return "fish";
         }
         return "";
     }
@@ -267,6 +274,31 @@ namespace mamba
         return content.str();
     }
 
+    std::string fish_content(const fs::path& env_prefix,
+                              const std::string& shell,
+                              const fs::path& mamba_exe)
+    {
+        std::stringstream content;
+        std::string s_mamba_exe;
+
+        if (on_win)
+        {
+            s_mamba_exe = native_path_to_unix(mamba_exe.string());
+        }
+        else
+        {
+            s_mamba_exe = mamba_exe;
+        }
+
+        content << "# >>> mamba initialize >>>\n";
+        content << "# !! Contents within this block are managed by 'mamba init' !!\n";
+        content << "set -gx MAMBA_EXE " << mamba_exe << "\n";
+        content << "set -gx MAMBA_ROOT_PREFIX " << env_prefix << "\n";
+        content << "eval " << mamba_exe << " shell hook --shell fish --prefix " << env_prefix << " | source\n";
+        content << "# <<< mamba initialize <<<\n";
+        return content.str();
+    }
+
     bool modify_rc_file(const fs::path& file_path,
                         const fs::path& conda_prefix,
                         const std::string& shell,
@@ -288,6 +320,10 @@ namespace mamba
         if (shell == "xonsh")
         {
             conda_init_content = xonsh_content(conda_prefix, shell, mamba_exe);
+        }
+        if (shell == "fish")
+        {
+            conda_init_content = fish_content(conda_prefix, shell, mamba_exe);
         }
         else
         {
@@ -348,6 +384,12 @@ namespace mamba
                 << "       CALL "
                 << std::quoted(
                        (Context::instance().root_prefix / "condabin" / "mamba_hook.bat").string());
+        }
+        else if (shell == "fish")
+        {
+            std::string contents = mamba_fish;
+            replace_all(contents, "$MAMBA_EXE", exe.string());
+            return contents;
         }
         return "";
     }
@@ -527,6 +569,11 @@ namespace mamba
             fs::path xonshrc_path = home / ".xonshrc";
             // std::cout << xonsh_content(conda_prefix, shell, mamba_exe);
             modify_rc_file(xonshrc_path, conda_prefix, shell, mamba_exe);
+        }
+        else if (shell == "fish")
+        {
+            fs::path fishrc_path = home / ".config" / "fish" / "config.fish";
+            modify_rc_file(fishrc_path, conda_prefix, shell, mamba_exe);
         }
         else if (shell == "cmd.exe")
         {

--- a/src/core/shell_init.cpp
+++ b/src/core/shell_init.cpp
@@ -275,8 +275,8 @@ namespace mamba
     }
 
     std::string fish_content(const fs::path& env_prefix,
-                              const std::string& shell,
-                              const fs::path& mamba_exe)
+                             const std::string& shell,
+                             const fs::path& mamba_exe)
     {
         std::stringstream content;
         std::string s_mamba_exe;
@@ -294,7 +294,8 @@ namespace mamba
         content << "# !! Contents within this block are managed by 'mamba init' !!\n";
         content << "set -gx MAMBA_EXE " << mamba_exe << "\n";
         content << "set -gx MAMBA_ROOT_PREFIX " << env_prefix << "\n";
-        content << "eval " << mamba_exe << " shell hook --shell fish --prefix " << env_prefix << " | source\n";
+        content << "eval " << mamba_exe << " shell hook --shell fish --prefix " << env_prefix
+                << " | source\n";
         content << "# <<< mamba initialize <<<\n";
         return content.str();
     }

--- a/src/micromamba/shell.cpp
+++ b/src/micromamba/shell.cpp
@@ -23,8 +23,8 @@ init_shell_parser(CLI::App* subcom)
     auto& shell_type = config.insert(
         Configurable("shell_type", std::string("")).group("cli").description("A shell type"));
     subcom->add_option("-s,--shell", shell_type.set_cli_config(""), shell_type.description())
-        ->check(CLI::IsMember(
-            std::set<std::string>({ "bash", "posix", "powershell", "cmd.exe", "xonsh", "zsh", "fish" })));
+        ->check(CLI::IsMember(std::set<std::string>(
+            { "bash", "posix", "powershell", "cmd.exe", "xonsh", "zsh", "fish" })));
 
     auto& stack = config.insert(Configurable("shell_stack", false)
                                     .group("cli")

--- a/src/micromamba/shell.cpp
+++ b/src/micromamba/shell.cpp
@@ -24,7 +24,7 @@ init_shell_parser(CLI::App* subcom)
         Configurable("shell_type", std::string("")).group("cli").description("A shell type"));
     subcom->add_option("-s,--shell", shell_type.set_cli_config(""), shell_type.description())
         ->check(CLI::IsMember(
-            std::set<std::string>({ "bash", "posix", "powershell", "cmd.exe", "xonsh", "zsh" })));
+            std::set<std::string>({ "bash", "posix", "powershell", "cmd.exe", "xonsh", "zsh", "fish" })));
 
     auto& stack = config.insert(Configurable("shell_stack", false)
                                     .group("cli")

--- a/src/micromamba/umamba.cpp
+++ b/src/micromamba/umamba.cpp
@@ -82,7 +82,7 @@ set_umamba_command(CLI::App* com)
         << "# notice the missing dot in front of the command\n\n"
         << "To permanently initialize your shell, use shell init like so:\n\n"
         << "    $ ./micromamba shell init -s bash -p /home/$USER/micromamba \n\n"
-        << "and restart your shell. Supported shells are bash, zsh, xonsh, cmd.exe, and powershell."
+        << "and restart your shell. Supported shells are bash, zsh, xonsh, cmd.exe, powershell, and fish."
         << termcolor::reset;
 
     com->footer(footer.str());

--- a/test/micromamba/test_activation.py
+++ b/test/micromamba/test_activation.py
@@ -43,8 +43,16 @@ suffixes = {
 
 paths = {
     "win": {"powershell": None, "cmdexe": None},
-    "osx": {"zsh": "~/.zshrc", "bash": "~/.bash_profile", "fish": "~/.config/fish/config.fish"},
-    "linux": {"zsh": "~/.zshrc", "bash": "~/.bashrc", "fish": "~/.config/fish/config.fish"},
+    "osx": {
+        "zsh": "~/.zshrc",
+        "bash": "~/.bash_profile",
+        "fish": "~/.config/fish/config.fish",
+    },
+    "linux": {
+        "zsh": "~/.zshrc",
+        "bash": "~/.bashrc",
+        "fish": "~/.config/fish/config.fish",
+    },
 }
 
 if plat == "win":
@@ -76,7 +84,13 @@ enable_on_os = {
 
 shell_files = [
     Path(x).expanduser()
-    for x in ["~/.bashrc", "~/.bash_profile", "~/.zshrc", "~/.zsh_profile", "~/.config/fish/config.fish"]
+    for x in [
+        "~/.bashrc",
+        "~/.bash_profile",
+        "~/.zshrc",
+        "~/.zsh_profile",
+        "~/.config/fish/config.fish",
+    ]
 ]
 
 if plat == "win":

--- a/test/micromamba/test_activation.py
+++ b/test/micromamba/test_activation.py
@@ -37,13 +37,14 @@ suffixes = {
     "bash": ".sh",
     "zsh": ".sh",
     "xonsh": ".sh",
+    "fish": ".fish",
     "powershell": ".ps1",
 }
 
 paths = {
     "win": {"powershell": None, "cmdexe": None},
-    "osx": {"zsh": "~/.zshrc", "bash": "~/.bash_profile"},
-    "linux": {"zsh": "~/.zshrc", "bash": "~/.bashrc"},
+    "osx": {"zsh": "~/.zshrc", "bash": "~/.bash_profile", "fish": "~/.config/fish/config.fish"},
+    "linux": {"zsh": "~/.zshrc", "bash": "~/.bashrc", "fish": "~/.config/fish/config.fish"},
 }
 
 if plat == "win":
@@ -70,12 +71,12 @@ def emit_check(cond):
 enable_on_os = {
     "win": {"powershell", "cmdexe"},
     # 'unix': {'bash', 'zsh', 'xonsh'},
-    "unix": {"bash", "zsh"},
+    "unix": {"bash", "zsh", "fish"},
 }
 
 shell_files = [
     Path(x).expanduser()
-    for x in ["~/.bashrc", "~/.bash_profile", "~/.zshrc", "~/.zsh_profile"]
+    for x in ["~/.bashrc", "~/.bash_profile", "~/.zshrc", "~/.zsh_profile", "~/.config/fish/config.fish"]
 ]
 
 if plat == "win":
@@ -182,6 +183,8 @@ def shvar(v, interpreter):
         return f"$Env:{v}"
     elif interpreter == "cmdexe":
         return f"%{v}%"
+    elif interpreter == "fish":
+        return f"${v}"
 
 
 class TestActivation:
@@ -329,6 +332,8 @@ class TestActivation:
             extract_vars = lambda vxs: [f"echo {v}=%{v}%" for v in vxs]
         elif interpreter in ["powershell"]:
             extract_vars = lambda vxs: [f"echo {v}=$Env:{v}" for v in vxs]
+        elif interpreter in ["fish"]:
+            extract_vars = lambda vxs: [f"echo {v}=${v}" for v in vxs]
 
         def to_dict(out):
             return {k: v for k, v in [x.split("=", 1) for x in out.splitlines()]}

--- a/test/micromamba/test_shell.py
+++ b/test/micromamba/test_shell.py
@@ -59,7 +59,7 @@ class TestShell:
             shutil.rmtree(TestShell.root_prefix)
 
     @pytest.mark.parametrize(
-        "shell_type", ["bash", "posix", "powershell", "cmd.exe", "xonsh", "zsh"]
+        "shell_type", ["bash", "posix", "powershell", "cmd.exe", "xonsh", "zsh", "fish"]
     )
     def test_hook(self, shell_type):
         res = shell("hook", "-s", shell_type)
@@ -76,6 +76,8 @@ class TestShell:
             assert res.count(mamba_exe) == 5
         elif shell_type == "xonsh":
             assert res.count(mamba_exe) == 8
+        elif shell_type == "fish":
+            assert res.count(mamba_exe) == 5
         elif shell_type == "cmd.exe":
             assert res == ""
 


### PR DESCRIPTION
This PR implements all the necessary fish scripts to support fish shell in mamba (along with fish shell autocompletes).

This closes #713.