### PR TITLE
Incremental ccache updates

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,14 +23,14 @@ jobs:
         run: |
           key_prefix="ccache-${{ runner.os }}-$(TZ=UTC date +%F)"
           echo ::set-output name=key_prefix::"$key_prefix"
-          echo ::set-output name=key::"$key_prefix-$GITHUB_JOB-$(TZ=UTC date '+%H:%M:%S')"
+          echo ::set-output name=key::"$key_prefix-${{ github.job }}-$(TZ=UTC date '+%H:%M:%S')"
       - name: cache CCACHE paths
         uses: actions/cache@v2
         with:
           path: ~/ccache
           key: ${{ steps.ccache_key.outputs.key }}
           restore-keys: |
-            ${{ steps.ccache_key.outputs.key_prefix }}-$GITHUB_JOB
+            ${{ steps.ccache_key.outputs.key_prefix }}-${{ github.job }}
       - name: create build environment
         uses: mamba-org/provision-with-micromamba@main
         with:
@@ -70,14 +70,14 @@ jobs:
         run: |
           key_prefix="ccache-${{ runner.os }}-$(TZ=UTC date +%F)"
           echo ::set-output name=key_prefix::"$key_prefix"
-          echo ::set-output name=key::"$key_prefix-$GITHUB_JOB-$(TZ=UTC date '+%H:%M:%S')"
+          echo ::set-output name=key::"$key_prefix-${{ github.job }}-$(TZ=UTC date '+%H:%M:%S')"
       - name: cache CCACHE paths
         uses: actions/cache@v2
         with:
           path: ~/ccache
           key: ${{ steps.ccache_key.outputs.key }}
           restore-keys: |
-            ${{ steps.ccache_key.outputs.key_prefix }}-$GITHUB_JOB
+            ${{ steps.ccache_key.outputs.key_prefix }}-${{ github.job }}
             ${{ steps.ccache_key.outputs.key_prefix }}-libmamba_static
       - name: create build environment
         uses: mamba-org/provision-with-micromamba@main
@@ -120,14 +120,14 @@ jobs:
         run: |
           key_prefix="ccache-${{ runner.os }}-$(TZ=UTC date +%F)"
           echo ::set-output name=key_prefix::"$key_prefix"
-          echo ::set-output name=key::"$key_prefix-$GITHUB_JOB-$(TZ=UTC date '+%H:%M:%S')"
+          echo ::set-output name=key::"$key_prefix-${{ github.job }}-$(TZ=UTC date '+%H:%M:%S')"
       - name: cache CCACHE paths
         uses: actions/cache@v2
         with:
           path: ~/ccache
           key: ${{ steps.ccache_key.outputs.key }}
           restore-keys: |
-            ${{ steps.ccache_key.outputs.key_prefix }}-$GITHUB_JOB
+            ${{ steps.ccache_key.outputs.key_prefix }}-${{ github.job }}
             ${{ steps.ccache_key.outputs.key_prefix }}-libmamba_static
       - name: create build environment
         uses: mamba-org/provision-with-micromamba@main
@@ -186,14 +186,14 @@ jobs:
         run: |
           key_prefix="ccache-${{ runner.os }}-$(TZ=UTC date +%F)"
           echo ::set-output name=key_prefix::"$key_prefix"
-          echo ::set-output name=key::"$key_prefix-$GITHUB_JOB-$(TZ=UTC date '+%H:%M:%S')"
+          echo ::set-output name=key::"$key_prefix-${{ github.job }}-$(TZ=UTC date '+%H:%M:%S')"
       - name: cache CCACHE paths
         uses: actions/cache@v2
         with:
           path: ~/ccache
           key: ${{ steps.ccache_key.outputs.key }}
           restore-keys: |
-            ${{ steps.ccache_key.outputs.key_prefix }}-$GITHUB_JOB
+            ${{ steps.ccache_key.outputs.key_prefix }}-${{ github.job }}
             ${{ steps.ccache_key.outputs.key_prefix }}-libmamba_static
       - name: create build environment
         uses: mamba-org/provision-with-micromamba@main

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,16 +25,20 @@ jobs:
           sudo apt clean
           docker rmi $(docker image ls -aq)
           df -h
