### PR TITLE
Fix JSON output issues

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,7 +32,7 @@ repos:
         -   id: isort
             exclude: tests/data
 -   repo: https://gitlab.com/pycqa/flake8
-    rev: 4.0.1
+    rev: 3.9.2
     hooks:
     -   id: flake8
         language_version: python3

--- a/libmamba/include/mamba/core/output.hpp
+++ b/libmamba/include/mamba/core/output.hpp
@@ -125,7 +125,6 @@ namespace mamba
 
         static std::string hide_secrets(const std::string_view& str);
 
-        void json_print();
         void json_write(const nlohmann::json& j);
         void json_append(const std::string& value);
         void json_append(const nlohmann::json& j);
@@ -138,6 +137,7 @@ namespace mamba
         Console();
         ~Console();
 
+        void json_print();
         void deactivate_progress_bar(std::size_t idx, const std::string_view& msg = "");
 
         std::unique_ptr<ConsoleData> p_data;

--- a/libmamba/include/mamba/core/output.hpp
+++ b/libmamba/include/mamba/core/output.hpp
@@ -140,7 +140,7 @@ namespace mamba
 
         void deactivate_progress_bar(std::size_t idx, const std::string_view& msg = "");
 
-        ConsoleData* p_data;
+        std::unique_ptr<ConsoleData> p_data;
 
         friend class ProgressProxy;
     };

--- a/libmamba/include/mamba/core/output.hpp
+++ b/libmamba/include/mamba/core/output.hpp
@@ -133,6 +133,8 @@ namespace mamba
 
         static void print_buffer(std::ostream& ostream);
 
+        void cancel_json_print();
+
     private:
         Console();
         ~Console();

--- a/libmamba/src/api/info.cpp
+++ b/libmamba/src/api/info.cpp
@@ -85,7 +85,6 @@ namespace mamba
                 items_map.insert({ key, val });
 
             Console::instance().json_write(items_map);
-            Console::instance().json_print();
         }
 
         void print_info()

--- a/libmamba/src/api/install.cpp
+++ b/libmamba/src/api/install.cpp
@@ -467,7 +467,6 @@ namespace mamba
             {
                 Console::instance().json_write(
                     { { "success", false }, { "solver_problems", solver.all_problems() } });
-                Console::instance().json_print();
             }
 
             Console::stream() << "The environment can't be solved, aborting the operation";
@@ -541,8 +540,6 @@ namespace mamba
             Console::print(join(
                 "", std::vector<std::string>({ "Empty environment created at prefix: ", prefix })));
             Console::instance().json_write({ { "success", true } });
-
-            Console::instance().json_print();
         }
 
         void create_target_directory(const fs::path prefix)

--- a/libmamba/src/api/shell.cpp
+++ b/libmamba/src/api/shell.cpp
@@ -106,7 +106,6 @@ namespace mamba
                       { "operation", "shell_hook" },
                       { "context", { { "shell_type", shell_type } } },
                       { "actions", { { "print", { activator->hook() } } } } });
