### PR TITLE
DOC: do provide -c conda-forge in depends --tree example

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Here are some examples:
 `mamba repoquery depends xtensor` will show you a tree view of the dependencies of xtensor.
 
 ```
-$ mamba repoquery depends --tree xtensor
+$ mamba repoquery depends --tree -c conda-forge xtensor
 
 xtensor == 0.21.5
   ├─ libgcc-ng [>=7.3.0]


### PR DESCRIPTION
Without it, if conda-forge is not added to default lits of channels,
no interesting output is displayed at all.  E.g. here is what I see

```
$> mamba repoquery depends --tree xtensor               

                  __    __    __    __
                 /  \  /  \  /  \  /  \
                /    \/    \/    \/    \
███████████████/  /██/  /██/  /██/  /████████████████████████
              /  / \   / \   / \   / \  \____
             /  /   \_/   \_/   \_/   \    o \__,
            / _/                       \_____/  `
            |/
        ███╗   ███╗ █████╗ ███╗   ███╗██████╗  █████╗
        ████╗ ████║██╔══██╗████╗ ████║██╔══██╗██╔══██╗
        ██╔████╔██║███████║██╔████╔██║██████╔╝███████║
        ██║╚██╔╝██║██╔══██║██║╚██╔╝██║██╔══██╗██╔══██║
        ██║ ╚═╝ ██║██║  ██║██║ ╚═╝ ██║██████╔╝██║  ██║
        ╚═╝     ╚═╝╚═╝  ╚═╝╚═╝     ╚═╝╚═════╝ ╚═╝  ╚═╝

        mamba (0.19.1) supported by @QuantStack

        GitHub:  https://github.com/mamba-org/mamba
        Twitter: https://twitter.com/QuantStack

█████████████████████████████████████████████████████████████


Executing the query xtensor




````