### PR TITLE
Update gitter to point to mamba-org/lobby

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 # mamba
 
 [![Build Status](https://github.com/mamba-org/mamba/workflows/CI/badge.svg)](https://github.com/mamba-org/mamba/actions)
-[![Join the Gitter Chat](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/QuantStack/Lobby?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![Join the Gitter Chat](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/mamba-org/Lobby?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![docs](https://readthedocs.org/projects/mamba/badge/?version=latest&style=flat)](https://mamba.readthedocs.io/en/latest)
 
 Mamba is a reimplementation of the conda package manager in C++.


### PR DESCRIPTION
Since there is now a dedicated mamba room on Gitter: https://gitter.im/mamba-org/Lobby