-                Console::instance().json_print();
             }
             else
             {

--- a/libmamba/src/core/output.cpp
+++ b/libmamba/src/core/output.cpp
@@ -282,8 +282,8 @@ namespace mamba
     Console::~Console()
     {
         if (!p_data->is_json_print_cancelled
-        && !p_data->json_log.is_null()) // Note: we cannot rely on Context::instance() to still be
-                                        // valid at this point.
+            && !p_data->json_log.is_null())  // Note: we cannot rely on Context::instance() to still
+                                             // be valid at this point.
         {
             this->json_print();
         }

--- a/libmamba/src/core/output.cpp
+++ b/libmamba/src/core/output.cpp
@@ -478,7 +478,7 @@ namespace mamba
     // go up in the hierarchy
     void Console::json_up()
     {
-        if (Context::instance().json)
+        if (Context::instance().json && !p_data->json_hier.empty())
             p_data->json_hier.erase(p_data->json_hier.rfind('/'));
     }
 

--- a/libmamba/src/core/output.cpp
+++ b/libmamba/src/core/output.cpp
@@ -280,8 +280,11 @@ namespace mamba
 
     Console::~Console()
     {
-        
-        
+        if (!p_data->json_log.is_null())  // Note: we cannot rely on Context::instance() to still be
+                                          // valid at this point.
+        {
+            this->json_print();
+        }
     }
 
     Console& Console::instance()
@@ -302,7 +305,7 @@ namespace mamba
 
     void Console::print(const std::string_view& str, bool force_print)
     {
-        if (!(Context::instance().quiet || Context::instance().json) || force_print)
+        if (force_print || !(Context::instance().quiet || Context::instance().json))
         {
             auto& data = instance().p_data;
             const std::lock_guard<std::mutex> lock(data->m_mutex);
@@ -423,8 +426,7 @@ namespace mamba
 
     void Console::json_print()
     {
-        if (Context::instance().json)
-            print(p_data->json_log.unflatten().dump(4), true);
+        print(p_data->json_log.unflatten().dump(4), true);
     }
 
     // write all the key/value pairs of a JSON object into the current entry, which

--- a/libmamba/src/core/output.cpp
+++ b/libmamba/src/core/output.cpp
@@ -280,8 +280,8 @@ namespace mamba
 
     Console::~Console()
     {
-        delete p_data;
-        p_data = nullptr;
+        
+        
     }
 
     Console& Console::instance()
@@ -304,7 +304,7 @@ namespace mamba
     {
         if (!(Context::instance().quiet || Context::instance().json) || force_print)
         {
-            ConsoleData* data = instance().p_data;
+            auto& data = instance().p_data;
             const std::lock_guard<std::mutex> lock(data->m_mutex);
 
             if (data->p_progress_bar_manager && data->p_progress_bar_manager->started())
@@ -318,11 +318,9 @@ namespace mamba
         }
     }
 
-    // std::vector<std::string> Console::m_buffer({});
-
     void Console::print_buffer(std::ostream& ostream)
     {
-        ConsoleData* data = instance().p_data;
+        auto& data = instance().p_data;
         for (auto& message : data->m_buffer)
             ostream << message << "\n";
 

--- a/libmamba/src/core/output.cpp
+++ b/libmamba/src/core/output.cpp
@@ -263,6 +263,7 @@ namespace mamba
         std::string json_hier;
         unsigned int json_index;
         nlohmann::json json_log;
+        bool is_json_print_cancelled = false;
 
         std::vector<std::string> m_buffer;
     };
@@ -280,8 +281,9 @@ namespace mamba
 
     Console::~Console()
     {
-        if (!p_data->json_log.is_null())  // Note: we cannot rely on Context::instance() to still be
-                                          // valid at this point.
+        if (!p_data->is_json_print_cancelled
+        && !p_data->json_log.is_null()) // Note: we cannot rely on Context::instance() to still be
+                                        // valid at this point.
         {
             this->json_print();
         }
@@ -296,6 +298,11 @@ namespace mamba
     ConsoleStream Console::stream()
     {
         return ConsoleStream();
+    }
+
+    void Console::cancel_json_print()
+    {
+        p_data->is_json_print_cancelled = true;
     }
 
     std::string Console::hide_secrets(const std::string_view& str)

--- a/libmamba/src/core/transaction.cpp
+++ b/libmamba/src/core/transaction.cpp
@@ -853,8 +853,6 @@ namespace mamba
         if (empty())
             Console::instance().json_write(
                 { { "message", "All requested packages already installed" } });
-        // finally, print the JSON
-        Console::instance().json_print();
 
         if (ctx.dry_run)
         {

--- a/libmambapy/src/main.cpp
+++ b/libmambapy/src/main.cpp
@@ -27,6 +27,7 @@
 #include "mamba/core/util.hpp"
 #include "mamba/core/validate.hpp"
 #include "mamba/core/virtual_packages.hpp"
+#include "mamba/core/output.hpp"
 
 #include <stdexcept>
 
@@ -508,6 +509,8 @@ PYBIND11_MODULE(bindings, m)
     m.def("transmute", &transmute);
 
     m.def("get_virtual_packages", &get_virtual_packages);
+
+    m.def("cancel_json_output", []{ Console::instance().cancel_json_print(); });
 
     m.attr("SOLVER_SOLVABLE") = SOLVER_SOLVABLE;
     m.attr("SOLVER_SOLVABLE_NAME") = SOLVER_SOLVABLE_NAME;

--- a/libmambapy/src/main.cpp
+++ b/libmambapy/src/main.cpp
@@ -510,7 +510,7 @@ PYBIND11_MODULE(bindings, m)
 
     m.def("get_virtual_packages", &get_virtual_packages);
 
-    m.def("cancel_json_output", []{ Console::instance().cancel_json_print(); });
+    m.def("cancel_json_output", [] { Console::instance().cancel_json_print(); });
 
     m.attr("SOLVER_SOLVABLE") = SOLVER_SOLVABLE;
     m.attr("SOLVER_SOLVABLE_NAME") = SOLVER_SOLVABLE_NAME;

--- a/mamba/mamba/linking.py
+++ b/mamba/mamba/linking.py
@@ -9,7 +9,7 @@ from conda.exceptions import (
     DryRunExit,
     PackagesNotFoundError,
 )
-
+from libmambapy import cancel_json_output as cancel_mamba_json_output
 
 def handle_txn(unlink_link_transaction, prefix, args, newenv, remove_op=False):
     if unlink_link_transaction.nothing_to_do:
@@ -18,6 +18,7 @@ def handle_txn(unlink_link_transaction, prefix, args, newenv, remove_op=False):
             raise PackagesNotFoundError(args.package_names)
         elif not newenv:
             if context.json:
+                cancel_mamba_json_output()
                 cli_common.stdout_json_success(
                     message="All requested packages already installed."
                 )
@@ -26,6 +27,7 @@ def handle_txn(unlink_link_transaction, prefix, args, newenv, remove_op=False):
     if context.dry_run:
         actions = unlink_link_transaction._make_legacy_action_groups()[0]
         if context.json:
+            cancel_mamba_json_output()
             cli_common.stdout_json_success(prefix=prefix, actions=actions, dry_run=True)
         raise DryRunExit()
 
@@ -42,5 +44,6 @@ def handle_txn(unlink_link_transaction, prefix, args, newenv, remove_op=False):
         raise CondaSystemExit("Exiting", e)
 
     if context.json:
+        cancel_mamba_json_output()
         actions = unlink_link_transaction._make_legacy_action_groups()[0]
         cli_common.stdout_json_success(prefix=prefix, actions=actions)

--- a/mamba/mamba/linking.py
+++ b/mamba/mamba/linking.py
@@ -9,7 +9,9 @@ from conda.exceptions import (
     DryRunExit,
     PackagesNotFoundError,
 )
+
 from libmambapy import cancel_json_output as cancel_mamba_json_output
+
 
 def handle_txn(unlink_link_transaction, prefix, args, newenv, remove_op=False):
     if unlink_link_transaction.nothing_to_do:

--- a/mamba/tests/test_all.py
+++ b/mamba/tests/test_all.py
@@ -234,7 +234,7 @@ def test_unicode(tmpdir):
         ["mamba", "create", "-p", str(tmpdir / uc), "--json", "xtensor"]
     )
     output = json.loads(output)
-    assert output["prefix"] == str(tmpdir / uc)
+    assert output["actions"]["PREFIX"] == str(tmpdir / uc)
 
     import libmambapy
 

--- a/mamba/tests/test_all.py
+++ b/mamba/tests/test_all.py
@@ -22,6 +22,7 @@ from utils import (
 def random_string(N=10):
     return "".join(random.choices(string.ascii_uppercase + string.digits, k=N))
 
+
 def test_install():
     add_glibc_virtual_package()
     copy_channels_osx()
@@ -206,7 +207,7 @@ def test_multi_channels(config_file, tmpdir):
             "--dry-run",
             "--json",
         ],
-        env=call_env
+        env=call_env,
     )
     result = output.decode()
     print(result)

--- a/mamba/tests/test_all.py
+++ b/mamba/tests/test_all.py
@@ -208,7 +208,6 @@ def test_multi_channels(config_file, tmpdir):
         ],
         env=call_env
     )
-    os.removedirs(call_env["CONDA_PKGS_DIRS"])
     result = output.decode()
     print(result)
     res = json.loads(result)

--- a/micromamba/tests/test_create.py
+++ b/micromamba/tests/test_create.py
@@ -117,6 +117,9 @@ class TestCreate:
         assert res["env_name"] == ""
         assert res["specs"] == specs
 
+        json_res = create(*cmd, "--json")
+        assert json_res["success"] == True
+
     @pytest.mark.parametrize("root_prefix", (None, "env_var", "cli"))
     @pytest.mark.parametrize("target_is_root", (False, True))
     @pytest.mark.parametrize("cli_prefix", (False, True))


### PR DESCRIPTION
This fixes several issues:
- potential unhandled exception thrown when a mix of args ends up calling `json_up()` but the json is empty;
- replaced explicit calls to json printing to the output by automatic printing to the output at the end of the program (after `main()`) - this is mainly to prevent the json output to end up invalid if called more than once:
```JSON
{ // output by the first part of the operation
    "success": true,
}
{
   // some other values from the rest of the operation
}
```
This is invalid json because there is more than one root objects and makes it difficult or impossible to check the json ouput in tests.
- refactored a bit and added a few checks;
- added a way to cancel the print of json log from libmamba, used in mamba which already output the right json;

Note that these issues were spotted while making tests for https://github.com/mamba-org/mamba/pull/1577 , they are hard to reproduce otherwise.