### PR TITLE
Make `show_banner` configurable

### DIFF
--- a/libmamba/src/api/configuration.cpp
+++ b/libmamba/src/api/configuration.cpp
@@ -954,6 +954,8 @@ namespace mamba
 
         insert(Configurable("show_banner", true)
                    .group("Output, Prompt and Flow Control")
+                   .set_rc_configurable()
+                   .set_env_var_names()
                    .needs({ "quiet", "json" })
                    .set_single_op_lifetime()
                    .description("Show the banner"));


### PR DESCRIPTION
Description
---

Make `show_banner` env var and rc configurable.
rc value doesn't have impact on `mamba` yet since it's using `conda` to read/load configs from rc files.
`micromamba` takes full benefit of both env var (`MAMBA_SHOW_BANNER`) and rc configurable (`show_banner`)