### PR TITLE
Improve lockfiles

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,7 +45,7 @@ jobs:
         run: |
           conda config --add channels conda-forge
           conda config --set channel_priority strict
-          conda install -n base python=$PYTHON_VERSION pip pybind11 libsolv libsodium libarchive "libcurl=7.76.1=*_0" nlohmann_json cpp-filesystem conda cxx-compiler ccache cmake gtest gmock reproc-cpp yaml-cpp
+          conda install -n base python=$PYTHON_VERSION pip pybind11 libsolv libsodium libarchive "libcurl=7.76.1=*_0" nlohmann_json "cpp-filesystem>=1.5.8" conda cxx-compiler ccache cmake gtest gmock reproc-cpp yaml-cpp
         env:
           PYTHON_VERSION: ${{ matrix.python-version }}
       - name: Install dependencies
@@ -147,7 +147,7 @@ jobs:
           export MAMBA_ROOT_PREFIX=~/mambaroot
           export MAMBA_EXE=$(pwd)/micromamba
           . $MAMBA_ROOT_PREFIX/etc/profile.d/mamba.sh
-          micromamba create -y -p ~/build_env pybind11 libsolv libsodium libarchive "libcurl=7.76.1=*_0" nlohmann_json cxx-compiler ccache cmake gtest gmock cpp-filesystem reproc-cpp yaml-cpp cli11 -c conda-forge
+          micromamba create -y -p ~/build_env pybind11 libsolv libsodium libarchive "libcurl=7.76.1=*_0" nlohmann_json cxx-compiler ccache cmake gtest gmock "cpp-filesystem>=1.5.8" reproc-cpp yaml-cpp cli11 -c conda-forge
         env:
           PYTHON_VERSION: ${{ matrix.python-version }}
       - name: build tests
@@ -169,6 +169,7 @@ jobs:
                    -DBUILD_BINDINGS=OFF \
                    -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
                    -DCMAKE_C_COMPILER_LAUNCHER=ccache
+          make test_mamba_lock -j2
           make test -j2
 
   umamba_tests:
@@ -208,7 +209,7 @@ jobs:
           export MAMBA_ROOT_PREFIX=~/mambaroot
           export MAMBA_EXE=$(pwd)/micromamba
           . $MAMBA_ROOT_PREFIX/etc/profile.d/mamba.sh
-          micromamba create -y -p ~/build_env pybind11 libsolv libsodium libarchive "libcurl=7.76.1=*_0" nlohmann_json cxx-compiler ccache cmake gtest gmock cpp-filesystem reproc-cpp yaml-cpp pyyaml cli11 -c conda-forge
+          micromamba create -y -p ~/build_env pybind11 libsolv libsodium libarchive "libcurl=7.76.1=*_0" nlohmann_json cxx-compiler ccache cmake gtest gmock "cpp-filesystem>=1.5.8" reproc-cpp yaml-cpp pyyaml cli11 -c conda-forge
         env:
           PYTHON_VERSION: ${{ matrix.python-version }}
       - name: build micromamba
@@ -323,7 +324,7 @@ jobs:
         run: |
           conda config --add channels conda-forge
           conda config --set channel_priority strict
-          conda install -n base -q -y vs2017_win-64 ccache python=$PYTHON_VERSION pip pybind11 libsolv libsodium libarchive "libcurl=7.76.1=*_0" nlohmann_json cpp-filesystem conda cmake gtest gmock ninja reproc-cpp yaml-cpp cli11
+          conda install -n base -q -y vs2017_win-64 ccache python=$PYTHON_VERSION pip pybind11 libsolv libsodium libarchive "libcurl=7.76.1=*_0" nlohmann_json "cpp-filesystem>=1.5.8" conda cmake gtest gmock ninja reproc-cpp yaml-cpp cli11
         env:
           PYTHON_VERSION: ${{ matrix.python-version }}
       - name: Install dependencies
@@ -398,7 +399,7 @@ jobs:
         run: |
           conda config --add channels conda-forge
           conda config --set channel_priority strict
-          conda create -q -y -n mamba-tests vs2017_win-64 ccache python=$PYTHON_VERSION pip pybind11 libsolv libsodium libarchive "libcurl=7.76.1=*_0" nlohmann_json cpp-filesystem conda cmake gtest gmock ninja reproc-cpp yaml-cpp cli11 pytest
+          conda create -q -y -n mamba-tests vs2017_win-64 ccache python=$PYTHON_VERSION pip pybind11 libsolv libsodium libarchive "libcurl=7.76.1=*_0" nlohmann_json "cpp-filesystem>=1.5.8" conda cmake gtest gmock ninja reproc-cpp yaml-cpp cli11 pytest
         env:
           PYTHON_VERSION: ${{ matrix.python-version }}
       - name: Run C++ tests Windows
@@ -412,8 +413,8 @@ jobs:
                    -G "Ninja" ^
                    -DCMAKE_CXX_COMPILER_LAUNCHER=ccache ^
                    -DCMAKE_C_COMPILER_LAUNCHER=ccache
-
-          ninja test
+          ninja test_mamba_lock -j2
+          ninja test -j2
 
   umamba_tests_win:
     runs-on: ${{ matrix.os }}
@@ -508,7 +509,7 @@ jobs:
         run: |
           conda config --add channels conda-forge
           conda config --set channel_priority strict
