### PR TITLE
Automatically set context when computing a config

### DIFF
--- a/include/mamba/api/configuration.hpp
+++ b/include/mamba/api/configuration.hpp
@@ -599,8 +599,6 @@ namespace mamba
 
         self_type& set_post_build_hook(hook_type hook);
 
-        self_type& set_context();
-
         self_type& set_cli_value(const cli_config_storage_type& value);
 
         cli_config_storage_type& set_cli_config(const cli_config_storage_type& init);
@@ -647,6 +645,8 @@ namespace mamba
         std::shared_ptr<cli_config_type> p_cli_config = 0;
         T* p_context = 0;
         hook_type p_hook;
+
+        self_type& set_context();
     };
 
     /*********************
@@ -1093,8 +1093,6 @@ namespace mamba
 
             virtual void clear_values() = 0;
 
-            virtual void set_context() = 0;
-
             virtual void set_env_var_names(const std::vector<std::string>& names) = 0;
 
             virtual void group(const std::string& name) = 0;
@@ -1311,11 +1309,6 @@ namespace mamba
             void clear_values()
             {
                 p_wrapped->clear_values();
-            };
-
-            void set_context()
-            {
-                p_wrapped->set_context();
             };
 
             void set_env_var_names(const std::vector<std::string>& names)
@@ -1595,12 +1588,6 @@ namespace mamba
             return *this;
         };
 
-        self_type& set_context()
-        {
-            p_impl->set_context();
-            return *this;
-        };
-
         self_type& set_env_var_names(const std::vector<std::string>& names = {})
         {
             p_impl->set_env_var_names(names);
@@ -1793,6 +1780,7 @@ namespace mamba
             p_hook(m_value);
 
         ++m_compute_counter;
+        set_context();
         return *this;
     }
 

--- a/src/api/configuration.cpp
+++ b/src/api/configuration.cpp
@@ -354,10 +354,10 @@ namespace mamba
             if (!ctx.no_rc)
             {
                 config.load_rc_files();
-                config.at("no_env").compute(MAMBA_CONF_FORCE_COMPUTE).set_context();
-                config.at("always_yes").compute(MAMBA_CONF_FORCE_COMPUTE).set_context();
-                config.at("quiet").compute(MAMBA_CONF_FORCE_COMPUTE).set_context();
-                config.at("json").compute(MAMBA_CONF_FORCE_COMPUTE).set_context();
+                config.at("no_env").compute(MAMBA_CONF_FORCE_COMPUTE);
+                config.at("always_yes").compute(MAMBA_CONF_FORCE_COMPUTE);
+                config.at("quiet").compute(MAMBA_CONF_FORCE_COMPUTE);
+                config.at("json").compute(MAMBA_CONF_FORCE_COMPUTE);
             }
         }
 
@@ -966,7 +966,7 @@ namespace mamba
         m_load_lock = true;
         for (auto& c : m_loading_sequence)
         {
-            at(c).compute().set_context();
+            at(c).compute();
         }
         m_load_lock = false;
         CONFIG_DEBUGGING;

--- a/test/test_configuration.cpp
+++ b/test/test_configuration.cpp
@@ -323,8 +323,7 @@ namespace mamba
 
             config.at("channels")
                 .set_yaml_value("https://my.channel, https://my2.channel")
-                .compute()
-                .set_context();
+                .compute();
             EXPECT_EQ(config.dump(MAMBA_SHOW_CONFIG_VALUES | MAMBA_SHOW_CONFIG_SRCS),
                       unindent((R"(
                                 channels:
@@ -393,8 +392,7 @@ namespace mamba
 
             config.at("default_channels")
                 .set_yaml_value("https://my.channel, https://my2.channel")
-                .compute()
-                .set_context();
+                .compute();
             EXPECT_EQ(config.dump(MAMBA_SHOW_CONFIG_VALUES | MAMBA_SHOW_CONFIG_SRCS),
                       unindent((R"(
                                 default_channels:
@@ -436,7 +434,7 @@ namespace mamba
             EXPECT_EQ(config.dump(MAMBA_SHOW_CONFIG_VALUES | MAMBA_SHOW_CONFIG_SRCS),
                       "channel_alias: https://foo.bar  # 'MAMBA_CHANNEL_ALIAS' > '" + src1 + "'");
 
-            config.at("channel_alias").set_yaml_value("https://my.channel").compute().set_context();
+            config.at("channel_alias").set_yaml_value("https://my.channel").compute();
             EXPECT_EQ(config.dump(MAMBA_SHOW_CONFIG_VALUES | MAMBA_SHOW_CONFIG_SRCS),
                       "channel_alias: https://my.channel  # 'API' > 'MAMBA_CHANNEL_ALIAS' > '"
                           + src1 + "'");
@@ -505,7 +503,7 @@ namespace mamba
             EXPECT_EQ(config.dump(MAMBA_SHOW_CONFIG_VALUES | MAMBA_SHOW_CONFIG_SRCS),
                       "ssl_verify: /env/bar/baz  # 'MAMBA_SSL_VERIFY' > '" + src1 + "'");
 
-            config.at("ssl_verify").set_yaml_value("/new/test").compute().set_context();
+            config.at("ssl_verify").set_yaml_value("/new/test").compute();
             EXPECT_EQ(config.dump(MAMBA_SHOW_CONFIG_VALUES | MAMBA_SHOW_CONFIG_SRCS),
                       "ssl_verify: /new/test  # 'API' > 'MAMBA_SSL_VERIFY' > '" + src1 + "'");
 
@@ -537,7 +535,7 @@ namespace mamba
                                    .c_str()));
             EXPECT_EQ(ctx.ssl_verify, "/env/ca/baz");
 
-            config.at("cacert_path").set_yaml_value("/new/test").compute().set_context();
+            config.at("cacert_path").set_yaml_value("/new/test").compute();
             EXPECT_EQ(config.dump(MAMBA_SHOW_CONFIG_VALUES | MAMBA_SHOW_CONFIG_SRCS),
                       unindent((R"(
                                 cacert_path: /new/test  # 'API' > 'MAMBA_CACERT_PATH' > ')"
@@ -547,7 +545,7 @@ namespace mamba
                                    .c_str()));
             EXPECT_EQ(ctx.ssl_verify, "/env/ca/baz");
 
-            config.at("ssl_verify").compute().set_context();
+            config.at("ssl_verify").compute();
             EXPECT_EQ(config.dump(MAMBA_SHOW_CONFIG_VALUES | MAMBA_SHOW_CONFIG_SRCS),
                       unindent((R"(
                                 cacert_path: /new/test  # 'API' > 'MAMBA_CACERT_PATH' > ')"
@@ -638,7 +636,7 @@ namespace mamba
         {                                                                                          \
             expected = std::string(#NAME) + ": true  # 'API' > '" + env_name + "'";                \
         }                                                                                          \
-        config.at(#NAME).set_yaml_value("true").compute().set_context();                           \
+        config.at(#NAME).set_yaml_value("true").compute();                                         \
         EXPECT_EQ((config.dump(dump_opts, { #NAME })), expected);                                  \
         EXPECT_TRUE(config.at(#NAME).value<bool>());                                               \
         EXPECT_TRUE(CTX);                                                                          \
@@ -690,7 +688,7 @@ namespace mamba
                       ChannelPriority::kStrict);
             EXPECT_EQ(ctx.channel_priority, ChannelPriority::kStrict);
 
-            config.at("channel_priority").set_yaml_value("flexible").compute().set_context();
+            config.at("channel_priority").set_yaml_value("flexible").compute();
             EXPECT_EQ(config.dump(MAMBA_SHOW_CONFIG_VALUES | MAMBA_SHOW_CONFIG_SRCS),
                       "channel_priority: flexible  # 'API' > 'MAMBA_CHANNEL_PRIORITY' > '" + src
                           + "'");
@@ -763,7 +761,7 @@ namespace mamba
                 ctx.pinned_packages,
                 std::vector<std::string>({ "mpl=10.2", "xtensor", "jupyterlab=3", "numpy=1.19" }));
 
-            config.at("pinned_packages").set_yaml_value("pytest").compute().set_context();
+            config.at("pinned_packages").set_yaml_value("pytest").compute();
             EXPECT_EQ(config.dump(MAMBA_SHOW_CONFIG_VALUES | MAMBA_SHOW_CONFIG_SRCS),
                       unindent((R"(
                                 pinned_packages:
@@ -840,7 +838,7 @@ namespace mamba
                       VerificationLevel::kWarn);
             EXPECT_EQ(ctx.safety_checks, VerificationLevel::kWarn);
 
-            config.at("safety_checks").set_yaml_value("disabled").compute().set_context();
+            config.at("safety_checks").set_yaml_value("disabled").compute();
             EXPECT_EQ(config.dump(MAMBA_SHOW_CONFIG_VALUES | MAMBA_SHOW_CONFIG_SRCS),
                       "safety_checks: disabled  # 'API' > 'MAMBA_SAFETY_CHECKS' > '" + src + "'");
             EXPECT_EQ(config.at("safety_checks").value<VerificationLevel>(),


### PR DESCRIPTION
Description
---

Automatically set context when computing a configurable value.
This will prevent possible inconsistencies between the context singleton and the configurable value.