### PR TITLE
 Add Adress-Sanitizer (ASAN) cmake option and fixes of some issues reported by it 

### DIFF
--- a/libmamba/CMakeLists.txt
+++ b/libmamba/CMakeLists.txt
@@ -68,6 +68,15 @@ if (WIN32)
     set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
 endif ()
 
+option(ENABLE_ASAN "Enable Address-Sanitizer (currently only supported on GCC and Clang)" OFF)
+
+if(ENABLE_ASAN)
+    message(WARNING "Address-Sanitizer instrumentation will be injected into binaries - do not release these binaries")
+    add_compile_options(-fno-omit-frame-pointer  -fsanitize=address)
+    add_link_options(-fno-omit-frame-pointer  -fsanitize=address)
+endif()
+
+
 # Source files
 # ============
 

--- a/libmamba/src/core/transaction.cpp
+++ b/libmamba/src/core/transaction.cpp
@@ -1152,7 +1152,7 @@ namespace mamba
             auto* dl_bar = aggregated_pbar_manager.aggregated_bar("Download");
             if (dl_bar)
                 dl_bar->set_repr_hook(
-                    [&](ProgressBarRepr& repr) -> void
+                    [=](ProgressBarRepr& repr) -> void
                     {
                         auto active_tasks = dl_bar->active_tasks().size();
                         if (active_tasks == 0)
@@ -1187,7 +1187,7 @@ namespace mamba
             auto* extract_bar = aggregated_pbar_manager.aggregated_bar("Extract");
             if (extract_bar)
                 extract_bar->set_repr_hook(
-                    [&](ProgressBarRepr& repr) -> void
+                    [=](ProgressBarRepr& repr) -> void
                     {
                         auto active_tasks = extract_bar->active_tasks().size();
                         if (active_tasks == 0)

--- a/libmamba/src/core/virtual_packages.cpp
+++ b/libmamba/src/core/virtual_packages.cpp
@@ -35,15 +35,14 @@ namespace mamba
 
             const char* version = "";
 #ifdef __linux__
-            size_t n;
-            char* ver;
-            n = confstr(_CS_GNU_LIBC_VERSION, NULL, (size_t) 0);
+            std::vector<char> ver;
+            const size_t n = confstr(_CS_GNU_LIBC_VERSION, NULL, (size_t) 0);
 
             if (n > 0)
             {
-                ver = (char*) malloc(n);
-                confstr(_CS_GNU_LIBC_VERSION, ver, n);
-                version = ver;
+                ver.assign(n, '\n');
+                confstr(_CS_GNU_LIBC_VERSION, ver.data(), n);
+                version = ver.data();
             }
 #endif
             return std::string(strip(version, "glibc "));


### PR DESCRIPTION
Notes:

- Not all issues reported are fixed, this is an ongoing work.
- The option is not yet used by the CI.