-          conda create -q -y -n mamba-tests vs2017_win-64 python=$PYTHON_VERSION pip pybind11 libsolv libsodium libarchive "libcurl=7.76.1=*_0" nlohmann_json cpp-filesystem conda cmake gtest gmock ninja reproc-cpp yaml-cpp pyyaml cli11 pytest pytest-lazy-fixture menuinst
+          conda create -q -y -n mamba-tests vs2017_win-64 python=$PYTHON_VERSION pip pybind11 libsolv libsodium libarchive "libcurl=7.76.1=*_0" nlohmann_json "cpp-filesystem>=1.5.8" conda cmake gtest gmock ninja reproc-cpp yaml-cpp pyyaml cli11 pytest pytest-lazy-fixture menuinst
         env:
           PYTHON_VERSION: ${{ matrix.python-version }}
       - name: micromamba python based tests
@@ -549,7 +550,7 @@ jobs:
         run: |
           conda config --add channels conda-forge
           conda config --set channel_priority strict
-          conda create -q -y -n mamba-tests vs2017_win-64 python=$PYTHON_VERSION pip pybind11 libsolv libsodium libarchive "libcurl=7.76.1=*_0" nlohmann_json cpp-filesystem conda cmake gtest gmock ninja reproc-cpp yaml-cpp pyyaml cli11 pytest pytest-lazy-fixture menuinst
+          conda create -q -y -n mamba-tests vs2017_win-64 python=$PYTHON_VERSION pip pybind11 libsolv libsodium libarchive "libcurl=7.76.1=*_0" nlohmann_json "cpp-filesystem>=1.5.8" conda cmake gtest gmock ninja reproc-cpp yaml-cpp pyyaml cli11 pytest pytest-lazy-fixture menuinst
         env:
           PYTHON_VERSION: ${{ matrix.python-version }}
       - name: micromamba python based tests with pwsh
@@ -588,7 +589,7 @@ jobs:
         run: |
           conda config --add channels conda-forge
           conda config --set channel_priority strict
-          conda create -q -y -n mamba-tests vs2017_win-64 python=$PYTHON_VERSION pip pybind11 libsolv libsodium libarchive "libcurl=7.76.1=*_0" nlohmann_json cpp-filesystem conda cmake gtest gmock ninja reproc-cpp yaml-cpp pyyaml cli11 pytest pytest-lazy-fixture menuinst
+          conda create -q -y -n mamba-tests vs2017_win-64 python=$PYTHON_VERSION pip pybind11 libsolv libsodium libarchive "libcurl=7.76.1=*_0" nlohmann_json "cpp-filesystem>=1.5.8" conda cmake gtest gmock ninja reproc-cpp yaml-cpp pyyaml cli11 pytest pytest-lazy-fixture menuinst
         env:
           PYTHON_VERSION: ${{ matrix.python-version }}
       - name: micromamba python based tests

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -15,7 +15,7 @@ dependencies:
   - cxx-compiler
   - gtest
   - gmock
-  - cpp-filesystem
+  - cpp-filesystem >=1.5.8
   - reproc-cpp
   - yaml-cpp
   - pyyaml

--- a/include/mamba/api/clean.hpp
+++ b/include/mamba/api/clean.hpp
@@ -14,6 +14,7 @@ namespace mamba
     const int MAMBA_CLEAN_INDEX = 1 << 1;
     const int MAMBA_CLEAN_PKGS = 1 << 2;
     const int MAMBA_CLEAN_TARBALLS = 1 << 3;
+    const int MAMBA_CLEAN_LOCKS = 1 << 4;
 
     void clean(int options);
 }

--- a/include/mamba/core/context.hpp
+++ b/include/mamba/core/context.hpp
@@ -163,6 +163,8 @@ namespace mamba
         bool no_rc = false;
         bool no_env = false;
 
+        std::size_t lock_timeout = 0;
+
         // Conda compat
         bool add_pip_as_python_dependency = true;
 

--- a/include/mamba/core/thread_utils.hpp
+++ b/include/mamba/core/thread_utils.hpp
@@ -26,6 +26,7 @@ namespace mamba
      ***********************/
 
     void set_default_signal_handler();
+    void set_signal_handler(const std::function<void(sigset_t)>& handler);
 
     bool is_sig_interrupted() noexcept;
     void set_sig_interrupted() noexcept;
@@ -56,7 +57,7 @@ namespace mamba
     // by threads still active.
     void wait_for_all_threads();
 
-    std::thread::native_handle_type get_signal_receiver_thread_id();
+    int stop_receiver_thread();
     void reset_sig_interrupted();
 
     /**********
@@ -86,6 +87,7 @@ namespace mamba
 
         void join();
         void detach();
+        std::thread::native_handle_type native_handle();
 
     private:
         std::thread m_thread;
@@ -103,6 +105,7 @@ namespace mamba
             }
             catch (thread_interrupted&)
             {
+                errno = EINTR;
             }
             decrease_thread_count();
         });

--- a/include/mamba/core/thread_utils.hpp
+++ b/include/mamba/core/thread_utils.hpp
@@ -25,11 +25,17 @@ namespace mamba
      * thread interruption *
      ***********************/
 
+#ifndef _WIN32
     void set_default_signal_handler();
     void set_signal_handler(const std::function<void(sigset_t)>& handler);
 
+    int stop_receiver_thread();
+    void reset_sig_interrupted();
+#endif
+
     bool is_sig_interrupted() noexcept;
     void set_sig_interrupted() noexcept;
+
 
     void interruption_point();
 
@@ -56,9 +62,6 @@ namespace mamba
     // it won't free ressources that could be required
     // by threads still active.
     void wait_for_all_threads();
-
-    int stop_receiver_thread();
-    void reset_sig_interrupted();
 
     /**********
      * thread *

--- a/include/mamba/core/thread_utils.hpp
+++ b/include/mamba/core/thread_utils.hpp
@@ -26,13 +26,13 @@ namespace mamba
      ***********************/
 
 #ifndef _WIN32
