### PR TITLE
Add missing space at the end of printed text

### DIFF
--- a/mamba/mamba_shell_init.py
+++ b/mamba/mamba_shell_init.py
@@ -110,7 +110,7 @@ def shell_init(args):
                 changed = True
     if changed:
         print(
-            "\n==> For changes to take effect, close"
+            "\n==> For changes to take effect, close "
             "and re-open your current shell. <==\n"
         )
     return exit_code


### PR DESCRIPTION
The text to be printed to the terminal is merged from two separate strings.
Neither the first string ends, nor the second one starts with whitespace, hence the tail word of the first line merges with the head word of the second line, giving `closeand`:

```
==> For changes to take effect, closeand re-open your current shell. <==
```