### PR TITLE
Remove import of init_std_stream_encoding.

### DIFF
--- a/mamba/mamba/mamba.py
+++ b/mamba/mamba/mamba.py
@@ -894,9 +894,7 @@ def main(*args, **kwargs):
     # Set to false so we don't allow uploading our issues to conda!
     context.report_errors = False
 
-    from conda.common.compat import ensure_text_type, init_std_stream_encoding
-
-    init_std_stream_encoding()
+    from conda.common.compat import ensure_text_type
 
     if "activate" in sys.argv or "deactivate" in sys.argv:
         print(


### PR DESCRIPTION
This was removed in https://github.com/conda/conda/pull/11309 and had already been defunct on Python 3 for a while.

We discovered it in a [test run for conda-libmamba-solver](https://github.com/conda-incubator/conda-libmamba-solver/runs/5665053567?check_suite_focus=true).