-    void set_default_signal_handler();
     void set_signal_handler(const std::function<void(sigset_t)>& handler);
 
     int stop_receiver_thread();
     void reset_sig_interrupted();
 #endif
 
+    void set_default_signal_handler();
     bool is_sig_interrupted() noexcept;
     void set_sig_interrupted() noexcept;
 

--- a/include/mamba/core/thread_utils.hpp
+++ b/include/mamba/core/thread_utils.hpp
@@ -29,6 +29,7 @@ namespace mamba
     void set_signal_handler(const std::function<void(sigset_t)>& handler);
 
     int stop_receiver_thread();
+    int kill_receiver_thread();
     void reset_sig_interrupted();
 #endif
 

--- a/include/mamba/core/util.hpp
+++ b/include/mamba/core/util.hpp
@@ -133,6 +133,8 @@ namespace mamba
         fs::path m_path;
     };
 
+    const std::size_t MAMBA_LOCK_POS = 21;
+
     class Lock;
 
     class LockFile

--- a/include/mamba/core/util.hpp
+++ b/include/mamba/core/util.hpp
@@ -135,16 +135,16 @@ namespace mamba
 
     const std::size_t MAMBA_LOCK_POS = 21;
 
-    class Lock
+    class LockFile
     {
     public:
-        Lock(const fs::path& path);
-        Lock(const fs::path& path, const std::chrono::seconds& timeout);
-        ~Lock();
+        LockFile(const fs::path& path);
+        LockFile(const fs::path& path, const std::chrono::seconds& timeout);
+        ~LockFile();
 
-        Lock(const Lock&) = delete;
-        Lock& operator=(const Lock&) = delete;
-        Lock& operator=(Lock&&) = default;
+        LockFile(const LockFile&) = delete;
+        LockFile& operator=(const LockFile&) = delete;
+        LockFile& operator=(LockFile&&) = default;
 
         int fd() const;
         fs::path path() const;

--- a/src/api/configuration.cpp
+++ b/src/api/configuration.cpp
@@ -814,6 +814,16 @@ namespace mamba
                         Spend extra time validating package contents. It consists of running
                         cryptographic verifications on channels and packages metadata.)")));
 
+        insert(Configurable("lock_timeout", &ctx.lock_timeout)
+                   .group("Link & Install")
+                   .set_rc_configurable()
+                   .set_env_var_names()
+                   .description("Lock timeout")
+                   .long_description(unindent(R"(
+                        Lock timeout for blocking mode when waiting for another process
+                        to release the path.
+                        Not configurable on Windows: set to 10s by WinAPI)")));
+
         // Output, Prompt and Flow
         insert(Configurable("always_yes", &ctx.always_yes)
                    .group("Output, Prompt and Flow Control")

--- a/src/api/configuration.cpp
+++ b/src/api/configuration.cpp
@@ -818,11 +818,10 @@ namespace mamba
                    .group("Link & Install")
                    .set_rc_configurable()
                    .set_env_var_names()
-                   .description("Lock timeout")
+                   .description("LockFile timeout")
                    .long_description(unindent(R"(
-                        Lock timeout for blocking mode when waiting for another process
-                        to release the path.
-                        Not configurable on Windows: set to 10s by WinAPI)")));
+                        LockFile timeout for blocking mode when waiting for another process
+                        to release the path. Default is 0 (no timeout))")));
 
         // Output, Prompt and Flow
         insert(Configurable("always_yes", &ctx.always_yes)

--- a/src/api/install.cpp
+++ b/src/api/install.cpp
@@ -339,10 +339,10 @@ namespace mamba
 
         std::vector<std::shared_ptr<MSubdirData>> subdirs;
         MultiDownloadTarget multi_dl;
-        std::unique_ptr<Lock> subdir_download_lock;
+        std::unique_ptr<LockFile> subdir_download_lock;
         if (!ctx.offline)
         {
-            subdir_download_lock = std::make_unique<Lock>(cache_dir);
+            subdir_download_lock = std::make_unique<LockFile>(cache_dir);
         }
 
         std::vector<std::pair<int, int>> priorities;
@@ -535,7 +535,7 @@ namespace mamba
                 detail::create_target_directory(ctx.target_prefix);
             }
             {
-                Lock pkgs_dirs_lock(pkgs_dirs);
+                LockFile pkgs_dirs_lock(pkgs_dirs);
                 trans.execute(prefix_data);
             }
             for (auto other_spec : config.at("others_pkg_mgrs_specs")
@@ -774,7 +774,7 @@ namespace mamba
                 fs::create_directories(pkgs_dirs);
             }
 
-            Lock pkgs_dirs_lock(pkgs_dirs);
+            LockFile pkgs_dirs_lock(pkgs_dirs);
 
             std::vector<std::unique_ptr<PackageDownloadExtractTarget>> targets;
             MultiDownloadTarget multi_dl;

--- a/src/api/install.cpp
+++ b/src/api/install.cpp
@@ -339,10 +339,10 @@ namespace mamba
 
         std::vector<std::shared_ptr<MSubdirData>> subdirs;
         MultiDownloadTarget multi_dl;
-        std::unique_ptr<LockFile> subdir_download_lock;
+        std::unique_ptr<Lock> subdir_download_lock;
         if (!ctx.offline)
         {
-            subdir_download_lock = std::make_unique<LockFile>(cache_dir / "mamba.lock");
+            subdir_download_lock = std::make_unique<Lock>(cache_dir);
         }
 
         std::vector<std::pair<int, int>> priorities;
@@ -535,7 +535,7 @@ namespace mamba
                 detail::create_target_directory(ctx.target_prefix);
             }
             {
-                LockFile(pkgs_dirs / "mamba.lock");
+                Lock pkgs_dirs_lock(pkgs_dirs);
                 trans.execute(prefix_data);
             }
             for (auto other_spec : config.at("others_pkg_mgrs_specs")
@@ -774,7 +774,7 @@ namespace mamba
                 fs::create_directories(pkgs_dirs);
             }
 
-            LockFile(pkgs_dirs / "mamba.lock");
+            Lock pkgs_dirs_lock(pkgs_dirs);
 
             std::vector<std::unique_ptr<PackageDownloadExtractTarget>> targets;
             MultiDownloadTarget multi_dl;

--- a/src/core/thread_utils.cpp
+++ b/src/core/thread_utils.cpp
@@ -35,6 +35,17 @@ namespace mamba
         set_default_signal_handler();
     }
 
+    int kill_receiver_thread()
+    {
+        if (receiver_exists.load())
+        {
+            pthread_cancel(sig_recv_thread);
+            receiver_exists.store(false);
+            return 0;
+        }
+        return -1;
+    }
+
     int stop_receiver_thread()
     {
         if (receiver_exists.load())

--- a/src/core/util.cpp
+++ b/src/core/util.cpp
@@ -863,6 +863,9 @@ namespace mamba
                 std::this_thread::sleep_for(std::chrono::seconds(1));
                 timer += std::chrono::seconds(1);
             }
+
+            if (has_timeout && (timer >= m_timeout) && (ret == -1))
+                errno = EINTR;
         }
         else
             ret = _locking(m_fd, LK_NBLCK, 1 /*lock_file_contents_length()*/);

