### PR TITLE
Update to Python 3.10 in the micromamba example snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ Note: currently the `-c` arguments have to come at the end of the command line.
 
 ```sh
 micromamba activate
-micromamba install python=3.6 jupyter -c conda-forge
+micromamba install python=3.10 jupyter -c conda-forge
 # or
 micromamba create -p /some/new/prefix xtensor -c conda-forge
 micromamba activate /some/new/prefix


### PR DESCRIPTION
Since Python 3.6 is now EOL, we might as well use a more recent version in the example snippet.