### PR TITLE
Include credentials for default channel URLs

### DIFF
--- a/mamba/mamba/utils.py
+++ b/mamba/mamba/utils.py
@@ -246,7 +246,9 @@ def init_api_context(use_mamba_experimental=False):
                 )
     api_ctx.custom_multichannels = additional_custom_multichannels
 
-    api_ctx.default_channels = [get_base_url(x.url(with_credentials=True)) for x in context.default_channels]
+    api_ctx.default_channels = [
+        get_base_url(x.url(with_credentials=True)) for x in context.default_channels
+    ]
 
     if context.ssl_verify is False:
         api_ctx.ssl_verify = "<false>"

--- a/mamba/mamba/utils.py
+++ b/mamba/mamba/utils.py
@@ -246,7 +246,7 @@ def init_api_context(use_mamba_experimental=False):
                 )
     api_ctx.custom_multichannels = additional_custom_multichannels
 
-    api_ctx.default_channels = [x.base_url for x in context.default_channels]
+    api_ctx.default_channels = [get_base_url(x.url(with_credentials=True)) for x in context.default_channels]
 
     if context.ssl_verify is False:
         api_ctx.ssl_verify = "<false>"


### PR DESCRIPTION
Fixes #1364.

In our organization, we are using default channels from an internal Artifactory mirror, which requires that default channel URLs have credentials.

This PR adds the missing credential information to the default channel URLs.

For recreating the bug, set your default channel to a URL with credentials and check to what URL mamba connects. Before this PR, mamba would connect to the URL without credentials, resulting in fetching errors. With this PR, the correct URL including the credentials is used.