### PR TITLE
Improve config umamba subcommand

### DIFF
--- a/include/mamba/api/configuration.hpp
+++ b/include/mamba/api/configuration.hpp
@@ -1703,6 +1703,7 @@ namespace mamba
     int const MAMBA_SHOW_CONFIG_LONG_DESCS = 1 << 3;
     int const MAMBA_SHOW_CONFIG_GROUPS = 1 << 4;
     int const MAMBA_SHOW_ALL_CONFIGS = 1 << 5;
+    int const MAMBA_SHOW_ALL_RC_CONFIGS = 1 << 6;
 
 
     /*****************

--- a/src/api/config.cpp
+++ b/src/api/config.cpp
@@ -47,6 +47,8 @@ namespace mamba
         auto show_sources
             = config.at("show_config_sources").value<bool>() ? MAMBA_SHOW_CONFIG_SRCS : 0;
         auto show_all = config.at("show_all_configs").value<bool>() ? MAMBA_SHOW_ALL_CONFIGS : 0;
+        auto show_all_rcs
+            = config.at("show_all_rc_configs").value<bool>() ? MAMBA_SHOW_ALL_RC_CONFIGS : 0;
         auto show_group
             = config.at("show_config_groups").value<bool>() ? MAMBA_SHOW_CONFIG_GROUPS : 0;
         auto show_desc
@@ -56,7 +58,7 @@ namespace mamba
                                   : 0;
         auto specs = config.at("specs").value<std::vector<std::string>>();
         int dump_opts = MAMBA_SHOW_CONFIG_VALUES | show_sources | show_desc | show_long_desc
-                        | show_group | show_all;
+                        | show_group | show_all_rcs | show_all;
 
         std::cout << config.dump(dump_opts, specs) << std::endl;
 

--- a/src/api/configuration.cpp
+++ b/src/api/configuration.cpp
@@ -895,27 +895,31 @@ namespace mamba
 
         insert(Configurable("show_all_configs", false)
                    .group("Output, Prompt and Flow Control")
-                   .description("Display all configurables, including not rc configurable"));
+                   .description("Display all configs, including not rc configurable"));
+
+        insert(Configurable("show_all_rc_configs", false)
+                   .group("Output, Prompt and Flow Control")
+                   .description("Display all rc configurable configs"));
 
         insert(Configurable("show_config_descriptions", false)
                    .group("Output, Prompt and Flow Control")
-                   .description("Display configurables descriptions"));
+                   .description("Display configs descriptions"));
 
         insert(Configurable("show_config_groups", false)
                    .group("Output, Prompt and Flow Control")
-                   .description("Display configurables groups"));
+                   .description("Display configs groups"));
 
         insert(Configurable("show_config_long_descriptions", false)
                    .group("Output, Prompt and Flow Control")
-                   .description("Display configurables long descriptions"));
+                   .description("Display configs long descriptions"));
 
         insert(Configurable("show_config_sources", false)
                    .group("Output, Prompt and Flow Control")
-                   .description("Display all identified configuration sources"));
+                   .description("Display all configs sources"));
 
         insert(Configurable("show_config_values", false)
                    .group("Output, Prompt and Flow Control")
-                   .description("Display configurables values"));
+                   .description("Display configs values"));
 
         insert(Configurable("quiet", &ctx.quiet)
                    .group("Output, Prompt and Flow Control")
@@ -1294,6 +1298,7 @@ namespace mamba
         bool show_descs = opts & MAMBA_SHOW_CONFIG_DESCS;
         bool show_long_descs = opts & MAMBA_SHOW_CONFIG_LONG_DESCS;
         bool show_groups = opts & MAMBA_SHOW_CONFIG_GROUPS;
+        bool show_all_rcs = opts & MAMBA_SHOW_ALL_RC_CONFIGS;
         bool show_all = opts & MAMBA_SHOW_ALL_CONFIGS;
 
         bool first_config = true;
@@ -1314,7 +1319,8 @@ namespace mamba
                     continue;
                 }
 
-                if ((c->rc_configurable() && c->configured()) || is_required || show_all)
+                if ((c->rc_configurable() && (c->configured() || show_all_rcs)) || is_required
+                    || show_all)
                 {
                     if (show_descs || show_long_descs)
                     {

--- a/src/micromamba/config.cpp
+++ b/src/micromamba/config.cpp
@@ -105,7 +105,7 @@ init_config_describe_options(CLI::App* subcom)
     auto& config = Configuration::instance();
 
     auto& specs = config.at("specs").get_wrapped<std::vector<std::string>>();
-    subcom->add_option("specs", specs.set_cli_config({}), specs.description());
+    subcom->add_option("configs", specs.set_cli_config({}), "Configuration keys");
 
     auto& show_long_descriptions = config.at("show_config_long_descriptions").get_wrapped<bool>();
     subcom->add_flag("-l,--long-descriptions",
@@ -127,7 +127,7 @@ init_config_list_options(CLI::App* subcom)
     auto& show_sources = config.at("show_config_sources").get_wrapped<bool>();
     subcom->add_flag("-s,--sources", show_sources.set_cli_config(0), show_sources.description());
 
-    auto& show_all = config.at("show_all_configs").get_wrapped<bool>();
+    auto& show_all = config.at("show_all_rc_configs").get_wrapped<bool>();
     subcom->add_flag("-a,--all", show_all.set_cli_config(0), show_all.description());
 
     auto& show_descriptions = config.at("show_config_descriptions").get_wrapped<bool>();


### PR DESCRIPTION
Description
---

- Add an extra `MAMBA_SHOW_ALL_RC_CONFIGS` for display to disambiguate with `MAMBA_SHOW_ALL_CONFIGS` in `Configuration::dump` options
- Use `-a,--all` flag of `micromamba config list` subcommand to only show rc configurable configs
- change config list and describe positional arg name and description

```bash
$ micromamba config list --help
...
Positionals:
  configs TEXT ...            Configuration keys
...
```