### PR TITLE
Add a post `set_context` hook

### DIFF
--- a/src/api/configuration.cpp
+++ b/src/api/configuration.cpp
@@ -452,7 +452,7 @@ namespace mamba
                    .set_env_var_names()
                    .needs({ "verbose", "create_base" })
                    .description("Path to the root prefix")
-                   .set_post_build_hook(detail::root_prefix_hook));
+                   .set_post_merge_hook(detail::root_prefix_hook));
 
         insert(Configurable("create_base", false)
                    .group("Basic")
@@ -470,7 +470,7 @@ namespace mamba
                             "always_yes" })
                    .set_single_op_lifetime()
                    .description("Path to the target prefix")
-                   .set_post_build_hook(detail::target_prefix_hook));
+                   .set_post_merge_hook(detail::target_prefix_hook));
 
         insert(Configurable("use_target_prefix_fallback", true)
                    .group("Basic")
@@ -482,13 +482,13 @@ namespace mamba
                    .needs({ "target_prefix", "rc_file" })
                    .description("The type of checks performed on the target prefix")
                    .set_single_op_lifetime()
-                   .set_post_build_hook(detail::target_prefix_checks_hook));
+                   .set_post_merge_hook(detail::target_prefix_checks_hook));
 
         insert(Configurable("env_name", std::string(""))
                    .group("Basic")
                    .needs({ "root_prefix", "spec_file_env_name" })
                    .set_single_op_lifetime()
-                   .set_post_build_hook(detail::env_name_hook)
+                   .set_post_merge_hook(detail::env_name_hook)
                    .description("Name of the target prefix"));
 
         insert(Configurable("platform", &ctx.platform)
@@ -505,7 +505,7 @@ namespace mamba
                    .group("Basic")
                    .needs({ "file_specs", "root_prefix" })
                    .set_single_op_lifetime()
-                   .set_post_build_hook(detail::file_spec_env_name_hook)
+                   .set_post_merge_hook(detail::file_spec_env_name_hook)
                    .description("Name of the target prefix, specified in a YAML spec file"));
 
         insert(Configurable("specs", std::vector<std::string>({}))
@@ -527,7 +527,7 @@ namespace mamba
                    .long_description(unindent(R"(
                         Enable experimental features that may be still.
                         under active development and not stable yet.)"))
-                   .set_post_build_hook(detail::experimental_hook));
+                   .set_post_merge_hook(detail::experimental_hook));
 
         insert(Configurable("debug", &ctx.debug)
                    .group("Basic")
@@ -538,7 +538,7 @@ namespace mamba
                         in intermediate steps of the operation called.
                         Debug features may/will interrupt the operation,
                         if you only need further logs refer to 'verbose'.)"))
-                   .set_post_build_hook(detail::debug_hook));
+                   .set_post_merge_hook(detail::debug_hook));
 
         // Channels
         insert(Configurable("channels", &ctx.channels)
@@ -629,7 +629,7 @@ namespace mamba
                         the string "<false>" to indicate no SSL verification, or a path to
                         a directory with cert files, or a cert file..)"))
                    .needs({ "cacert_path", "offline" })