-      - name: generate ccache timestamp
-        id: ccache_cache_timestamp
+      - name: generate ccache key
+        id: ccache_key
         shell: bash -l {0}
-        run: echo ::set-output name=timestamp::"$(TZ=UTC date +%F)"
+        run: |
+          key_prefix="ccache-${{ runner.os }}-$(TZ=UTC date +%F)"
+          echo ::set-output name=key_prefix::"$key_prefix"
+          echo ::set-output name=key::"$key_prefix-$(TZ=UTC date '+%H:%M:%S')"
       - name: cache CCACHE paths
         uses: actions/cache@v2
         with:
-          path: |
-            ~/ccache
-          key: ${{ runner.os }}-ccache-${{ steps.ccache_cache_timestamp.outputs.timestamp }}
+          path: ~/ccache
+          key: ${{ steps.ccache_key.key }}
+          restore-keys: |
+            ${{ steps.ccache_key.key_prefix }}
       - name: create build environment
         uses: mamba-org/provision-with-micromamba@main
         with:
@@ -65,16 +69,20 @@ jobs:
         os: [ubuntu-latest, macos-latest]
     steps:
       - uses: actions/checkout@v2
-      - name: generate ccache timestamp
-        id: ccache_cache_timestamp
+      - name: generate ccache key
+        id: ccache_key
         shell: bash -l {0}
-        run: echo ::set-output name=timestamp::"$(date --utc +%F)"
+        run: |
+          key_prefix="ccache-${{ runner.os }}-$(TZ=UTC date +%F)"
+          echo ::set-output name=key_prefix::"$key_prefix"
+          echo ::set-output name=key::"$key_prefix-$(TZ=UTC date '+%H:%M:%S')"
       - name: cache CCACHE paths
         uses: actions/cache@v2
         with:
-          path: |
-            ~/ccache
-          key: ${{ runner.os }}-ccache-${{ steps.ccache_cache_timestamp.outputs.timestamp }}
+          path: ~/ccache
+          key: ${{ steps.ccache_key.key }}
+          restore-keys: |
+            ${{ steps.ccache_key.key_prefix }}
       - name: create build environment
         uses: mamba-org/provision-with-micromamba@main
         with:
@@ -115,16 +123,20 @@ jobs:
           sudo apt clean
           docker rmi $(docker image ls -aq)
           df -h
-      - name: generate ccache timestamp
-        id: ccache_cache_timestamp
+      - name: generate ccache key
+        id: ccache_key
         shell: bash -l {0}
-        run: echo ::set-output name=timestamp::"$(date --utc +%F)"
+        run: |
+          key_prefix="ccache-${{ runner.os }}-$(TZ=UTC date +%F)"
+          echo ::set-output name=key_prefix::"$key_prefix"
+          echo ::set-output name=key::"$key_prefix-$(TZ=UTC date '+%H:%M:%S')"
       - name: cache CCACHE paths
         uses: actions/cache@v2
         with:
-          path: |
-            ~/ccache
-          key: ${{ runner.os }}-ccache-${{ steps.ccache_cache_timestamp.outputs.timestamp }}
+          path: ~/ccache
+          key: ${{ steps.ccache_key.key }}
+          restore-keys: |
+            ${{ steps.ccache_key.key_prefix }}
       - name: create build environment
         uses: mamba-org/provision-with-micromamba@main
         with:
@@ -181,16 +193,20 @@ jobs:
           sudo apt clean
           docker rmi $(docker image ls -aq)
           df -h
-      - name: generate ccache timestamp
-        id: ccache_cache_timestamp
+      - name: generate ccache key
+        id: ccache_key
         shell: bash -l {0}
-        run: echo ::set-output name=timestamp::"$(date --utc +%F)"
+        run: |
+          key_prefix="ccache-${{ runner.os }}-$(TZ=UTC date +%F)"
+          echo ::set-output name=key_prefix::"$key_prefix"
+          echo ::set-output name=key::"$key_prefix-$(TZ=UTC date '+%H:%M:%S')"
       - name: cache CCACHE paths
         uses: actions/cache@v2
         with:
