### PR TITLE
Use cpp-terminal

### DIFF
--- a/libmamba/CMakeLists.txt
+++ b/libmamba/CMakeLists.txt
@@ -384,6 +384,7 @@ macro(libmamba_create_target target_name linkage deps_linkage output_name)
     if (${linkage_upper} STREQUAL "STATIC")
         find_package(nlohmann_json CONFIG REQUIRED)
         find_package(Threads REQUIRED)
+        find_package(cpp-terminal REQUIRED)
 
         target_link_libraries(${target_name} PUBLIC
                               nlohmann_json::nlohmann_json

--- a/libmamba/CMakeLists.txt
+++ b/libmamba/CMakeLists.txt
@@ -384,7 +384,6 @@ macro(libmamba_create_target target_name linkage deps_linkage output_name)
     if (${linkage_upper} STREQUAL "STATIC")
         find_package(nlohmann_json CONFIG REQUIRED)
         find_package(Threads REQUIRED)
-        find_package(cpp-terminal REQUIRED)
 
         target_link_libraries(${target_name} PUBLIC
                               nlohmann_json::nlohmann_json

--- a/libmamba/environment-dev.yml
+++ b/libmamba/environment-dev.yml
@@ -14,6 +14,7 @@ dependencies:
   - gtest
   - gmock
   - cpp-filesystem >=1.5.8
+  - cpp-terminal
   - reproc-cpp
   - yaml-cpp
   - termcolor-cpp

--- a/libmambapy/environment-dev.yml
+++ b/libmambapy/environment-dev.yml
@@ -17,6 +17,7 @@ dependencies:
   - reproc-cpp
   - yaml-cpp
   - termcolor-cpp
+  - cpp-terminal
   - cli11
   - spdlog
   - pybind11

--- a/mamba/environment-dev.yml
+++ b/mamba/environment-dev.yml
@@ -17,6 +17,7 @@ dependencies:
   - reproc-cpp
   - yaml-cpp
   - termcolor-cpp
+  - cpp-terminal
   - cli11
   - spdlog
   - pybind11

--- a/micromamba/environment-dev.yml
+++ b/micromamba/environment-dev.yml
@@ -17,6 +17,7 @@ dependencies:
   - reproc-cpp
   - yaml-cpp
   - termcolor-cpp
+  - cpp-terminal
   - cli11
   - pytest
   - pytest-lazy-fixture


### PR DESCRIPTION
Resurrected https://github.com/mamba-org/mamba/pull/541.

Seems like cpp-terminal development has moved back to https://github.com/jupyter-xeus/cpp-terminal. I've asked what's their recommended version to use at https://github.com/jupyter-xeus/cpp-terminal/issues/130.