### PR TITLE
fix failing package cache checks

### DIFF
--- a/libmamba/src/core/package_cache.cpp
+++ b/libmamba/src/core/package_cache.cpp
@@ -187,7 +187,8 @@ namespace mamba
                     valid = true;
 
                     // we can only validate if we have at least one data point of these three
-                    can_validate = !s.md5.empty() || !s.sha256.empty();
+                    can_validate = (!s.md5.empty() && repodata_record.contains("md5"))
+                                   || (!s.sha256.empty() && repodata_record.contains("sha256"));
                     if (!can_validate)
                     {
                         if (Context::instance().safety_checks == VerificationLevel::kWarn)
@@ -218,7 +219,7 @@ namespace mamba
                     }
 
                     // Validate checksum
-                    if (!s.sha256.empty())
+                    if (!s.sha256.empty() && repodata_record.contains("sha256"))
                     {
                         // TODO handle case if repodata_record __does not__ contain any value
                         if (s.sha256 != repodata_record["sha256"].get<std::string>())
@@ -234,7 +235,7 @@ namespace mamba
                             valid = true;
                         }
                     }
-                    else if (!s.md5.empty())
+                    else if (!s.md5.empty() && repodata_record.contains("md5"))
                     {
                         // TODO handle case if repodata_record __does not__ contain any value
                         if (s.md5 != repodata_record["md5"].get<std::string>())


### PR DESCRIPTION
This should fix warnings such as

```
WARNING Extracted package cache '/Users/runner/miniforge3/pkgs/ca-certificates-2021.10.8-h033912b_0' has invalid 'repodata_record.json' file: [json.exception.type_error.302] type must be string, but is null
WARNING Extracted package cache '/Users/runner/miniforge3/pkgs/libcxx-12.0.1-habf9029_0' has invalid 'repodata_record.json' file: [json.exception.type_error.302] type must be string, but is null
WARNING Extracted package cache '/Users/runner/miniforge3/pkgs/libffi-3.4.2-he49afe7_4' has invalid 'repodata_record.json' file: [json.exception.type_error.302] type must be string, but is null
WARNING Extracted package cache '/Users/runner/miniforge3/pkgs/libzlib-1.2.11-h9173be1_1013' has invalid 'repodata_record.json' file: [json.exception.type_error.302] type must be string, but is null
WARNING Extracted package cache '/Users/runner/miniforge3/pkgs/ncurses-6.2-h2e338ed_4' has invalid 'repodata_record.json' file: [json.exception.type_error.302] type must be string, but is null
WARNING Extracted package cache '/Users/runner/miniforge3/pkgs/openssl-1.1.1l-h0d85af4_0' has invalid 'repodata_record.json' file: [json.exception.type_error.302] type must be string, but is null
WARNING Extracted package cache '/Users/runner/miniforge3/pkgs/readline-8.1-h05e3726_0' has invalid 'repodata_record.json' file: [json.exception.type_error.302] type must be string, but is null
WARNING Extracted package cache '/Users/runner/miniforge3/pkgs/xz-5.2.5-haf1e3a3_1' has invalid 'repodata_record.json' file: [json.exception.type_error.302] type must be string, but is null
WARNING Extracted package cache '/Users/runner/miniforge3/pkgs/yaml-0.2.5-haf1e3a3_0' has invalid 'repodata_record.json' file: [json.exception.type_error.302] type must be string, but is null
WARNING Extracted package cache '/Users/runner/miniforge3/pkgs/zlib-1.2.11-h9173be1_1013' has invalid 'repodata_record.json' file: [json.exception.type_error.302] type must be string, but is null
```

Seen in the Azure logs from conda-forge