### PR TITLE
Prepare 2021.11.17 release

### DIFF
--- a/libmamba/CHANGELOG.md
+++ b/libmamba/CHANGELOG.md
@@ -1,3 +1,26 @@
+0.18.0 (November 17, 2021)
+==========================
+
+New features
+- Implement parallel packages extraction using subprocesses (@jonashaag @adriendelsalle) #1195
+- Add channel URLs to info (@jonashaag) #1235
+- Read custom_multichannels from .condarc (@jonashaag) #1240
+- Improve pyc compilation, make it configurable (@adriendelsalle) #1249
+- Use `spdlog` for nicer and configurable logs (@adriendelsalle) #1255
+- Make show_banner rc and env_var configurable (@adriendelsalle) #1257
+- Add info JSON output (@adriendelsalle) #1271
+
+Bug fixes
+- Fix failing package cache checks (@wolfv) #1237
+- Improve catching of reproc errors (such as OOM-killed) (@adriendelsalle) #1250
+- Fix shell init with relative paths (@adriendelsalle) #1252
+- Fix not thrown error in multiple caches logic (@adriendelsalle) #1253
+
+General improvements
+- Split projects, improve CMake options (@adriendelsalle) #1219 #1243
+- Test that a missing file doesn't cause an unlink error (@adriendelsalle) #1251
+- Improve logging on YAML errors (@adriendelsalle) #1254
+
 0.17.0 (October 13, 2021)
 =========================
 

