### PR TITLE
Stores channel into msubdirdata and libsolv repo appdata

### DIFF
--- a/libmamba/include/mamba/core/channel.hpp
+++ b/libmamba/include/mamba/core/channel.hpp
@@ -62,6 +62,9 @@ namespace mamba
         friend class ChannelBuilder;
     };
 
+    bool operator==(const Channel& lhs, const Channel& rhs);
+    bool operator!=(const Channel& lhs, const Channel& rhs);
+
     const Channel& make_channel(const std::string& value);
     std::vector<const Channel*> get_channels(const std::vector<std::string>& channel_names);
 

--- a/libmamba/include/mamba/core/repo.hpp
+++ b/libmamba/include/mamba/core/repo.hpp
@@ -10,6 +10,7 @@
 #include <string>
 #include <tuple>
 
+#include "channel.hpp"
 #include "prefix_data.hpp"
 
 extern "C"
@@ -82,6 +83,12 @@ namespace mamba
               const fs::path& filename,
               const RepoMetadata& meta);
 
+        MRepo(MPool& pool,
+              const std::string& name,
+              const fs::path& filename,
+              const RepoMetadata& meta,
+              const Channel& channel);
+
         /**
          * Constructor.
          * @param pool ``libsolv`` pool wrapper
@@ -91,6 +98,12 @@ namespace mamba
         MRepo(MPool& pool, const std::string& name, const std::vector<PackageInfo>& uris);
 
         ~MRepo();
+
+        MRepo(const MRepo&) = delete;
+        MRepo& operator=(const MRepo&) = delete;
+
+        MRepo(MRepo&&);
+        MRepo& operator=(MRepo&&);
 
         void set_installed();
         void set_priority(int priority, int subpriority);
@@ -103,6 +116,7 @@ namespace mamba
         bool write() const;
         const std::string& url() const;
         Repo* repo() const;
+        const Channel* channel() const;
         std::tuple<int, int> priority() const;
         std::size_t size() const;
 
@@ -117,6 +131,7 @@ namespace mamba
         RepoMetadata m_metadata;
 
         Repo* m_repo;
+        const Channel* p_channel = nullptr;
     };
 }  // namespace mamba
 

--- a/libmamba/include/mamba/core/subdirdata.hpp
+++ b/libmamba/include/mamba/core/subdirdata.hpp
@@ -13,6 +13,7 @@
 
 #include "nlohmann/json.hpp"
 
+#include "mamba/core/channel.hpp"
 #include "mamba/core/context.hpp"
 #include "mamba/core/fetch.hpp"
 #include "mamba/core/mamba_fs.hpp"
@@ -57,6 +58,11 @@ namespace mamba
                     MultiPackageCache& caches,
                     bool is_noarch);
 
+        MSubdirData(const Channel& channel,
+                    const std::string& platform,
+                    const std::string& url,
+                    MultiPackageCache& caches);
+
         // TODO return seconds as double
         fs::file_time_type::duration check_cache(const fs::path& cache_file,
                                                  const fs::file_time_type::clock::time_point& ref);
@@ -100,6 +106,7 @@ namespace mamba
         bool m_is_noarch;
         nlohmann::json m_mod_etag;
         std::unique_ptr<TemporaryFile> m_temp_file;
+        const Channel* p_channel = nullptr;
     };
 
     // Contrary to conda original function, this one expects a full url

--- a/libmamba/include/mamba/core/subdirdata.hpp
+++ b/libmamba/include/mamba/core/subdirdata.hpp
@@ -44,24 +44,11 @@ namespace mamba
     class MSubdirData
     {
     public:
-        /**
-         * Constructor.
-         * @param name Name of the subdirectory (<channel>/<subdir>)
-         * @param repodata_url URL of the repodata file
-         * @param repodata_fn Local path of the repodata file
-         * @param possible packages caches
-         * @param is_noarch Local path of the repodata file
-         */
-        MSubdirData(const std::string& name,
-                    const std::string& repodata_url,
-                    const std::string& repodata_fn,
-                    MultiPackageCache& caches,
-                    bool is_noarch);
-
         MSubdirData(const Channel& channel,
                     const std::string& platform,
                     const std::string& url,
-                    MultiPackageCache& caches);
+                    MultiPackageCache& caches,
+                    const std::string& repodata_fn = "repodata.json");
 
         // TODO return seconds as double
         fs::file_time_type::duration check_cache(const fs::path& cache_file,

--- a/libmamba/include/mamba/core/transaction.hpp
+++ b/libmamba/include/mamba/core/transaction.hpp
@@ -121,9 +121,8 @@ namespace mamba
         MTransaction(MPool& pool,
                      const std::vector<MatchSpec>& specs_to_remove,
                      const std::vector<MatchSpec>& specs_to_install,
-                     MultiPackageCache& caches,
-                     std::vector<MRepo*> repos);
-        MTransaction(MSolver& solver, MultiPackageCache& caches, std::vector<MRepo*> repos);
+                     MultiPackageCache& caches);
+        MTransaction(MSolver& solver, MultiPackageCache& caches);
 
         ~MTransaction();
 
