### PR TITLE
allow non-env prefix for constructor

### DIFF
--- a/micromamba/src/constructor.cpp
+++ b/micromamba/src/constructor.cpp
@@ -71,7 +71,8 @@ construct(const fs::path& prefix, bool extract_conda_pkgs, bool extract_tarball)
     config.at("show_banner").set_value(false);
     config.at("use_target_prefix_fallback").set_value(true);
     config.at("target_prefix_checks")
-        .set_value(MAMBA_ALLOW_EXISTING_PREFIX | MAMBA_ALLOW_MISSING_PREFIX);
+        .set_value(MAMBA_ALLOW_EXISTING_PREFIX | MAMBA_ALLOW_MISSING_PREFIX
+                   | MAMBA_ALLOW_NOT_ENV_PREFIX);
     config.load();
 
     if (extract_conda_pkgs)


### PR DESCRIPTION
@isuruf this will allow the usage of existing folders for constructor which do _not_ contain a `conda-meta` folder: https://github.com/mamba-org/mamba/blob/6ff7fe3ab034154aeb6a0c578699518bf482011f/libmamba/src/api/configuration.cpp#L617

