### PR TITLE
Improvement: Log the thrown error while validating extracted package cache

### DIFF
--- a/libmamba/src/core/package_cache.cpp
+++ b/libmamba/src/core/package_cache.cpp
@@ -292,10 +292,16 @@ namespace mamba
                                 << "' has invalid 'repodata_record.json' file: " << e.what();
                     valid = false;
                 }
-                catch (...)
+                catch(const std::runtime_error& re)
                 {
                     LOG_WARNING << "Extracted package cache '" << extracted_dir.string()
-                                << "' is invalid'";
+                                << " couldn't be validated due to runtime error: " << re.what();
+                    valid = false;
+                }
+                catch(const std::exception& ex)
+                {
+                    LOG_WARNING << "Extracted package cache '" << extracted_dir.string()
+                                << " couldn't be validated due to error: " << ex.what();
                     valid = false;
                 }
 

--- a/libmamba/src/core/package_cache.cpp
+++ b/libmamba/src/core/package_cache.cpp
@@ -292,13 +292,13 @@ namespace mamba
                                 << "' has invalid 'repodata_record.json' file: " << e.what();
                     valid = false;
                 }
-                catch(const std::runtime_error& re)
+                catch (const std::runtime_error& re)
                 {
                     LOG_WARNING << "Extracted package cache '" << extracted_dir.string()
                                 << " couldn't be validated due to runtime error: " << re.what();
                     valid = false;
                 }
-                catch(const std::exception& ex)
+                catch (const std::exception& ex)
                 {
                     LOG_WARNING << "Extracted package cache '" << extracted_dir.string()
                                 << " couldn't be validated due to error: " << ex.what();


### PR DESCRIPTION
## Before this PR

When an error is thrown when validating the extracted package cache, the following is seen:
```
debug    libmamba Verify cache '/home/circleci/micromamba/pkgs' for package extracted directory '_libgcc_mutex-0.1-main'
warning  libmamba Extracted package cache '/home/circleci/micromamba/pkgs/_libgcc_mutex-0.1-main' is invalid'
debug    libmamba '_libgcc_mutex-0.1-main' extracted directory cache is invalid
error    libmamba Cannot find a valid extracted directory cache for '_libgcc_mutex-0.1-main.tar.bz2'
```

## After this PR

The actual error encountered is no longer swallowed and is instead logged to help the user debug the issue further.