--- a/libmamba/include/mamba/core/context.hpp
+++ b/libmamba/include/mamba/core/context.hpp
@@ -97,6 +97,7 @@ namespace mamba
     class Context
     {
     public:
+        std::string caller_version = "";
         std::string conda_version = "3.8.0";
         std::string current_command = "mamba";
         std::string custom_banner = "";

--- a/libmamba/include/mamba/version.hpp
+++ b/libmamba/include/mamba/version.hpp
@@ -11,7 +11,7 @@
 #include <string>
 
 #define LIBMAMBA_VERSION_MAJOR 0
-#define LIBMAMBA_VERSION_MINOR 17
+#define LIBMAMBA_VERSION_MINOR 18
 #define LIBMAMBA_VERSION_PATCH 0
 
 // Binary version
@@ -21,7 +21,7 @@
 
 #define LIBMAMBA_VERSION                                                                           \
     (LIBMAMBA_VERSION_MAJOR * 10000 + LIBMAMBA_VERSION_MINOR * 100 + LIBMAMBA_VERSION_PATCH)
-#define LIBMAMBA_VERSION_STRING "0.17.0"
+#define LIBMAMBA_VERSION_STRING "0.18.0"
 
 namespace mamba
 {

--- a/libmamba/src/api/info.cpp
+++ b/libmamba/src/api/info.cpp
@@ -133,7 +133,10 @@ namespace mamba
             };
             items.push_back({ "populated config files", sources });
 
-            items.push_back({ "micromamba version", version() });
+            items.push_back({ "libmamba version", version() });
+
+            if (ctx.is_micromamba && !ctx.caller_version.empty())
+                items.push_back({ "micromamba version", ctx.caller_version });
 
             std::vector<std::string> virtual_pkgs;
             for (auto pkg : get_virtual_packages())

--- a/libmambapy/CHANGELOG.md
+++ b/libmambapy/CHANGELOG.md
@@ -1,3 +1,9 @@
+0.18.0 (November 17, 2021)
+==========================
+
+New features
+- Create a separate target for Python bindings, split projects, improve CMake options (@adriendelsalle) #1219 #1243
+
 0.17.0 (October 13, 2021)
 =========================
 

--- a/libmambapy/libmambapy/_version.py
+++ b/libmambapy/libmambapy/_version.py
@@ -1,2 +1,2 @@
-version_info = (0, 17, 0)
+version_info = (0, 18, 0)
 __version__ = ".".join(map(str, version_info))

--- a/mamba/CHANGELOG.md
+++ b/mamba/CHANGELOG.md
@@ -1,3 +1,16 @@
+0.18.0 (November 17, 2021)
+==========================
+
+New features
+- Make mamba env download and extract using `libmamba` (@adriendelsalle) #1270
+
+Bug fixes
+- Use libmamba LockFile, add `clean --lock` flag (@adriendelsalle) #1238
+
+General improvements
+- Make dependency on `libmambapy` Python bindings, split projects, improve CMake options (@adriendelsalle) #1219 #1243
+- Conditionally import bindings for cross-compiling (@adriendelsalle) #1263
+
 0.17.0 (October 13, 2021)
 =========================
 

--- a/mamba/mamba/_version.py
+++ b/mamba/mamba/_version.py
@@ -1,2 +1,2 @@
-version_info = (0, 17, 0)
+version_info = (0, 18, 0)
 __version__ = ".".join(map(str, version_info))

--- a/micromamba/CHANGELOG.md
+++ b/micromamba/CHANGELOG.md
@@ -1,3 +1,25 @@
+0.18.0 (November 17, 2021)
+==========================
+
+New features
+- Parallel packages extraction using subproc (@jonashaag @adriendelsalle) #1195
+- Improve bash completion (activate sub-command, directories completion) (@adriendelsalle) #1234
+- Add channel URLs to info (@jonashaag) #1235
+- Make pyc compilation configurable using `--pyc,--no-pyc` flags (@adriendelsalle) #1249
+- Add `--log-level` option to control log level independently of verbosity (@adriendelsalle) #1255
+- Add zsh completion (@adriendelsalle) #1269
+- Add info JSON output and `--json` CLI flag (@adriendelsalle) #1271
+
+Bug fixes
+- Init all powershell profiles (@adriendelsalle) #1226
+- Fix multiple activations in Windows bash (@adriendelsalle) #1228
+
+Docs
+- Document fish support (@izahn) #1216
+
+General improvements
+- Split projects, improve CMake options (@adriendelsalle) #1219 #1243
+
 0.17.0 (October 13, 2021)
 =========================
 

--- a/micromamba/CMakeLists.txt
+++ b/micromamba/CMakeLists.txt
@@ -37,11 +37,13 @@ set(MICROMAMBA_SRCS
     ${CMAKE_CURRENT_SOURCE_DIR}/src/shell.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/umamba.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/update.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/version.cpp
 )
 
 set(MICROMAMBA_HEADERS
     ${CMAKE_CURRENT_SOURCE_DIR}/src/common_options.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/umamba.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/version.hpp
 )
 
 add_executable(micromamba ${MICROMAMBA_SRCS} ${MICROMAMBA_HEADERS})

--- a/micromamba/src/umamba.cpp
+++ b/micromamba/src/umamba.cpp
@@ -4,11 +4,11 @@
 //
 // The full license is in the file LICENSE, distributed with this software.
 
-#include "mamba/version.hpp"
-
+#include "version.hpp"
 #include "common_options.hpp"
 #include "umamba.hpp"
 
+#include "mamba/version.hpp"
 #include "mamba/core/context.hpp"
 
 #include "termcolor/termcolor.hpp"
@@ -28,8 +28,11 @@ set_umamba_command(CLI::App* com)
 {
     init_umamba_options(com);
 
+    Context::instance().caller_version = umamba::version();
+
     auto print_version = [](int count) {
-        std::cout << version() << std::endl;
+        std::cout << "micromamba: " << umamba::version() << "\nlibmamba: " << mamba::version()
+                  << std::endl;
         exit(0);
     };
 

--- a/micromamba/src/version.cpp
+++ b/micromamba/src/version.cpp
@@ -1,0 +1,21 @@
+// Copyright (c) 2019, QuantStack and Mamba Contributors
+//
+// Distributed under the terms of the BSD 3-Clause License.
+//
+// The full license is in the file LICENSE, distributed with this software.
+
+#include "version.hpp"
+
+
+namespace umamba
+{
+    std::string version()
+    {
+        return UMAMBA_VERSION_STRING;
+    }
+
+    std::array<int, 3> version_arr()
+    {
+        return { UMAMBA_VERSION_MAJOR, UMAMBA_VERSION_MINOR, UMAMBA_VERSION_PATCH };
+    }
+}

--- a/micromamba/src/version.hpp
+++ b/micromamba/src/version.hpp
@@ -1,0 +1,33 @@
+// Copyright (c) 2019, QuantStack and Mamba Contributors
+//
+// Distributed under the terms of the BSD 3-Clause License.
+//
+// The full license is in the file LICENSE, distributed with this software.
+
+#ifndef UMAMBA_VERSION_HPP
+#define UMAMBA_VERSION_HPP
+
+#include <array>
+#include <string>
+
+#define UMAMBA_VERSION_MAJOR 0
+#define UMAMBA_VERSION_MINOR 18
+#define UMAMBA_VERSION_PATCH 0
+
+// Binary version
+#define UMAMBA_BINARY_CURRENT 1
+#define UMAMBA_BINARY_REVISION 0
+#define UMAMBA_BINARY_AGE 0
+
+#define UMAMBA_VERSION                                                                             \
+    (UMAMBA_VERSION_MAJOR * 10000 + UMAMBA_VERSION_MINOR * 100 + UMAMBA_VERSION_PATCH)
+#define UMAMBA_VERSION_STRING "0.18.0"
+
+namespace umamba
+{
+    std::string version();
+
+    std::array<int, 3> version_arr();
+}
+
+#endif


### PR DESCRIPTION
Description
--

update changelogs
bump versions to `0.18.0` for all packages (`libmamba`, `libmambapy`, `mamba` and `micromamba`)
add `micromamba` independent version
print both `libmamba` and `micromamba` version in umamba CLI