### PR TITLE
Improve pyc compilation

### DIFF
--- a/libmamba/include/mamba/core/context.hpp
+++ b/libmamba/include/mamba/core/context.hpp
@@ -175,6 +175,8 @@ namespace mamba
 
         std::size_t lock_timeout = 0;
 
+        bool compile_pyc = true;
+
         // Conda compat
         bool add_pip_as_python_dependency = true;
 

--- a/libmamba/include/mamba/core/transaction_context.hpp
+++ b/libmamba/include/mamba/core/transaction_context.hpp
@@ -25,7 +25,7 @@ namespace mamba
     class TransactionContext
     {
     public:
-        TransactionContext() = default;
+        TransactionContext();
         TransactionContext(const fs::path& prefix, const std::string& py_version);
 
         bool has_python;
@@ -37,6 +37,7 @@ namespace mamba
         bool allow_softlinks = false;
         bool always_copy = false;
         bool always_softlink = false;
+        bool compile_pyc = true;
     };
 }  // namespace mamba
 

--- a/libmamba/src/api/configuration.cpp
+++ b/libmamba/src/api/configuration.cpp
@@ -862,6 +862,12 @@ namespace mamba
                         LockFile timeout for blocking mode when waiting for another process
                         to release the path. Default is 0 (no timeout))")));
 
+        insert(Configurable("compile_pyc", &ctx.compile_pyc)
+                   .group("Extract, Link & Install")
+                   .set_rc_configurable()
+                   .set_env_var_names()
+                   .description("Defines if PYC files will be compiled or not"));
+
         // Output, Prompt and Flow
         insert(Configurable("always_yes", &ctx.always_yes)
                    .group("Output, Prompt and Flow Control")

--- a/libmamba/src/api/install.cpp
+++ b/libmamba/src/api/install.cpp
@@ -538,6 +538,10 @@ namespace mamba
         MultiPackageCache pkg_caches({ pkgs_dirs });
         auto transaction = create_explicit_transaction_from_urls(pool, specs, pkg_caches);
 
+        prefix_data.load();
+        prefix_data.add_virtual_packages(get_virtual_packages());
+        MRepo(pool, prefix_data);
+
         std::vector<MRepo*> repo_ptrs;
 
         if (ctx.json)

--- a/libmamba/src/core/link.cpp
+++ b/libmamba/src/core/link.cpp
@@ -1192,15 +1192,21 @@ namespace mamba
                 }
             }
 
-            std::vector<fs::path> pyc_files = compile_pyc_files(for_compilation);
-
-            for (const fs::path& pyc_path : pyc_files)
+            if (m_context->compile_pyc)
             {
-                out_json["paths_data"]["paths"].push_back(
-                    { { "_path", std::string(pyc_path) }, { "path_type", "pyc_file" } });
+                LOG_INFO << "Compiling '.pyc' files";
+                std::vector<fs::path> pyc_files = compile_pyc_files(for_compilation);
 
-                out_json["files"].push_back(pyc_path);
+                for (const fs::path& pyc_path : pyc_files)
+                {
+                    out_json["paths_data"]["paths"].push_back(
+                        { { "_path", std::string(pyc_path) }, { "path_type", "pyc_file" } });
+
+                    out_json["files"].push_back(pyc_path);
+                }
             }
+            else
+                LOG_INFO << "Skipping '.pyc' files compilation";
 
             if (link_json.find("noarch") != link_json.end()
                 && link_json["noarch"].find("entry_points") != link_json["noarch"].end())

--- a/libmamba/src/core/transaction_context.cpp
+++ b/libmamba/src/core/transaction_context.cpp
@@ -69,12 +69,18 @@ namespace mamba
         }
     }
 
