### PR TITLE
Fix dangling `LockFile`s

### DIFF
--- a/libmamba/src/api/clean.cpp
+++ b/libmamba/src/api/clean.cpp
@@ -67,10 +67,13 @@ namespace mamba
                     for (auto& p : fs::directory_iterator(pkg_cache->path()))
                     {
                         if (p.exists() && ends_with(p.path().string(), ".lock")
-                            && fs::exists(rstrip(p.path().string(), ".lock")))
+                            && (fs::exists(rstrip(p.path().string(), ".lock"))
+                                || (rstrip(p.path().filename().string(), ".lock")
+                                    == p.path().parent_path().filename())))
                         {
                             try
                             {
+                                LOG_INFO << "Removing lock file '" << p.path().string() << "'";
                                 fs::remove(p);
                             }
                             catch (...)
@@ -88,6 +91,7 @@ namespace mamba
                         {
                             try
                             {
+                                LOG_INFO << "Removing lock file '" << p.path().string() << "'";
                                 fs::remove(p);
                             }
                             catch (...)

--- a/libmamba/src/core/util.cpp
+++ b/libmamba/src/core/util.cpp
@@ -669,7 +669,7 @@ namespace mamba
         if (fs::is_directory(path))
         {
             LOG_DEBUG << "Locking directory '" << path.string() << "'";
-            m_lock = m_path / "mamba.lock";
+            m_lock = m_path / (m_path.filename().string() + ".lock");
         }
         else
         {
@@ -995,7 +995,7 @@ namespace mamba
         {
             if (old_pid == m_pid)
             {
-                LOG_ERROR << "Path already locked by the same PID";
+                LOG_ERROR << "Path already locked by the same PID: '" << m_path.string() << "'";
                 unlock();
                 throw std::logic_error("LockFile error.");
             }
@@ -1007,6 +1007,11 @@ namespace mamba
             // sending `0` with kill will check if the process is still alive
             if (kill(old_pid, 0) != -1)
                 return false;
+            else
+            {
+                LOG_TRACE << "Removing dangling lock file '" << m_lock << "'";
+                m_lockfile_existed = false;
+            }
 #endif
         }
 

--- a/libmamba/tests/test_lockfile.cpp
+++ b/libmamba/tests/test_lockfile.cpp
@@ -62,7 +62,7 @@ namespace mamba
                 // check the first lock is still locked
                 EXPECT_TRUE(fs::exists(lock.lockfile_path()));
             }
-            EXPECT_FALSE(fs::exists(tempdir_path / "mamba.lock"));
+            EXPECT_FALSE(fs::exists(tempdir_path / (tempdir_path.filename().string() + ".lock")));
         }
 
         TEST_F(LockDirTest, different_pid)
@@ -128,7 +128,7 @@ namespace mamba
                 EXPECT_EQ(mamba::LockFile::read_pid(lock.fd()), pid);
             }
 
-            fs::path lock_path = tempdir_path / "mamba.lock";
+            fs::path lock_path = tempdir_path / (tempdir_path.filename().string() + ".lock");
             EXPECT_FALSE(fs::exists(lock_path));
 
             args = { lock_cli, "is-locked", lock_path };

--- a/mamba/mamba/mamba.py
+++ b/mamba/mamba/mamba.py
@@ -704,8 +704,16 @@ def repoquery(args, parser):
 
 def clean(args, parser):
     if args.locks:
+        init_api_context()
+
+        root_prefix = os.environ.get("MAMBA_ROOT_PREFIX")
+        if api.Context().root_prefix != root_prefix:
+            os.environ["MAMBA_ROOT_PREFIX"] = str(api.Context().root_prefix)
+
         api.Configuration().show_banner = False
         api.clean(api.MAMBA_CLEAN_LOCKS)
+        if root_prefix:
+            os.environ["MAMBA_ROOT_PREFIX"] = root_prefix
 
     try:
         from importlib import import_module

--- a/micromamba/tests/helpers.py
+++ b/micromamba/tests/helpers.py
@@ -6,6 +6,7 @@ import random
 import shutil
 import string
 import subprocess
+import sys
 from enum import Enum
 from pathlib import Path
 
@@ -112,8 +113,11 @@ def install(*args, default_channel=True, no_rc=True, no_dry_run=False):
         cmd += ["--offline"]
     if (dry_run_tests == DryRun.DRY) and "--dry-run" not in args and not no_dry_run:
         cmd += ["--dry-run"]
+    cmd += ["--log-level=info"]
 
-    res = subprocess.check_output(cmd)
+    print(f"Running command {' '.join(cmd)}", file=sys.stderr)
+    res = subprocess.check_output(cmd, stderr=sys.stderr)
+
     if "--json" in args:
         try:
             j = json.loads(res)


### PR DESCRIPTION
Description
---

Fix dangling `LockFile`s cleaning when the PID of the file doesn't match a running process on Unix systems:
- set the variable storing already existing lock file to false when a dangling lock file is detected
- improve debuggability by adding the path of the dangling lock file to the error log message
- change lock file name for directories locks to make the filename more obvious to understand to the user when a dangling one is found
- set the root prefix from `conda` context if `MAMBA_ROOT_PREFIX` is set from a `micromamba` installation to make sure the correct package cache is cleaned
- improve debuggability of micromamba install Python tests suite by redirecting subprocess stderr to system one and printing the ran sub-command

Closes https://github.com/mamba-org/mamba/issues/1285