### PR TITLE
misc: experimental is logged twice

### DIFF
--- a/libmamba/src/api/configuration.cpp
+++ b/libmamba/src/api/configuration.cpp
@@ -380,8 +380,6 @@ namespace mamba
         {
             if (value)
             {
-                Console::stream() << termcolor::yellow << "Experimental mode enabled!"
-                                  << termcolor::reset;
                 LOG_WARNING << "Experimental mode enabled";
             }
         }


### PR DESCRIPTION
I noticed that in my `--json` runs the line:

```
Experimental mode enabled
```

was outputted. I simply removed this line because its also logged as a warning. 

I only use the experimental mode to be able to use authentication tokens. Any idea when that will become stable?