### PR TITLE
Fix curl progress callback

### DIFF
--- a/libmamba/include/mamba/core/fetch.hpp
+++ b/libmamba/include/mamba/core/fetch.hpp
@@ -36,7 +36,7 @@ namespace mamba
         static size_t write_callback(char* ptr, size_t size, size_t nmemb, void* self);
         static size_t header_callback(char* buffer, size_t size, size_t nitems, void* self);
 
-        int progress_callback(
+        static std::size_t progress_callback(
             void*, curl_off_t total_to_download, curl_off_t now_downloaded, curl_off_t, curl_off_t);
         void set_mod_etag_headers(const nlohmann::json& mod_etag);
         void set_progress_bar(ProgressProxy progress_proxy);
@@ -90,8 +90,6 @@ namespace mamba
 
         // validation
         std::size_t m_expected_size = 0;
-
-        std::chrono::steady_clock::time_point m_progress_throttle_time;
 
         // retry & backoff
         std::chrono::steady_clock::time_point m_next_retry;

--- a/libmamba/include/mamba/core/fetch.hpp
+++ b/libmamba/include/mamba/core/fetch.hpp
@@ -36,7 +36,7 @@ namespace mamba
         static size_t write_callback(char* ptr, size_t size, size_t nmemb, void* self);
         static size_t header_callback(char* buffer, size_t size, size_t nitems, void* self);
 
-        static std::size_t progress_callback(
+        static int progress_callback(
             void*, curl_off_t total_to_download, curl_off_t now_downloaded, curl_off_t, curl_off_t);
         void set_mod_etag_headers(const nlohmann::json& mod_etag);
         void set_progress_bar(ProgressProxy progress_proxy);

--- a/libmamba/src/core/fetch.cpp
+++ b/libmamba/src/core/fetch.cpp
@@ -337,28 +337,17 @@ namespace mamba
         return nitems * size;
     }
 
-    int DownloadTarget::progress_callback(
-        void*, curl_off_t total_to_download, curl_off_t now_downloaded, curl_off_t, curl_off_t)
+    std::size_t DownloadTarget::progress_callback(
+        void* f, curl_off_t total_to_download, curl_off_t now_downloaded, curl_off_t, curl_off_t)
     {
+        auto* target = static_cast<DownloadTarget*>(f);
+
         if (Context::instance().quiet || Context::instance().json)
         {
             return 0;
         }
 
-        auto now = std::chrono::steady_clock::now();
-        if (now - m_progress_throttle_time < std::chrono::milliseconds(150))
-        {
-            return 0;
-        }
-        m_progress_throttle_time = now;
-
-        if (total_to_download != 0 && now_downloaded == 0 && m_expected_size != 0)
-        {
-            now_downloaded = total_to_download;
-            total_to_download = m_expected_size;
-        }
-
-        if ((total_to_download != 0 || m_expected_size != 0) && now_downloaded != 0)
+        if ((total_to_download != 0 || target->m_expected_size != 0))
         {
             std::stringstream postfix;
             postfix << std::setw(6);
@@ -368,20 +357,20 @@ namespace mamba
             to_human_readable_filesize(postfix, total_to_download);
             postfix << " (";
             postfix << std::setw(6);
-            to_human_readable_filesize(postfix, get_speed(), 2);
+            to_human_readable_filesize(postfix, target->get_speed(), 2);
             postfix << "/s)";
-            m_progress_bar.set_progress(now_downloaded, total_to_download);
-            m_progress_bar.set_postfix(postfix.str());
+            target->m_progress_bar.set_progress(now_downloaded, total_to_download);
+            target->m_progress_bar.set_postfix(postfix.str());
         }
-        if (now_downloaded == 0 && total_to_download != 0)
+        else
         {
             std::stringstream postfix;
-            to_human_readable_filesize(postfix, total_to_download);
+            to_human_readable_filesize(postfix, now_downloaded);
             postfix << " / ?? (";
-            to_human_readable_filesize(postfix, get_speed(), 2);
+            to_human_readable_filesize(postfix, target->get_speed(), 2);
             postfix << "/s)";
-            m_progress_bar.set_progress(SIZE_MAX, SIZE_MAX);
-            m_progress_bar.set_postfix(postfix.str());
+            target->m_progress_bar.set_progress(SIZE_MAX, SIZE_MAX);
+            target->m_progress_bar.set_postfix(postfix.str());
         }
         return 0;
     }

--- a/libmamba/src/core/fetch.cpp
+++ b/libmamba/src/core/fetch.cpp
@@ -337,7 +337,7 @@ namespace mamba
         return nitems * size;
     }
 
-    std::size_t DownloadTarget::progress_callback(
+    int DownloadTarget::progress_callback(
         void* f, curl_off_t total_to_download, curl_off_t now_downloaded, curl_off_t, curl_off_t)
     {
         auto* target = static_cast<DownloadTarget*>(f);


### PR DESCRIPTION
Description
---

Fix curl progress callback
- use static method and cast the first argument (`void*`) as data `DownloadTarget*`
- fixes badly passed hidden this pointer, shifting *total to download* to *now downloaded*
- remove unnecessary patch reversing *total to download* and *now downloaded*
- remove delay added for the previously mentioned patch