### PR TITLE
Remove libmamba from install_requires for libmambapy

### DIFF
--- a/libmambapy/setup.cfg
+++ b/libmambapy/setup.cfg
@@ -18,6 +18,3 @@ universal = 1
 include_package_data = True
 packages = find:
 python_requires = >=3.7
-
-install_requires =
-  libmamba


### PR DESCRIPTION
This PR removes `libmamba` from the `install_requires` metadata for `libmambapy` - the former isn't a python package, so doesn't provide python metadata (`.egg-info/.dist-info`), meaning `pip check` complains loudly that the requirement isn't fulfilled after installing `libmambapy`:

```console
+ python -m pip check
libmambapy 0.18.2 requires libmamba, which is not installed.
```