### PR TITLE
libmamba: correct macOS header casing

### DIFF
--- a/libmamba/src/core/util_os.cpp
+++ b/libmamba/src/core/util_os.cpp
@@ -12,7 +12,7 @@
 #include <sys/ioctl.h>
 #if defined(__APPLE__)
 #include <mach-o/dyld.h>
-#include <libProc.h>
+#include <libproc.h>
 #endif
 #include <inttypes.h>
 #include <limits.h>


### PR DESCRIPTION
macOS can be installed on case-sensitive file systems, where libmamba fails to build.

```
.../mamba-2022.02.11/libmamba/src/core/util_os.cpp:15:10: fatal error: 'libProc.h' file not found
```