### PR TITLE
perf: use the original sha256 hash if a file doesnt change

### DIFF
--- a/libmamba/src/core/link.cpp
+++ b/libmamba/src/core/link.cpp
@@ -859,10 +859,6 @@ namespace mamba
                     }
                     return std::make_tuple(validate::sha256sum(dst), rel_dst);
                 }
-                else
-                {
-                    std::make_tuple(validate::sha256sum(dst), rel_dst);
-                }
 
 #else
                 std::size_t padding_size
@@ -978,8 +974,8 @@ namespace mamba
             throw std::runtime_error(std::string("Path type not implemented: ")
                                      + std::to_string(static_cast<int>(path_data.path_type)));
         }
-        // TODO we could also use the SHA256 sum of the paths json
-        return std::make_tuple(validate::sha256sum(dst), rel_dst);
+        return std::make_tuple(
+            path_data.sha256.empty() ? validate::sha256sum(dst) : path_data.sha256, rel_dst);
     }
 
     std::vector<fs::path> LinkPackage::compile_pyc_files(const std::vector<fs::path>& py_files)


### PR DESCRIPTION
This PR implements using the original path data's sha256 hash during linking if the file that is copied is not modified.

Profiling this change results in the following flamegraph, before this change a large chunk if time is spend computing sha's:

![flamegraph_unoptimized](https://user-images.githubusercontent.com/4995967/145072722-d05f7437-1fbc-4bf9-b541-a6a815b83b90.png)

After this change computing sha hashes takes a lot less time (the highlighted block is the sha256sum function):

![flamegraph_optimized](https://user-images.githubusercontent.com/4995967/145072805-4a883642-f620-4635-8f0a-ce03a1450ba3.png)

In practice, a stupid test showed on an install of 14seconds a ~2sec improvement (taking only 12sec).

I also removed some code that doesn't seem to do anything in the first place? Or maybe there should be a return in front of it?
