### PR TITLE
Store platform when creating an env

### DIFF
--- a/libmamba/include/mamba/api/create.hpp
+++ b/libmamba/include/mamba/api/create.hpp
@@ -11,6 +11,11 @@
 namespace mamba
 {
     void create();
+
+    namespace detail
+    {
+        void store_platform_config(const fs::path& prefix, const std::string& platform);
+    }
 }
 
 #endif

--- a/libmamba/src/api/configuration.cpp
+++ b/libmamba/src/api/configuration.cpp
@@ -582,11 +582,11 @@ namespace mamba
         insert(Configurable("platform", &ctx.platform)
                    .group("Basic")
                    .set_rc_configurable()
-                   .set_env_var_names({ "CONDA_SUBDIR" })
+                   .set_env_var_names({ "CONDA_SUBDIR", "MAMBA_PLATFORM" })
                    .description("The platform description")
                    .long_description(unindent(R"(
                         The plaftorm description points what channels
-                        subdir(s) have to fetched for package solving.
+                        subdir/platform have to be fetched for package solving.
                         This can be 'linux-64' or similar.)")));
 
         insert(Configurable("spec_file_env_name", std::string(""))

--- a/libmamba/src/api/create.cpp
+++ b/libmamba/src/api/create.cpp
@@ -63,7 +63,8 @@ namespace mamba
             if (!ctx.dry_run)
                 detail::create_empty_target(ctx.target_prefix);
         }
-        if (!ctx.dry_run && config.at("platform").configured())
+        if (!ctx.dry_run && config.at("platform").configured()
+            && (!config.at("platform").rc_configured()))
             detail::store_platform_config(ctx.target_prefix, ctx.platform);
 
         config.operation_teardown();

--- a/libmamba/src/api/create.cpp
+++ b/libmamba/src/api/create.cpp
@@ -28,27 +28,35 @@ namespace mamba
         auto& create_specs = config.at("specs").value<std::vector<std::string>>();
         auto& use_explicit = config.at("explicit_install").value<bool>();
 
-        if (ctx.target_prefix == ctx.root_prefix && !create_specs.empty())
+        if (!ctx.dry_run)
         {
-            LOG_ERROR << "Overwriting root prefix is not permitted";
-            throw std::runtime_error("Aborting.");
-        }
-        else if (fs::exists(ctx.target_prefix))
-        {
-            if (fs::exists(ctx.target_prefix / "conda-meta"))
+            if (fs::exists(ctx.target_prefix))
             {
-                if (Console::prompt("Found conda-prefix at '" + ctx.target_prefix.string()
-                                        + "'. Overwrite?",
-                                    'n'))
-                    fs::remove_all(ctx.target_prefix);
-                else
+                if (ctx.target_prefix == ctx.root_prefix)
+                {
+                    LOG_ERROR << "Overwriting root prefix is not permitted";
                     throw std::runtime_error("Aborting.");
+                }
+                else if (fs::exists(ctx.target_prefix / "conda-meta"))
+                {
+                    if (Console::prompt("Found conda-prefix at '" + ctx.target_prefix.string()
+                                            + "'. Overwrite?",
+                                        'n'))
+                        fs::remove_all(ctx.target_prefix);
+                    else
+                        throw std::runtime_error("Aborting.");
+                }
+                else
+                {
+                    LOG_ERROR << "Non-conda folder exists at prefix";
+                    throw std::runtime_error("Aborting.");
+                }
             }
-            else
-            {
-                LOG_ERROR << "Non-conda folder exists at prefix";
-                throw std::runtime_error("Aborting.");
-            }
+            if (create_specs.empty())
+                detail::create_empty_target(ctx.target_prefix);
+
+            if (config.at("platform").configured() && !config.at("platform").rc_configured())
+                detail::store_platform_config(ctx.target_prefix, ctx.platform);
         }
 
         if (!create_specs.empty())
@@ -58,14 +66,6 @@ namespace mamba
             else
                 install_specs(create_specs, true);
         }
-        else
-        {
-            if (!ctx.dry_run)
-                detail::create_empty_target(ctx.target_prefix);
-        }
-        if (!ctx.dry_run && config.at("platform").configured()
-            && (!config.at("platform").rc_configured()))
-            detail::store_platform_config(ctx.target_prefix, ctx.platform);
 
         config.operation_teardown();
     }

--- a/micromamba/src/common_options.cpp
+++ b/micromamba/src/common_options.cpp
@@ -350,4 +350,7 @@ init_install_options(CLI::App* subcom)
 
     auto& av = config.at("verify_artifacts").get_wrapped<bool>();
     subcom->add_flag("--verify-artifacts", av.set_cli_config(0), av.description());
+
+    auto& platform = config.at("platform").get_wrapped<std::string>();
+    subcom->add_option("--platform", platform.set_cli_config(""), platform.description());
 }

--- a/micromamba/tests/test_create.py
+++ b/micromamba/tests/test_create.py
@@ -319,7 +319,7 @@ class TestCreate:
         if has_specs:
             cmd += ["xtensor"]
 
-        if has_specs:
+        if already_exists:
             with pytest.raises(subprocess.CalledProcessError):
                 create(*cmd)
         else:

--- a/micromamba/tests/test_create.py
+++ b/micromamba/tests/test_create.py
@@ -514,3 +514,27 @@ class TestCreate:
                 assert l["channel"].startswith(f"{ca}/conda-forge/")
                 assert l["url"].startswith(f"{ca}/conda-forge/")
                 assert l["version"].startswith("0.22.")
+
+    def test_set_platform(self, existing_cache):
+        # test a dummy platform/arch
+        create("-n", TestCreate.env_name, "--platform", "ptf-128")
+        rc_file = Path(TestCreate.prefix) / ".mambarc"
+        assert (rc_file).exists()
+
+        rc_dict = None
+        with open(rc_file) as f:
+            rc_dict = yaml.load(f, Loader=yaml.FullLoader)
+        assert rc_dict
+        assert set(rc_dict.keys()) == {"platform"}
+        assert rc_dict["platform"] == "ptf-128"
+
+        res = info("-n", TestCreate.env_name, "--json")
+        assert "__archspec=1=128" in res["virtual packages"]
+        assert res["platform"] == "ptf-128"
+
+        # test virtual packages
+        create("-n", TestCreate.env_name, "--platform", "win-32")
+        res = info("-n", TestCreate.env_name, "--json")
+        assert "__archspec=1=x86" in res["virtual packages"]
+        assert "__win=0=0" in res["virtual packages"]
+        assert res["platform"] == "win-32"


### PR DESCRIPTION
Description
---

Add `--platform` option to `micromamba` to define the platform.
Write the platform to a rc file at target prefix level when creating a new env to automatically allow re-use of that same platform for later operations
Add test

**Note**
Prevent use of rc configured `platform` when creating an env at an already existing prefix (overwriting it) to strange behavior where `create -n foo -y` would still write `platform` from a previous command.

In that special case, it's not that relevant neither to consider home dir or root prefix located rc values because they would still be read from those locations in later operations