### PR TITLE
Close m_file before deletion

### DIFF
--- a/libmamba/src/core/fetch.cpp
+++ b/libmamba/src/core/fetch.cpp
@@ -248,6 +248,10 @@ namespace mamba
         auto now = std::chrono::steady_clock::now();
         if (now >= m_next_retry)
         {
+            if (m_file.is_open())
+            {
+                m_file.close();
+            }
             if (fs::exists(m_filename))
             {
                 fs::remove(m_filename);


### PR DESCRIPTION
In the current implementation, retries won't actually succeed as the underlying file is deleted but the file handle is kept open.  

Currently the following behaviour exists:
1. File *handle* is opened
2. First try of downloading starts and aborts
3. The file is unlinked *by name*
4. Second try of downloading starts and uses the same file handle
5. If successful, the content is written to disk but inaccessible as the file was already unlinked from the filesystem.

Adding the close statement should resolve the issue as this will then lead to a new file handle being opened on each new try.