### PR TITLE
Micromamba: Substitute env vars in .condarc

### DIFF
--- a/libmamba/include/mamba/api/configuration.hpp
+++ b/libmamba/include/mamba/api/configuration.hpp
@@ -1042,7 +1042,7 @@ namespace mamba
     {
         if (env_var_configured())
             for (const auto& ev : m_env_var_names)
-                env::set(ev, "");
+                env::unset(ev);
         return *this;
     };
 

--- a/libmamba/include/mamba/api/configuration.hpp
+++ b/libmamba/include/mamba/api/configuration.hpp
@@ -866,7 +866,7 @@ namespace mamba
             return false;
 
         for (const auto& env_var : m_env_var_names)
-            if (!env::get(env_var).empty())
+            if (env::get(env_var))
                 return true;
 
         return false;
@@ -1948,18 +1948,19 @@ namespace mamba
             for (const auto& env_var : m_env_var_names)
             {
                 auto env_var_value = env::get(env_var);
-                if (!env_var_value.empty())
+                if (env_var_value)
                 {
                     try
                     {
-                        m_values.insert({ env_var, detail::Source<T>::deserialize(env_var_value) });
+                        m_values.insert(
+                            { env_var, detail::Source<T>::deserialize(env_var_value.value()) });
                         m_sources.push_back(env_var);
                     }
                     catch (const YAML::Exception& e)
                     {
                         LOG_ERROR << "Bad conversion of configurable '" << name()
                                   << "' from environment variable '" << env_var << "' with value '"
-                                  << env_var_value << "'";
+                                  << env_var_value.value() << "'";
                         throw e;
                     }
                 }

--- a/libmamba/include/mamba/core/environment.hpp
+++ b/libmamba/include/mamba/core/environment.hpp
@@ -87,6 +87,19 @@ namespace mamba
 #endif
         }
 