@@ -157,7 +156,6 @@ namespace mamba
         MultiPackageCache m_multi_cache;
         const fs::path m_cache_path;
         std::vector<Solvable*> m_to_install, m_to_remove;
-        std::vector<MRepo*> m_repos;
 
         History::UserRequest m_history_entry;
         Transaction* m_transaction;
@@ -169,8 +167,7 @@ namespace mamba
 
     MTransaction create_explicit_transaction_from_urls(MPool& pool,
                                                        const std::vector<std::string>& urls,
-                                                       MultiPackageCache& package_caches,
-                                                       std::vector<MRepo*>& repos);
+                                                       MultiPackageCache& package_caches);
 }  // namespace mamba
 
 #endif  // MAMBA_TRANSACTION_HPP

--- a/libmamba/src/api/channel_loader.cpp
+++ b/libmamba/src/api/channel_loader.cpp
@@ -54,14 +54,7 @@ namespace mamba
         {
             for (auto& [platform, url] : channel->platform_urls(true))
             {
-                std::string repodata_full_url = concat(url, "/repodata.json");
-
-                auto sdir = std::make_shared<MSubdirData>(
-                    concat(channel->canonical_name(), "/", platform),
-                    repodata_full_url,
-                    cache_fn_url(repodata_full_url),
-                    package_caches,
-                    platform == "noarch");
+                auto sdir = std::make_shared<MSubdirData>(*channel, platform, url, package_caches);
 
                 sdir->load();
                 multi_dl.add(sdir->target());
@@ -118,7 +111,7 @@ namespace mamba
             {
                 MRepo repo = subdir->create_repo(pool);
                 repo.set_priority(prio.first, prio.second);
-                repos.push_back(repo);
+                repos.push_back(std::move(repo));
             }
             catch (std::runtime_error& e)
             {

--- a/libmamba/src/api/install.cpp
+++ b/libmamba/src/api/install.cpp
@@ -435,11 +435,7 @@ namespace mamba
             throw std::runtime_error("UnsatisfiableError");
         }
 
-        std::vector<MRepo*> repo_ptrs;
-        for (auto& r : repos)
-            repo_ptrs.push_back(&r);
-
-        MTransaction trans(solver, package_caches, repo_ptrs);
+        MTransaction trans(solver, package_caches);
 
         if (ctx.json)
         {
@@ -472,8 +468,7 @@ namespace mamba
         fs::path pkgs_dirs(Context::instance().root_prefix / "pkgs");
         MultiPackageCache pkg_caches({ pkgs_dirs });
 
-        std::vector<MRepo*> repos = {};
-        auto transaction = create_explicit_transaction_from_urls(pool, specs, pkg_caches, repos);
+        auto transaction = create_explicit_transaction_from_urls(pool, specs, pkg_caches);
 
         prefix_data.load();
         prefix_data.add_virtual_packages(get_virtual_packages());

--- a/libmamba/src/api/install.cpp
+++ b/libmamba/src/api/install.cpp
@@ -368,8 +368,7 @@ namespace mamba
 
         prefix_data.add_virtual_packages(get_virtual_packages());
 
-        auto repo = MRepo(pool, prefix_data);
-        repos.push_back(repo);
+        repos.push_back(MRepo(pool, prefix_data));
 
         MSolver solver(pool,
                        { { SOLVER_FLAG_ALLOW_UNINSTALL, ctx.allow_uninstall },

--- a/libmamba/src/api/remove.cpp
+++ b/libmamba/src/api/remove.cpp
@@ -72,8 +72,7 @@ namespace mamba
             MPool pool;
             PrefixData prefix_data(ctx.target_prefix);
             prefix_data.load();
-            auto repo = MRepo(pool, prefix_data);
-            repos.push_back(repo);
+            repos.push_back(MRepo(pool, prefix_data));
 
             std::vector<MRepo*> repo_ptrs;
             for (auto& r : repos)

--- a/libmamba/src/api/remove.cpp
+++ b/libmamba/src/api/remove.cpp
@@ -74,10 +74,6 @@ namespace mamba
             prefix_data.load();
             repos.push_back(MRepo(pool, prefix_data));
 
-            std::vector<MRepo*> repo_ptrs;
-            for (auto& r : repos)
-                repo_ptrs.push_back(&r);
-
             const fs::path pkgs_dirs(ctx.root_prefix / "pkgs");
             MultiPackageCache package_caches({ pkgs_dirs });
 
@@ -93,7 +89,7 @@ namespace mamba
             if (force)
             {
                 std::vector<MatchSpec> mspecs(specs.begin(), specs.end());
-                auto transaction = MTransaction(pool, mspecs, {}, package_caches, repo_ptrs);
+                auto transaction = MTransaction(pool, mspecs, {}, package_caches);
                 execute_transaction(transaction);
             }
             else
@@ -120,7 +116,7 @@ namespace mamba
                 solver.add_jobs(specs, solver_flag);
                 solver.solve();
 
-                MTransaction transaction(solver, package_caches, repo_ptrs);
+                MTransaction transaction(solver, package_caches);
                 execute_transaction(transaction);
             }
         }

--- a/libmamba/src/api/update.cpp
+++ b/libmamba/src/api/update.cpp
@@ -105,13 +105,7 @@ namespace mamba
 
         solver.solve();
 
-        // TODO this is not so great
-        std::vector<MRepo*> repo_ptrs;
-        for (auto& r : repos)
-        {
-            repo_ptrs.push_back(&r);
-        }
-        MTransaction transaction(solver, package_caches, repo_ptrs);
+        MTransaction transaction(solver, package_caches);
 
         auto execute_transaction = [&](MTransaction& transaction)
         {

--- a/libmamba/src/api/update.cpp
+++ b/libmamba/src/api/update.cpp
@@ -46,8 +46,7 @@ namespace mamba
 
         prefix_data.add_virtual_packages(get_virtual_packages());
 
-        auto repo = MRepo(pool, prefix_data);
-        repos.push_back(repo);
+        repos.push_back(MRepo(pool, prefix_data));
 
         MSolver solver(pool,
                        { { SOLVER_FLAG_ALLOW_DOWNGRADE, ctx.allow_downgrade },

--- a/libmamba/src/core/channel.cpp
+++ b/libmamba/src/core/channel.cpp
@@ -244,6 +244,16 @@ namespace mamba
         return build_url(*this, join_url(base, name(), platform), with_credential);
     }
 
+    bool operator==(const Channel& lhs, const Channel& rhs)
+    {
+        return lhs.location() == rhs.location() && lhs.name() == rhs.name();
+    }
+
+    bool operator!=(const Channel& lhs, const Channel& rhs)
+    {
+        return !(lhs == rhs);
+    }
+
     /************************************
      * utility functions implementation *
      ************************************/

--- a/libmamba/src/core/solver.cpp
+++ b/libmamba/src/core/solver.cpp
@@ -8,6 +8,7 @@
 #include "mamba/core/channel.hpp"
 #include "mamba/core/output.hpp"
 #include "mamba/core/package_info.hpp"
+#include "mamba/core/repo.hpp"
 #include "mamba/core/util.hpp"
 
 namespace mamba
@@ -36,20 +37,9 @@ namespace mamba
 
     inline bool channel_match(Solvable* s, const std::string& channel)
     {
-        // TODO this could should be a lot better.
-        // TODO this might match too much (e.g. bioconda would also match
-        // bioconda-experimental etc) Note: s->repo->name is the URL of the repo
-        // TODO maybe better to check all repos, select pointers, and compare the
-        // pointer (s->repo == ptr?)
-        const Channel& chan = make_channel(s->repo->name);
-        for (const auto& url : chan.urls(false))
-        {
-            if (url.find(channel) != std::string::npos)
-            {
-                return true;
-            }
-        }
-        return false;
+        MRepo* mrepo = reinterpret_cast<MRepo*>(s->repo->appdata);
+        const Channel* chan = mrepo->channel();
+        return chan && chan->name() == channel;
     }
 
     void MSolver::add_global_job(int job_flag)

--- a/libmamba/src/core/subdirdata.cpp
+++ b/libmamba/src/core/subdirdata.cpp
@@ -160,32 +160,15 @@ namespace mamba
 
     }
 
-
-    MSubdirData::MSubdirData(const std::string& name,
-                             const std::string& repodata_url,
-                             const std::string& repodata_fn,
-                             MultiPackageCache& caches,
-                             bool is_noarch)
-        : m_progress_bar(ProgressProxy())
-        , m_loaded(false)
-        , m_download_complete(false)
-        , m_repodata_url(repodata_url)
-        , m_name(name)
-        , m_json_fn(repodata_fn)
-        , m_solv_fn(repodata_fn.substr(0, repodata_fn.size() - 4) + "solv")
-        , m_caches(caches)
-        , m_is_noarch(is_noarch)
-    {
-    }
-
     MSubdirData::MSubdirData(const Channel& channel,
                              const std::string& platform,
                              const std::string& url,
-                             MultiPackageCache& caches)
+                             MultiPackageCache& caches,
+                             const std::string& repodata_fn)
         : m_progress_bar(ProgressProxy())
         , m_loaded(false)
         , m_download_complete(false)
-        , m_repodata_url(concat(url, "/repodata.json"))
+        , m_repodata_url(concat(url, "/", repodata_fn))
         , m_name(concat(channel.canonical_name(), "/", platform))
         , m_caches(caches)
         , m_is_noarch(platform == "noarch")

--- a/libmamba/src/core/subdirdata.cpp
+++ b/libmamba/src/core/subdirdata.cpp
@@ -178,6 +178,23 @@ namespace mamba
     {
     }
 
+    MSubdirData::MSubdirData(const Channel& channel,
+                             const std::string& platform,
+                             const std::string& url,
+                             MultiPackageCache& caches)
+        : m_progress_bar(ProgressProxy())
+        , m_loaded(false)
+        , m_download_complete(false)
+        , m_repodata_url(concat(url, "/repodata.json"))
+        , m_name(concat(channel.canonical_name(), "/", platform))
+        , m_caches(caches)
+        , m_is_noarch(platform == "noarch")
+        , p_channel(&channel)
+    {
+        m_json_fn = cache_fn_url(m_repodata_url);
+        m_solv_fn = m_json_fn.substr(0, m_json_fn.size() - 4) + "solv";
+    }
+
     fs::file_time_type::duration MSubdirData::check_cache(
         const fs::path& cache_file, const fs::file_time_type::clock::time_point& ref)
     {
@@ -593,7 +610,7 @@ namespace mamba
                            m_mod_etag.value("_etag", ""),
                            m_mod_etag.value("_mod", "") };
 
-        return MRepo(pool, m_name, cache_path(), meta);
+        return MRepo(pool, m_name, cache_path(), meta, *p_channel);
     }
 
     void MSubdirData::clear_cache()

--- a/libmamba/src/core/transaction.cpp
+++ b/libmamba/src/core/transaction.cpp
@@ -420,10 +420,8 @@ namespace mamba
     MTransaction::MTransaction(MPool& pool,
                                const std::vector<MatchSpec>& specs_to_remove,
                                const std::vector<MatchSpec>& specs_to_install,
-                               MultiPackageCache& caches,
-                               std::vector<MRepo*> repos)
+                               MultiPackageCache& caches)
         : m_multi_cache(caches)
-        , m_repos(repos)
     {
         // auto& ctx = Context::instance();
         std::vector<PackageInfo> pi_result;
@@ -525,11 +523,8 @@ namespace mamba
     }
 
 
-    MTransaction::MTransaction(MSolver& solver,
-                               MultiPackageCache& caches,
-                               std::vector<MRepo*> repos)
+    MTransaction::MTransaction(MSolver& solver, MultiPackageCache& caches)
         : m_multi_cache(caches)
-        , m_repos(repos)
     {
         if (!solver.is_solved())
         {
@@ -1063,15 +1058,6 @@ namespace mamba
         for (auto& s : m_to_install)
         {
             MRepo* mamba_repo = reinterpret_cast<MRepo*>(s->repo->appdata);
-            /*MRepo* mamba_repo = nullptr;
-            for (auto& r : m_repos)
-            {
-                if (r->repo() == s->repo)
-                {
-                    mamba_repo = r;
-                    break;
-                }
-            }*/
 
             std::string url;
             if (mamba_repo == nullptr || mamba_repo->url() == "")
@@ -1492,8 +1478,7 @@ namespace mamba
 
     MTransaction create_explicit_transaction_from_urls(MPool& pool,
                                                        const std::vector<std::string>& urls,
-                                                       MultiPackageCache& package_caches,
-                                                       std::vector<MRepo*>& repos)
+                                                       MultiPackageCache& package_caches)
     {
         std::vector<MatchSpec> specs_to_install;
         for (auto& u : urls)
@@ -1519,6 +1504,6 @@ namespace mamba
             }
             specs_to_install.push_back(ms);
         }
-        return MTransaction(pool, {}, specs_to_install, package_caches, repos);
+        return MTransaction(pool, {}, specs_to_install, package_caches);
     }
 }  // namespace mamba

