### PR TITLE
Fix `mamba` log level

### DIFF
--- a/libmamba/include/mamba/core/context.hpp
+++ b/libmamba/include/mamba/core/context.hpp
@@ -133,6 +133,7 @@ namespace mamba
         long max_parallel_downloads = 5;
         int verbosity = 0;
         void set_verbosity(int lvl);
+        void set_log_level(const spdlog::level::level_enum& level);
 
         spdlog::level::level_enum log_level = spdlog::level::level_enum::warn;
         std::string log_pattern = "%^%-8!l%$ %v";

--- a/libmamba/src/api/configuration.cpp
+++ b/libmamba/src/api/configuration.cpp
@@ -294,14 +294,14 @@ namespace mamba
                 }
                 else
                 {
-                    ctx.set_verbosity(lvl);
+                    ctx.verbosity = lvl;
                     // Make it appears like set with the CLI
                     // TODO: find a better way than passing by YAML to convert to string?
                     log_level.set_cli_config(YAML::Node(ctx.verbosity).as<std::string>());
                 }
             }
             */
-            ctx.set_verbosity(lvl);
+            ctx.verbosity = lvl;
         }
 
         void target_prefix_checks_hook(int& options)

--- a/libmamba/src/core/context.cpp
+++ b/libmamba/src/core/context.cpp
@@ -40,6 +40,35 @@ namespace mamba
     void Context::set_verbosity(int lvl)
     {
         this->verbosity = lvl;
+
+        switch (lvl)
+        {
+            case -3:
+                this->log_level = spdlog::level::off;
+                break;
+            case -2:
+                this->log_level = spdlog::level::critical;
+                break;
+            case -1:
+                this->log_level = spdlog::level::err;
+                break;
+            case 0:
+                this->log_level = spdlog::level::warn;
+                break;
+            case 1:
+                this->log_level = spdlog::level::info;
+                break;
+            case 2:
+                this->log_level = spdlog::level::debug;
+                break;
+            case 3:
+                this->log_level = spdlog::level::trace;
+                break;
+            default:
+                this->log_level = spdlog::level::info;
+                break;
+        }
+        spdlog::set_level(log_level);
     }
 
     void Context::set_log_level(const spdlog::level::level_enum& level)

