### PR TITLE
Add zsh completion

### DIFF
--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -151,7 +151,7 @@ Windows
 Shell completion
 ================
 
-For now, only ``micromamba`` provides shell completion on ``bash``.
+For now, only ``micromamba`` provides shell completion on ``bash`` and ``zsh``.
 
 To activate it, it's as simple as running:
 
@@ -159,10 +159,11 @@ To activate it, it's as simple as running:
 
   micromamba shell completion
 
-.. note::
-  This command will only work on ``bash``
+The completion is now available in any new shell opened or in the current shell after sourcing the configuration file to take modifications into account.
 
-The completion is now available in any new shell opened or in the current shell after running ``source ~/.bashrc`` to take modifications into account.
+.. code::
+
+  source ~/.<shell>rc
 
 | Just hit ``<TAB><TAB>`` to get completion when typing your command.
 | For example the following command will help you to pick a named environment to activate:

--- a/micromamba/src/completer.zsh
+++ b/micromamba/src/completer.zsh
@@ -1,0 +1,13 @@
+R"MAMBARAW(
+# >>> umamba completion >>>
+autoload -U +X compinit && compinit     
+autoload -U +X bashcompinit && bashcompinit
+
+_umamba_completions()
+{
+  COMPREPLY=($(micromamba completer "${(@s: :)${(@s: :)COMP_LINE}:1}"))
+}
+
+complete -o default -F _umamba_completions micromamba
+# <<< umamba completion <<<
+)MAMBARAW"

--- a/micromamba/src/completer.zsh
+++ b/micromamba/src/completer.zsh
@@ -1,6 +1,6 @@
 R"MAMBARAW(
 # >>> umamba completion >>>
-autoload -U +X compinit && compinit     
+autoload -U +X compinit && compinit
 autoload -U +X bashcompinit && bashcompinit
 
 _umamba_completions()

--- a/micromamba/src/umamba.hpp
+++ b/micromamba/src/umamba.hpp
@@ -66,6 +66,9 @@ namespace
     constexpr const char umamba_bash_completion[] =
 #include "./completer.bash"
         ;
+    constexpr const char umamba_zsh_completion[] =
+#include "./completer.zsh"
+        ;
 }
 
 #endif


### PR DESCRIPTION
Description
---

Add `zsh` completion:
- use `bashcompinit` in `zsh`
- add custom `zsh` completer script to have working `COMPREPLY`
- update documentation

Closes #1262 