### PR TITLE
Fix shell init with relative paths

### DIFF
--- a/micromamba/tests/test_shell.py
+++ b/micromamba/tests/test_shell.py
@@ -213,11 +213,9 @@ class TestShell:
         skip_if_shell_incompat(shell_type)
 
         if prefix_selector is None:
-            with pytest.raises(subprocess.CalledProcessError):
-                shell("-y", "init", "-s", shell_type)
-            return
-
-        res = shell("-y", "init", "-s", shell_type, "-p", TestShell.root_prefix)
+            res = shell("-y", "init", "-s", shell_type)
+        else:
+            res = shell("-y", "init", "-s", shell_type, "-p", TestShell.root_prefix)
         assert res
 
         if multiple_time:


### PR DESCRIPTION
Description
---

Expand relative paths in `micromamba shell init` sub-command
Also accept missing prefix and use root prefix as fallback

This fixes calls like `micromamba shell init -p ./micromamba`:
```bash
$ micromamba shell init ./micromamba/
Modifiying RC file "/home/adrien/.bashrc"
Generating config for root prefix "/home/adrien/micromamba"
Setting mamba executable to: "<path-to-executable>/micromamba"
Adding (or replacing) the following in your "/home/adrien/.bashrc" file
# >>> mamba initialize >>>
# !! Contents within this block are managed by 'mamba init' !!
export MAMBA_EXE="<path-to-executable>/micromamba";
export MAMBA_ROOT_PREFIX="/home/adrien/micromamba";
(...)
unset __mamba_setup
# <<< mamba initialize <<<
```
This makes possible to run `micromamba shell init`:
- the shell is automatically detected
- the prefix is defaulted to root prefix

Closes https://github.com/mamba-org/mamba/issues/1207