--- a/libmamba/src/core/context.cpp
+++ b/libmamba/src/core/context.cpp
@@ -17,7 +17,6 @@ namespace mamba
 {
     Context::Context()
     {
-        set_verbosity(0);
         on_ci = (std::getenv("CI") != nullptr);
         if (on_ci || !termcolor::_internal::is_atty(std::cout))
         {
@@ -29,6 +28,7 @@ namespace mamba
         std::shared_ptr<spdlog::logger> l = std::make_shared<Logger>(log_pattern);
         spdlog::set_default_logger(l);
         logger = std::dynamic_pointer_cast<Logger>(l);
+        spdlog::set_level(log_level);
     }
 
     Context& Context::instance()
@@ -40,6 +40,12 @@ namespace mamba
     void Context::set_verbosity(int lvl)
     {
         this->verbosity = lvl;
+    }
+
+    void Context::set_log_level(const spdlog::level::level_enum& level)
+    {
+        log_level = level;
+        spdlog::set_level(level);
     }
 
     std::vector<std::string> Context::platforms()

--- a/libmamba/tests/test_cpp.cpp
+++ b/libmamba/tests/test_cpp.cpp
@@ -13,7 +13,7 @@ namespace mamba
 {
     // TEST(cpp_install, install)
     // {
-    //     Context::instance().set_verbosity(3);
+    //     Context::instance().verbosity = 3;
     //     PackageInfo pkg("wheel", "0.34.2", "py_1", 1);
     //     fs::path prefix = "C:\\Users\\wolfv\\miniconda3\\";
     //     TransactionContext tc(prefix, "3.8.x");

--- a/libmambapy/src/main.cpp
+++ b/libmambapy/src/main.cpp
@@ -217,6 +217,15 @@ PYBIND11_MODULE(bindings, m)
         .value("kStrict", ChannelPriority::kStrict)
         .value("kDisabled", ChannelPriority::kDisabled);
 
+    py::enum_<spdlog::level::level_enum>(m, "LogLevel")
+        .value("TRACE", spdlog::level::trace)
+        .value("DEBUG", spdlog::level::debug)
+        .value("INFO", spdlog::level::info)
+        .value("WARNING", spdlog::level::warn)
+        .value("ERROR", spdlog::level::err)
+        .value("CRITICAL", spdlog::level::critical)
+        .value("OFF", spdlog::level::off);
+
     py::class_<Context, std::unique_ptr<Context, py::nodelete>>(m, "Context")
         .def(
             py::init([]() { return std::unique_ptr<Context, py::nodelete>(&Context::instance()); }))
@@ -243,14 +252,15 @@ PYBIND11_MODULE(bindings, m)
         .def_readwrite("envs_dirs", &Context::envs_dirs)
         .def_readwrite("pkgs_dirs", &Context::pkgs_dirs)
         .def_readwrite("platform", &Context::platform)
-        .def("set_verbosity", &Context::set_verbosity)
         .def_readwrite("channels", &Context::channels)
         .def_readwrite("custom_channels", &Context::custom_channels)
         .def_readwrite("custom_multichannels", &Context::custom_multichannels)
         .def_readwrite("default_channels", &Context::default_channels)
         .def_readwrite("channel_alias", &Context::channel_alias)
         .def_readwrite("use_only_tar_bz2", &Context::use_only_tar_bz2)
-        .def_readwrite("channel_priority", &Context::channel_priority);
+        .def_readwrite("channel_priority", &Context::channel_priority)
+        .def("set_verbosity", &Context::set_verbosity)
+        .def("set_log_level", &Context::set_log_level);
 
     py::class_<PrefixData>(m, "PrefixData")
         .def(py::init<const std::string&>())

--- a/mamba/mamba/utils.py
+++ b/mamba/mamba/utils.py
@@ -191,6 +191,17 @@ def load_channels(
     return index
 
 
+def log_level_from_verbosity(verbosity: int):
+    if verbosity == 0:
+        return api.LogLevel.WARNING
+    elif verbosity == 1:
+        return api.LogLevel.INFO
+    elif verbosity == 2:
+        return api.LogLevel.DEBUG
+    else:
+        return api.LogLevel.TRACE
+
+
 def init_api_context(use_mamba_experimental=False):
     api_ctx = api.Context()
 
@@ -202,7 +213,8 @@ def init_api_context(use_mamba_experimental=False):
         if use_mamba_experimental:
             context.json = False
 
-    api_ctx.set_verbosity(context.verbosity)
+    api_ctx.verbosity = context.verbosity
+    api_ctx.set_log_level(log_level_from_verbosity(context.verbosity))
     api_ctx.quiet = context.quiet
     api_ctx.offline = context.offline
     api_ctx.local_repodata_ttl = context.local_repodata_ttl

--- a/mamba/mamba/utils.py
+++ b/mamba/mamba/utils.py
@@ -214,7 +214,7 @@ def init_api_context(use_mamba_experimental=False):
             context.json = False
 
     api_ctx.verbosity = context.verbosity
-    api_ctx.set_log_level(log_level_from_verbosity(context.verbosity))
+    api_ctx.set_verbosity(context.verbosity)
     api_ctx.quiet = context.quiet
     api_ctx.offline = context.offline
     api_ctx.local_repodata_ttl = context.local_repodata_ttl


### PR DESCRIPTION
Description
---

Fix `mamba` log level (both default and set from verbosity):
- set log level in `Context` ctor
- remove useless `set_verbosity` method
- add `set_log_level` method
- add python bindings for `set_log_level` and log levels enum (`spdlog::level::level_enum`)
- use `set_log_level` in `mamba`