### PR TITLE
Added api to remove repo from pool

### DIFF
--- a/libmamba/include/mamba/core/pool.hpp
+++ b/libmamba/include/mamba/core/pool.hpp
@@ -7,6 +7,7 @@
 #ifndef MAMBA_CORE_POOL_HPP
 #define MAMBA_CORE_POOL_HPP
 
+#include <list>
 #include "context.hpp"
 #include "repo.hpp"
 
@@ -34,11 +35,12 @@ namespace mamba
         operator Pool*();
 
         MRepo& add_repo(MRepo&& repo);
+        void remove_repo(Id repo_id);
 
     private:
         std::pair<spdlog::logger*, std::string> m_debug_logger;
         Pool* m_pool;
-        std::vector<MRepo> m_repo_list;
+        std::list<MRepo> m_repo_list;
     };
 }  // namespace mamba
 

--- a/libmamba/include/mamba/core/repo.hpp
+++ b/libmamba/include/mamba/core/repo.hpp
@@ -67,6 +67,7 @@ namespace mamba
 
         const fs::path& index_file();
 
+        Id id() const;
         std::string name() const;
         bool write() const;
         const std::string& url() const;

--- a/libmamba/src/core/pool.cpp
+++ b/libmamba/src/core/pool.cpp
@@ -45,6 +45,7 @@ namespace mamba
     MPool::~MPool()
     {
         LOG_INFO << "Freeing pool.";
+        m_repo_list.clear();
         pool_free(m_pool);
     }
 
@@ -75,6 +76,11 @@ namespace mamba
     {
         m_repo_list.push_back(std::move(repo));
         return m_repo_list.back();
+    }
+
+    void MPool::remove_repo(Id repo_id)
+    {
+        m_repo_list.remove_if([repo_id](const MRepo& repo) { return repo_id == repo.id(); });
     }
 
 }  // namespace mamba

--- a/libmamba/src/core/repo.cpp
+++ b/libmamba/src/core/repo.cpp
@@ -95,6 +95,10 @@ namespace mamba
 
     MRepo::~MRepo()
     {
+        if (m_repo)
+        {
+            repo_free(m_repo, 1);
+        }
         // not sure if reuse_ids is useful here
         // repo will be freed with pool as well though
         // maybe explicitly free pool for faster repo deletion as well
@@ -202,6 +206,11 @@ namespace mamba
 
         s->provides
             = repo_addid_dep(m_repo, s->provides, pool_rel2id(pool, s->name, s->evr, REL_EQ, 1), 0);
+    }
+
+    Id MRepo::id() const
+    {
+        return m_repo->repoid;
     }
 
     std::string MRepo::name() const


### PR DESCRIPTION
The cleanup is not optimal: we could call `repo_freeallrepos` in the MPool's destructor, but that would require to provide a `MRepo::reset` method which I don't really like. Let's do it only if we see a performance issue.