+        inline bool unset(const std::string& key)
+        {
+#ifdef _WIN32
+            auto res = SetEnvironmentVariableA(key.c_str(), NULL);
+            if (!res)
+            {
+                LOG_ERROR << "Could not unset environment variable: " << GetLastError();
+            }
+#else
+            return unsetenv(key.c_str());
+#endif
+        }
+
         inline fs::path which(const std::string& exe)
         {
             // TODO maybe add a cache?

--- a/libmamba/include/mamba/core/environment.hpp
+++ b/libmamba/include/mamba/core/environment.hpp
@@ -53,22 +53,16 @@ namespace mamba
             const size_t initial_size = 1024;
             std::unique_ptr<char[]> temp_small = std::make_unique<char[]>(initial_size);
             std::size_t size = GetEnvironmentVariableA(key.c_str(), temp_small.get(), initial_size);
-            if (size == 0)  // Error
+            if (size == 0)  // Error or empty/missing
             {
+                // Note that on Windows environment variables can never be empty,
+                // only missing. See https://stackoverflow.com/a/39095782
                 auto last_err = GetLastError();
-                if (last_err == ERROR_ENVVAR_NOT_FOUND)
-                {
-                    return {};
-                }
-                else if (last_err == NO_ERROR)
-                {
-                    return "";
-                }
-                else
+                if (last_err != ERROR_ENVVAR_NOT_FOUND)
                 {
                     LOG_ERROR << "Could not get environment variable: " << last_err;
-                    return {};
                 }
+                return {};
             }
             else if (size > initial_size)  // Buffer too small
             {

--- a/libmamba/include/mamba/core/environment.hpp
+++ b/libmamba/include/mamba/core/environment.hpp
@@ -52,7 +52,7 @@ namespace mamba
 #ifdef _WIN32
             const size_t initial_size = 1024;
             std::unique_ptr<char[]> temp_small = std::make_unique<char[]>(initial_size);
-            std::size_t size = GetEnvironmentVariableA(key.c_str(), tmp_small.get(), 0);
+            std::size_t size = GetEnvironmentVariableA(key.c_str(), temp_small.get(), 0);
             if (size == 0)  // Error
             {
                 auto last_err = GetLastError();

--- a/libmamba/include/mamba/core/environment.hpp
+++ b/libmamba/include/mamba/core/environment.hpp
@@ -87,7 +87,7 @@ namespace mamba
 #endif
         }
 
-        inline bool unset(const std::string& key)
+        inline void unset(const std::string& key)
         {
 #ifdef _WIN32
             auto res = SetEnvironmentVariableA(key.c_str(), NULL);
@@ -96,7 +96,7 @@ namespace mamba
                 LOG_ERROR << "Could not unset environment variable: " << GetLastError();
             }
 #else
-            return unsetenv(key.c_str());
+            unsetenv(key.c_str());
 #endif
         }
 

--- a/libmamba/include/mamba/core/environment.hpp
+++ b/libmamba/include/mamba/core/environment.hpp
@@ -52,7 +52,7 @@ namespace mamba
 #ifdef _WIN32
             const size_t initial_size = 1024;
             std::unique_ptr<char[]> temp_small = std::make_unique<char[]>(initial_size);
-            std::size_t size = GetEnvironmentVariableA(key.c_str(), temp_small.get(), 0);
+            std::size_t size = GetEnvironmentVariableA(key.c_str(), temp_small.get(), initial_size);
             if (size == 0)  // Error
             {
                 auto last_err = GetLastError();

--- a/libmamba/include/mamba/core/environment.hpp
+++ b/libmamba/include/mamba/core/environment.hpp
@@ -11,6 +11,7 @@
 #include <cstdlib>
 #include <cassert>
 #include <string_view>
+#include <optional>
 #include "mamba/core/output.hpp"
 
 #include "mamba_fs.hpp"
@@ -178,7 +179,8 @@ namespace mamba
             std::string maybe_home = env::get("USERPROFILE").value_or("");
             if (maybe_home.empty())
             {
-                maybe_home = concat(env::get("HOMEDRIVE"), env::get("HOMEPATH"));
+                maybe_home
+                    = concat(env::get("HOMEDRIVE").value_or(""), env::get("HOMEPATH").value_or(""));
             }
             if (maybe_home.empty())
             {

--- a/libmamba/src/api/configuration.cpp
+++ b/libmamba/src/api/configuration.cpp
@@ -465,9 +465,10 @@ namespace mamba
             std::vector<fs::path> paths = { Context::instance().root_prefix / "pkgs",
                                             env::home_directory() / ".mamba" / "pkgs" };
 #ifdef _WIN32
-            if (!env::get("APPDATA").empty())
+            auto appdata = env::get("APPDATA");
+            if (appdata)
             {
-                paths.push_back(fs::path(env::get("APPDATA")) / ".mamba" / "pkgs");
+                paths.push_back(fs::path(appdata.value()) / ".mamba" / "pkgs");
             }
 #endif
             return paths;

--- a/libmamba/src/core/activation.cpp
+++ b/libmamba/src/core/activation.cpp
@@ -780,10 +780,10 @@ namespace mamba
             // use.
             return { "", "" };
         }
-        std::string current_prompt_modifier = env::get("CONDA_PROMPT_MODIFIER");
-        if (!current_prompt_modifier.empty())
+        auto current_prompt_modifier = env::get("CONDA_PROMPT_MODIFIER");
+        if (current_prompt_modifier)
         {
-            replace_all(ps1, current_prompt_modifier, "");
+            replace_all(ps1, current_prompt_modifier.value(), "");
         }
         // Because we're using single-quotes to set shell variables, we need to handle
         // the proper escaping of single quotes that are already part of the string.

--- a/libmamba/src/core/link.cpp
+++ b/libmamba/src/core/link.cpp
@@ -344,8 +344,8 @@ namespace mamba
         if (on_win)
         {
             ensure_comspec_set();
-            std::string comspec = env::get("COMSPEC");
-            if (comspec.size() == 0)
+            auto comspec = env::get("COMSPEC");
+            if (!comspec)
             {
                 LOG_ERROR << "Failed to run " << action << " for " << pkg_info.name
                           << " due to COMSPEC not set in env vars.";
@@ -360,11 +360,11 @@ namespace mamba
                                         false,
                                         { "@CALL", path });
 
-                command_args = { comspec, "/d", "/c", script_file->path() };
+                command_args = { comspec.value(), "/d", "/c", script_file->path() };
             }
             else
             {
-                command_args = { comspec, "/d", "/c", path };
+                command_args = { comspec.value(), "/d", "/c", path };
             }
         }
 
@@ -404,7 +404,7 @@ namespace mamba
                                      ? std::to_string(pkg_info.build_number)
                                      : pkg_info.build_string;
 
-        std::string PATH = env::get("PATH");
+        std::string PATH = env::get("PATH").value_or("");
         envmap["PATH"] = concat(path.parent_path().c_str(), env::pathsep(), PATH);
 
         std::string cargs = join(" ", command_args);
@@ -442,7 +442,7 @@ namespace mamba
         if (ec)
         {
             LOG_ERROR << "response code: " << status << " error message: " << ec.message();
-            if (script_file != nullptr && env::get("CONDA_TEST_SAVE_TEMPS").size())
+            if (script_file != nullptr && env::get("CONDA_TEST_SAVE_TEMPS"))
             {
                 LOG_ERROR << "CONDA_TEST_SAVE_TEMPS :: retaining run_script" << script_file->path();
             }

--- a/libmamba/src/core/util.cpp
+++ b/libmamba/src/core/util.cpp
@@ -1259,13 +1259,13 @@ namespace mamba
 
     bool ensure_comspec_set()
     {
-        std::string cmd_exe = env::get("COMSPEC");
+        std::string cmd_exe = env::get("COMSPEC").value_or("");
         if (!ends_with(to_lower(cmd_exe), "cmd.exe"))
         {
-            cmd_exe = fs::path(env::get("SystemRoot")) / "System32" / "cmd.exe";
+            cmd_exe = fs::path(env::get("SystemRoot").value_or("")) / "System32" / "cmd.exe";
             if (!fs::is_regular_file(cmd_exe))
             {
-                cmd_exe = fs::path(env::get("windir")) / "System32" / "cmd.exe";
+                cmd_exe = fs::path(env::get("windir").value_or("")) / "System32" / "cmd.exe";
             }
             if (!fs::is_regular_file(cmd_exe))
             {
@@ -1291,7 +1291,6 @@ namespace mamba
 
 #ifdef _WIN32
         ensure_comspec_set();
-        std::string comspec = env::get("COMSPEC");
         std::string conda_bat;
 
         // TODO
@@ -1305,11 +1304,8 @@ namespace mamba
         }
         else
         {
-            conda_bat = env::get("CONDA_BAT");
-            if (conda_bat.size() == 0)
-            {
-                conda_bat = fs::absolute(root_prefix) / "condabin" / bat_name;
-            }
+            conda_bat
+                = env::get("CONDA_BAT").value_or(fs::absolute(root_prefix) / "condabin" / bat_name);
         }
         if (!fs::exists(conda_bat) && Context::instance().is_micromamba)
         {
@@ -1444,8 +1440,8 @@ namespace mamba
         if (on_win)
         {
             ensure_comspec_set();
-            std::string comspec = env::get("COMSPEC");
-            if (comspec.size() == 0)
+            auto comspec = env::get("COMSPEC");
+            if (!comspec)
             {
                 throw std::runtime_error(
                     concat("Failed to run script: COMSPEC not set in env vars."));
@@ -1454,7 +1450,7 @@ namespace mamba
             script_file = wrap_call(
                 Context::instance().root_prefix, prefix, Context::instance().dev, false, cmd);
 
-            command_args = { comspec, "/D", "/C", script_file->path() };
+            command_args = { comspec.value(), "/D", "/C", script_file->path() };
         }
         else
         {

--- a/libmamba/src/core/util_os.cpp
+++ b/libmamba/src/core/util_os.cpp
@@ -195,9 +195,10 @@ namespace mamba
     std::string windows_version()
     {
         LOG_DEBUG << "Loading Windows virtual package";
-        if (!env::get("CONDA_OVERRIDE_WIN").empty())
+        auto override_version = env::get("CONDA_OVERRIDE_WIN");
+        if (override_version)
         {
-            return env::get("CONDA_OVERRIDE_WIN");
+            return override_version.value();
         }
 
         if (!on_win)
@@ -206,7 +207,7 @@ namespace mamba
         }
 
         std::string out, err;
-        std::vector<std::string> args = { env::get("COMSPEC"), "/c", "ver" };
+        std::vector<std::string> args = { env::get("COMSPEC").value_or(""), "/c", "ver" };
         auto [status, ec] = reproc::run(
             args, reproc::options{}, reproc::sink::string(out), reproc::sink::string(err));
 
@@ -242,9 +243,10 @@ namespace mamba
     std::string macos_version()
     {
         LOG_DEBUG << "Loading macos virtual package";
-        if (!env::get("CONDA_OVERRIDE_OSX").empty())
+        auto override_version = env::get("CONDA_OVERRIDE_OSX");
+        if (override_version)
         {
-            return env::get("CONDA_OVERRIDE_OSX");
+            return override_version.value();
         }
 
         if (!on_mac)
@@ -277,9 +279,10 @@ namespace mamba
     std::string linux_version()
     {
         LOG_DEBUG << "Loading linux virtual package";
-        if (!env::get("CONDA_OVERRIDE_LINUX").empty())
+        auto override_version = env::get("CONDA_OVERRIDE_LINUX");
+        if (override_version)
         {
-            return env::get("CONDA_OVERRIDE_LINUX");
+            return override_version.value();
         }
         if (!on_linux)
         {

--- a/libmamba/src/core/virtual_packages.cpp
+++ b/libmamba/src/core/virtual_packages.cpp
@@ -21,9 +21,10 @@ namespace mamba
     {
         std::string glibc_version()
         {
-            if (!env::get("CONDA_OVERRIDE_GLIBC").empty())
+            auto override_version = env::get("CONDA_OVERRIDE_GLIBC");
+            if (override_version)
             {
-                return env::get("CONDA_OVERRIDE_GLIBC");
+                return override_version.value();
             }
 
             if (!on_linux)
@@ -51,9 +52,10 @@ namespace mamba
         {
             LOG_DEBUG << "Loading CUDA virtual package";
 
-            if (!env::get("CONDA_OVERRIDE_CUDA").empty())
+            auto override_version = env::get("CONDA_OVERRIDE_CUDA");
+            if (override_version)
             {
-                return env::get("CONDA_OVERRIDE_CUDA");
+                return override_version.value();
             }
 
             std::string out, err;
@@ -70,7 +72,7 @@ namespace mamba
             {
                 // Windows fallback
                 bool may_exist = false;
-                std::string path = env::get("PATH");
+                std::string path = env::get("PATH").value_or("");
                 std::vector<std::string> paths = split(path, env::pathsep());
 
                 for (auto& p : paths)

--- a/libmamba/tests/test_configuration.cpp
+++ b/libmamba/tests/test_configuration.cpp
@@ -726,347 +726,352 @@ namespace mamba
         env::set(env_name, "yeap");                                                                \
         ASSERT_THROW(load_test_config(rc2), YAML::Exception);                                      \
                                                                                                    \
-        env::unset(env_name);
-        load_test_config(rc2);
+        env::unset(env_name);                                                                      \
+        load_test_config(rc2);                                                                     \
     }
 
-    TEST_BOOL_CONFIGURABLE(ssl_no_revoke, ctx.ssl_no_revoke);
+        TEST_BOOL_CONFIGURABLE(ssl_no_revoke, ctx.ssl_no_revoke);
 
-    TEST_BOOL_CONFIGURABLE(override_channels_enabled, ctx.override_channels_enabled);
+        TEST_BOOL_CONFIGURABLE(override_channels_enabled, ctx.override_channels_enabled);
 
-    TEST_BOOL_CONFIGURABLE(auto_activate_base, ctx.auto_activate_base);
+        TEST_BOOL_CONFIGURABLE(auto_activate_base, ctx.auto_activate_base);
 
-    TEST_F(Configuration, channel_priority)
-    {
-        std::string rc1 = "channel_priority: flexible";
-        std::string rc2 = "channel_priority: strict";
-        std::string rc3 = "channel_priority: disabled";
+        TEST_F(Configuration, channel_priority)
+        {
+            std::string rc1 = "channel_priority: flexible";
+            std::string rc2 = "channel_priority: strict";
+            std::string rc3 = "channel_priority: disabled";
 
-        load_test_config({ rc1, rc2, rc3 });
-        EXPECT_EQ(config.at("channel_priority").value<ChannelPriority>(),
-                  ChannelPriority::kFlexible);
-        EXPECT_TRUE(ctx.channel_priority == ChannelPriority::kFlexible);
+            load_test_config({ rc1, rc2, rc3 });
+            EXPECT_EQ(config.at("channel_priority").value<ChannelPriority>(),
+                      ChannelPriority::kFlexible);
+            EXPECT_TRUE(ctx.channel_priority == ChannelPriority::kFlexible);
 
-        load_test_config({ rc3, rc1, rc2 });
-        EXPECT_EQ(config.at("channel_priority").value<ChannelPriority>(),
-                  ChannelPriority::kDisabled);
-        EXPECT_TRUE(ctx.channel_priority == ChannelPriority::kDisabled);
+            load_test_config({ rc3, rc1, rc2 });
+            EXPECT_EQ(config.at("channel_priority").value<ChannelPriority>(),
+                      ChannelPriority::kDisabled);
+            EXPECT_TRUE(ctx.channel_priority == ChannelPriority::kDisabled);
 
-        load_test_config({ rc2, rc1, rc3 });
-        EXPECT_EQ(config.at("channel_priority").value<ChannelPriority>(), ChannelPriority::kStrict);
-        EXPECT_TRUE(ctx.channel_priority == ChannelPriority::kStrict);
+            load_test_config({ rc2, rc1, rc3 });
+            EXPECT_EQ(config.at("channel_priority").value<ChannelPriority>(),
+                      ChannelPriority::kStrict);
+            EXPECT_TRUE(ctx.channel_priority == ChannelPriority::kStrict);
 
-        env::set("MAMBA_CHANNEL_PRIORITY", "strict");
-        load_test_config(rc3);
+            env::set("MAMBA_CHANNEL_PRIORITY", "strict");
+            load_test_config(rc3);
 
-        ASSERT_EQ(config.sources().size(), 1);
-        ASSERT_EQ(config.valid_sources().size(), 1);
-        std::string src = shrink_source(0);
+            ASSERT_EQ(config.sources().size(), 1);
+            ASSERT_EQ(config.valid_sources().size(), 1);
+            std::string src = shrink_source(0);
 
-        EXPECT_EQ(config.dump(MAMBA_SHOW_CONFIG_VALUES | MAMBA_SHOW_CONFIG_SRCS),
-                  "channel_priority: strict  # 'MAMBA_CHANNEL_PRIORITY' > '" + src + "'");
-        EXPECT_EQ(config.at("channel_priority").value<ChannelPriority>(), ChannelPriority::kStrict);
-        EXPECT_EQ(ctx.channel_priority, ChannelPriority::kStrict);
+            EXPECT_EQ(config.dump(MAMBA_SHOW_CONFIG_VALUES | MAMBA_SHOW_CONFIG_SRCS),
+                      "channel_priority: strict  # 'MAMBA_CHANNEL_PRIORITY' > '" + src + "'");
+            EXPECT_EQ(config.at("channel_priority").value<ChannelPriority>(),
+                      ChannelPriority::kStrict);
+            EXPECT_EQ(ctx.channel_priority, ChannelPriority::kStrict);
 
-        config.at("channel_priority").set_yaml_value("flexible").compute();
-        EXPECT_EQ(config.dump(MAMBA_SHOW_CONFIG_VALUES | MAMBA_SHOW_CONFIG_SRCS),
-                  "channel_priority: flexible  # 'API' > 'MAMBA_CHANNEL_PRIORITY' > '" + src + "'");
-        EXPECT_EQ(config.at("channel_priority").value<ChannelPriority>(),
-                  ChannelPriority::kFlexible);
-        EXPECT_EQ(ctx.channel_priority, ChannelPriority::kFlexible);
+            config.at("channel_priority").set_yaml_value("flexible").compute();
+            EXPECT_EQ(config.dump(MAMBA_SHOW_CONFIG_VALUES | MAMBA_SHOW_CONFIG_SRCS),
+                      "channel_priority: flexible  # 'API' > 'MAMBA_CHANNEL_PRIORITY' > '" + src
+                          + "'");
+            EXPECT_EQ(config.at("channel_priority").value<ChannelPriority>(),
+                      ChannelPriority::kFlexible);
+            EXPECT_EQ(ctx.channel_priority, ChannelPriority::kFlexible);
 
-        env::set("MAMBA_CHANNEL_PRIORITY", "stric");
-        ASSERT_THROW(load_test_config(rc3), YAML::Exception);
+            env::set("MAMBA_CHANNEL_PRIORITY", "stric");
+            ASSERT_THROW(load_test_config(rc3), YAML::Exception);
 
-        env::unset("MAMBA_CHANNEL_PRIORITY");
-    }
+            env::unset("MAMBA_CHANNEL_PRIORITY");
+        }
 
-    TEST_F(Configuration, pinned_packages)
-    {
-        std::string rc1 = unindent(R"(
+        TEST_F(Configuration, pinned_packages)
+        {
+            std::string rc1 = unindent(R"(
                 pinned_packages:
                     - jupyterlab=3
                     - numpy=1.19)");
-        std::string rc2 = unindent(R"(
+            std::string rc2 = unindent(R"(
                 pinned_packages:
                     - matplotlib
                     - numpy=1.19)");
-        std::string rc3 = unindent(R"(
+            std::string rc3 = unindent(R"(
                 pinned_packages:
                     - jupyterlab=3
                     - bokeh
                     - matplotlib)");
 
-        load_test_config({ rc1, rc2, rc3 });
-        EXPECT_EQ(config.dump(), unindent(R"(
+            load_test_config({ rc1, rc2, rc3 });
+            EXPECT_EQ(config.dump(), unindent(R"(
                                         pinned_packages:
                                           - jupyterlab=3
                                           - numpy=1.19
                                           - matplotlib
                                           - bokeh)"));
-        EXPECT_EQ(
-            ctx.pinned_packages,
-            std::vector<std::string>({ "jupyterlab=3", "numpy=1.19", "matplotlib", "bokeh" }));
+            EXPECT_EQ(
+                ctx.pinned_packages,
+                std::vector<std::string>({ "jupyterlab=3", "numpy=1.19", "matplotlib", "bokeh" }));
 
-        load_test_config({ rc2, rc1, rc3 });
-        ASSERT_TRUE(config.at("pinned_packages").yaml_value());
-        EXPECT_EQ(config.dump(), unindent(R"(
+            load_test_config({ rc2, rc1, rc3 });
+            ASSERT_TRUE(config.at("pinned_packages").yaml_value());
+            EXPECT_EQ(config.dump(), unindent(R"(
                                         pinned_packages:
                                           - matplotlib
                                           - numpy=1.19
                                           - jupyterlab=3
                                           - bokeh)"));
-        EXPECT_EQ(
-            ctx.pinned_packages,
-            std::vector<std::string>({ "matplotlib", "numpy=1.19", "jupyterlab=3", "bokeh" }));
+            EXPECT_EQ(
+                ctx.pinned_packages,
+                std::vector<std::string>({ "matplotlib", "numpy=1.19", "jupyterlab=3", "bokeh" }));
 
-        env::set("MAMBA_PINNED_PACKAGES", "mpl=10.2,xtensor");
-        load_test_config(rc1);
-        ASSERT_EQ(config.sources().size(), 1);
-        ASSERT_EQ(config.valid_sources().size(), 1);
-        std::string src1 = shrink_source(0);
+            env::set("MAMBA_PINNED_PACKAGES", "mpl=10.2,xtensor");
+            load_test_config(rc1);
+            ASSERT_EQ(config.sources().size(), 1);
+            ASSERT_EQ(config.valid_sources().size(), 1);
+            std::string src1 = shrink_source(0);
 
-        EXPECT_EQ(config.dump(MAMBA_SHOW_CONFIG_VALUES | MAMBA_SHOW_CONFIG_SRCS),
-                  unindent((R"(
+            EXPECT_EQ(config.dump(MAMBA_SHOW_CONFIG_VALUES | MAMBA_SHOW_CONFIG_SRCS),
+                      unindent((R"(
                                 pinned_packages:
                                   - mpl=10.2  # 'MAMBA_PINNED_PACKAGES'
                                   - xtensor  # 'MAMBA_PINNED_PACKAGES'
                                   - jupyterlab=3  # ')"
-                            + src1 + R"('
+                                + src1 + R"('
                                   - numpy=1.19  # ')"
-                            + src1 + "'")
-                               .c_str()));
-        EXPECT_EQ(
-            ctx.pinned_packages,
-            std::vector<std::string>({ "mpl=10.2", "xtensor", "jupyterlab=3", "numpy=1.19" }));
+                                + src1 + "'")
+                                   .c_str()));
+            EXPECT_EQ(
+                ctx.pinned_packages,
+                std::vector<std::string>({ "mpl=10.2", "xtensor", "jupyterlab=3", "numpy=1.19" }));
 
-        config.at("pinned_packages").set_yaml_value("pytest").compute();
-        EXPECT_EQ(config.dump(MAMBA_SHOW_CONFIG_VALUES | MAMBA_SHOW_CONFIG_SRCS),
-                  unindent((R"(
+            config.at("pinned_packages").set_yaml_value("pytest").compute();
+            EXPECT_EQ(config.dump(MAMBA_SHOW_CONFIG_VALUES | MAMBA_SHOW_CONFIG_SRCS),
+                      unindent((R"(
                                 pinned_packages:
                                   - pytest  # 'API'
                                   - mpl=10.2  # 'MAMBA_PINNED_PACKAGES'
                                   - xtensor  # 'MAMBA_PINNED_PACKAGES'
                                   - jupyterlab=3  # ')"
-                            + src1 + R"('
+                                + src1 + R"('
                                   - numpy=1.19  # ')"
-                            + src1 + "'")
-                               .c_str()));
-        EXPECT_EQ(ctx.pinned_packages,
-                  std::vector<std::string>(
-                      { "pytest", "mpl=10.2", "xtensor", "jupyterlab=3", "numpy=1.19" }));
+                                + src1 + "'")
+                                   .c_str()));
+            EXPECT_EQ(ctx.pinned_packages,
+                      std::vector<std::string>(
+                          { "pytest", "mpl=10.2", "xtensor", "jupyterlab=3", "numpy=1.19" }));
 
-        env::unset("MAMBA_PINNED_PACKAGES");
-    }
+            env::unset("MAMBA_PINNED_PACKAGES");
+        }
 
 
-    TEST_BOOL_CONFIGURABLE(no_pin, config.at("no_pin").value<bool>());
+        TEST_BOOL_CONFIGURABLE(no_pin, config.at("no_pin").value<bool>());
 
-    TEST_BOOL_CONFIGURABLE(retry_clean_cache, config.at("retry_clean_cache").value<bool>());
+        TEST_BOOL_CONFIGURABLE(retry_clean_cache, config.at("retry_clean_cache").value<bool>());
 
-    TEST_BOOL_CONFIGURABLE(allow_softlinks, ctx.allow_softlinks);
+        TEST_BOOL_CONFIGURABLE(allow_softlinks, ctx.allow_softlinks);
 
-    TEST_BOOL_CONFIGURABLE(always_softlink, ctx.always_softlink);
+        TEST_BOOL_CONFIGURABLE(always_softlink, ctx.always_softlink);
 
-    TEST_BOOL_CONFIGURABLE(always_copy, ctx.always_copy);
+        TEST_BOOL_CONFIGURABLE(always_copy, ctx.always_copy);
 
-    TEST_F(Configuration, always_softlink_and_copy)
-    {
-        env::set("MAMBA_ALWAYS_COPY", "true");
-        ASSERT_THROW(load_test_config("always_softlink: true"), std::runtime_error);
-        env::unset("MAMBA_ALWAYS_COPY");
+        TEST_F(Configuration, always_softlink_and_copy)
+        {
+            env::set("MAMBA_ALWAYS_COPY", "true");
+            ASSERT_THROW(load_test_config("always_softlink: true"), std::runtime_error);
+            env::unset("MAMBA_ALWAYS_COPY");
 
-        env::set("MAMBA_ALWAYS_SOFTLINK", "true");
-        ASSERT_THROW(load_test_config("always_copy: true"), std::runtime_error);
-        env::unset("MAMBA_ALWAYS_SOFTLINK");
+            env::set("MAMBA_ALWAYS_SOFTLINK", "true");
+            ASSERT_THROW(load_test_config("always_copy: true"), std::runtime_error);
+            env::unset("MAMBA_ALWAYS_SOFTLINK");
 
-        load_test_config("always_softlink: false\nalways_copy: false");
-    }
+            load_test_config("always_softlink: false\nalways_copy: false");
+        }
 
-    TEST_F(Configuration, safety_checks)
-    {
-        std::string rc1 = "safety_checks: enabled";
-        std::string rc2 = "safety_checks: warn";
-        std::string rc3 = "safety_checks: disabled";
+        TEST_F(Configuration, safety_checks)
+        {
+            std::string rc1 = "safety_checks: enabled";
+            std::string rc2 = "safety_checks: warn";
+            std::string rc3 = "safety_checks: disabled";
 
-        load_test_config({ rc1, rc2, rc3 });
-        EXPECT_EQ(config.at("safety_checks").value<VerificationLevel>(),
-                  VerificationLevel::kEnabled);
-        EXPECT_EQ(ctx.safety_checks, VerificationLevel::kEnabled);
+            load_test_config({ rc1, rc2, rc3 });
+            EXPECT_EQ(config.at("safety_checks").value<VerificationLevel>(),
+                      VerificationLevel::kEnabled);
+            EXPECT_EQ(ctx.safety_checks, VerificationLevel::kEnabled);
 
-        load_test_config({ rc2, rc1, rc3 });
-        EXPECT_EQ(config.at("safety_checks").value<VerificationLevel>(), VerificationLevel::kWarn);
-        EXPECT_EQ(ctx.safety_checks, VerificationLevel::kWarn);
+            load_test_config({ rc2, rc1, rc3 });
+            EXPECT_EQ(config.at("safety_checks").value<VerificationLevel>(),
+                      VerificationLevel::kWarn);
+            EXPECT_EQ(ctx.safety_checks, VerificationLevel::kWarn);
 
-        load_test_config({ rc3, rc1, rc3 });
-        EXPECT_EQ(config.at("safety_checks").value<VerificationLevel>(),
-                  VerificationLevel::kDisabled);
-        EXPECT_EQ(ctx.safety_checks, VerificationLevel::kDisabled);
+            load_test_config({ rc3, rc1, rc3 });
+            EXPECT_EQ(config.at("safety_checks").value<VerificationLevel>(),
+                      VerificationLevel::kDisabled);
+            EXPECT_EQ(ctx.safety_checks, VerificationLevel::kDisabled);
 
-        env::set("MAMBA_SAFETY_CHECKS", "warn");
-        load_test_config(rc1);
+            env::set("MAMBA_SAFETY_CHECKS", "warn");
+            load_test_config(rc1);
 
-        ASSERT_EQ(config.sources().size(), 1);
-        ASSERT_EQ(config.valid_sources().size(), 1);
-        std::string src = shrink_source(0);
+            ASSERT_EQ(config.sources().size(), 1);
+            ASSERT_EQ(config.valid_sources().size(), 1);
+            std::string src = shrink_source(0);
 
-        EXPECT_EQ(config.dump(MAMBA_SHOW_CONFIG_VALUES | MAMBA_SHOW_CONFIG_SRCS),
-                  "safety_checks: warn  # 'MAMBA_SAFETY_CHECKS' > '" + src + "'");
-        EXPECT_EQ(config.at("safety_checks").value<VerificationLevel>(), VerificationLevel::kWarn);
-        EXPECT_EQ(ctx.safety_checks, VerificationLevel::kWarn);
+            EXPECT_EQ(config.dump(MAMBA_SHOW_CONFIG_VALUES | MAMBA_SHOW_CONFIG_SRCS),
+                      "safety_checks: warn  # 'MAMBA_SAFETY_CHECKS' > '" + src + "'");
+            EXPECT_EQ(config.at("safety_checks").value<VerificationLevel>(),
+                      VerificationLevel::kWarn);
+            EXPECT_EQ(ctx.safety_checks, VerificationLevel::kWarn);
 
-        config.at("safety_checks").set_yaml_value("disabled").compute();
-        EXPECT_EQ(config.dump(MAMBA_SHOW_CONFIG_VALUES | MAMBA_SHOW_CONFIG_SRCS),
-                  "safety_checks: disabled  # 'API' > 'MAMBA_SAFETY_CHECKS' > '" + src + "'");
-        EXPECT_EQ(config.at("safety_checks").value<VerificationLevel>(),
-                  VerificationLevel::kDisabled);
-        EXPECT_EQ(ctx.safety_checks, VerificationLevel::kDisabled);
+            config.at("safety_checks").set_yaml_value("disabled").compute();
+            EXPECT_EQ(config.dump(MAMBA_SHOW_CONFIG_VALUES | MAMBA_SHOW_CONFIG_SRCS),
+                      "safety_checks: disabled  # 'API' > 'MAMBA_SAFETY_CHECKS' > '" + src + "'");
+            EXPECT_EQ(config.at("safety_checks").value<VerificationLevel>(),
+                      VerificationLevel::kDisabled);
+            EXPECT_EQ(ctx.safety_checks, VerificationLevel::kDisabled);
 
-        env::set("MAMBA_SAFETY_CHECKS", "yeap");
-        ASSERT_THROW(load_test_config(rc2), std::runtime_error);
+            env::set("MAMBA_SAFETY_CHECKS", "yeap");
+            ASSERT_THROW(load_test_config(rc2), std::runtime_error);
 
-        env::unset("MAMBA_SAFETY_CHECKS");
-        load_test_config(rc2);
-    }
+            env::unset("MAMBA_SAFETY_CHECKS");
+            load_test_config(rc2);
+        }
 
-    TEST_BOOL_CONFIGURABLE(extra_safety_checks, ctx.extra_safety_checks);
+        TEST_BOOL_CONFIGURABLE(extra_safety_checks, ctx.extra_safety_checks);
 
 #undef TEST_BOOL_CONFIGURABLE
 
-    TEST_F(Configuration, has_config_name)
-    {
-        using namespace detail;
-
-        EXPECT_FALSE(has_config_name(""));
-        EXPECT_FALSE(has_config_name("conf"));
-        EXPECT_FALSE(has_config_name("config"));
-        EXPECT_FALSE(has_config_name("config.conda"));
-        EXPECT_FALSE(has_config_name("conf.condarc"));
-        EXPECT_FALSE(has_config_name("conf.mambarc"));
-
-        EXPECT_TRUE(has_config_name("condarc"));
-        EXPECT_TRUE(has_config_name("mambarc"));
-        EXPECT_TRUE(has_config_name(".condarc"));
-        EXPECT_TRUE(has_config_name(".mambarc"));
-        EXPECT_TRUE(has_config_name(".yaml"));
-        EXPECT_TRUE(has_config_name(".yml"));
-        EXPECT_TRUE(has_config_name("conf.yaml"));
-        EXPECT_TRUE(has_config_name("config.yml"));
-    }
-
-    TEST_F(Configuration, is_config_file)
-    {
-        using namespace detail;
-
-        fs::path p = "config_test/.condarc";
-
-        std::vector<fs::path> wrong_paths = {
-            "config_test", "conf_test", "config_test/condarc", "history_test/conda-meta/history"
-        };
-
-        EXPECT_TRUE(is_config_file(p));
-
-        for (fs::path p : wrong_paths)
+        TEST_F(Configuration, has_config_name)
         {
-            EXPECT_FALSE(is_config_file(p));
+            using namespace detail;
+
+            EXPECT_FALSE(has_config_name(""));
+            EXPECT_FALSE(has_config_name("conf"));
+            EXPECT_FALSE(has_config_name("config"));
+            EXPECT_FALSE(has_config_name("config.conda"));
+            EXPECT_FALSE(has_config_name("conf.condarc"));
+            EXPECT_FALSE(has_config_name("conf.mambarc"));
+
+            EXPECT_TRUE(has_config_name("condarc"));
+            EXPECT_TRUE(has_config_name("mambarc"));
+            EXPECT_TRUE(has_config_name(".condarc"));
+            EXPECT_TRUE(has_config_name(".mambarc"));
+            EXPECT_TRUE(has_config_name(".yaml"));
+            EXPECT_TRUE(has_config_name(".yml"));
+            EXPECT_TRUE(has_config_name("conf.yaml"));
+            EXPECT_TRUE(has_config_name("config.yml"));
         }
-    }
 
-    TEST_F(Configuration, print_scalar_node)
-    {
-        using namespace detail;
+        TEST_F(Configuration, is_config_file)
+        {
+            using namespace detail;
 
-        std::string rc = "foo";
-        auto node = YAML::Load(rc);
-        auto node_src = YAML::Load("/some/source1");
-        YAML::Emitter out;
-        print_scalar_node(out, node, node_src, true);
+            fs::path p = "config_test/.condarc";
 
-        std::string res = out.c_str();
-        EXPECT_EQ(res, "foo  # '/some/source1'");
+            std::vector<fs::path> wrong_paths = {
+                "config_test", "conf_test", "config_test/condarc", "history_test/conda-meta/history"
+            };
 
-        rc = unindent(R"(
+            EXPECT_TRUE(is_config_file(p));
+
+            for (fs::path p : wrong_paths)
+            {
+                EXPECT_FALSE(is_config_file(p));
+            }
+        }
+
+        TEST_F(Configuration, print_scalar_node)
+        {
+            using namespace detail;
+
+            std::string rc = "foo";
+            auto node = YAML::Load(rc);
+            auto node_src = YAML::Load("/some/source1");
+            YAML::Emitter out;
+            print_scalar_node(out, node, node_src, true);
+
+            std::string res = out.c_str();
+            EXPECT_EQ(res, "foo  # '/some/source1'");
+
+            rc = unindent(R"(
                             foo: bar
                             bar: baz)");
-        node = YAML::Load(rc);
-        EXPECT_THROW(print_scalar_node(out, node, node_src, true), std::runtime_error);
+            node = YAML::Load(rc);
+            EXPECT_THROW(print_scalar_node(out, node, node_src, true), std::runtime_error);
 
-        rc = unindent(R"(
+            rc = unindent(R"(
                             - foo
                             - bar)");
-        node = YAML::Load(rc);
-        EXPECT_THROW(print_scalar_node(out, node, node_src, true), std::runtime_error);
+            node = YAML::Load(rc);
+            EXPECT_THROW(print_scalar_node(out, node, node_src, true), std::runtime_error);
 
-        node = YAML::Node();
-        EXPECT_THROW(print_scalar_node(out, node, node_src, true), std::runtime_error);
-    }
+            node = YAML::Node();
+            EXPECT_THROW(print_scalar_node(out, node, node_src, true), std::runtime_error);
+        }
 
-    TEST_F(Configuration, print_map_node)
-    {
-        using namespace detail;
+        TEST_F(Configuration, print_map_node)
+        {
+            using namespace detail;
 
-        std::string rc = unindent(R"(
+            std::string rc = unindent(R"(
                                 foo: bar
                                 bar: baz)");
-        auto node = YAML::Load(rc);
-        auto node_src = YAML::Load(unindent(R"(
+            auto node = YAML::Load(rc);
+            auto node_src = YAML::Load(unindent(R"(
                                           foo: /some/source1
                                           bar: /some/source2)"));
-        YAML::Emitter out;
-        print_map_node(out, node, node_src, true);
+            YAML::Emitter out;
+            print_map_node(out, node, node_src, true);
 
-        std::string res = out.c_str();
-        EXPECT_EQ(res, unindent(R"(
+            std::string res = out.c_str();
+            EXPECT_EQ(res, unindent(R"(
                                 foo: bar  # '/some/source1'
                                 bar: baz  # '/some/source2')"));
 
-        rc = "foo";
-        node = YAML::Load(rc);
-        EXPECT_THROW(print_map_node(out, node, node_src, true), std::runtime_error);
+            rc = "foo";
+            node = YAML::Load(rc);
+            EXPECT_THROW(print_map_node(out, node, node_src, true), std::runtime_error);
 
-        rc = unindent(R"(
+            rc = unindent(R"(
                             - foo
                             - bar)");
-        node = YAML::Load(rc);
-        EXPECT_THROW(print_map_node(out, node, node_src, true), std::runtime_error);
+            node = YAML::Load(rc);
+            EXPECT_THROW(print_map_node(out, node, node_src, true), std::runtime_error);
 
-        node = YAML::Node();
-        EXPECT_THROW(print_map_node(out, node, node_src, true), std::runtime_error);
-    }
+            node = YAML::Node();
+            EXPECT_THROW(print_map_node(out, node, node_src, true), std::runtime_error);
+        }
 
-    TEST_F(Configuration, print_seq_node)
-    {
-        using namespace detail;
+        TEST_F(Configuration, print_seq_node)
+        {
+            using namespace detail;
 
-        std::string rc = unindent(R"(
+            std::string rc = unindent(R"(
                                         - foo
                                         - bar
                                         )");
-        auto node = YAML::Load(rc);
-        auto node_src = YAML::Load(unindent(R"(
+            auto node = YAML::Load(rc);
+            auto node_src = YAML::Load(unindent(R"(
                                                 - /some/source1
                                                 - /some/source2
                                                 )"));
-        YAML::Emitter out;
-        print_seq_node(out, node, node_src, true);
+            YAML::Emitter out;
+            print_seq_node(out, node, node_src, true);
 
-        std::string res = out.c_str();
-        EXPECT_EQ(res, unindent(R"(
+            std::string res = out.c_str();
+            EXPECT_EQ(res, unindent(R"(
                                   - foo  # '/some/source1'
                                   - bar  # '/some/source2')"));
 
-        rc = "foo";
-        node = YAML::Load(rc);
-        EXPECT_THROW(print_seq_node(out, node, node_src, true), std::runtime_error);
+            rc = "foo";
+            node = YAML::Load(rc);
+            EXPECT_THROW(print_seq_node(out, node, node_src, true), std::runtime_error);
 
-        rc = unindent(R"(
+            rc = unindent(R"(
                             foo: bar
                             bar: baz)");
-        node = YAML::Load(rc);
-        EXPECT_THROW(print_seq_node(out, node, node_src, true), std::runtime_error);
+            node = YAML::Load(rc);
+            EXPECT_THROW(print_seq_node(out, node, node_src, true), std::runtime_error);
 
-        node = YAML::Node();
-        EXPECT_THROW(print_seq_node(out, node, node_src, true), std::runtime_error);
-    }
-}  // namespace testing
+            node = YAML::Node();
+            EXPECT_THROW(print_seq_node(out, node, node_src, true), std::runtime_error);
+        }
+    }  // namespace testing
 }  // namespace mamba

--- a/libmamba/tests/test_configuration.cpp
+++ b/libmamba/tests/test_configuration.cpp
@@ -490,9 +490,10 @@ namespace mamba
             load_test_config(empty_rc);
 
 #ifdef _WIN32
-            std::string extra_cache = "\n  - "
-                                      + (fs::path(env::get("APPDATA")) / ".mamba" / "pkgs").string()
-                                      + "  # 'fallback'";
+            std::string extra_cache
+                = "\n  - "
+                  + (fs::path(env::get("APPDATA").value_or("")) / ".mamba" / "pkgs").string()
+                  + "  # 'fallback'";
 #else
             std::string extra_cache = "";
 #endif

--- a/libmamba/tests/test_virtual_packages.cpp
+++ b/libmamba/tests/test_virtual_packages.cpp
@@ -62,7 +62,7 @@ namespace mamba
             EXPECT_EQ(pkgs[2].name, "__archspec");
             EXPECT_EQ(pkgs[2].build_string, "arm");
 
-            env::set("CONDA_OVERRIDE_OSX", "");
+            env::unset("CONDA_OVERRIDE_OSX");
             ctx.platform = "linux-32";
             env::set("CONDA_OVERRIDE_LINUX", "5.7");
             env::set("CONDA_OVERRIDE_GLIBC", "2.15");
@@ -75,15 +75,15 @@ namespace mamba
             EXPECT_EQ(pkgs[2].version, "2.15");
             EXPECT_EQ(pkgs[3].name, "__archspec");
             EXPECT_EQ(pkgs[3].build_string, "x86");
-            env::set("CONDA_OVERRIDE_GLIBC", "");
-            env::set("CONDA_OVERRIDE_LINUX", "");
+            env::unset("CONDA_OVERRIDE_GLIBC");
+            env::unset("CONDA_OVERRIDE_LINUX");
 
             ctx.platform = "lin-850";
             pkgs = detail::dist_packages();
             ASSERT_EQ(pkgs.size(), 1);
             EXPECT_EQ(pkgs[0].name, "__archspec");
             EXPECT_EQ(pkgs[0].build_string, "850");
-            env::set("CONDA_SUBDIR", "");
+            env::unset("CONDA_SUBDIR");
 
             ctx.platform = "linux";
             pkgs = detail::dist_packages();
@@ -117,7 +117,7 @@ namespace mamba
             EXPECT_EQ(pkgs.back().name, "__cuda");
             EXPECT_EQ(pkgs.back().version, "9.0");
 
-            env::set("CONDA_OVERRIDE_CUDA", "");
+            env::unset("CONDA_OVERRIDE_CUDA");
             pkgs = get_virtual_packages();
 
             if (!detail::cuda_version().empty())

--- a/micromamba/tests/test_config.py
+++ b/micromamba/tests/test_config.py
@@ -886,4 +886,4 @@ class TestConfigExpandVars:
 
     def test_envsubst_empty_var(self, monkeypatch, rc_file_path):
         monkeypatch.setenv("foo", "", True)
-        assert self._roundtrip(rc_file_path, "channel_alias", "${foo}") == ""
+        assert self._roundtrip(rc_file_path, "channel_alias", "'${foo}'") == ""

--- a/micromamba/tests/test_config.py
+++ b/micromamba/tests/test_config.py
@@ -883,3 +883,7 @@ class TestConfigExpandVars:
     )
     def test_envsubst_yaml_mixup(self, monkeypatch, rc_file_path, inp, outp):
         assert self._roundtrip(rc_file_path, "channels", f'["${{{inp}}}"]') == outp
+
+    def test_envsubst_empty_var(self, monkeypatch, rc_file_path):
+        monkeypatch.setenv("foo", "", True)
+        assert self._roundtrip(rc_file_path, "channel_alias", "${foo}") == ""

--- a/micromamba/tests/test_config.py
+++ b/micromamba/tests/test_config.py
@@ -5,6 +5,7 @@ import subprocess
 from pathlib import Path
 
 import pytest
+import yaml
 
 from .helpers import create, get_umamba, random_string, remove
 
@@ -14,19 +15,21 @@ def config(*args):
     cmd = [umamba, "config"] + [arg for arg in args if arg]
     res = subprocess.check_output(cmd)
     if "--json" in args:
-        j = json.loads(res)
+        j = yaml.load(res, yaml.FullLoader)
         return j
 
     return res.decode()
 
 
-@pytest.fixture(scope="session")
-def rc_file(tmpdir_factory):
-    fn = tmpdir_factory.mktemp("umamba").join("config.yaml")
-    content = "channels:\n  - channel1\n  - channel2\n"
-    with open(fn, "w") as f:
-        f.write(content)
-    return fn
+@pytest.fixture
+def rc_file_path(tmpdir_factory):
+    return Path(tmpdir_factory.mktemp("umamba").join("config.yaml"))
+
+
+@pytest.fixture
+def rc_file_args(rc_file_path):
+    rc_file_path.write_text("channels:\n  - channel1\n  - channel2\n")
+    return ["--rc-file", rc_file_path]
 
 
 class TestConfig:
@@ -191,53 +194,42 @@ class TestConfigSources:
 
 
 class TestConfigList:
-    @pytest.mark.parametrize("rc_flag", ["--no-rc", "--rc-file="])
-    def test_list(self, rc_file, rc_flag):
-        expected = {
-            "--no-rc": "",
-            "--rc-file=" + str(rc_file): "channels:\n  - channel1\n  - channel2\n",
-        }
-        if rc_flag == "--rc-file=":
-            rc_flag += str(rc_file)
-
+    def test_list_with_rc(self, rc_file_args):
         assert (
-            config("list", "--no-env", rc_flag).splitlines()[:-1]
-            == expected[rc_flag].splitlines()
+            config("list", "--no-env", *rc_file_args).splitlines()[:-1]
+            == "channels:\n  - channel1\n  - channel2\n".splitlines()
         )
 
+    def test_list_without_rc(self):
+        assert config("list", "--no-env", "--no-rc").splitlines()[:-1] == []
+
     @pytest.mark.parametrize("source_flag", ["--sources", "-s"])
-    def test_list_with_sources(self, rc_file, source_flag):
+    def test_list_with_sources(self, rc_file_args, source_flag):
         home_folder = os.path.expanduser("~")
-        src = f"  # '{str(rc_file).replace(home_folder, '~')}'"
+        src = f"  # '{str(rc_file_args[-1]).replace(home_folder, '~')}'"
         assert (
-            config(
-                "list", "--no-env", "--rc-file=" + str(rc_file), source_flag
-            ).splitlines()[:-1]
+            config("list", "--no-env", *rc_file_args, source_flag).splitlines()[:-1]
             == f"channels:\n  - channel1{src}\n  - channel2{src}\n".splitlines()
         )
 
     @pytest.mark.parametrize("desc_flag", ["--descriptions", "-d"])
-    def test_list_with_descriptions(self, rc_file, desc_flag):
+    def test_list_with_descriptions(self, rc_file_args, desc_flag):
         assert (
-            config(
-                "list", "--no-env", "--rc-file=" + str(rc_file), desc_flag
-            ).splitlines()[:-4]
+            config("list", "--no-env", *rc_file_args, desc_flag).splitlines()[:-4]
             == f"# channels\n#   Define the list of channels\nchannels:\n"
             "  - channel1\n  - channel2\n".splitlines()
         )
 
     @pytest.mark.parametrize("desc_flag", ["--long-descriptions", "-l"])
-    def test_list_with_long_descriptions(self, rc_file, desc_flag):
+    def test_list_with_long_descriptions(self, rc_file_args, desc_flag):
         assert (
-            config(
-                "list", "--no-env", "--rc-file=" + str(rc_file), desc_flag
-            ).splitlines()[:-4]
+            config("list", "--no-env", *rc_file_args, desc_flag).splitlines()[:-4]
             == f"# channels\n#   The list of channels where the packages will be searched for.\n"
             "#   See also 'channel_priority'.\nchannels:\n  - channel1\n  - channel2\n".splitlines()
         )
 
     @pytest.mark.parametrize("group_flag", ["--groups", "-g"])
-    def test_list_with_groups(self, rc_file, group_flag):
+    def test_list_with_groups(self, rc_file_args, group_flag):
         group = (
             "# ######################################################\n"
             "# #               Channels Configuration               #\n"
@@ -245,9 +237,9 @@ class TestConfigList:
         )
 
         assert (
-            config(
-                "list", "--no-env", "--rc-file=" + str(rc_file), "-d", group_flag
-            ).splitlines()[:-8]
+            config("list", "--no-env", *rc_file_args, "-d", group_flag).splitlines()[
+                :-8
+            ]
             == f"{group}# channels\n#   Define the list of channels\nchannels:\n"
             "  - channel1\n  - channel2\n".splitlines()
         )
@@ -748,3 +740,146 @@ class TestConfigModifiers:
             "  - finn",
             "  - jake",
         ]
+
+
+class TestConfigExpandVars:
+    @staticmethod
+    def _roundtrip(rc_file_path, attr, config_expr):
+        rc_file_path.write_text(f"{attr}: {config_expr}")
+        conf = config("list", "--json", "--no-env", "--rc-file", rc_file_path)
+        return conf[attr]
+
+    @pytest.mark.parametrize("yaml_quote", ["", '"'])
+    def test_expandvars_conda(
+        self, monkeypatch, tmpdir_factory, rc_file_path, yaml_quote
+    ):
+        """
+        Environment variables should be expanded in settings that have expandvars=True.
+
+        Test copied from Conda.
+        """
+
+        def _expandvars(attr, config_expr, env_value):
+            config_expr = config_expr.replace("'", yaml_quote)
+            monkeypatch.setenv("TEST_VAR", env_value)
+            return self._roundtrip(rc_file_path, attr, config_expr)
+
+        ssl_verify = _expandvars("ssl_verify", "${TEST_VAR}", "yes")
+        assert ssl_verify
+
+        for attr, env_value in [
+            # Not supported by Micromamba
+            # ("client_ssl_cert", "foo"),
+            # ("client_ssl_cert_key", "foo"),
+            ("channel_alias", "http://foo"),
+        ]:
+            value = _expandvars(attr, "${TEST_VAR}", env_value)
+            assert value == env_value
+
+        for attr in [
+            # Not supported by Micromamba
+            # "migrated_custom_channels",
+            # "proxy_servers",
+        ]:
+            value = _expandvars(attr, "{'x': '${TEST_VAR}'}", "foo")
+            assert value == {"x": "foo"}
+
+        for attr in [
+            "channels",
+            "default_channels",
+            # Not supported by Micromamba
+            # "whitelist_channels",
+        ]:
+            value = _expandvars(attr, "['${TEST_VAR}']", "foo")
+            assert value == ["foo"]
+
+        custom_channels = _expandvars(
+            "custom_channels", "{'x': '${TEST_VAR}'}", "http://foo"
+        )
+        assert custom_channels["x"] == "http://foo"
+
+        custom_multichannels = _expandvars(
+            "custom_multichannels", "{'x': ['${TEST_VAR}']}", "http://foo"
+        )
+        assert len(custom_multichannels["x"]) == 1
+        assert custom_multichannels["x"][0] == "http://foo"
+
+        envs_dirs = _expandvars("envs_dirs", "['${TEST_VAR}']", "/foo")
+        assert any("foo" in d for d in envs_dirs)
+
+        pkgs_dirs = _expandvars("pkgs_dirs", "['${TEST_VAR}']", "/foo")
+        assert any("foo" in d for d in pkgs_dirs)
+
+    @pytest.mark.parametrize(
+        "inp,outp",
+        [
+            ("$", "$"),
+            ("$$", "$"),
+            ("foo", "foo"),
+            ("${foo}bar1", "barbar1"),
+            ("$[foo]bar", "$[foo]bar"),
+            ("$bar bar", "$bar bar"),
+            ("$?bar", "$?bar"),
+            ("${foo", "${foo"),
+            ("${{foo}}2", "baz1}2"),
+            ("$bar$bar", "$bar$bar"),
+            # Not supported by Micromamba
+            # ("$foo$foo", "barbar"),
+            # ("$foo}bar", "bar}bar"),
+            # ("$foo$$foo bar", "bar$foo bar"),
+            # ("$foo bar", "bar bar"),
+            # *(
+            #     [
+            #         ("%", "%"),
+            #         ("foo", "foo"),
+            #         ("$foo bar", "bar bar"),
+            #         ("${foo}bar", "barbar"),
+            #         ("$[foo]bar", "$[foo]bar"),
+            #         ("$bar bar", "$bar bar"),
+            #         ("$?bar", "$?bar"),
+            #         ("$foo}bar", "bar}bar"),
+            #         ("${foo", "${foo"),
+            #         ("${{foo}}", "baz1}"),
+            #         ("$foo$foo", "barbar"),
+            #         ("$bar$bar", "$bar$bar"),
+            #         ("%foo% bar", "bar bar"),
+            #         ("%foo%bar", "barbar"),
+            #         ("%foo%%foo%", "barbar"),
+            #         ("%%foo%%foo%foo%", "%foo%foobar"),
+            #         ("%?bar%", "%?bar%"),
+            #         ("%foo%%bar", "bar%bar"),
+            #         ("'%foo%'%bar", "'%foo%'%bar"),
+            #         ("bar'%foo%", "bar'%foo%"),
+            #         ("'$foo'$foo", "'$foo'bar"),
+            #         ("'$foo$foo", "'$foo$foo"),
+            #     ]
+            #     if platform.system() == "Windows"
+            #     else []
+            # ),
+        ],
+    )
+    @pytest.mark.parametrize("yaml_quote", ["", '"', "'"])
+    def test_expandvars_cpython(self, monkeypatch, rc_file_path, inp, outp, yaml_quote):
+        """Tests copied from CPython."""
+        monkeypatch.setenv("foo", "bar", True)
+        monkeypatch.setenv("{foo", "baz1", True)
+        monkeypatch.setenv("{foo}", "baz2", True)
+        assert outp == self._roundtrip(
+            rc_file_path, "channel_alias", yaml_quote + inp + yaml_quote
+        )
+
+    @pytest.mark.parametrize(
+        "inp,outp",
+        [
+            (
+                'x", "y',
+                [
+                    "${x",
+                    "y}",
+                ],
+            ),
+            ("x\ny", ["${x y}"]),
+        ],
+    )
+    def test_envsubst_yaml_mixup(self, monkeypatch, rc_file_path, inp, outp):
+        assert self._roundtrip(rc_file_path, "channels", f'["${{{inp}}}"]') == outp

--- a/micromamba/tests/test_config.py
+++ b/micromamba/tests/test_config.py
@@ -1,5 +1,6 @@
 import json
 import os
+import platform
 import shutil
 import subprocess
 from pathlib import Path
@@ -886,4 +887,6 @@ class TestConfigExpandVars:
 
     def test_envsubst_empty_var(self, monkeypatch, rc_file_path):
         monkeypatch.setenv("foo", "", True)
-        assert self._roundtrip(rc_file_path, "channel_alias", "'${foo}'") == ""
+        # Windows does not support empty environment variables
+        expected = "${foo}" if platform.system == "Windows" else ""
+        assert self._roundtrip(rc_file_path, "channel_alias", "'${foo}'") == expected

--- a/micromamba/tests/test_config.py
+++ b/micromamba/tests/test_config.py
@@ -888,5 +888,5 @@ class TestConfigExpandVars:
     def test_envsubst_empty_var(self, monkeypatch, rc_file_path):
         monkeypatch.setenv("foo", "", True)
         # Windows does not support empty environment variables
-        expected = "${foo}" if platform.system == "Windows" else ""
+        expected = "${foo}" if platform.system() == "Windows" else ""
         assert self._roundtrip(rc_file_path, "channel_alias", "'${foo}'") == expected


### PR DESCRIPTION
New version of https://github.com/mamba-org/mamba/pull/1416 with only `${var}` support (and `$$` support)