### PR TITLE
feat: log json if solving failed

### DIFF
--- a/libmamba/include/mamba/core/solver.hpp
+++ b/libmamba/include/mamba/core/solver.hpp
@@ -11,6 +11,7 @@
 #include <string>
 #include <utility>
 #include <vector>
+#include <nlohmann/json.hpp>
 
 #include "match_spec.hpp"
 #include "output.hpp"
@@ -50,10 +51,11 @@ namespace mamba
         void add_pins(const std::vector<std::string>& pins);
         void set_flags(const std::vector<std::pair<int, int>>& flags);
         void set_postsolve_flags(const std::vector<std::pair<int, int>>& flags);
-        bool is_solved();
+        bool is_solved() const;
         bool solve();
-        std::string problems_to_str();
-        std::string all_problems_to_str();
+        std::string problems_to_str() const;
+        nlohmann::json problems_to_json() const;
+        std::string all_problems_to_str() const;
 
         const std::vector<MatchSpec>& install_specs() const;
         const std::vector<MatchSpec>& remove_specs() const;

--- a/libmamba/include/mamba/core/solver.hpp
+++ b/libmamba/include/mamba/core/solver.hpp
@@ -11,7 +11,6 @@
 #include <string>
 #include <utility>
 #include <vector>
-#include <nlohmann/json.hpp>
 
 #include "match_spec.hpp"
 #include "output.hpp"
@@ -54,7 +53,7 @@ namespace mamba
         bool is_solved() const;
         bool solve();
         std::string problems_to_str() const;
-        nlohmann::json problems_to_json() const;
+        std::vector<std::string> all_problems() const;
         std::string all_problems_to_str() const;
 
         const std::vector<MatchSpec>& install_specs() const;

--- a/libmamba/src/api/install.cpp
+++ b/libmamba/src/api/install.cpp
@@ -522,7 +522,7 @@ namespace mamba
             if (ctx.json)
             {
                 Console::instance().json_write(
-                    { { "success", false }, { "solver_problems", solver.problems_to_json() } });
+                    { { "success", false }, { "solver_problems", solver.all_problems() } });
                 Console::instance().json_print();
             }
 

--- a/libmamba/src/api/install.cpp
+++ b/libmamba/src/api/install.cpp
@@ -519,6 +519,13 @@ namespace mamba
             if (ctx.freeze_installed)
                 Console::print("Possible hints:\n  - 'freeze_installed' is turned on\n");
 
+            if (ctx.json)
+            {
+                Console::instance().json_write(
+                    { { "success", false }, { "solver_problems", solver.problems_to_json() } });
+                Console::instance().json_print();
+            }
+
             Console::stream() << "The environment can't be solved, aborting the operation";
             LOG_ERROR << "Could not solve for environment specs";
             throw std::runtime_error("UnsatisfiableError");

--- a/libmamba/src/core/solver.cpp
+++ b/libmamba/src/core/solver.cpp
@@ -315,7 +315,7 @@ namespace mamba
         }
     }
 
-    bool MSolver::is_solved()
+    bool MSolver::is_solved() const
     {
         return m_is_solved;
     }
@@ -354,7 +354,7 @@ namespace mamba
         return success;
     }
 
-    std::string MSolver::all_problems_to_str()
+    std::string MSolver::all_problems_to_str() const
     {
         std::stringstream problems;
 
@@ -387,7 +387,7 @@ namespace mamba
         return problems.str();
     }
 
-    std::string MSolver::problems_to_str()
+    std::string MSolver::problems_to_str() const
     {
         Queue problem_queue;
         queue_init(&problem_queue);
@@ -400,6 +400,22 @@ namespace mamba
         }
         queue_free(&problem_queue);
         return "Encountered problems while solving:\n" + problems.str();
+    }
+
+    nlohmann::json MSolver::problems_to_json() const
+    {
+        std::vector<nlohmann::json> problems;
+        Queue problem_queue;
+        queue_init(&problem_queue);
+        int count = solver_problem_count(m_solver);
+        for (int i = 1; i <= count; i++)
+        {
+            queue_push(&problem_queue, i);
+            problems.push_back(solver_problem2str(m_solver, i));
+        }
+        queue_free(&problem_queue);
+
+        return problems;
     }
 
     MSolver::operator Solver*()

--- a/libmamba/src/core/solver.cpp
+++ b/libmamba/src/core/solver.cpp
@@ -402,16 +402,16 @@ namespace mamba
         return "Encountered problems while solving:\n" + problems.str();
     }
 
-    nlohmann::json MSolver::problems_to_json() const
+    std::vector<std::string> MSolver::all_problems() const
     {
-        std::vector<nlohmann::json> problems;
+        std::vector<std::string> problems;
         Queue problem_queue;
         queue_init(&problem_queue);
-        int count = solver_problem_count(m_solver);
+        int count = static_cast<int>(solver_problem_count(m_solver));
         for (int i = 1; i <= count; i++)
         {
             queue_push(&problem_queue, i);
-            problems.push_back(solver_problem2str(m_solver, i));
+            problems.emplace_back(solver_problem2str(m_solver, i));
         }
         queue_free(&problem_queue);
 


### PR DESCRIPTION
This implements the logic to output solver problems when running with `--json` as discussed in #1335 

I also solved some `const` correctness issues in `MSolver`