-          path: |
-            ~/ccache
-          key: ${{ runner.os }}-ccache-${{ steps.ccache_cache_timestamp.outputs.timestamp }}
+          path: ~/ccache
+          key: ${{ steps.ccache_key.key }}
+          restore-keys: |
+            ${{ steps.ccache_key.key_prefix }}
       - name: create build environment
         uses: mamba-org/provision-with-micromamba@main
         with:
@@ -282,16 +298,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: generate ccache timestamp
-        id: ccache_cache_timestamp
-        shell: bash -l {0}
-        run: echo ::set-output name=timestamp::"$(date --utc +%FT%H)"
-      - name: cache CCACHE paths
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/ccache
-          key: ${{ runner.os }}-ccache-${{ steps.ccache_cache_timestamp.outputs.timestamp }}
       - name: create build environment
         uses: mamba-org/provision-with-micromamba@main
         with:
@@ -303,13 +309,10 @@ jobs:
           call micromamba activate build_env
           mkdir build
           cd build
-          set CCACHE_DIR=%HOME%\ccache
           cmake .. -DCMAKE_INSTALL_PREFIX=%CONDA_PREFIX%\Library ^
                    -DBUILD_LIBMAMBA=ON ^
                    -DBUILD_STATIC=ON ^
-                   -GNinja ^
-                   -DCMAKE_CXX_COMPILER_LAUNCHER=ccache ^
-                   -DCMAKE_C_COMPILER_LAUNCHER=ccache
+                   -GNinja
           ninja
 
   mamba_python_tests_win:
@@ -322,16 +325,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: generate ccache timestamp
-        id: ccache_cache_timestamp
-        shell: bash -l {0}
-        run: echo ::set-output name=timestamp::"$(date --utc +%FT%H)"
-      - name: cache CCACHE paths
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/ccache
-          key: ${{ runner.os }}-ccache-${{ steps.ccache_cache_timestamp.outputs.timestamp }}
       - name: create build environment
         uses: mamba-org/provision-with-micromamba@main
         with:
@@ -349,15 +342,12 @@ jobs:
           call micromamba activate build_env
           mkdir build
           cd build
-          set CCACHE_DIR=%HOME%\ccache
           cmake .. -DCMAKE_INSTALL_PREFIX=%CONDA_PREFIX%\Library ^
                    -DBUILD_LIBMAMBAPY=ON ^
                    -DBUILD_LIBMAMBA=ON ^
                    -DBUILD_SHARED=ON ^
                    -DBUILD_MAMBA_PACKAGE=ON ^
-                   -GNinja ^
-                   -DCMAKE_CXX_COMPILER_LAUNCHER=ccache ^
-                   -DCMAKE_C_COMPILER_LAUNCHER=ccache
+                   -GNinja
           ninja
           ninja install
           pip install -e ..\libmambapy\ --no-deps
@@ -408,16 +398,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: generate ccache timestamp
-        id: ccache_cache_timestamp
-        shell: bash -l {0}
-        run: echo ::set-output name=timestamp::"$(date --utc +%FT%H)"
-      - name: cache CCACHE paths
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/ccache
-          key: ${{ runner.os }}-ccache-${{ steps.ccache_cache_timestamp.outputs.timestamp }}
       - name: create build environment
         uses: mamba-org/provision-with-micromamba@main
         with:
@@ -429,14 +409,11 @@ jobs:
           call micromamba activate build_env
           mkdir build
           cd build
-          set CCACHE_DIR=%HOME%\ccache
           cmake .. -DCMAKE_INSTALL_PREFIX=%CONDA_PREFIX%\Library ^
                    -DBUILD_LIBMAMBA_TESTS=ON ^
                    -DBUILD_LIBMAMBA=ON ^
                    -DBUILD_SHARED=ON ^
-                   -GNinja ^
-                   -DCMAKE_CXX_COMPILER_LAUNCHER=ccache ^
-                   -DCMAKE_C_COMPILER_LAUNCHER=ccache
+                   -GNinja
           ninja install
           ninja test
 
