### PR TITLE
Fix use of a read-only cache

### DIFF
--- a/libmamba/src/core/package_cache.cpp
+++ b/libmamba/src/core/package_cache.cpp
@@ -64,7 +64,8 @@ namespace mamba
         fs::path magic_file = m_path / PACKAGE_CACHE_MAGIC_FILE;
         LOG_DEBUG << "Checking if '" << m_path.string() << "' is writable";
 
-        if (fs::exists(m_path))
+        std::error_code ec;
+        if (fs::exists(m_path, ec))
         {
             if (fs::is_regular_file(magic_file))
             {
@@ -84,7 +85,7 @@ namespace mamba
             }
         }
         else
-            LOG_TRACE << "Cache path does not exists";
+            LOG_TRACE << "Cache path does not exists or is not writable";
 
         try
         {

--- a/libmamba/src/core/repo.cpp
+++ b/libmamba/src/core/repo.cpp
@@ -247,6 +247,7 @@ namespace mamba
 
         if (is_solv)
         {
+            auto lock = LockFile::try_lock(m_solv_file);
             auto fp = fopen(m_solv_file.c_str(), "rb");
             if (!fp)
             {
@@ -316,6 +317,7 @@ namespace mamba
             fclose(fp);
         }
 
+        auto lock = LockFile::try_lock(m_json_file);
         auto fp = fopen(m_json_file.c_str(), "r");
         if (!fp)
         {

--- a/libmamba/src/core/util.cpp
+++ b/libmamba/src/core/util.cpp
@@ -660,7 +660,8 @@ namespace mamba
         , m_timeout(timeout)
         , m_locked(false)
     {
-        if (!fs::exists(path))
+        std::error_code ec;
+        if (!fs::exists(path, ec))
         {
             LOG_ERROR << "Could not lock non-existing path '" << path.string() << "'";
             throw std::runtime_error("LockFile error. Aborting.");
@@ -677,7 +678,7 @@ namespace mamba
             m_lock = m_path.string() + ".lock";
         }
 
-        m_lockfile_existed = fs::exists(m_lock);
+        m_lockfile_existed = fs::exists(m_lock, ec);
         m_fd = open(m_lock.c_str(), O_RDWR | O_CREAT, 0666);
 
         if (m_fd <= 0)

--- a/mamba/mamba/linking.py
+++ b/mamba/mamba/linking.py
@@ -3,15 +3,12 @@
 
 from conda.base.context import context
 from conda.cli import common as cli_common
-from conda.core.package_cache_data import PackageCacheData
 from conda.exceptions import (
     CondaExitZero,
     CondaSystemExit,
     DryRunExit,
     PackagesNotFoundError,
 )
-
-from mamba.utils import lock_file
 
 
 def handle_txn(unlink_link_transaction, prefix, args, newenv, remove_op=False):
@@ -33,14 +30,13 @@ def handle_txn(unlink_link_transaction, prefix, args, newenv, remove_op=False):
         raise DryRunExit()
 
     try:
-        with lock_file(PackageCacheData.first_writable().pkgs_dir):
-            unlink_link_transaction.download_and_extract()
-            if context.download_only:
-                raise CondaExitZero(
-                    "Package caches prepared. UnlinkLinkTransaction cancelled with "
-                    "--download-only option."
-                )
-            unlink_link_transaction.execute()
+        unlink_link_transaction.download_and_extract()
+        if context.download_only:
+            raise CondaExitZero(
+                "Package caches prepared. UnlinkLinkTransaction cancelled with "
+                "--download-only option."
+            )
+        unlink_link_transaction.execute()
 
     except SystemExit as e:
         raise CondaSystemExit("Exiting", e)


### PR DESCRIPTION
Description
---

Some cases relying on a read-only cache are currently not working as expected (see #1292).

Fix wrong use of `LockFile` in `mamba`:
- remove obsolete use to `LockFile` in `mamba`
- use `LockFile` in `libmamba` when reading repodata files, instead of doing it from `mamba`

Fix use a wrong cache when multiple are expired:
- get expired cache from highest precedence cache
  - this avoids unnecessary copy of index files from a read-only location to a read-write one
 
Fix paths operations:
- fix errors when copying an expired but still valid index file from a read-only location to a read-write one
  - delete pre-existing repodata files before copy
- use `fs::exists` `noexcept` overload to catch errors when directory is not executable

Closes #1292 