### PR TITLE
Renamed `micromamba run` option `--pname` to `--label`

### DIFF
--- a/micromamba/src/run.cpp
+++ b/micromamba/src/run.cpp
@@ -276,7 +276,7 @@ set_run_command(CLI::App* subcom)
     subcom->add_option(
         "--label",
         specific_process_name,
-        "Specifies the name of the process. If not set, a unique name enerated by deriving from the executable name will be generated.");
+        "Specifies the name of the process. If not set, a unique name will be generated derived from the executable name if possible.");
 #endif
 
     subcom->prefix_command();

--- a/micromamba/src/run.cpp
+++ b/micromamba/src/run.cpp
@@ -274,7 +274,7 @@ set_run_command(CLI::App* subcom)
 #ifndef _WIN32
     static std::string specific_process_name;
     subcom->add_option(
-        "--pname",
+        "--label",
         specific_process_name,
         "Specifies the name of the process. If not set, a unique name enerated by deriving from the executable name will be generated.");
 #endif


### PR DESCRIPTION
The directory was accessed before use by a log, changed to be sure the directory exists even if the command falis.