### PR TITLE
Add subproblems printing code

### DIFF
--- a/libmamba/include/mamba/core/solver.hpp
+++ b/libmamba/include/mamba/core/solver.hpp
@@ -53,9 +53,11 @@ namespace mamba
         void set_postsolve_flags(const std::vector<std::pair<int, int>>& flags);
         bool is_solved() const;
         bool solve();
-        std::string problems_to_str() const;
         std::vector<std::string> all_problems() const;
-        std::string all_problems_to_str() const;
+        std::vector<std::vector<std::string>> all_subproblems() const;
+        std::string problems_to_str() const;
+        std::string all_subproblems_to_str() const;
+        std::string unique_subproblems_to_str() const;
 
         const std::vector<MatchSpec>& install_specs() const;
         const std::vector<MatchSpec>& remove_specs() const;
@@ -71,6 +73,7 @@ namespace mamba
     private:
         void add_channel_specific_job(const MatchSpec& ms, int job_flag);
         void add_reinstall_job(MatchSpec& ms, int job_flag);
+        std::string subproblems_to_str(std::vector<std::vector<std::string>>) const;
 
         std::vector<std::pair<int, int>> m_flags;
         std::vector<MatchSpec> m_install_specs;

--- a/libmamba/src/core/solver.cpp
+++ b/libmamba/src/core/solver.cpp
@@ -359,9 +359,46 @@ namespace mamba
         return success;
     }
 
-    std::string MSolver::all_problems_to_str() const
+    std::string MSolver::all_subproblems_to_str() const
+    {
+        return subproblems_to_str(all_subproblems());
+    }
+
+    std::string MSolver::unique_subproblems_to_str() const
+    {
+        std::vector<std::vector<std::string>> unique_subproblems;
+        for (auto subproblems : all_subproblems())
+        {
+            auto subproblems_set = std::set<std::string>(subproblems.begin(), subproblems.end());
+            unique_subproblems.push_back(
+                std::vector(subproblems_set.begin(), subproblems_set.end()));
+        }
+        return subproblems_to_str(unique_subproblems);
+    }
+
+    std::string MSolver::subproblems_to_str(std::vector<std::vector<std::string>> subproblems) const
     {
         std::stringstream problems;
+        for (auto subproblems : subproblems)
+        {
+            for (auto subproblem : subproblems)
+            {
+                if (subproblem.empty())
+                {
+                    problems << "- [SKIP] no problem rule?\n";
+                }
+                else
+                {
+                    problems << "  - " << subproblem << "\n";
+                }
+            }
+        }
+        return problems.str();
+    }
+
+    std::vector<std::vector<std::string>> MSolver::all_subproblems() const
+    {
+        std::vector<std::vector<std::string>> problems;
 
         Queue problem_rules;
         queue_init(&problem_rules);
@@ -369,26 +406,26 @@ namespace mamba
         for (Id i = 1; i <= count; ++i)
         {
             solver_findallproblemrules(m_solver, i, &problem_rules);
+            std::vector<std::string> subproblems;
             for (Id j = 0; j < problem_rules.count; ++j)
             {
                 Id type, source, target, dep;
                 Id r = problem_rules.elements[j];
                 if (!r)
                 {
-                    problems << "- [SKIP] no problem rule?\n";
+                    subproblems.push_back("");
                 }
                 else
                 {
                     type = solver_ruleinfo(m_solver, r, &source, &target, &dep);
-                    problems << "  - "
-                             << solver_problemruleinfo2str(
-                                    m_solver, (SolverRuleinfo) type, source, target, dep)
-                             << "\n";
+                    subproblems.push_back(solver_problemruleinfo2str(
+                        m_solver, (SolverRuleinfo) type, source, target, dep));
                 }
             }
+            problems.push_back(subproblems);
         }
         queue_free(&problem_rules);
-        return problems.str();
+        return problems;
     }
 
     std::string MSolver::problems_to_str() const

--- a/libmambapy/src/main.cpp
+++ b/libmambapy/src/main.cpp
@@ -101,8 +101,11 @@ PYBIND11_MODULE(bindings, m)
         .def("set_flags", &MSolver::set_flags)
         .def("set_postsolve_flags", &MSolver::set_postsolve_flags)
         .def("is_solved", &MSolver::is_solved)
+        .def("all_problems", &MSolver::all_problems)
+        .def("all_subproblems", &MSolver::all_subproblems)
         .def("problems_to_str", &MSolver::problems_to_str)
-        .def("all_problems_to_str", &MSolver::all_problems_to_str)
+        .def("all_subproblems_to_str", &MSolver::all_subproblems_to_str)
+        .def("unique_subproblems_to_str", &MSolver::unique_subproblems_to_str)
         .def("solve", &MSolver::solve);
 
     py::class_<History>(m, "History")


### PR DESCRIPTION
Lightweight refactoring to be able to print all unique "subproblems". Code is not actually used at the moment. Breaks the (undocumented?) `Solver` Python interface by renaming a function.