### PR TITLE
Bump libcurl to 7.82.0 and add a test that catches the bug

### DIFF
--- a/libmamba/environment-dev.yml
+++ b/libmamba/environment-dev.yml
@@ -10,7 +10,7 @@ dependencies:
   - libsolv >=0.7.18
   - libarchive
   - libsodium
-  - libcurl 7.76.1 *_0
+  - libcurl 7.82.0 *_0
   - gtest
   - gmock
   - cpp-filesystem >=1.5.8

--- a/libmamba/environment-static-dev.yml
+++ b/libmamba/environment-static-dev.yml
@@ -3,8 +3,8 @@ channels:
   - conda-forge
 dependencies:
   - yaml-cpp-static
-  - libcurl=7.76.1=*_0
-  - libcurl-static=7.76.1 *_0
+  - libcurl=7.82.0=*_0
+  - libcurl-static=7.82.0 *_0
   - xz-static
   - libssh2-static
   - libarchive=3.3

--- a/libmambapy/environment-dev.yml
+++ b/libmambapy/environment-dev.yml
@@ -10,7 +10,7 @@ dependencies:
   - libsolv >=0.7.18
   - libarchive
   - libsodium
-  - libcurl 7.76.1 *_0
+  - libcurl 7.82.0 *_0
   - gtest
   - gmock
   - cpp-filesystem >=1.5.8

--- a/mamba/environment-dev.yml
+++ b/mamba/environment-dev.yml
@@ -10,7 +10,7 @@ dependencies:
   - libsolv >=0.7.18
   - libarchive
   - libsodium
-  - libcurl 7.76.1 *_0
+  - libcurl 7.82.0 *_0
   - gtest
   - gmock
   - cpp-filesystem >=1.5.8

--- a/mamba/tests/testserver.sh
+++ b/mamba/tests/testserver.sh
@@ -35,3 +35,13 @@ if [[ "$(uname -s)" == "Linux" ]]; then
 	sleep 5s
 	kill -TERM $PID
 fi
+
+export TESTPWD=":test"
+python reposerver.py -d repo/ --auth basic --port 8005 & PID=$!
+python reposerver.py -d repo/ --auth basic --port 8006 & PID2=$!
+python reposerver.py -d repo/ --auth basic --port 8007 & PID3=$!
+mamba create -y -q -n $ENV_NAME --override-channels -c http://:test@localhost:8005/ -c http://:test@localhost:8006/ -c http://:test@localhost:8007/ test-package --json
+kill -TERM $PID
+kill -TERM $PID2
+kill -TERM $PID3
+rm -rf $CONDA_PREFIX/envs/$ENV_NAME

--- a/micromamba/environment-dev.yml
+++ b/micromamba/environment-dev.yml
@@ -10,7 +10,7 @@ dependencies:
   - libsolv >=0.7.18
   - libarchive
   - libsodium
-  - libcurl 7.76.1 *_0
+  - libcurl 7.82.0 *_0
   - gtest
   - gmock
   - cpp-filesystem >=1.5.8


### PR DESCRIPTION
Originally reproed & written in https://github.com/mamba-org/mamba/pull/1141.

We found that reusing the connections through libcurl where the url had the credentials in basic auth form would yield 401s.

This was fixed by curl in https://github.com/curl/curl/pull/8451/

This PR bumps libcurl to the version with the fix (7.82.0) and adds the test that was used to repro the multi-use scenario.