-                   .set_post_build_hook(detail::ssl_verify_hook));
+                   .set_post_merge_hook(detail::ssl_verify_hook));
 
         // Solver
         insert(Configurable("channel_priority", &ctx.channel_priority)
@@ -653,7 +653,7 @@ namespace mamba
 
         insert(Configurable("file_specs", std::vector<std::string>({}))
                    .group("Solver")
-                   .set_post_build_hook(detail::file_specs_hook)
+                   .set_post_merge_hook(detail::file_specs_hook)
                    .description("File (yaml, explicit or plain)"));
 
         insert(Configurable("no_pin", false)
@@ -711,7 +711,7 @@ namespace mamba
                    .set_rc_configurable()
                    .set_env_var_names()
                    .needs({ "always_copy" })
-                   .set_post_build_hook(detail::always_softlink_hook)
+                   .set_post_merge_hook(detail::always_softlink_hook)
                    .description("Use soft-link instead of hard-link")
                    .long_description(unindent(R"(
                         Register a preference that files be soft-linked (symlinked) into a
@@ -783,7 +783,7 @@ namespace mamba
                            .long_description(unindent(R"(
                             Set the log level. Log level can be one of {'off', 'fatal',
                             'error', 'warning', 'info', 'debug', 'trace'}.)"))
-                           .set_post_build_hook(detail::log_level_hook));
+                           .set_post_merge_hook(detail::log_level_hook));
         */
         insert(Configurable("json", &ctx.json)
                    .group("Output, Prompt and Flow Control")
@@ -794,20 +794,20 @@ namespace mamba
         insert(Configurable("print_config_only", false)
                    .group("Output, Prompt and Flow Control")
                    .needs({ "debug" })
-                   .set_post_build_hook(detail::print_config_only_hook)
+                   .set_post_merge_hook(detail::print_config_only_hook)
                    .description("Print the config after loading. Allow ultra-dry runs"));
 
         insert(
             Configurable("print_context_only", false)
                 .group("Output, Prompt and Flow Control")
                 .needs({ "debug" })
-                .set_post_build_hook(detail::print_context_only_hook)
+                .set_post_merge_hook(detail::print_context_only_hook)
                 .description("Print the context after loading the config. Allow ultra-dry runs"));
 
         insert(Configurable("show_banner", true)
                    .group("Output, Prompt and Flow Control")
                    .needs({ "quiet", "json" })
-                   .set_post_build_hook(detail::show_banner_hook)
+                   .set_post_merge_hook(detail::show_banner_hook)
                    .set_single_op_lifetime()
                    .description("Show the banner"));
 
@@ -845,7 +845,7 @@ namespace mamba
 
         insert(Configurable("verbose", std::uint8_t(0))
                    .group("Output, Prompt and Flow Control")
-                   .set_post_build_hook(detail::verbose_hook)
+                   .set_post_merge_hook(detail::verbose_hook)
                    .description("Set higher verbosity")
                    .long_description(unindent(R"(
                     Set a higher log verbosity than the default one.
@@ -859,7 +859,7 @@ namespace mamba
                    .group("Config sources")
                    .set_env_var_names()
                    .needs({ "no_rc", "target_prefix", "root_prefix" })
-                   .set_post_build_hook(detail::rc_file_hook)
+                   .set_post_merge_hook(detail::rc_file_hook)
                    .description("Path to the unique configuration file to use"));
 
         insert(Configurable("no_rc", &ctx.no_rc)

--- a/src/micromamba/common_options.cpp
+++ b/src/micromamba/common_options.cpp
@@ -17,8 +17,8 @@ init_rc_options(CLI::App* subcom)
     auto& config = Configuration::instance();
     std::string cli_group = "Configuration options";
 
-    auto& rc_file = config.at("rc_file").get_wrapped<std::vector<fs::path>>();
-    subcom->add_option("--rc-file", rc_file.set_cli_config({}), rc_file.description())
+    auto& rc_files = config.at("rc_files").get_wrapped<std::vector<fs::path>>();
+    subcom->add_option("--rc-file", rc_files.set_cli_config({}), rc_files.description())
         ->group(cli_group);
 
     auto& no_rc = config.at("no_rc").get_wrapped<bool>();
@@ -140,7 +140,7 @@ init_channel_parser(CLI::App* subcom)
     auto& config = Configuration::instance();
 
     auto& channels = config.at("channels").get_wrapped<std::vector<std::string>>();
-    channels.set_post_build_hook(channels_hook).needs({ "override_channels" });
+    channels.set_post_merge_hook(channels_hook).needs({ "override_channels" });
     subcom->add_option("-c,--channel", channels.set_cli_config({}), channels.description())
         ->type_size(1)
         ->allow_extra_args(false);
@@ -150,7 +150,7 @@ init_channel_parser(CLI::App* subcom)
                                                 .set_env_var_names()
                                                 .description("Override channels")
                                                 .needs({ "override_channels_enabled" })
-                                                .set_post_build_hook(override_channels_hook),
+                                                .set_post_merge_hook(override_channels_hook),
                                             true);
     subcom->add_flag("--override-channels",
                      override_channels.set_cli_config(false),
@@ -171,7 +171,7 @@ init_channel_parser(CLI::App* subcom)
         = config.insert(Configurable("strict_channel_priority", false)
                             .group("cli")
                             .description("Enable strict channel priority")
-                            .set_post_build_hook(strict_channel_priority_hook),
+                            .set_post_merge_hook(strict_channel_priority_hook),
                         true);
     subcom->add_flag("--strict-channel-priority",
                      strict_channel_priority.set_cli_config(0),
@@ -180,7 +180,7 @@ init_channel_parser(CLI::App* subcom)
     auto& no_channel_priority = config.insert(Configurable("no_channel_priority", false)
                                                   .group("cli")
                                                   .description("Disable channel priority")
-                                                  .set_post_build_hook(no_channel_priority_hook),
+                                                  .set_post_merge_hook(no_channel_priority_hook),
                                               true);
     subcom->add_flag("--no-channel-priority",
                      no_channel_priority.set_cli_config(0),


### PR DESCRIPTION
Description
---

Add a post `set_context` hook in the `Configurable<T>::compute` method: `post_context_hook`
Rename the current and only `hook` to disambiguate: `post_merge_hook`