--- a/src/core/util.cpp
+++ b/src/core/util.cpp
@@ -901,6 +901,7 @@ namespace mamba
             std::unique_lock<std::mutex> l(m);
             if (cv.wait_for(l, timeout) == std::cv_status::timeout)
             {
+                pthread_cancel(th);
                 kill_receiver_thread();
                 err = EINTR;
                 ret = -1;

--- a/src/core/util.cpp
+++ b/src/core/util.cpp
@@ -852,16 +852,16 @@ namespace mamba
 
         if (blocking)
         {
-            std::size_t timer = 0;
+            std::chrono::seconds timer(0);
             bool has_timeout = m_timeout.count() > 0;
 
-            while (!has_timeout || (timer < timeout))
+            while (!has_timeout || (timer < m_timeout))
             {
                 ret = _locking(m_fd, LK_NBLCK, 1 /*lock_file_contents_length()*/);
                 if (ret == 0)
                     break;
                 std::this_thread::sleep_for(std::chrono::seconds(1));
-                timer += 1;
+                timer += std::chrono::seconds(1);
             }
         }
         else

--- a/src/core/util.cpp
+++ b/src/core/util.cpp
@@ -660,8 +660,8 @@ namespace mamba
     {
         if (!fs::exists(path))
         {
-            LOG_DEBUG << "Could not lock non-existing path '" << path.string() << "'";
-            return;
+            LOG_ERROR << "Could not lock non-existing path '" << path.string() << "'";
+            throw std::runtime_error("Lock error. Aborting.");
         }
 
         if (fs::is_directory(path))
@@ -680,7 +680,7 @@ namespace mamba
 
         if (m_fd <= 0)
         {
-            LOG_DEBUG << "Could not open lockfile '" << m_lock.string() << "'";
+            LOG_ERROR << "Could not open lockfile '" << m_lock.string() << "'";
             unlock();
             throw std::runtime_error("Lock error. Aborting.");
         }
@@ -901,7 +901,7 @@ namespace mamba
             if (cv.wait_for(l, timeout) == std::cv_status::timeout)
             {
                 pthread_cancel(th);
-                errno = EINTR;
+                err = EINTR;
                 ret = -1;
             }
         }

--- a/src/micromamba/clean.cpp
+++ b/src/micromamba/clean.cpp
@@ -32,12 +32,16 @@ init_clean_parser(CLI::App* subcom)
     auto& clean_tarballs = config.insert(Configurable("clean_tarballs", false)
                                              .group("cli")
                                              .description("Remove cached package tarballs"));
+    auto& clean_locks = config.insert(Configurable("clean_locks", false)
+                                          .group("cli")
+                                          .description("Remove lock files from caches"));
 
     subcom->add_flag("-a,--all", clean_all.set_cli_config(0), clean_all.description());
     subcom->add_flag("-i,--index-cache", clean_index.set_cli_config(0), clean_index.description());
     subcom->add_flag("-p,--packages", clean_pkgs.set_cli_config(0), clean_pkgs.description());
     subcom->add_flag(
         "-t,--tarballs", clean_tarballs.set_cli_config(0), clean_tarballs.description());
+    subcom->add_flag("-l,--locks", clean_locks.set_cli_config(0), clean_locks.description());
 }
 
 void
@@ -57,6 +61,8 @@ set_clean_command(CLI::App* subcom)
             options = options | MAMBA_CLEAN_PKGS;
         if (config.at("clean_tarballs").compute().value<bool>())
             options = options | MAMBA_CLEAN_TARBALLS;
+        if (config.at("clean_locks").compute().value<bool>())
+            options = options | MAMBA_CLEAN_LOCKS;
 
         clean(options);
     });

