### PR TITLE
Storing repos in pool

### DIFF
--- a/libmamba/include/mamba/api/channel_loader.hpp
+++ b/libmamba/include/mamba/api/channel_loader.hpp
@@ -8,8 +8,8 @@ namespace mamba
 {
     namespace detail
     {
-        MRepo create_repo_from_pkgs_dir(MPool& pool, const fs::path& pkgs_dir);
+        MRepo& create_repo_from_pkgs_dir(MPool& pool, const fs::path& pkgs_dir);
     }
 
-    std::vector<MRepo> load_channels(MPool& pool, MultiPackageCache& package_caches, int is_retry);
+    void load_channels(MPool& pool, MultiPackageCache& package_caches, int is_retry);
 }

--- a/libmamba/include/mamba/core/pool.hpp
+++ b/libmamba/include/mamba/core/pool.hpp
@@ -8,6 +8,7 @@
 #define MAMBA_CORE_POOL_HPP
 
 #include "context.hpp"
+#include "repo.hpp"
 
 extern "C"
 {
@@ -32,9 +33,12 @@ namespace mamba
 
         operator Pool*();
 
+        MRepo& add_repo(MRepo&& repo);
+
     private:
         std::pair<spdlog::logger*, std::string> m_debug_logger;
         Pool* m_pool;
+        std::vector<MRepo> m_repo_list;
     };
 }  // namespace mamba
 

--- a/libmamba/include/mamba/core/repo.hpp
+++ b/libmamba/include/mamba/core/repo.hpp
@@ -21,10 +21,10 @@ extern "C"
 #include "solv/repo_solv.h"
 }
 