@@ -450,16 +427,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: generate ccache timestamp
-        id: ccache_cache_timestamp
-        shell: bash -l {0}
-        run: echo ::set-output name=timestamp::"$(date --utc +%FT%H)"
-      - name: cache CCACHE paths
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/ccache
-          key: ${{ runner.os }}-ccache-${{ steps.ccache_cache_timestamp.outputs.timestamp }}
       - name: create build environment
         uses: mamba-org/provision-with-micromamba@main
         with:
@@ -471,15 +438,12 @@ jobs:
           call micromamba activate build_env
           mkdir build
           cd build
-          set CCACHE_DIR=%HOME%\ccache
           cmake .. -DCMAKE_INSTALL_PREFIX=%CONDA_PREFIX%\Library ^
                    -DBUILD_MICROMAMBA=ON ^
                    -DMICROMAMBA_LINKAGE=STATIC ^
                    -DBUILD_LIBMAMBA=ON ^
                    -DBUILD_STATIC=ON ^
-                   -GNinja ^
-                   -DCMAKE_CXX_COMPILER_LAUNCHER=ccache ^
-                   -DCMAKE_C_COMPILER_LAUNCHER=ccache
+                   -GNinja
           ninja install
           .\micromamba\micromamba.exe --help
       - name: tar micromamba artifact

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,14 +17,6 @@ jobs:
         os: [ubuntu-latest, macos-latest]
     steps:
       - uses: actions/checkout@v2
-      - name: free disk space
-        if: matrix.os == 'ubuntu-latest'
-        run: |
-          sudo swapoff -a
-          sudo rm -f /swapfile
-          sudo apt clean
-          docker rmi $(docker image ls -aq)
-          df -h
       - name: generate ccache key
         id: ccache_key
         shell: bash -l {0}
@@ -38,7 +30,7 @@ jobs:
           path: ~/ccache
           key: ${{ steps.ccache_key.outputs.key }}
           restore-keys: |
-            ${{ steps.ccache_key.outputs.key_prefix }}
+            ${{ steps.ccache_key.outputs.key_prefix }}-$GITHUB_JOB
       - name: create build environment
         uses: mamba-org/provision-with-micromamba@main
         with:
@@ -50,6 +42,8 @@ jobs:
           micromamba activate build_env
           mkdir build
           cd build
+          ccache --show-stats
+          ccache -z
           export CCACHE_DIR=$HOME/ccache
           cmake \
               -GNinja \
@@ -59,6 +53,7 @@ jobs:
               -DCMAKE_C_COMPILER_LAUNCHER=ccache \
               ..
           ninja
+          ccache --show-stats
 
   libmamba_cpp_tests:
     needs: [libmamba_static]
@@ -73,7 +68,7 @@ jobs:
         id: ccache_key
         shell: bash -l {0}
         run: |
-          key_prefix="ccache-${{ runner.os }}-$(TZ=UTC date +%F)-libmamba_static"
+          key_prefix="ccache-${{ runner.os }}-$(TZ=UTC date +%F)"
           echo ::set-output name=key_prefix::"$key_prefix"
           echo ::set-output name=key::"$key_prefix-$GITHUB_JOB-$(TZ=UTC date '+%H:%M:%S')"
       - name: cache CCACHE paths
@@ -82,7 +77,8 @@ jobs:
           path: ~/ccache
           key: ${{ steps.ccache_key.outputs.key }}
           restore-keys: |
-            ${{ steps.ccache_key.outputs.key_prefix }}
+            ${{ steps.ccache_key.outputs.key_prefix }}-$GITHUB_JOB
+            ${{ steps.ccache_key.outputs.key_prefix }}-libmamba_static
       - name: create build environment
         uses: mamba-org/provision-with-micromamba@main
         with:
@@ -94,6 +90,8 @@ jobs:
           micromamba activate build_env
           mkdir build
           cd build
+          ccache --show-stats
+          ccache -z
           export CCACHE_DIR=$HOME/ccache
           cmake \
               -GNinja \
@@ -105,6 +103,7 @@ jobs:
               ..
           ninja testing_libmamba_lock
           ninja test
+          ccache --show-stats
 
   umamba_tests:
     needs: [libmamba_static]
@@ -115,19 +114,11 @@ jobs:
         os: [ubuntu-latest, macos-latest]
     steps:
       - uses: actions/checkout@v2
