### PR TITLE
Fix not thrown error in multiple caches logic

### DIFF
--- a/libmamba/src/core/package_cache.cpp
+++ b/libmamba/src/core/package_cache.cpp
@@ -68,7 +68,7 @@ namespace mamba
         {
             if (fs::is_regular_file(magic_file))
             {
-                LOG_TRACE << "'" << magic_file << "' exists, checking if writable";
+                LOG_TRACE << "'" << magic_file.string() << "' exists, checking if writable";
                 if (path::is_writable(magic_file))
                 {
                     m_writable = Writable::WRITABLE;

--- a/libmamba/src/core/subdirdata.cpp
+++ b/libmamba/src/core/subdirdata.cpp
@@ -283,7 +283,7 @@ namespace mamba
                 if (writable_cache_path.empty())
                 {
                     LOG_ERROR << "Could not find any writable cache directory for repodata file";
-                    std::runtime_error("Non-writable cache error.");
+                    throw std::runtime_error("Non-writable cache error.");
                 }
 
                 LOG_DEBUG << "Copying repodata cache files from '" << m_expired_cache_path.string()
@@ -327,6 +327,14 @@ namespace mamba
             m_loaded = true;
             m_temp_file.reset(nullptr);
             return true;
+        }
+        else
+        {
+            if (writable_cache_path.empty())
+            {
+                LOG_ERROR << "Could not find any writable cache directory for repodata file";
+                throw std::runtime_error("Non-writable cache error.");
+            }
         }
 
         LOG_DEBUG << "Finalized transfer of '" << m_repodata_url << "'";


### PR DESCRIPTION
Description
---

- Fix not thrown error when no writable cache provided
- Also throw if no writable cache provided and http status is not 304 (e.g. repodata changed)
  - avoid creation of the cache in the current working dir (if writable)
  - avoid throwing an error when creating the `<cache>/cache` dir (if current working dir is not writable)