-#include "pool.hpp"
-
 namespace mamba
 {
+    class MPool;
+
     /**
      * Represents a channel subdirectory
      * index.

--- a/libmamba/include/mamba/core/subdirdata.hpp
+++ b/libmamba/include/mamba/core/subdirdata.hpp
@@ -19,6 +19,7 @@
 #include "mamba/core/mamba_fs.hpp"
 #include "mamba/core/output.hpp"
 #include "mamba/core/package_cache.hpp"
+#include "mamba/core/pool.hpp"
 #include "mamba/core/repo.hpp"
 #include "mamba/core/util.hpp"
 
@@ -65,7 +66,7 @@ namespace mamba
         DownloadTarget* target();
         bool finalize_transfer();
 
-        MRepo create_repo(MPool& pool);
+        MRepo& create_repo(MPool& pool);
 
     private:
         bool decompress();

--- a/libmamba/src/api/install.cpp
+++ b/libmamba/src/api/install.cpp
@@ -357,7 +357,7 @@ namespace mamba
         }
 
         MPool pool;
-        std::vector<MRepo> repos = load_channels(pool, package_caches, is_retry);
+        load_channels(pool, package_caches, is_retry);
 
         PrefixData prefix_data(ctx.target_prefix);
         prefix_data.load();
@@ -368,7 +368,7 @@ namespace mamba
 
         prefix_data.add_virtual_packages(get_virtual_packages());
 
-        repos.push_back(MRepo(pool, prefix_data));
+        pool.add_repo(MRepo(pool, prefix_data));
 
         MSolver solver(pool,
                        { { SOLVER_FLAG_ALLOW_UNINSTALL, ctx.allow_uninstall },

--- a/libmamba/src/api/remove.cpp
+++ b/libmamba/src/api/remove.cpp
@@ -68,11 +68,10 @@ namespace mamba
                 throw std::runtime_error("Aborted.");
             }
 
-            std::vector<MRepo> repos;
-            MPool pool;
             PrefixData prefix_data(ctx.target_prefix);
             prefix_data.load();
-            repos.push_back(MRepo(pool, prefix_data));
+            MPool pool;
+            pool.add_repo(MRepo(pool, prefix_data));
 
             const fs::path pkgs_dirs(ctx.root_prefix / "pkgs");
             MultiPackageCache package_caches({ pkgs_dirs });

--- a/libmamba/src/api/repoquery.cpp
+++ b/libmamba/src/api/repoquery.cpp
@@ -27,17 +27,16 @@ namespace mamba
 
         // bool installed = (type == QueryType::kDepends) || (type == QueryType::kWhoneeds);
         MultiPackageCache package_caches(ctx.pkgs_dirs);
-        std::vector<MRepo> repos;
         if (use_local)
         {
             auto prefix_data = PrefixData(ctx.target_prefix);
             prefix_data.load();
-            repos.push_back(MRepo(pool, prefix_data));
+            pool.add_repo(MRepo(pool, prefix_data));
             Console::stream() << "Loaded current active prefix: " << ctx.target_prefix << std::endl;
         }
         else
         {
-            repos = load_channels(pool, package_caches, 0);
+            load_channels(pool, package_caches, 0);
         }
 
         Query q(pool);

--- a/libmamba/src/api/update.cpp
+++ b/libmamba/src/api/update.cpp
@@ -35,7 +35,7 @@ namespace mamba
         MPool pool;
         MultiPackageCache package_caches(ctx.pkgs_dirs);
 
-        auto repos = load_channels(pool, package_caches, 0);
+        load_channels(pool, package_caches, 0);
 
         PrefixData prefix_data(ctx.target_prefix);
         prefix_data.load();
@@ -46,7 +46,7 @@ namespace mamba
 
         prefix_data.add_virtual_packages(get_virtual_packages());
 
-        repos.push_back(MRepo(pool, prefix_data));
+        pool.add_repo(MRepo(pool, prefix_data));
 
         MSolver solver(pool,
                        { { SOLVER_FLAG_ALLOW_DOWNGRADE, ctx.allow_downgrade },

--- a/libmamba/src/core/pool.cpp
+++ b/libmamba/src/core/pool.cpp
@@ -70,4 +70,11 @@ namespace mamba
     {
         return m_pool;
     }
+
+    MRepo& MPool::add_repo(MRepo&& repo)
+    {
+        m_repo_list.push_back(std::move(repo));
+        return m_repo_list.back();
+    }
+
 }  // namespace mamba

--- a/libmamba/src/core/repo.cpp
+++ b/libmamba/src/core/repo.cpp
@@ -4,6 +4,7 @@
 //
 // The full license is in the file LICENSE, distributed with this software.
 
+#include "mamba/core/pool.hpp"
 #include "mamba/core/repo.hpp"
 #include "mamba/core/output.hpp"
 #include "mamba/core/package_info.hpp"

--- a/libmamba/src/core/subdirdata.cpp
+++ b/libmamba/src/core/subdirdata.cpp
@@ -586,14 +586,14 @@ namespace mamba
         return cache_dir;
     }
 
-    MRepo MSubdirData::create_repo(MPool& pool)
+    MRepo& MSubdirData::create_repo(MPool& pool)
     {
         RepoMetadata meta{ m_repodata_url,
                            Context::instance().add_pip_as_python_dependency,
                            m_mod_etag.value("_etag", ""),
                            m_mod_etag.value("_mod", "") };
 
-        return MRepo(pool, m_name, cache_path(), meta, *p_channel);
+        return pool.add_repo(MRepo(pool, m_name, cache_path(), meta, *p_channel));
     }
 
     void MSubdirData::clear_cache()

--- a/libmambapy/src/main.cpp
+++ b/libmambapy/src/main.cpp
@@ -223,7 +223,7 @@ PYBIND11_MODULE(bindings, m)
                       const std::string&,
                       MultiPackageCache&,
                       const std::string&>())
-        .def("create_repo", &MSubdirData::create_repo)
+        .def("create_repo", &MSubdirData::create_repo, py::return_value_policy::reference)
         .def("load", &MSubdirData::load)
         .def("loaded", &MSubdirData::loaded)
         .def("cache_path", &MSubdirData::cache_path);


### PR DESCRIPTION
Not perfect yet, I will add a `create_repo_from_prefix_data` function that adds the repo to the pool after creating it, and returns a reference to the repo. This way, the user never has to deal with repo lifetime.