### PR TITLE
Generate `PkgMgr` TUF role from file

### DIFF
--- a/libmamba/include/mamba/api/configuration.hpp
+++ b/libmamba/include/mamba/api/configuration.hpp
@@ -958,7 +958,8 @@ namespace mamba
     template <class T>
     auto Configurable<T>::set_default_value(const T& value) -> self_type&
     {
-        m_value = m_default_value;
+        m_default_value = value;
+        m_value = value;
         return *this;
     };
 

--- a/libmamba/include/mamba/core/validate.hpp
+++ b/libmamba/include/mamba/core/validate.hpp
@@ -703,7 +703,8 @@ namespace validate
             // std::set<std::string> roles() const override;
             RoleFullKeys self_keys() const override;
 
-            PkgMgrRole create_pkg_mgr() const;
+            PkgMgrRole create_pkg_mgr(const fs::path& p) const;
+            PkgMgrRole create_pkg_mgr(const json& j) const;
 
             /**
              * Return a ``RepoIndexChecker`` implementation (derived class)

--- a/libmamba/tests/test_configuration.cpp
+++ b/libmamba/tests/test_configuration.cpp
@@ -34,6 +34,10 @@ namespace mamba
                     .at("rc_files")
                     .get_wrapped<std::vector<fs::path>>()
                     .set_value({ fs::path(unique_location) });
+                mamba::Configuration::instance()
+                    .at("show_banner")
+                    .get_wrapped<bool>()
+                    .set_default_value(false);
                 mamba::Configuration::instance().load();
             }
 
@@ -59,6 +63,10 @@ namespace mamba
                     .at("rc_files")
                     .get_wrapped<std::vector<fs::path>>()
                     .set_value(sources);
+                mamba::Configuration::instance()
+                    .at("show_banner")
+                    .get_wrapped<bool>()
+                    .set_default_value(false);
                 mamba::Configuration::instance().load();
             }
 


### PR DESCRIPTION
Description
---

Generate `PkgMgr` TUF role from its file definition instead of only relying on `KeyMgr` delegated keys:
- update `KeyMgr::build_index_checker`
- update `KeyMgr::create_pkg_mgr`
- update tests

Also:
- remove banners in configuration tests
- fix `Configurable<T>::set_default_value`