### PR TITLE
run arguments

### DIFF
--- a/micromamba/src/run.cpp
+++ b/micromamba/src/run.cpp
@@ -17,7 +17,7 @@ set_run_command(CLI::App* subcom)
 
     static std::string cwd;
     subcom->add_option("--cwd", cwd, "Current working directory for command to run in. Defaults to cwd");
-    
+
     static std::vector<std::string> command;
     subcom->prefix_command();
 

--- a/micromamba/src/run.cpp
+++ b/micromamba/src/run.cpp
@@ -15,6 +15,9 @@ set_run_command(CLI::App* subcom)
     static std::string streams;
     CLI::Option* stream_option = subcom->add_option("-a,--attach", streams, "Attach to stdin, stdout and/or stderr. -a \"\" for disabling stream redirection")->join(',');
 
+    static std::string cwd;
+    subcom->add_option("--cwd", cwd, "Current working directory for command to run in. Defaults to cwd");
+    
     static std::vector<std::string> command;
     subcom->prefix_command();
 
@@ -29,13 +32,16 @@ set_run_command(CLI::App* subcom)
 
         LOG_DEBUG << "Running wrapped script " << join(" ", command);
 
-        std::string out, err;
-
         bool all_streams = stream_option->count() == 0u;
         bool sinkout = !all_streams && streams.find("stdout") == std::string::npos;
         bool sinkerr = !all_streams && streams.find("stderr") == std::string::npos;
 
         reproc::options opt;
+        if (cwd != "")
+        {
+            opt.working_directory = cwd.c_str();
+        }
+
         opt.redirect.out.type = sinkout ? reproc::redirect::discard : reproc::redirect::parent;
         opt.redirect.err.type = sinkerr ? reproc::redirect::discard : reproc::redirect::parent;
         auto [_, ec] = reproc::run(wrapped_command, opt);

--- a/micromamba/src/run.cpp
+++ b/micromamba/src/run.cpp
@@ -12,13 +12,13 @@ set_run_command(CLI::App* subcom)
 {
     init_prefix_options(subcom);
 
-    static bool live_stream = true;
-    subcom->add_flag("--live-stream", live_stream, "Display output live");
+    static std::string streams;
+    CLI::Option* stream_option = subcom->add_option("-a,--attach", streams, "Attach to stdin, stdout and/or stderr. -a \"\" for disabling stream redirection")->join(',');
 
     static std::vector<std::string> command;
     subcom->prefix_command();
 
-    subcom->callback([subcom]() {
+    subcom->callback([subcom, stream_option]() {
         auto& config = Configuration::instance();
         config.load();
 
@@ -30,25 +30,19 @@ set_run_command(CLI::App* subcom)
         LOG_DEBUG << "Running wrapped script " << join(" ", command);
 
         std::string out, err;
-        if (!live_stream)
-        {
-            auto [_, ec] = reproc::run(wrapped_command,
-                                       reproc::options(),
-                                       reproc::sink::string(out),
-                                       reproc::sink::string(err));
-            if (ec)
-            {
-                std::cerr << ec.message() << std::endl;
-            }
-        }
-        else
-        {
-            auto [_, ec] = reproc::run(wrapped_command, reproc::options());
 
-            if (ec)
-            {
-                std::cerr << ec.message() << std::endl;
-            }
+        bool all_streams = stream_option->count() == 0u;
+        bool sinkout = !all_streams && streams.find("stdout") == std::string::npos;
+        bool sinkerr = !all_streams && streams.find("stderr") == std::string::npos;
+
+        reproc::options opt;
+        opt.redirect.out.type = sinkout ? reproc::redirect::discard : reproc::redirect::parent;
+        opt.redirect.err.type = sinkerr ? reproc::redirect::discard : reproc::redirect::parent;
+        auto [_, ec] = reproc::run(wrapped_command, opt);
+
+        if (ec)
+        {
+            std::cerr << ec.message() << std::endl;
         }
     });
 }


### PR DESCRIPTION
By default, `micromamba run` redirects all the streams to the parent process.

- To select the stream to redirect: `micromamba run -a stdout -a stderr command args` or `micromamba run -a stdout,stderr command args`
- To disable redirection: `micromamba run -a command args`