### PR TITLE
micromamba run process names

### DIFF
--- a/libmamba/include/mamba/core/util.hpp
+++ b/libmamba/include/mamba/core/util.hpp
@@ -98,6 +98,12 @@ namespace mamba
         return rng;
     }
 
+    template<typename T = int, typename G = std::mt19937>
+    inline T random_int(T min, T max, G& generator = local_random_generator())
+    {
+        return std::uniform_int_distribution<T>{ min, max }(generator);
+    }
+
     inline std::string generate_random_alphanumeric_string(std::size_t len)
     {
         static constexpr auto chars = "0123456789"

--- a/libmamba/include/mamba/core/util.hpp
+++ b/libmamba/include/mamba/core/util.hpp
@@ -79,6 +79,8 @@ namespace mamba
     template <typename T = std::mt19937>
     inline auto random_generator() -> T
     {
+        using std::begin;
+        using std::end;
         auto constexpr seed_bits = sizeof(typename T::result_type) * T::state_size;
         auto constexpr seed_len
             = seed_bits / std::numeric_limits<std::seed_seq::result_type>::digits;
@@ -89,12 +91,19 @@ namespace mamba
         return T{ seed_seq };
     }
 
+    template<typename T = std::mt19937>
+    inline auto local_random_generator() -> T&
+    {
+        thread_local auto rng = random_generator<T>();
+        return rng;
+    }
+
     inline std::string generate_random_alphanumeric_string(std::size_t len)
     {
         static constexpr auto chars = "0123456789"
                                       "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
                                       "abcdefghijklmnopqrstuvwxyz";
-        thread_local auto rng = random_generator<std::mt19937>();
+        auto& rng = local_random_generator<std::mt19937>();
 
         auto dist = std::uniform_int_distribution{ {}, std::strlen(chars) - 1 };
         auto result = std::string(len, '\0');

--- a/libmamba/include/mamba/core/util_os.hpp
+++ b/libmamba/include/mamba/core/util_os.hpp
@@ -15,11 +15,17 @@ namespace mamba
     bool is_admin();
     fs::path get_self_exe_path();
 
-#ifndef _WIN32
-    std::string get_process_name_by_pid(const int pid);
+using PID =
+#ifdef _WIN32
+    DWORD
 #else
-    DWORD getppid();
-    std::string get_process_name_by_pid(DWORD processId);
+    int
+#endif
+;
+
+    std::string get_process_name_by_pid(const PID pid);
+#ifdef _WIN32
+    PID getppid();
 #endif
 
     void run_as_admin(const std::string& args);

--- a/libmamba/tests/CMakeLists.txt
+++ b/libmamba/tests/CMakeLists.txt
@@ -25,6 +25,7 @@ set(TEST_SRCS
     test_url.cpp
     test_validate.cpp
     test_virtual_packages.cpp
+    test_util.cpp
 )
 
 message(STATUS "Building libmamba C++ tests")

--- a/libmamba/tests/test_util.cpp
+++ b/libmamba/tests/test_util.cpp
@@ -1,0 +1,36 @@
+#include <gtest/gtest.h>
+
+#include <thread>
+
+#include "mamba/core/util.hpp"
+
+namespace mamba
+{
+    TEST(local_random_generator, one_rng_per_thread_and_type)
+    {
+        auto same_thread_checks = []{
+            auto& a = local_random_generator();
+            auto& b = local_random_generator();
+            EXPECT_EQ(&a, &b);
+
+            auto& c = local_random_generator<std::mt19937>();
+            EXPECT_EQ(&a, &c);
+
+            auto& d = local_random_generator<std::mt19937_64>();
+            EXPECT_NE(static_cast<void*>(&a), static_cast<void*>(&d));
+
+            return &a;
+        };
+        void* pointer_to_this_thread_rng = same_thread_checks();
+
+        void* pointer_to_another_thread_rng = nullptr;
+        std::thread another_thread{[&]{
+            pointer_to_another_thread_rng = same_thread_checks();
+        }};
+        another_thread.join();
+
+        EXPECT_NE(pointer_to_this_thread_rng, pointer_to_another_thread_rng);
+    }
+}
+
+

--- a/libmamba/tests/test_util.cpp
+++ b/libmamba/tests/test_util.cpp
@@ -45,5 +45,3 @@ namespace mamba
         }
     }
 }
-
-

--- a/libmamba/tests/test_util.cpp
+++ b/libmamba/tests/test_util.cpp
@@ -31,6 +31,19 @@ namespace mamba
 
         EXPECT_NE(pointer_to_this_thread_rng, pointer_to_another_thread_rng);
     }
+
+    TEST(random_int, value_in_range)
+    {
+        constexpr int arbitrary_min = -20;
+        constexpr int arbitrary_max = 20;
+        constexpr int attempts = 2000;
+        for(int i = 0; i < attempts; ++i)
+        {
+            const int value = random_int(arbitrary_min, arbitrary_max);
+            EXPECT_GE(value, arbitrary_min);
+            EXPECT_LE(value, arbitrary_max);
+        }
+    }
 }
 
 

