### PR TITLE
Test that missing file doesn't cause an unlink error

### DIFF
--- a/libmamba/src/core/link.cpp
+++ b/libmamba/src/core/link.cpp
@@ -680,7 +680,11 @@ namespace mamba
     {
         std::string subtarget = path_data["_path"].get<std::string>();
         fs::path dst = m_context->target_prefix / subtarget;
-        fs::remove(dst);
+
+        LOG_TRACE << "Unlinking '" << dst.string() << "'";
+        std::error_code err;
+        if (!fs::remove(dst, err))
+            LOG_DEBUG << "Error when removing file '" << dst.string() << "' will be ignored";
 
         // TODO what do we do with empty directories?
         // remove empty parent path
@@ -697,7 +701,9 @@ namespace mamba
     {
         // find the recorded JSON file
         fs::path json = m_context->target_prefix / "conda-meta" / (m_specifier + ".json");
-        LOG_INFO << "unlink: opening " << json << std::endl;
+        LOG_INFO << "Unlinking package '" << m_specifier << "'";
+        LOG_DEBUG << "Use metadata found at '" << json.string() << "'";
+
         std::ifstream json_file(json);
         nlohmann::json json_record;
         json_file >> json_record;

--- a/micromamba/tests/test_linking.py
+++ b/micromamba/tests/test_linking.py
@@ -121,3 +121,13 @@ class TestLinking:
         assert cache_file.stat().st_dev == linked_file.stat().st_dev
         assert (cache_file.stat().st_ino == linked_file.stat().st_ino) == is_hardlink
         assert linked_file.is_symlink() == is_softlink
+
+    def test_unlink_missing_file(self):
+        create("xtensor", "-n", TestLinking.env_name, "--json", no_dry_run=True)
+
+        linked_file = get_env(TestLinking.env_name, xtensor_hpp)
+        assert linked_file.exists()
+        assert not linked_file.is_symlink()
+
+        os.remove(linked_file)
+        remove("xtensor", "-n", TestLinking.env_name)


### PR DESCRIPTION
Description
---

Test that missing file doesn't cause an unlink error
Improve logs to emit a debug log when a file is missing and add a trace log for every file unlinked (equivalent to link logs)

Closes #1067