-      - name: free disk space
-        if: matrix.os == 'ubuntu-latest'
-        run: |
-          sudo swapoff -a
-          sudo rm -f /swapfile
-          sudo apt clean
-          docker rmi $(docker image ls -aq)
-          df -h
       - name: generate ccache key
         id: ccache_key
         shell: bash -l {0}
         run: |
-          key_prefix="ccache-${{ runner.os }}-$(TZ=UTC date +%F)-libmamba_static"
+          key_prefix="ccache-${{ runner.os }}-$(TZ=UTC date +%F)"
           echo ::set-output name=key_prefix::"$key_prefix"
           echo ::set-output name=key::"$key_prefix-$GITHUB_JOB-$(TZ=UTC date '+%H:%M:%S')"
       - name: cache CCACHE paths
@@ -136,7 +127,8 @@ jobs:
           path: ~/ccache
           key: ${{ steps.ccache_key.outputs.key }}
           restore-keys: |
-            ${{ steps.ccache_key.outputs.key_prefix }}
+            ${{ steps.ccache_key.outputs.key_prefix }}-$GITHUB_JOB
+            ${{ steps.ccache_key.outputs.key_prefix }}-libmamba_static
       - name: create build environment
         uses: mamba-org/provision-with-micromamba@main
         with:
@@ -146,6 +138,8 @@ jobs:
         shell: bash -l {0}
         run: |
           micromamba activate build_env
+          ccache --show-stats
+          ccache -z
           export CCACHE_DIR=$HOME/ccache
           mkdir build
           cd build
@@ -157,6 +151,7 @@ jobs:
               -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
               -DCMAKE_C_COMPILER_LAUNCHER=ccache
           ninja
+          ccache --show-stats
       - name: install zsh, xonsh and fish in linux
         if: matrix.os == 'ubuntu-latest'
         shell: bash -l -eo pipefail {0}
@@ -185,19 +180,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: free disk space
-        if: matrix.os == 'ubuntu-latest'
-        run: |
-          sudo swapoff -a
-          sudo rm -f /swapfile
-          sudo apt clean
-          docker rmi $(docker image ls -aq)
-          df -h
       - name: generate ccache key
         id: ccache_key
         shell: bash -l {0}
         run: |
-          key_prefix="ccache-${{ runner.os }}-$(TZ=UTC date +%F)-libmamba_static"
+          key_prefix="ccache-${{ runner.os }}-$(TZ=UTC date +%F)"
           echo ::set-output name=key_prefix::"$key_prefix"
           echo ::set-output name=key::"$key_prefix-$GITHUB_JOB-$(TZ=UTC date '+%H:%M:%S')"
       - name: cache CCACHE paths
@@ -206,7 +193,8 @@ jobs:
           path: ~/ccache
           key: ${{ steps.ccache_key.outputs.key }}
           restore-keys: |
-            ${{ steps.ccache_key.outputs.key_prefix }}
+            ${{ steps.ccache_key.outputs.key_prefix }}-$GITHUB_JOB
+            ${{ steps.ccache_key.outputs.key_prefix }}-libmamba_static
       - name: create build environment
         uses: mamba-org/provision-with-micromamba@main
         with:
@@ -222,6 +210,8 @@ jobs:
           micromamba activate build_env
           mkdir build
           cd build
+          ccache --show-stats
+          ccache -z
           export CCACHE_DIR=$HOME/ccache
           cmake \
               -GNinja \
@@ -236,6 +226,7 @@ jobs:
           ninja
           ninja install
           pip install -e ../libmambapy/ --no-deps
+          ccache --show-stats
       - name: install mamba
         shell: bash -l {0}
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,7 +31,7 @@ jobs:
         run: |
           key_prefix="ccache-${{ runner.os }}-$(TZ=UTC date +%F)"
           echo ::set-output name=key_prefix::"$key_prefix"
-          echo ::set-output name=key::"$key_prefix-${{ env.GITHUB_JOB }}-$(TZ=UTC date '+%H:%M:%S')"
+          echo ::set-output name=key::"$key_prefix-$GITHUB_JOB-$(TZ=UTC date '+%H:%M:%S')"
       - name: cache CCACHE paths
         uses: actions/cache@v2
         with:
