### PR TITLE
do not clear env for post-link scripts

### DIFF
--- a/libmamba/src/core/link.cpp
+++ b/libmamba/src/core/link.cpp
@@ -413,20 +413,10 @@ namespace mamba
 
         reproc::options options;
         options.redirect.parent = true;
-        if (activate)
-        {
-            options.env.behavior = reproc::env::empty;
-            auto qemu_ld_prefix = env::get("QEMU_LD_PREFIX");
-            if (qemu_ld_prefix)
-            {
-                envmap["QEMU_LD_PREFIX"] = qemu_ld_prefix.value();
-            }
-        }
-        else
-        {
-            options.env.behavior = reproc::env::extend;
-        }
+
+        options.env.behavior = reproc::env::extend;
         options.env.extra = envmap;
+
         std::string cwd = path.parent_path();
         options.working_directory = cwd.c_str();
 


### PR DESCRIPTION
@chrisburr unfortunately I think I'll revert this change for now since we had reports where the Qt post-link script doesn't work on Windows because some env vars are missing. 

We could still define a sensible subset of env vars to pass through but not sure if it's worth it. 
Woudl be better to continue discouraging / removing these scripts everywhere possible :)