### PR TITLE
CHANGELOG.md: fix release year for the last version (2021->2022)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-2021.01.25
+2022.01.25
 ==========
 
 Releases: libmamba 0.20.0, libmambapy 0.20.0, mamba 0.20.0, micromamba 0.20.0


### PR DESCRIPTION
Signed-off-by: Asaf Kahlon <asafka7@gmail.com>