### PR TITLE
Passthrough QEMU_LD_PREFIX to subprocesses with empty environments

### DIFF
--- a/libmamba/src/core/link.cpp
+++ b/libmamba/src/core/link.cpp
@@ -419,6 +419,11 @@ namespace mamba
         if (activate)
         {
             options.env.behavior = reproc::env::empty;
+            auto qemu_ld_prefix = env::get("QEMU_LD_PREFIX");
+            if (qemu_ld_prefix)
+            {
+                envmap["QEMU_LD_PREFIX"] = qemu_ld_prefix.value();
+            }
         }
         else
         {

--- a/libmamba/src/core/transaction_context.cpp
+++ b/libmamba/src/core/transaction_context.cpp
@@ -9,6 +9,7 @@
 
 #include <reproc++/drain.hpp>
 
+#include "mamba/core/environment.hpp"
 #include "mamba/core/transaction_context.hpp"
 #include "mamba/core/output.hpp"
 #include "mamba/core/util.hpp"
@@ -203,6 +204,11 @@ namespace mamba
         std::map<std::string, std::string> envmap;
         auto& ctx = Context::instance();
         envmap["MAMBA_EXTRACT_THREADS"] = std::to_string(ctx.extract_threads);
+        auto qemu_ld_prefix = env::get("QEMU_LD_PREFIX");
+        if (qemu_ld_prefix)
+        {
+            envmap["QEMU_LD_PREFIX"] = qemu_ld_prefix.value();
+        }
         options.env.extra = envmap;
 
         options.stop = {


### PR DESCRIPTION
When running with emulation I've hit a couple of cases where mamba's subprocesses fail due to `QEMU_LD_PREFIX` not being set causing. I don't particularly like this solution but I don't see a cleaner option other than maybe centralising the creation of subprocesses and having a way of configuring the environment of subprocesses (e.g. `MAMBA_ENV_xxxx` environment variables).

What do you think?