### PR TITLE
Constrains cli11 to v2.1.2

### DIFF
--- a/libmamba/environment-dev.yml
+++ b/libmamba/environment-dev.yml
@@ -18,6 +18,6 @@ dependencies:
   - reproc-cpp
   - yaml-cpp
   - termcolor-cpp
-  - cli11
+  - cli11 2.1.2
   - spdlog
   - sel(win): winreg

--- a/libmambapy/environment-dev.yml
+++ b/libmambapy/environment-dev.yml
@@ -18,7 +18,7 @@ dependencies:
   - reproc-cpp
   - yaml-cpp
   - termcolor-cpp
-  - cli11
+  - cli11 2.1.2
   - spdlog
   - pybind11
   - pytest

--- a/mamba/environment-dev.yml
+++ b/mamba/environment-dev.yml
@@ -18,7 +18,7 @@ dependencies:
   - reproc-cpp
   - yaml-cpp
   - termcolor-cpp
-  - cli11
+  - cli11 2.1.2
   - spdlog
   - pybind11
   - pytest

--- a/micromamba/environment-dev.yml
+++ b/micromamba/environment-dev.yml
@@ -18,7 +18,7 @@ dependencies:
   - reproc-cpp
   - yaml-cpp
   - termcolor-cpp
-  - cli11
+  - cli11 2.1.2
   - pytest
   - pytest-lazy-fixture
   - pyyaml


### PR DESCRIPTION
This is to prevent broken builds with cli 2.2.0 update.