@@ -75,7 +75,7 @@ jobs:
         run: |
           key_prefix="ccache-${{ runner.os }}-$(TZ=UTC date +%F)-libmamba_static"
           echo ::set-output name=key_prefix::"$key_prefix"
-          echo ::set-output name=key::"$key_prefix-${{ env.GITHUB_JOB }}-$(TZ=UTC date '+%H:%M:%S')"
+          echo ::set-output name=key::"$key_prefix-$GITHUB_JOB-$(TZ=UTC date '+%H:%M:%S')"
       - name: cache CCACHE paths
         uses: actions/cache@v2
         with:
@@ -129,7 +129,7 @@ jobs:
         run: |
           key_prefix="ccache-${{ runner.os }}-$(TZ=UTC date +%F)-libmamba_static"
           echo ::set-output name=key_prefix::"$key_prefix"
-          echo ::set-output name=key::"$key_prefix-${{ env.GITHUB_JOB }}-$(TZ=UTC date '+%H:%M:%S')"
+          echo ::set-output name=key::"$key_prefix-$GITHUB_JOB-$(TZ=UTC date '+%H:%M:%S')"
       - name: cache CCACHE paths
         uses: actions/cache@v2
         with:
@@ -199,7 +199,7 @@ jobs:
         run: |
           key_prefix="ccache-${{ runner.os }}-$(TZ=UTC date +%F)-libmamba_static"
           echo ::set-output name=key_prefix::"$key_prefix"
-          echo ::set-output name=key::"$key_prefix-${{ env.GITHUB_JOB }}-$(TZ=UTC date '+%H:%M:%S')"
+          echo ::set-output name=key::"$key_prefix-$GITHUB_JOB-$(TZ=UTC date '+%H:%M:%S')"
       - name: cache CCACHE paths
         uses: actions/cache@v2
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,9 +36,9 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/ccache
-          key: ${{ steps.ccache_key.key }}
+          key: ${{ steps.ccache_key.outputs.key }}
           restore-keys: |
-            ${{ steps.ccache_key.key_prefix }}
+            ${{ steps.ccache_key.outputs.key_prefix }}
       - name: create build environment
         uses: mamba-org/provision-with-micromamba@main
         with:
@@ -80,9 +80,9 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/ccache
-          key: ${{ steps.ccache_key.key }}
+          key: ${{ steps.ccache_key.outputs.key }}
           restore-keys: |
-            ${{ steps.ccache_key.key_prefix }}
+            ${{ steps.ccache_key.outputs.key_prefix }}
       - name: create build environment
         uses: mamba-org/provision-with-micromamba@main
         with:
@@ -134,9 +134,9 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/ccache
-          key: ${{ steps.ccache_key.key }}
+          key: ${{ steps.ccache_key.outputs.key }}
           restore-keys: |
-            ${{ steps.ccache_key.key_prefix }}
+            ${{ steps.ccache_key.outputs.key_prefix }}
       - name: create build environment
         uses: mamba-org/provision-with-micromamba@main
         with:
@@ -204,9 +204,9 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/ccache
-          key: ${{ steps.ccache_key.key }}
+          key: ${{ steps.ccache_key.outputs.key }}
           restore-keys: |
-            ${{ steps.ccache_key.key_prefix }}
+            ${{ steps.ccache_key.outputs.key_prefix }}
       - name: create build environment
         uses: mamba-org/provision-with-micromamba@main
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,7 +31,7 @@ jobs:
         run: |
           key_prefix="ccache-${{ runner.os }}-$(TZ=UTC date +%F)"
           echo ::set-output name=key_prefix::"$key_prefix"
-          echo ::set-output name=key::"$key_prefix-$(TZ=UTC date '+%H:%M:%S')"
+          echo ::set-output name=key::"$key_prefix-${{ env.GITHUB_JOB }}-$(TZ=UTC date '+%H:%M:%S')"
       - name: cache CCACHE paths
         uses: actions/cache@v2
         with:
@@ -73,9 +73,9 @@ jobs:
         id: ccache_key
         shell: bash -l {0}
         run: |
