### PR TITLE
Add fallback and default config hooks

### DIFF
--- a/src/micromamba/common_options.cpp
+++ b/src/micromamba/common_options.cpp
@@ -17,7 +17,7 @@ init_rc_options(CLI::App* subcom)
     auto& config = Configuration::instance();
     std::string cli_group = "Configuration options";
 
-    auto& rc_files = config.at("rc_files").get_wrapped<std::vector<fs::path>>();
+    auto& rc_files = config.at("rc_file").get_wrapped<std::vector<fs::path>>();
     subcom->add_option("--rc-file", rc_files.set_cli_config({}), rc_files.description())
         ->group(cli_group);
 


### PR DESCRIPTION
Description
---

The current implementation set init=default configurable value at the context current value when a reference is picked on it.
It is an issue for the configurable when the a context value is initialized such as `pkgs_dirs = { root_prefix / "pkgs"}`, because the `pkgs_dirs` configurable init=default value is not updated to the latest value of the `root_prefix`.

- disambiguate init from default values
- add fallback and default config hooks, such as:
  - `default` value is computed with lowest precedence: `api` > `cli` > `env_var` > `rc_file` > `default`
  - `fallback` is computed only if any of the other sources are empty
  - init value is set when no source are set

Note: `default` and `fallback` have equivalent results for scalar types, not for vector ones
