### PR TITLE
perf: add fast path for hide_secrets

### DIFF
--- a/libmamba/src/core/output.cpp
+++ b/libmamba/src/core/output.cpp
@@ -320,8 +320,17 @@ namespace mamba
     std::string Console::hide_secrets(const std::string_view& str)
     {
         std::string copy(str);
-        copy = std::regex_replace(copy, token_re, "/t/*****");
-        copy = std::regex_replace(copy, http_basicauth_re, "://$1:*****@");
+
+        if (contains(str, "/t/"))
+        {
+            copy = std::regex_replace(copy, token_re, "/t/*****");
+        }
+
+        if (contains(str, "://"))
+        {
+            copy = std::regex_replace(copy, http_basicauth_re, "://$1:*****@");
+        }
+
         return copy;
     }
 


### PR DESCRIPTION
Adds a fast path to the `Console::hide_secrets` function. `std::regex_replace` is rather slow as can be seen in this flamegraph of the `LinkPackage::execute` method:

![flamegraph_unoptimized](https://user-images.githubusercontent.com/4995967/144996518-58bf0dd7-5a15-4b05-ace9-4583794711b5.png)

I added a fast path by checking if `/t/` is contained within the string and only then use regex to replace to contents of the string. The same goes for the http_basicauth regex. After this change the framegraph looks like this:

![flamegraph_optimized](https://user-images.githubusercontent.com/4995967/144996661-c9343dc6-d178-4ad0-b1b1-d93a8200e412.png)

In real life this shaves off about ~1sec of a 10sec install. 

Note that the other changes in the file are due to clang-format! I assume they are correct since there is a .clang-format file in the repo.