-          key_prefix="ccache-${{ runner.os }}-$(TZ=UTC date +%F)"
+          key_prefix="ccache-${{ runner.os }}-$(TZ=UTC date +%F)-${{ jobs.libmamba_static.job_id }}"
           echo ::set-output name=key_prefix::"$key_prefix"
-          echo ::set-output name=key::"$key_prefix-$(TZ=UTC date '+%H:%M:%S')"
+          echo ::set-output name=key::"$key_prefix-${{ env.GITHUB_JOB }}-$(TZ=UTC date '+%H:%M:%S')"
       - name: cache CCACHE paths
         uses: actions/cache@v2
         with:
@@ -127,9 +127,9 @@ jobs:
         id: ccache_key
         shell: bash -l {0}
         run: |
-          key_prefix="ccache-${{ runner.os }}-$(TZ=UTC date +%F)"
+          key_prefix="ccache-${{ runner.os }}-$(TZ=UTC date +%F)-${{ jobs.libmamba_static.job_id }}"
           echo ::set-output name=key_prefix::"$key_prefix"
-          echo ::set-output name=key::"$key_prefix-$(TZ=UTC date '+%H:%M:%S')"
+          echo ::set-output name=key::"$key_prefix-${{ env.GITHUB_JOB }}-$(TZ=UTC date '+%H:%M:%S')"
       - name: cache CCACHE paths
         uses: actions/cache@v2
         with:
@@ -197,9 +197,9 @@ jobs:
         id: ccache_key
         shell: bash -l {0}
         run: |
-          key_prefix="ccache-${{ runner.os }}-$(TZ=UTC date +%F)"
+          key_prefix="ccache-${{ runner.os }}-$(TZ=UTC date +%F)-${{ jobs.libmamba_static.job_id }}"
           echo ::set-output name=key_prefix::"$key_prefix"
-          echo ::set-output name=key::"$key_prefix-$(TZ=UTC date '+%H:%M:%S')"
+          echo ::set-output name=key::"$key_prefix-${{ env.GITHUB_JOB }}-$(TZ=UTC date '+%H:%M:%S')"
       - name: cache CCACHE paths
         uses: actions/cache@v2
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -73,7 +73,7 @@ jobs:
         id: ccache_key
         shell: bash -l {0}
         run: |
-          key_prefix="ccache-${{ runner.os }}-$(TZ=UTC date +%F)-${{ jobs.libmamba_static.job_id }}"
+          key_prefix="ccache-${{ runner.os }}-$(TZ=UTC date +%F)-libmamba_static"
           echo ::set-output name=key_prefix::"$key_prefix"
           echo ::set-output name=key::"$key_prefix-${{ env.GITHUB_JOB }}-$(TZ=UTC date '+%H:%M:%S')"
       - name: cache CCACHE paths
@@ -127,7 +127,7 @@ jobs:
         id: ccache_key
         shell: bash -l {0}
         run: |
-          key_prefix="ccache-${{ runner.os }}-$(TZ=UTC date +%F)-${{ jobs.libmamba_static.job_id }}"
+          key_prefix="ccache-${{ runner.os }}-$(TZ=UTC date +%F)-libmamba_static"
           echo ::set-output name=key_prefix::"$key_prefix"
           echo ::set-output name=key::"$key_prefix-${{ env.GITHUB_JOB }}-$(TZ=UTC date '+%H:%M:%S')"
       - name: cache CCACHE paths
@@ -197,7 +197,7 @@ jobs:
         id: ccache_key
         shell: bash -l {0}
         run: |
-          key_prefix="ccache-${{ runner.os }}-$(TZ=UTC date +%F)-${{ jobs.libmamba_static.job_id }}"
+          key_prefix="ccache-${{ runner.os }}-$(TZ=UTC date +%F)-libmamba_static"
           echo ::set-output name=key_prefix::"$key_prefix"
           echo ::set-output name=key::"$key_prefix-${{ env.GITHUB_JOB }}-$(TZ=UTC date '+%H:%M:%S')"
       - name: cache CCACHE paths


### PR DESCRIPTION
- Use separate ccache for each of the libmamba_static downstream tasks
- Use incremental ccache, not only a single cache update per day
- Drop ccache from Windows setup