### PR TITLE
Conditionally import libmambapy bindings for cross-compiling

### DIFF
--- a/libmambapy/libmambapy/__init__.py
+++ b/libmambapy/libmambapy/__init__.py
@@ -1,1 +1,4 @@
-from libmambapy.bindings import *  # noqa: F401,F403
+try:
+    from libmambapy.bindings import *  # noqa: F401,F403
+except ImportError:
+    pass


### PR DESCRIPTION
Description
---

Conditionally import libmambapy bindings for cross-compiling:
- when version is imported by `pip install` it currenly also tries to import the bindings
- catch import error to fix cross compiling osx arm64
