### PR TITLE
Improve logging on YAML errors

### DIFF
--- a/libmamba/include/mamba/api/configuration.hpp
+++ b/libmamba/include/mamba/api/configuration.hpp
@@ -1332,7 +1332,8 @@ namespace mamba
                 }
                 catch (const YAML::Exception& e)
                 {
-                    LOG_ERROR << "Bad conversion of configurable '" << name() << "'";
+                    LOG_ERROR << "Bad conversion of configurable '" << name() << "' with value '"
+                              << value << "'";
                     throw e;
                 }
             };
@@ -1826,8 +1827,18 @@ namespace mamba
                 auto env_var_value = env::get(env_var);
                 if (!env_var_value.empty())
                 {
-                    m_sources.push_back(env_var);
-                    m_values.insert({ env_var, detail::Source<T>::deserialize(env_var_value) });
+                    try
+                    {
+                        m_values.insert({ env_var, detail::Source<T>::deserialize(env_var_value) });
+                        m_sources.push_back(env_var);
+                    }
+                    catch (const YAML::Exception& e)
+                    {
+                        LOG_ERROR << "Bad conversion of configurable '" << name()
+                                  << "' from environment variable '" << env_var << "' with value '"
+                                  << env_var_value << "'";
+                        throw e;
+                    }
                 }
             }
         }

--- a/libmamba/src/api/install.cpp
+++ b/libmamba/src/api/install.cpp
@@ -126,7 +126,7 @@ namespace mamba
             }
             catch (YAML::Exception& e)
             {
-                LOG_ERROR << "Error in spec file: " << yaml_file;
+                LOG_ERROR << "YAML error in spec file '" << yaml_file.string() << "'";
             }
 
             YAML::Node deps = f["dependencies"];
@@ -189,8 +189,9 @@ namespace mamba
                 }
                 catch (YAML::Exception& e)
                 {
-                    throw std::runtime_error(mamba::concat(
-                        "Could not read 'channels' as list of strings from ", yaml_file.string()));
+                    LOG_ERROR << "Could not read 'channels' as list of strings from '"
+                              << yaml_file.string() << "'";
+                    throw e;
                 }
             }
             else

--- a/libmamba/src/api/install.cpp
+++ b/libmamba/src/api/install.cpp
@@ -118,18 +118,34 @@ namespace mamba
 
         yaml_file_contents read_yaml_file(fs::path yaml_file)
         {
+            auto file = fs::weakly_canonical(env::expand_user(yaml_file));
+            if (!fs::exists(file))
+            {
+                LOG_ERROR << "YAML spec file '" << file.string() << "' not found";
+                throw std::runtime_error("File not found. Aborting.");
+            }
+
             yaml_file_contents result;
             YAML::Node f;
             try
             {
-                f = YAML::LoadFile(yaml_file);
+                f = YAML::LoadFile(file);
             }
             catch (YAML::Exception& e)
             {
-                LOG_ERROR << "YAML error in spec file '" << yaml_file.string() << "'";
+                LOG_ERROR << "YAML error in spec file '" << file.string() << "'";
+                throw e;
             }
 
-            YAML::Node deps = f["dependencies"];
+            YAML::Node deps;
+            if (f["dependencies"] && f["dependencies"].IsSequence() && f["dependencies"].size() > 0)
+                deps = f["dependencies"];
+            else
+            {
+                LOG_ERROR << "No 'dependencies' specified in YAML spec file '" << file.string()
+                          << "'";
+                throw std::runtime_error("Invalid spec file. Aborting.");
+            }
             YAML::Node final_deps;
 
             bool has_pip_deps = false;
@@ -174,7 +190,17 @@ namespace mamba
                 }
             }
 
-            std::vector<std::string> dependencies = final_deps.as<std::vector<std::string>>();
+            std::vector<std::string> dependencies;
+            try
+            {
+                dependencies = final_deps.as<std::vector<std::string>>();
+            }
+            catch (const YAML::Exception& e)
+            {
+                LOG_ERROR << "Bad conversion of 'dependencies' to a vector of string: "
+                          << final_deps;
+                throw e;
+            }
 
             if (has_pip_deps && !std::count(dependencies.begin(), dependencies.end(), "pip"))
                 dependencies.push_back("pip");
@@ -189,14 +215,14 @@ namespace mamba
                 }
                 catch (YAML::Exception& e)
                 {
-                    LOG_ERROR << "Could not read 'channels' as list of strings from '"
-                              << yaml_file.string() << "'";
+                    LOG_ERROR << "Could not read 'channels' as vector of strings from '"
+                              << file.string() << "'";
                     throw e;
                 }
             }
             else
             {
-                LOG_DEBUG << "No 'channels' specified in file: " << yaml_file;
+                LOG_DEBUG << "No 'channels' specified in YAML spec file '" << file.string() << "'";
             }
 
             if (f["name"])
@@ -204,7 +230,7 @@ namespace mamba
                 result.name = f["name"].as<std::string>();
             }
             {
-                LOG_DEBUG << "No env 'name' specified in file: " << yaml_file;
+                LOG_DEBUG << "No env 'name' specified in YAML spec file '" << file.string() << "'";
             }
             return result;
         }


### PR DESCRIPTION
Description
---

Improve YAML logged errors
- give more info about conversion error of env vars
- log and throw when not existing spec file
- log and throw when spec file doesn't contain `dependencies` key
- improve logs if `dependencies` is empty

Environment variable bad conversion:
```
$ MAMBA_ALLOW_SOFTLINKS=badtype micromamba create -q -n test xtensor
ERROR   Bad conversion of configurable 'allow_softlinks' from environment variable 'MAMBA_ALLOW_SOFTLINKS' with value 'badtype'
ERROR   yaml-cpp: error at line 1, column 1: bad conversion
```

YAML spec file not existing:
```
$ micromamba create -q -f sec.yml 
ERROR   YAML spec file 'sec.yml' not found
ERROR   File not found. Aborting.
```

Invalid YAML spec file
```
$ micromamba create -q -f spec.yml 
ERROR   YAML error in spec file '/home/adrien/sandbox/spec.yml'
ERROR   yaml-cpp: error at line 5, column 1: end of sequence flow not found
```

YAML spec file with missing `dependencies` key 
```
$ micromamba create -q -f spec.yml 
ERROR   No 'dependencies' specified in YAML spec file '/home/adrien/sandbox/spec.yml'
ERROR   Invalid spec file. Aborting.
```

Closes #1136 
Closes #1146