+    TransactionContext::TransactionContext()
+    {
+        compile_pyc = Context::instance().compile_pyc;
+    }
+
     TransactionContext::TransactionContext(const fs::path& prefix, const std::string& py_version)
         : has_python(py_version.size() != 0)
         , target_prefix(prefix)
         , python_version(py_version)
     {
         auto& ctx = Context::instance();
+        compile_pyc = ctx.compile_pyc;
         allow_softlinks = ctx.allow_softlinks;
         always_copy = ctx.always_copy;
         always_softlink = ctx.always_softlink;

--- a/micromamba/src/common_options.cpp
+++ b/micromamba/src/common_options.cpp
@@ -305,6 +305,9 @@ init_install_options(CLI::App* subcom)
     auto& no_py_pin = config.at("no_py_pin").get_wrapped<bool>();
     subcom->add_flag("--no-py-pin,!--py-pin", no_py_pin.set_cli_config(0), no_py_pin.description());
 
+    auto& compile_pyc = config.at("compile_pyc").get_wrapped<bool>();
+    subcom->add_flag("--pyc,!--no-pyc", compile_pyc.set_cli_config(0), compile_pyc.description());
+
     auto& allow_softlinks = config.at("allow_softlinks").get_wrapped<bool>();
     subcom->add_flag("--allow-softlinks,!--no-allow-softlinks",
                      allow_softlinks.set_cli_config(0),

--- a/micromamba/tests/test_install.py
+++ b/micromamba/tests/test_install.py
@@ -497,3 +497,25 @@ class TestInstall:
 
         for pkg in res["actions"]["LINK"]:
             assert pkg["channel"].startswith("https://conda.anaconda.org/conda-forge/")
+
+    def test_explicit_noarch(self, existing_cache):
+        install("python", no_dry_run=True)
+
+        channel = "https://conda.anaconda.org/conda-forge/noarch/"
+        explicit_spec = channel + "appdirs-1.4.4-pyh9f0ad1d_0.tar.bz2#5f095bc6454094e96f146491fd03633b"
+        file_content = ["@EXPLICIT", explicit_spec]
+
+        spec_file = os.path.join(TestInstall.root_prefix, "explicit_specs_no_arch.txt")
+        with open(spec_file, "w") as f:
+            f.write("\n".join(file_content))
+
+        cmd = ("-p", TestInstall.prefix, "-q", "-f", spec_file)
+
+        install(*cmd, default_channel=False)
+
+        list_res = umamba_list("-p", TestInstall.prefix, "--json")
+        pkgs = [p for p in list_res if p["name"] == "appdirs"]
+        assert len(pkgs) == 1
+        pkg = pkgs[0]
+        assert pkg["version"] == "1.4.4"
+        assert pkg["build_string"] == "pyh9f0ad1d_0"

--- a/micromamba/tests/test_install.py
+++ b/micromamba/tests/test_install.py
@@ -502,7 +502,10 @@ class TestInstall:
         install("python", no_dry_run=True)
 
         channel = "https://conda.anaconda.org/conda-forge/noarch/"
-        explicit_spec = channel + "appdirs-1.4.4-pyh9f0ad1d_0.tar.bz2#5f095bc6454094e96f146491fd03633b"
+        explicit_spec = (
+            channel
+            + "appdirs-1.4.4-pyh9f0ad1d_0.tar.bz2#5f095bc6454094e96f146491fd03633b"
+        )
         file_content = ["@EXPLICIT", explicit_spec]
 
         spec_file = os.path.join(TestInstall.root_prefix, "explicit_specs_no_arch.txt")


### PR DESCRIPTION
Description
---

Fix pyc compilation when using explicit spec but also make it optional:
- add target prefix as installed repo in `install_explicit_specs`
- detect missing Python, warn and skip compilation
- add capability to skip pyc compilation using a config value
  - add `compile_pyc` in `Context` and `TransactionContext`
  - add `compile_pyc` configurable, make it env var (using `MAMBA_COMPILE_PYC`) and rc configurable (using `compile_pyc`)
  - add `micromamba` CLI flags `--pyc,--no-pyc`
- also catch wrong Python version conversion from string
- add test

Closes #1244 
Closes #1206