--- a/libmamba/src/core/transaction.cpp
+++ b/libmamba/src/core/transaction.cpp
@@ -1062,8 +1062,8 @@ namespace mamba
 
         for (auto& s : m_to_install)
         {
-            std::string url;
-            MRepo* mamba_repo = nullptr;
+            MRepo* mamba_repo = reinterpret_cast<MRepo*>(s->repo->appdata);
+            /*MRepo* mamba_repo = nullptr;
             for (auto& r : m_repos)
             {
                 if (r->repo() == s->repo)
@@ -1071,8 +1071,9 @@ namespace mamba
                     mamba_repo = r;
                     break;
                 }
-            }
+            }*/
 
+            std::string url;
             if (mamba_repo == nullptr || mamba_repo->url() == "")
             {
                 // use fallback mediadir / mediafile

--- a/libmamba/tests/test_transfer.cpp
+++ b/libmamba/tests/test_transfer.cpp
@@ -10,13 +10,10 @@ namespace mamba
 #ifdef __linux__
         Context::instance().quiet = true;
         {
+            const mamba::Channel& c = mamba::make_channel("conda-forge");
             mamba::MultiDownloadTarget multi_dl;
             mamba::MultiPackageCache pkg_cache({ "/tmp/" });
-            mamba::MSubdirData cf("conda-forge/linux-64",
-                                  "file:///nonexistent/repodata.json",
-                                  "zyx.json",
-                                  pkg_cache,
-                                  false);
+            mamba::MSubdirData cf(c, "linux-64", "file:///nonexistent/repodata.json", pkg_cache);
             cf.load();
             multi_dl.add(cf.target());
 
@@ -29,13 +26,10 @@ namespace mamba
             EXPECT_EQ(cf.target()->result, 37);
         }
         {
+            const mamba::Channel& c = mamba::make_channel("conda-forge");
             mamba::MultiDownloadTarget multi_dl;
             mamba::MultiPackageCache pkg_cache({ "/tmp/" });
-            mamba::MSubdirData cf("conda-forge/noarch",
-                                  "file:///nonexistent/repodata.json",
-                                  "zyx.json",
-                                  pkg_cache,
-                                  true);
+            mamba::MSubdirData cf(c, "noarch", "file:///nonexistent/repodata.json", pkg_cache);
             cf.load();
             multi_dl.add(cf.target());
             EXPECT_THROW(multi_dl.download(MAMBA_DOWNLOAD_FAILFAST), std::runtime_error);

--- a/libmambapy/src/main.cpp
+++ b/libmambapy/src/main.cpp
@@ -218,11 +218,11 @@ PYBIND11_MODULE(bindings, m)
              });
 
     py::class_<MSubdirData>(m, "SubdirData")
-        .def(py::init<const std::string&,
+        .def(py::init<const Channel&,
                       const std::string&,
                       const std::string&,
                       MultiPackageCache&,
-                      bool>())
+                      const std::string&>())
         .def("create_repo", &MSubdirData::create_repo)
         .def("load", &MSubdirData::load)
         .def("loaded", &MSubdirData::loaded)

--- a/libmambapy/src/main.cpp
+++ b/libmambapy/src/main.cpp
@@ -104,7 +104,7 @@ PYBIND11_MODULE(bindings, m)
         .def("clear", &MRepo::clear);
 
     py::class_<MTransaction>(m, "Transaction")
-        .def(py::init<MSolver&, MultiPackageCache&, std::vector<MRepo*>&>())
+        .def(py::init<MSolver&, MultiPackageCache&>())
         .def("to_conda", &MTransaction::to_conda)
         .def("log_json", &MTransaction::log_json)
         .def("print", &MTransaction::print)

--- a/mamba/mamba/mamba.py
+++ b/mamba/mamba/mamba.py
@@ -231,7 +231,7 @@ def remove(args, parser):
             return exit_code
 
         package_cache = api.MultiPackageCache(context.pkgs_dirs)
-        transaction = api.Transaction(solver, package_cache, repos)
+        transaction = api.Transaction(solver, package_cache)
 
         if not transaction.prompt():
             exit(0)
@@ -573,7 +573,7 @@ def install(args, parser, command="install"):
             return exit_code
 
         package_cache = api.MultiPackageCache(context.pkgs_dirs)
-        transaction = api.Transaction(solver, package_cache, repos)
+        transaction = api.Transaction(solver, package_cache)
         mmb_specs, to_link, to_unlink = transaction.to_conda()
 
         specs_to_add = [MatchSpec(m) for m in mmb_specs[0]]

--- a/mamba/mamba/mamba_env.py
+++ b/mamba/mamba/mamba_env.py
@@ -136,7 +136,7 @@ def mamba_install(prefix, specs, args, env, dry_run=False, *_, **kwargs):
         exit(1)
 
     package_cache = api.MultiPackageCache(context.pkgs_dirs)
-    transaction = api.Transaction(solver, package_cache, repos)
+    transaction = api.Transaction(solver, package_cache)
     mmb_specs, to_link, to_unlink = transaction.to_conda()
 
     specs_to_add = [MatchSpec(m) for m in mmb_specs[0]]

--- a/mamba/mamba/utils.py
+++ b/mamba/mamba/utils.py
@@ -79,20 +79,12 @@ def get_index(
 
     for channel in api.get_channels(all_channels):
         for channel_platform, url in channel.platform_urls(with_credentials=True):
-            full_url = CondaHttpAuth.add_binstar_token(url + "/" + repodata_fn)
-            name = None
-            if channel.name:
-                name = channel.name + "/" + channel_platform
-            else:
-                name = channel.platform_url(channel_platform, with_credentials=False)
+            full_url = CondaHttpAuth.add_binstar_token(url)
 
             sd = api.SubdirData(
-                name,
-                full_url,
-                api.cache_fn_url(full_url),
-                pkgs_dirs,
-                channel_platform == "noarch",
+                channel, channel_platform, full_url, pkgs_dirs, repodata_fn
             )
+
             sd.load()
 
             index.append(


### PR DESCRIPTION
~~@wolfv this is not exactly what we want in the end, but storing th MRepo in repo->appdata instead of the channel leads to a weird bug (repo->appdata has an empty channel when retrieving it in the channel_match function).~~