### PR TITLE
play around with detaching of process

### DIFF
--- a/micromamba/CMakeLists.txt
+++ b/micromamba/CMakeLists.txt
@@ -62,6 +62,9 @@ endif ()
 
 message(STATUS "Micromamba linkage: ${MICROMAMBA_LINKAGE}")
 
+find_package(Threads REQUIRED)
+target_link_libraries(micromamba PRIVATE Threads::Threads)
+
 if (${MICROMAMBA_LINKAGE} STREQUAL "FULL_STATIC")
     target_link_libraries(micromamba PRIVATE libmamba-full-static)
     if (WIN32)

--- a/micromamba/src/run.cpp
+++ b/micromamba/src/run.cpp
@@ -4,8 +4,59 @@
 #include "mamba/api/configuration.hpp"
 #include "mamba/api/install.hpp"
 
+extern "C" {
+    #include <stdio.h>
+    #include <stdlib.h>
+    #include <unistd.h>
+    #include <sys/types.h>
+    #include <sys/stat.h>
+    #include <fcntl.h>
+}
 
 using namespace mamba;  // NOLINT(build/namespaces)
+
+#ifndef _WIN32
+void daemonize()
+{
+    pid_t pid, sid;
+    int fd;
+
+    // already a daemon
+    if (getppid() == 1)
+        return;
+
+    // fork parent process
+    pid = fork();
+    if (pid < 0)
+        exit(1);
+
+    // exit parent process
+    if (pid > 0)
+        exit(0);
+
+    // at this point we are executing as the child process
+    // create a new SID for the child process
+    sid = setsid();
+    if (sid < 0)
+        exit(1);
+
+    fd = open("/dev/null", O_RDWR, 0);
+
+    std::cout << fmt::format("Kill process with: kill -s TERM {}", getpid()) << std::endl;
+
+    if (fd != -1)
+    {
+        dup2 (fd, STDIN_FILENO);
+        dup2 (fd, STDOUT_FILENO);
+        dup2 (fd, STDERR_FILENO);
+
+        if (fd > 2)
+        {
+            close (fd);
+        }
+    }
+}
+#endif
 
 void
 set_run_command(CLI::App* subcom)
@@ -17,6 +68,9 @@ set_run_command(CLI::App* subcom)
 
     static std::string cwd;
     subcom->add_option("--cwd", cwd, "Current working directory for command to run in. Defaults to cwd");
+
+    static bool detach = false;
+    subcom->add_flag("--daemon", detach, "Detach process from terminal");
 
     static std::vector<std::string> command;
     subcom->prefix_command();
@@ -45,6 +99,12 @@ set_run_command(CLI::App* subcom)
         opt.redirect.out.type = sinkout ? reproc::redirect::discard : reproc::redirect::parent;
         opt.redirect.err.type = sinkerr ? reproc::redirect::discard : reproc::redirect::parent;
         auto [_, ec] = reproc::run(wrapped_command, opt);
+
+        if (detach)
+        {
+            std::cout << fmt::format(fmt::fg(fmt::terminal_color::green), "Running wrapped script {} in the background", join(" ", command)) << std::endl;
+            daemonize();
+        }
 
         if (ec)
         {

--- a/micromamba/src/run.cpp
+++ b/micromamba/src/run.cpp
@@ -72,7 +72,7 @@ set_run_command(CLI::App* subcom)
     subcom->add_option("--cwd", cwd, "Current working directory for command to run in. Defaults to cwd");
 
     static bool detach = false;
-    subcom->add_flag("--daemon", detach, "Detach process from terminal");
+    subcom->add_flag("-d,--detach", detach, "Detach process from terminal");
 
     static std::vector<std::string> command;
     subcom->prefix_command();
@@ -85,9 +85,12 @@ set_run_command(CLI::App* subcom)
 
         std::vector<std::string> command = subcom->remaining();
 
+
         // replace the wrapping bash with new process entirely
+        #ifndef _WIN32
         if (command.front() != "exec")
             command.insert(command.begin(), "exec");
+        #endif
 
         auto [wrapped_command, script_file]
             = prepare_wrapped_call(Context::instance().target_prefix, command);


### PR DESCRIPTION
This allows detaching the `micromamba run` from the terminal. It works nicely, however we might have to deal with signals better or figure something out.

```
micromamba create -n jupyter notebook
micromamba run --daemon -n jupyter jupyter notebook
```

We print the correct PID fo the `micromamba run` command, but the process started with `reproc` has another PID.
When running `kill -s TERM PID` the `micromamba run` process is properly killed. However, the `reproc` process continues (and e.g. jupyter continues to run).
I am not sure how we should solve this. Would need some investigation into `reproc` and UNIX process management :)

It would also be good to write the PID of the started process into a global PID file. Then we could also implement another command like `micromamba ps` that prints the running processes and allows to easily kill them.

Also, I haven't looked into Windows at all, yet.