--- a/src/micromamba/common_options.cpp
+++ b/src/micromamba/common_options.cpp
@@ -325,6 +325,10 @@ init_install_options(CLI::App* subcom)
                      extra_safety_checks.set_cli_config(0),
                      extra_safety_checks.description());
 
+    auto& lock_timeout = config.at("lock_timeout").get_wrapped<std::size_t>();
+    subcom->add_option(
+        "--lock-timeout", lock_timeout.set_cli_config(-1), lock_timeout.description());
+
     auto& shortcuts = config.at("shortcuts").get_wrapped<bool>();
     subcom->add_flag(
         "--shortcuts,!--no-shortcuts", shortcuts.set_cli_config(0), shortcuts.description());

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -21,6 +21,7 @@ set(TEST_SRCS
     test_validate.cpp
     test_virtual_packages.cpp
     test_env_file_reading.cpp
+    test_lockfile.cpp
 )
 
 add_executable(test_mamba ${TEST_SRCS})
@@ -43,3 +44,8 @@ target_link_libraries(test_mamba PUBLIC mamba-static)
 set_property(TARGET test_mamba PROPERTY CXX_STANDARD 17)
 
 add_custom_target(test COMMAND test_mamba DEPENDS test_mamba)
+
+add_executable(test_mamba_lock testing/lock.cpp)
+target_link_libraries(test_mamba_lock PRIVATE GTest::GTest GTest::Main ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries(test_mamba_lock PUBLIC mamba-static)
+set_property(TARGET test_mamba_lock PROPERTY CXX_STANDARD 17)

--- a/test/micromamba/test_pkg_cache.py
+++ b/test/micromamba/test_pkg_cache.py
@@ -288,13 +288,7 @@ class TestMultiplePkgCaches:
         os.environ["CONDA_PKGS_DIRS"] = f"{cache1},{cache2}"
         env_name = TestMultiplePkgCaches.env_name
 
-        res = create(
-            "-n",
-            env_name,
-            "xtensor",
-            "--json",
-            no_dry_run=True,
-        )
+        res = create("-n", env_name, "xtensor", "--json", no_dry_run=True,)
 
         linked_file = get_env(env_name, xtensor_hpp)
         assert linked_file.exists()

--- a/test/test_lockfile.cpp
+++ b/test/test_lockfile.cpp
@@ -1,0 +1,272 @@
+#include <gtest/gtest.h>
+
+#include "mamba/core/mamba_fs.hpp"
+#include "mamba/core/output.hpp"
+#include "mamba/core/util.hpp"
+
+#include <reproc++/run.hpp>
+
+#include <cstdio>
+#include <string>
+#include <ostream>
+
+#ifdef _WIN32
+#include <io.h>
+
+extern "C"
+{
+#include <io.h>
+#include <process.h>
+#include <fcntl.h>
+}
+#endif
+
+namespace mamba
+{
+    namespace testing
+    {
+#ifdef _WIN32
+#define EXPECT_LOCKED(lock) EXPECT_TRUE(mamba::LockFile::is_locked(lock.path()));
+#else
+#define EXPECT_LOCKED(lock) EXPECT_TRUE(mamba::LockFile::is_locked(lock.fd()));
+#endif
+
+        class LockDirTest : public ::testing::Test
+        {
+        protected:
+            std::unique_ptr<TemporaryDirectory> p_tempdir;
+            fs::path tempdir_path;
+
+            LockDirTest()
+            {
+                p_tempdir = std::make_unique<TemporaryDirectory>();
+                tempdir_path = p_tempdir->path();
+
+                mamba::MessageLogger::global_log_severity() = mamba::LogSeverity::kTrace;
+            }
+
+            ~LockDirTest()
+            {
+                mamba::MessageLogger::global_log_severity() = mamba::LogSeverity::kInfo;
+            }
+        };
+
+        TEST_F(LockDirTest, same_pid)
+        {
+            {
+                auto lock = Lock(tempdir_path);
+                EXPECT_TRUE(lock.locked());
+                EXPECT_TRUE(fs::exists(lock.path()));
+
+                EXPECT_THROW(Lock lock2(tempdir_path), std::logic_error);
+
+                // check the first lock is still locked
+                EXPECT_TRUE(lock.locked());
+                EXPECT_TRUE(fs::exists(lock.path()));
+            }
+            EXPECT_FALSE(fs::exists(tempdir_path / "mamba.lock"));
+        }
+
+        TEST_F(LockDirTest, different_pid)
+        {
+            std::string lock_cli;
+            std::string out, err;
+            std::vector<std::string> args;
+
+#ifdef _WIN32
+            lock_cli = "test_mamba_lock";
+#else
+            lock_cli = "./test_mamba_lock";
+#endif
+
+            {
+                auto lock = Lock(tempdir_path);
+                EXPECT_TRUE(lock.locked());
+                EXPECT_TRUE(fs::exists(lock.path()));
+
+                // Check lock PID
+                int pid = getpid();
+                EXPECT_EQ(mamba::LockFile::read_pid(lock.fd()), pid);
+
+                // Check lock status
+                EXPECT_LOCKED(lock);
+
+                // Check lock status from another process
+                args = { lock_cli, "is-locked", lock.path() };
+                out.clear();
+                err.clear();
+                reproc::run(
+                    args, reproc::options{}, reproc::sink::string(out), reproc::sink::string(err));
+
+                int is_locked = 0;
+                try
+                {
+                    is_locked = std::stoi(out);
+                }
+                catch (...)
+                {
+                }
+                EXPECT_TRUE(is_locked);
+
+
+                // Try to lock from another process
+                args = { lock_cli, "lock", "--timeout=1", tempdir_path };
+                out.clear();
+                err.clear();
+                reproc::run(
+                    args, reproc::options{}, reproc::sink::string(out), reproc::sink::string(err));
+
+                bool new_lock_created = true;
+                try
+                {
+                    new_lock_created = std::stoi(out);
+                }
+                catch (...)
+                {
+                }
+                EXPECT_FALSE(new_lock_created);
+
+                // Check the PID hasn't changed
+                EXPECT_EQ(mamba::LockFile::read_pid(lock.fd()), pid);
+            }
+
+            fs::path lock_path = tempdir_path / "mamba.lock";
+            EXPECT_FALSE(fs::exists(lock_path));
+
+            args = { lock_cli, "is-locked", lock_path };
+            out.clear();
+            err.clear();
+            reproc::run(
+                args, reproc::options{}, reproc::sink::string(out), reproc::sink::string(err));
+
+            int is_locked = 0;
+            try
+            {
+                is_locked = std::stoi(out);
+            }
+            catch (...)
+            {
+            }
+            EXPECT_FALSE(is_locked);
+        }
+
+        class LockFileTest : public ::testing::Test
+        {
+        protected:
+            std::unique_ptr<TemporaryFile> p_tempfile;
+            fs::path tempfile_path;
+
+            LockFileTest()
+            {
+                p_tempfile = std::make_unique<TemporaryFile>();
+                tempfile_path = p_tempfile->path();
+
+                mamba::MessageLogger::global_log_severity() = mamba::LogSeverity::kTrace;
+            }
+
+            ~LockFileTest()
+            {
+                mamba::MessageLogger::global_log_severity() = mamba::LogSeverity::kInfo;
+            }
+        };
+
+        TEST_F(LockFileTest, same_pid)
+        {
+            {
+                auto lock = Lock(tempfile_path);
+                EXPECT_TRUE(lock.locked());
+                EXPECT_TRUE(fs::exists(lock.path()));
+
+                EXPECT_THROW(Lock lock2(tempfile_path), std::logic_error);
+
+                // check the first lock is still locked
+                EXPECT_TRUE(lock.locked());
+                EXPECT_TRUE(fs::exists(lock.path()));
+            }
+            EXPECT_FALSE(fs::exists(tempfile_path.string() + ".lock"));
+        }
+
+        TEST_F(LockFileTest, different_pid)
+        {
+            std::string lock_cli;
+            std::string out, err;
+            std::vector<std::string> args;
+
+#ifdef _WIN32
+            lock_cli = "test_mamba_lock";
+#else
+            lock_cli = "./test_mamba_lock";
+#endif
+            {
+                // Create a lock
+                auto lock = Lock(tempfile_path);
+                EXPECT_TRUE(lock.locked());
+                EXPECT_TRUE(fs::exists(lock.path()));
+
+                // Check lock PID
+                int pid = getpid();
+                EXPECT_EQ(mamba::LockFile::read_pid(lock.fd()), pid);
+
+                // Check lock status from current PID
+                EXPECT_LOCKED(lock);
+
+                // Check lock status from another process
+                args = { lock_cli, "is-locked", lock.path() };
+                out.clear();
+                err.clear();
+                reproc::run(
+                    args, reproc::options{}, reproc::sink::string(out), reproc::sink::string(err));
+
+                int is_locked = 0;
+                try
+                {
+                    is_locked = std::stoi(out);
+                }
+                catch (...)
+                {
+                }
+                EXPECT_TRUE(is_locked);
+
+                // Try to lock from another process
+                args = { lock_cli, "lock", "--timeout=1", tempfile_path };
+                out.clear();
+                err.clear();
+                reproc::run(
+                    args, reproc::options{}, reproc::sink::string(out), reproc::sink::string(err));
+
+                bool new_lock_created = true;
+                try
+                {
+                    new_lock_created = std::stoi(out);
+                }
+                catch (...)
+                {
+                }
+                EXPECT_FALSE(new_lock_created);
+
+                // Check the PID hasn't changed
+                EXPECT_EQ(mamba::LockFile::read_pid(lock.fd()), pid);
+            }
+
+            fs::path lock_path = tempfile_path.string() + ".lock";
+            EXPECT_FALSE(fs::exists(lock_path));
+
+            args = { lock_cli, "is-locked", lock_path };
+            out.clear();
+            err.clear();
+            reproc::run(
+                args, reproc::options{}, reproc::sink::string(out), reproc::sink::string(err));
+
+            int is_locked = 0;
+            try
+            {
+                is_locked = std::stoi(out);
+            }
+            catch (...)
+            {
+            }
+            EXPECT_FALSE(is_locked);
+        }
+#undef EXPECT_LOCKED
+    }
+}

--- a/test/test_lockfile.cpp
+++ b/test/test_lockfile.cpp
@@ -26,9 +26,9 @@ namespace mamba
     namespace testing
     {
 #ifdef _WIN32
-#define EXPECT_LOCKED(lock) EXPECT_TRUE(mamba::Lock::is_locked(lock.lockfile_path()));
+#define EXPECT_LOCKED(lock) EXPECT_TRUE(mamba::LockFile::is_locked(lock.lockfile_path()));
 #else
-#define EXPECT_LOCKED(lock) EXPECT_TRUE(mamba::Lock::is_locked(lock.fd()));
+#define EXPECT_LOCKED(lock) EXPECT_TRUE(mamba::LockFile::is_locked(lock.fd()));
 #endif
 
         class LockDirTest : public ::testing::Test
@@ -54,10 +54,10 @@ namespace mamba
         TEST_F(LockDirTest, same_pid)
         {
             {
-                auto lock = Lock(tempdir_path);
+                auto lock = LockFile(tempdir_path);
                 EXPECT_TRUE(fs::exists(lock.lockfile_path()));
 
-                EXPECT_THROW(Lock lock2(tempdir_path), std::logic_error);
+                EXPECT_THROW(LockFile lock2(tempdir_path), std::logic_error);
 
                 // check the first lock is still locked
                 EXPECT_TRUE(fs::exists(lock.lockfile_path()));
@@ -78,12 +78,12 @@ namespace mamba
 #endif
 
             {
-                auto lock = Lock(tempdir_path);
+                auto lock = LockFile(tempdir_path);
                 EXPECT_TRUE(fs::exists(lock.lockfile_path()));
 
                 // Check lock PID
                 int pid = getpid();
-                EXPECT_EQ(mamba::Lock::read_pid(lock.fd()), pid);
+                EXPECT_EQ(mamba::LockFile::read_pid(lock.fd()), pid);
 
                 // Check lock status
                 EXPECT_LOCKED(lock);
@@ -102,6 +102,7 @@ namespace mamba
                 }
                 catch (...)
                 {
+                    std::cout << "convertion error" << std::endl;
                 }
                 EXPECT_TRUE(is_locked);
 
@@ -119,11 +120,12 @@ namespace mamba
                 }
                 catch (...)
                 {
+                    std::cout << "convertion error" << std::endl;
                 }
                 EXPECT_FALSE(new_lock_created);
 
                 // Check the PID hasn't changed
-                EXPECT_EQ(mamba::Lock::read_pid(lock.fd()), pid);
+                EXPECT_EQ(mamba::LockFile::read_pid(lock.fd()), pid);
             }
 
             fs::path lock_path = tempdir_path / "mamba.lock";
@@ -169,10 +171,10 @@ namespace mamba
         TEST_F(LockFileTest, same_pid)
         {
             {
-                auto lock = Lock(tempfile_path);
+                auto lock = LockFile(tempfile_path);
                 EXPECT_TRUE(fs::exists(lock.lockfile_path()));
 
-                EXPECT_THROW(Lock lock2(tempfile_path), std::logic_error);
+                EXPECT_THROW(LockFile lock2(tempfile_path), std::logic_error);
 
                 // check the first lock is still locked
                 EXPECT_TRUE(fs::exists(lock.lockfile_path()));
@@ -193,12 +195,12 @@ namespace mamba
 #endif
             {
                 // Create a lock
-                auto lock = Lock(tempfile_path);
+                auto lock = LockFile(tempfile_path);
                 EXPECT_TRUE(fs::exists(lock.lockfile_path()));
 
                 // Check lock PID
                 int pid = getpid();
-                EXPECT_EQ(mamba::Lock::read_pid(lock.fd()), pid);
+                EXPECT_EQ(mamba::LockFile::read_pid(lock.fd()), pid);
 
                 // Check lock status from current PID
                 EXPECT_LOCKED(lock);
@@ -217,6 +219,7 @@ namespace mamba
                 }
                 catch (...)
                 {
+                    std::cout << "convertion error" << std::endl;
                 }
                 EXPECT_TRUE(is_locked);
 
@@ -234,11 +237,12 @@ namespace mamba
                 }
                 catch (...)
                 {
+                    std::cout << "convertion error" << std::endl;
                 }
                 EXPECT_FALSE(new_lock_created);
 
                 // Check the PID hasn't changed
-                EXPECT_EQ(mamba::Lock::read_pid(lock.fd()), pid);
+                EXPECT_EQ(mamba::LockFile::read_pid(lock.fd()), pid);
             }
 
             fs::path lock_path = tempfile_path.string() + ".lock";

--- a/test/test_lockfile.cpp
+++ b/test/test_lockfile.cpp
@@ -26,7 +26,7 @@ namespace mamba
     namespace testing
     {
 #ifdef _WIN32
-#define EXPECT_LOCKED(lock) EXPECT_TRUE(mamba::Lock::is_locked(lock.path()));
+#define EXPECT_LOCKED(lock) EXPECT_TRUE(mamba::Lock::is_locked(lock.lockfile_path()));
 #else
 #define EXPECT_LOCKED(lock) EXPECT_TRUE(mamba::Lock::is_locked(lock.fd()));
 #endif
@@ -104,7 +104,6 @@ namespace mamba
                 {
                 }
                 EXPECT_TRUE(is_locked);
-
 
                 // Try to lock from another process
                 args = { lock_cli, "lock", "--timeout=1", tempdir_path };

--- a/test/test_thread_utils.cpp
+++ b/test/test_thread_utils.cpp
@@ -20,7 +20,7 @@ namespace mamba
         Console::instance().init_multi_progress();
         {
             interruption_guard g([&res]() {
-                // Test for double free (segfault if that happends)
+                // Test for double free (segfault if that happens)
                 std::cout << "Interruption guard is interrupting" << std::endl;
                 Console::instance().init_multi_progress();
                 {
@@ -43,9 +43,8 @@ namespace mamba
             }
             if (interrupt)
             {
-                pthread_kill(get_signal_receiver_thread_id(), SIGINT);
-                // sleep before resetting sig_interrupted
-                std::this_thread::sleep_for(std::chrono::milliseconds(1000));
+                stop_receiver_thread();
+                std::this_thread::sleep_for(std::chrono::milliseconds(10));
             }
         }
         return res;

--- a/test/testing/lock.cpp
+++ b/test/testing/lock.cpp
@@ -27,7 +27,7 @@ is_locked(const fs::path& path)
     // From another process than the lockfile one, we can open/close
     // a new file descriptor without risk to clear locks
     int fd = open(path.c_str(), O_RDWR | O_CREAT, 0666);
-    bool is_locked = mamba::LockFile::is_locked(fd);
+    bool is_locked = mamba::Lock::is_locked(fd);
     close(fd);
     return is_locked;
 #endif
@@ -48,7 +48,7 @@ main(int argc, char** argv)
         try
         {
             mamba::Lock lock(path);
-            std::cout << lock.locked();
+            std::cout << 1;
         }
         catch (std::runtime_error&)
         {

--- a/test/testing/lock.cpp
+++ b/test/testing/lock.cpp
@@ -1,0 +1,75 @@
+#include "mamba/core/context.hpp"
+#include "mamba/core/mamba_fs.hpp"
+#include "mamba/core/util.hpp"
+#include "mamba/core/thread_utils.hpp"
+
+#include <CLI/CLI.hpp>
+
+#if defined(__APPLE__) || defined(__linux__)
+#include <stdio.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <pthread.h>
+
+#include <csignal>
+#include <sys/file.h>
+#endif
+
+
+bool
+is_locked(const fs::path& path)
+{
+#ifdef _WIN32
+    return mamba::LockFile::is_locked(path);
+#else
+    // From another process than the lockfile one, we can open/close
+    // a new file descriptor without risk to clear locks
+    int fd = open(path.c_str(), O_RDWR | O_CREAT, 0666);
+    bool is_locked = mamba::LockFile::is_locked(fd);
+    close(fd);
+    return is_locked;
+#endif
+}
+
+int
+main(int argc, char** argv)
+{
+    CLI::App app{};
+    fs::path path;
+    int timeout = 1;
+
+    CLI::App* lock_com = app.add_subcommand("lock", "Lock a path");
+    lock_com->add_option("path", path, "Path to lock");
+    lock_com->add_option("-t,--timeout", timeout, "Timeout in seconds");
+    lock_com->callback([&]() {
+        mamba::Context::instance().lock_timeout = timeout;
+        try
+        {
+            mamba::Lock lock(path);
+            std::cout << lock.locked();
+        }
+        catch (std::runtime_error&)
+        {
+            std::cout << 0;
+        }
+    });
+
+    CLI::App* is_locked_com = app.add_subcommand("is-locked", "Check if a path is locked");
+    is_locked_com->add_option("path", path, "Path to check");
+    is_locked_com->callback([&]() { std::cout << (fs::exists(path) && is_locked(path)); });
+
+    try
+    {
+        CLI11_PARSE(app, argc, argv);
+    }
+    catch (const std::exception& e)
+    {
+        LOG_ERROR << e.what();
+        mamba::set_sig_interrupted();
+        return 1;
+    }
+
+    return 0;
+}

--- a/test/testing/lock.cpp
+++ b/test/testing/lock.cpp
@@ -22,7 +22,7 @@ bool
 is_locked(const fs::path& path)
 {
 #ifdef _WIN32
-    return mamba::LockFile::is_locked(path);
+    return mamba::Lock::is_locked(path);
 #else
     // From another process than the lockfile one, we can open/close
     // a new file descriptor without risk to clear locks

--- a/test/testing/lock.cpp
+++ b/test/testing/lock.cpp
@@ -22,12 +22,12 @@ bool
 is_locked(const fs::path& path)
 {
 #ifdef _WIN32
-    return mamba::Lock::is_locked(path);
+    return mamba::LockFile::is_locked(path);
 #else
     // From another process than the lockfile one, we can open/close
     // a new file descriptor without risk to clear locks
     int fd = open(path.c_str(), O_RDWR | O_CREAT, 0666);
-    bool is_locked = mamba::Lock::is_locked(fd);
+    bool is_locked = mamba::LockFile::is_locked(fd);
     close(fd);
     return is_locked;
 #endif
@@ -47,10 +47,10 @@ main(int argc, char** argv)
         mamba::Context::instance().lock_timeout = timeout;
         try
         {
-            mamba::Lock lock(path);
+            mamba::LockFile lock(path);
             std::cout << 1;
         }
-        catch (std::runtime_error&)
+        catch (...)
         {
             std::cout << 0;
         }


### PR DESCRIPTION
Description
---

- Handle files and directories locks
  - API is now `Lock` and takes the path *to* lock instead of the name of the supposed lock file
    - this allows to disambiguate a file path between the lock file or the file to be locked
  - `LockFile` is the holder of the file descriptor
    - it allows throwing in `Lock` constructor with a clean handling of the file descriptor (e.g. closing it)
- Handle multiple locks acquired on the same path
  - from the same process -> raise a `std::logic_error`
  - from the another process: try lock in a blocking way and raise a `std::runtime_error` is a timeout is set
    - on Windows, implement a timeout calling [_locking](https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/locking?view=msvc-160) with `_LK_LOCK` every seconds
      - which is similar to `_LK_NBLOCK` but with control over the timeout
      - allows infinite loops as on Unix systems
    - on Unix, call `fcntl` with `F_SETLKW` in a separate thread and cancel it if timeout is met
    - we could change the default behavior to avoid infinite loops later (setting the timeout to some large number)
- Improve logs
- Add tests
  - add another testing CMake target `mamba_test_lock` to have a CLI for testing `is_locked` and `lock` paths for subprocesses
  - check creation of one or multiple locks on the same path from both current and foreign processes
- Add `micromamba` CLI options/flags
  - `-l,--locks` to `micromamba clean` to remove lock files in caches
  - `--lock-timeout` to set the lock file timeout