--- a/micromamba/src/run.cpp
+++ b/micromamba/src/run.cpp
@@ -37,6 +37,36 @@ namespace mamba {
             "gentle",
             "happy",
             "stubborn",
+            "boring",
+            "interesting",
+            "funny",
+            "weird",
+            "surprising",
+            "serious",
+            "tender",
+            "obvious",
+            "great",
+            "proud",
+            "silent",
+            "loud",
+            "vacuous",
+            "focused",
+            "pretty",
+            "slick",
+            "tedious",
+            "stubborn",
+            "daring",
+            "tenacious",
+            "resilient",
+            "rigorous",
+            "friendly",
+            "creative",
+            "polite",
+            "frank",
+            "honest",
+            "warm",
+            "smart",
+            "intriguing",
             // TODO: add more here
         };
 
@@ -81,13 +111,13 @@ namespace mamba {
         return lockfile;
     }
 
-    struct PredicateTrue
+    struct Predicate_AlwaysTrue
     {
         template<typename T>
         constexpr bool operator()(T&&) noexcept { return true; }
     };
 
-    template<typename Predicate = PredicateTrue>
+    template<typename Predicate = Predicate_AlwaysTrue>
     nlohmann::json get_all_running_processes_info(Predicate filter = {})
     {
         nlohmann::json all_processes_info;

--- a/micromamba/src/run.cpp
+++ b/micromamba/src/run.cpp
@@ -26,7 +26,7 @@ extern "C" {
 namespace mamba {
 
 
-    bool is_process_name_running(std::string_view name);
+    bool is_process_name_running(const std::string& name);
 
     std::string generate_unique_process_name(std::string_view program_name)
     {
@@ -169,7 +169,7 @@ namespace mamba {
         return all_processes_info;
     }
 
-    bool is_process_name_running(std::string_view name)
+    bool is_process_name_running(const std::string& name)
     {
         const auto other_processes_with_same_name = get_all_running_processes_info([&](auto&& process_info){
             return process_info["child_name"] == name;

--- a/micromamba/src/run.cpp
+++ b/micromamba/src/run.cpp
@@ -133,7 +133,7 @@ namespace mamba {
             fs::ifstream pid_file{ file_location, open_mode };
             if(!pid_file.is_open())
             {
-                LOG_WARNING << fmt::format("could not open {}", file_location);
+                LOG_WARNING << fmt::format("failed to open {}", file_location);
                 continue;
             }
 
@@ -283,9 +283,8 @@ set_run_command(CLI::App* subcom)
             exit(1);
         }
 
-        LOG_WARNING << "currently running processes: " << get_all_running_processes_info();
-
-        LOG_WARNING << "Remaining args to run as command: " << join(" ", command); // TODO: lower log level and then check why they never print in info and debug
+        LOG_DEBUG << "Currently running processes: " << get_all_running_processes_info();
+        LOG_DEBUG << "Remaining args to run as command: " << join(" ", command); // TODO: lower log level and then check why they never print in info and debug
 
         // Lock the process directory to read and write in it until we manage to run the file or exit.
         static auto proc_dir_lock = lock_proc_dir();  // Note: this object is static only so that calls to `std::exit()` will call the destructor.
@@ -310,7 +309,7 @@ set_run_command(CLI::App* subcom)
             {
                 if(is_process_name_running(specific_process_name))
                 {
-                    LOG_ERROR << fmt::format("Another process with name '{}' is running.", specific_process_name);
+                    LOG_ERROR << fmt::format("Another process with name '{}' is currently running.", specific_process_name);
                     exit(1);
                 }
                 command.insert(exe_name_it, { {"-a"}, specific_process_name });
@@ -322,7 +321,7 @@ set_run_command(CLI::App* subcom)
         auto [wrapped_command, script_file]
             = prepare_wrapped_call(Context::instance().target_prefix, command);
 
-        LOG_WARNING << "Running wrapped script: " << join(" ", command); // TODO: lower log level and then check why they never print in info and debug
+        LOG_DEBUG << "Running wrapped script: " << join(" ", command); // TODO: lower log level and then check why they never print in info and debug
 
         bool all_streams = stream_option->count() == 0u;
         bool sinkout = !all_streams && streams.find("stdout") == std::string::npos;


### PR DESCRIPTION
`micromamba run` now runs unix-like systems programs with an associated name. (see #1491)
By default that name is made unique either by using a prefix adjective to the name of the executable program, or by using a randomly generated prefix if no prefix+program name is available.
Users can specify a name using `--pname <name>`.

To guarantee unique names, we randomly chose a prefix to generate the name then check against the currently used names launched by other `micromamba run` commands, retry generating until we find a name that is not being used and if we don't have alternative prefixes to add we simply generate a random one and try again. If the user specified a name using `--pname`, we prevent execution of the program if the name is already used, we do not generate a new one.

This feature is not supported on  Windows. `--pname` will not appear in the possible options.
