### PR TITLE
Tollerate PATH variable being unset

### DIFF
--- a/libmamba/include/mamba/core/environment.hpp
+++ b/libmamba/include/mamba/core/environment.hpp
@@ -112,10 +112,10 @@ namespace mamba
 #endif
         }
 
-        inline fs::path which(const std::string& exe)
+        inline fs::path which(const std::string& exe, const std::string& override_path = "")
         {
             // TODO maybe add a cache?
-            auto env_path = env::get("PATH");
+            auto env_path = override_path == "" ? env::get("PATH") : override_path;
             if (env_path)
             {
                 std::string path = env_path.value();
@@ -135,6 +135,21 @@ namespace mamba
                     }
                 }
             }
+
+#ifndef _WIN32
+            if (override_path == "")
+            {
+                char* pathbuf;
+                size_t n = confstr(_CS_PATH, NULL, (size_t) 0);
+                pathbuf = (char*) malloc(n);
+                if (pathbuf != NULL)
+                {
+                    confstr(_CS_PATH, pathbuf, n);
+                    return which(exe, pathbuf);
+                }
+            }
+#endif
+
             return "";  // empty path
         }
 

--- a/libmamba/src/core/transaction_context.cpp
+++ b/libmamba/src/core/transaction_context.cpp
@@ -173,7 +173,7 @@ namespace mamba
         {
             LOG_ERROR << "Bad conversion of Python version '" << python_version
                       << "': " << e.what();
-            throw std::runtime_error("Bad conversion. Aborting.");
+            return false;
         }
 
         m_pyc_process = std::make_unique<reproc::process>();
@@ -209,7 +209,8 @@ namespace mamba
         {
             LOG_ERROR << "Program not found. Make sure it's available from the PATH. "
                       << ec.message();
-            throw std::runtime_error("pyc compilation failed with program not found. Aborting.");
+            m_pyc_process = nullptr;
+            return false;
         }
 
         return true;
@@ -226,8 +227,7 @@ namespace mamba
             return false;
         }
 
-        start_pyc_compilation_process();
-        if (!m_pyc_process)
+        if (start_pyc_compilation_process() && !m_pyc_process)
         {
             return false;
         }

--- a/libmamba/src/core/util.cpp
+++ b/libmamba/src/core/util.cpp
@@ -1465,6 +1465,11 @@ namespace mamba
             {
                 shell_path = env::which("sh");
             }
+            if (shell_path.empty())
+            {
+                LOG_ERROR << "Failed to find a shell to run the script with.";
+                shell_path = "sh";
+            }
 
             script_file = wrap_call(
                 Context::instance().root_prefix, prefix, Context::instance().dev, false, cmd);


### PR DESCRIPTION
I've found when running a installer created with constructor I've ran into this error:

```
Linking setuptools-60.9.1-py39hf3d152e_0
Linking pango-1.48.10-h54213e6_2
Linking rrdtool-1.7.2-h80f2daa_2
Linking wheel-0.37.1-pyhd8ed1ab_0
error    Program not found. Make sure it's available from the PATH. No such file or directory
critical pyc compilation failed with program not found. Aborting.
```

This first bug here is that `pyc` compilation should be allowed to fail (which was my fault, sorry about that 😅).

The underlying issue was that the machine didn't have `$PATH` set which means when `micromamba` looks for `bash` [here](https://github.com/mamba-org/mamba/blob/42f2cd88ba7e50d696dc6d7376a1cfa7d02315a2/libmamba/src/core/util.cpp#L1463-L1467) the lookup fails and defaults to an empty string [here](https://github.com/mamba-org/mamba/blob/master/libmamba/include/mamba/core/environment.hpp#L115-L139). This then results in the `Program not found. Make sure it's available from the PATH. No such file or directory.`.

The same failure can be reproduced using:

```bash
PATH= micromamba create --prefix /tmp/test-env six
```