### PR TITLE
Get clang-format from PyPI and version pre-commit hook

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -32,7 +32,7 @@ jobs:
     - name: Install dependencies
       shell: pwsh
       run: |
-        conda install clang clang-tools=11.1.0 pre-commit
+        conda install pre-commit
     - name: Conda info
       shell: pwsh
       run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,8 +40,8 @@ repos:
             - flake8-builtins==1.5.3
             - flake8-bugbear==22.1.11
             - flake8-isort==4.1.1
--   repo: https://github.com/bmorcos/pre-commit-hooks-cpp
-    rev: master
+-   repo: https://github.com/pre-commit/mirrors-clang-format
+    rev: v11.1.0
     hooks:
     -   id: clang-format
         args: [--style=file]


### PR DESCRIPTION
Currently the `clang-format` version used by pre-commit isn't versioned so the output isn't stable. I quite like https://github.com/ssciwr/clang-format-wheel for this as it's a <2MB download and users don't need to worry having `clang-format` installed, it's all automatically managed by pre-commit.

Feel free to close if you'd prefer to do it another way 😃 