### PR TITLE
Implement activate as a micromamba subcommand

### DIFF
--- a/micromamba/CMakeLists.txt
+++ b/micromamba/CMakeLists.txt
@@ -21,6 +21,7 @@ set(MICROMAMBA_LINKAGE "DYNAMIC" CACHE STRING "micromamba linkage against librar
 # ============
 
 set(MICROMAMBA_SRCS
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/activate.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/clean.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/config.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/completer.cpp

--- a/micromamba/src/activate.cpp
+++ b/micromamba/src/activate.cpp
@@ -1,0 +1,49 @@
+// Copyright (c) 2019, QuantStack and Mamba Contributors
+//
+// Distributed under the terms of the BSD 3-Clause License.
+//
+// The full license is in the file LICENSE, distributed with this software.
+
+#include "common_options.hpp"
+
+#include "mamba/api/configuration.hpp"
+
+#include "termcolor/termcolor.hpp"
+
+
+using namespace mamba;  // NOLINT(build/namespaces)
+
+void
+init_activate_parser(CLI::App* subcom)
+{
+    auto& config = Configuration::instance();
+
+    auto& env_name = config.insert(Configurable("activate_env_name", std::string(""))
+                                       .group("cli")
+                                       .description("The name of the environment to activate"));
+    subcom->add_option("env_name", env_name.set_cli_config(""), env_name.description());
+}
+
+void
+set_activate_command(CLI::App* subcom)
+{
+    init_activate_parser(subcom);
+
+    subcom->callback([&]() {
+        std::stringstream message;
+
+        message
+            << "\nIn order to use activate and deactivate you need to initialize your shell.\n"
+            << "Either call shell init ... or execute the shell hook directly:\n\n"
+            << "    $ eval \"$(./micromamba shell hook -s bash)\"\n\n"
+            << "and then run activate and deactivate like so:\n\n"
+            << "    $ micromamba activate  " << termcolor::white
+            << "# notice the missing dot in front of the command\n\n"
+            << "To permanently initialize your shell, use shell init like so:\n\n"
+            << "    $ ./micromamba shell init -s bash -p /home/$USER/micromamba \n\n"
+            << "and restart your shell. Supported shells are bash, zsh, xonsh, cmd.exe, powershell, and fish."
+            << termcolor::reset;
+
+        throw std::runtime_error(message.str());
+    });
+}

--- a/micromamba/src/activate.cpp
+++ b/micromamba/src/activate.cpp
@@ -33,15 +33,16 @@ set_activate_command(CLI::App* subcom)
         std::stringstream message;
 
         message
-            << "\nIn order to use activate and deactivate you need to initialize your shell.\n"
-            << "Either call shell init ... or execute the shell hook directly:\n\n"
-            << "    $ eval \"$(./micromamba shell hook -s bash)\"\n\n"
-            << "and then run activate and deactivate like so:\n\n"
-            << "    $ micromamba activate  " << termcolor::white
-            << "# notice the missing dot in front of the command\n\n"
-            << "To permanently initialize your shell, use shell init like so:\n\n"
-            << "    $ ./micromamba shell init -s bash -p /home/$USER/micromamba \n\n"
-            << "and restart your shell. Supported shells are bash, zsh, xonsh, cmd.exe, powershell, and fish."
+            << "\n"
+            << "In order to use activate and deactivate you need to initialize your shell. "
+            << "(Micromamba is running as a subprocess, so it cannot modify the parent shell.)\n"
+            << "To initialize the current (bash) shell, run:\n\n"
+            << "    $ eval \"$(micromamba shell hook --shell=bash)\"\n\n"
+            << "and then activate or deactivate with:\n\n"
+            << "    $ micromamba activate\n\n"
+            << "To automatically initialize all future (bash) shells, run:\n\n"
+            << "    $ micromamba shell init --shell=bash --prefix=/home/$USER/micromamba \n\n"
+            << "Supported shells are bash, zsh, xonsh, cmd.exe, powershell, and fish."
             << termcolor::reset;
 
         throw std::runtime_error(message.str());

--- a/micromamba/src/umamba.cpp
+++ b/micromamba/src/umamba.cpp
@@ -79,19 +79,6 @@ set_umamba_command(CLI::App* com)
     CLI::App* env_subcom = com->add_subcommand("env", "List environments");
     set_env_command(env_subcom);
 
-    std::stringstream footer;  // just for the help text
-
-    footer
-        << "In order to use activate and deactivate you need to initialize your shell.\n"
-        << "Either call shell init ... or execute the shell hook directly:\n\n"
-        << "    $ eval \"$(./micromamba shell hook -s bash)\"\n\n"
-        << "and then run activate and deactivate like so:\n\n"
-        << "    $ micromamba activate  " << termcolor::white
-        << "# notice the missing dot in front of the command\n\n"
-        << "To permanently initialize your shell, use shell init like so:\n\n"
-        << "    $ ./micromamba shell init -s bash -p /home/$USER/micromamba \n\n"
-        << "and restart your shell. Supported shells are bash, zsh, xonsh, cmd.exe, powershell, and fish."
-        << termcolor::reset;
-
-    com->footer(footer.str());
+    CLI::App* activate_subcom = com->add_subcommand("activate", "Activate an environment");
+    set_activate_command(activate_subcom);
 }

--- a/micromamba/src/umamba.hpp
+++ b/micromamba/src/umamba.hpp
@@ -59,6 +59,9 @@ void
 set_env_command(CLI::App* subcom);
 
 void
+set_activate_command(CLI::App* subcom);
+
+void
 get_completions(CLI::App* app, int argc, char** argv);
 
 #endif


### PR DESCRIPTION
This way it shows up under `micromamba --help`, and it prints a useful error message when running `./micromamba activate`.

Closes #1359 
Closes #1323