### PR TITLE
Locking on lock-less filesystems.

### DIFF
--- a/libmamba/src/core/util.cpp
+++ b/libmamba/src/core/util.cpp
@@ -1080,6 +1080,14 @@ namespace mamba
         }
         else
             ret = fcntl(m_fd, F_SETLK, &lock);
+        // Test for ENOSYS result. If that is the case, use alternate locking
+        // where the file is assumed to be successfully locked if the lock
+        // file did *not* exist.
+        if (ret != 0 && errno == ENOSYS)
+        {
+            LOG_WARNING << "File locking unimplemented on this filesystem. Using alternate locking strategy";
+            return !m_lockfile_existed;
+        }
 #endif
         return ret == 0;
     }


### PR DESCRIPTION
When ENOSYS/Function not implemented is returned by fcntl when trying to use advisory locks, switch to a simple locking system where the file is assumed to be successfully locked if the lockfile did not initially exist (e.g. we were the first process to create the lock).

Draft pull request to address #1446. Will add tests/etc.