### PR TITLE
Fix `history.parse` tests generating expenentionally bigger test data file

### DIFF
--- a/libmamba/src/core/history.cpp
+++ b/libmamba/src/core/history.cpp
@@ -14,7 +14,7 @@ namespace mamba
 {
     History::History(const fs::path& prefix)
         : m_prefix(prefix)
-        , m_history_file_path(m_prefix / "conda-meta" / "history")
+        , m_history_file_path(fs::absolute(m_prefix / "conda-meta" / "history"))
     {
     }
 
@@ -29,7 +29,7 @@ namespace mamba
             return res;
         }
 
-        static std::regex head_re("==>\\s*(.+?)\\s*<==");
+        static const std::regex head_re("==>\\s*(.+?)\\s*<==");
         std::ifstream in_file = open_ifstream(m_history_file_path, std::ios::in);
 
         std::string line;

--- a/libmamba/tests/history_test/test_history.cpp
+++ b/libmamba/tests/history_test/test_history.cpp
@@ -9,11 +9,14 @@ namespace mamba
 {
     TEST(history, parse)
     {
+        static constexpr auto history_file_path = "history_test/parse/conda-meta/history";
+        static constexpr auto aux_file_path = "history_test/parse/conda-meta/aux_file";
+
         History history_instance("history_test/parse");
 
         std::vector<History::UserRequest> user_reqs = history_instance.get_user_requests();
 
-        std::ifstream history_file("history_test/parse/conda-meta/history");
+        std::ifstream history_file(history_file_path);
         std::stringstream original_history_buffer;
         std::string line;
         while (getline(history_file, line))
@@ -22,11 +25,8 @@ namespace mamba
         }
         history_file.close();
 
-        std::ifstream src_beg("history_test/parse/conda-meta/history", std::ios::binary);
-        std::ofstream dst_beg("history_test/parse/conda-meta/aux_file", std::ios::binary);
-        dst_beg << src_beg.rdbuf();
-        src_beg.close();
-        dst_beg.close();
+        fs::remove(aux_file_path);
+        fs::copy(history_file_path, aux_file_path);
 
         std::stringstream check_buffer;
         check_buffer << original_history_buffer.str() << original_history_buffer.str();
@@ -37,7 +37,7 @@ namespace mamba
             history_instance.add_entry(req);
         }
 
-        history_file.open("history_test/parse/conda-meta/history");
+        history_file.open(history_file_path);
         std::stringstream updated_history_buffer;
         while (getline(history_file, line))
         {
@@ -47,11 +47,8 @@ namespace mamba
 
         ASSERT_EQ(updated_history_buffer.str(), check_buffer.str());
 
-        std::ofstream src_end("history_test/conda-meta/history", std::ios::binary);
-        std::ifstream dst_end("history_test/conda-meta/aux_file", std::ios::binary);
-        src_end << dst_end.rdbuf();
-        src_end.close();
-        dst_end.close();
+        fs::remove(history_file_path);
+        fs::copy(aux_file_path, history_file_path);
     }
 
 #ifndef _WIN32


### PR DESCRIPTION
The issue, I believe, was that the code was trying to backup, modify and then restore the history file. However the path to the history files were wrong in the last bit. This lead to the history file size used in that test to double size at each run (because the test needs to re-inject it's content in the history), instead of being restored to it's initial size each end of run. Note that this issue is only visible if you run the tests more than once locally, the CI will re-configure each run which overwrite the history file and prevent from making the issue visible.

These changes mainly refactor the test for clarity and future maintenance, which lead to fixing the issue.
(please tell me if my understanding of the test is wrong)
- Made sure the history files are always the same, no way to make the same mistake again.
- Some manual file content copy/pasting were replaced by explicit file copies.
- Added some RAII for making sure the history file is restored even if an operation fails in the test (except if file access fails, but then a reconfigure would fix that).
- Added some comments to help figuring out what this test was testing.
- Also made some paths absolute for helping with debugging (it is not always clear which files are being used when running `make test` vs when running the test executable manually).