### PR TITLE
Curl correct init & cleanup

### DIFF
--- a/libmamba/src/core/validate.cpp
+++ b/libmamba/src/core/validate.cpp
@@ -22,6 +22,23 @@
 
 namespace mamba
 {
+    class CURLSetup final
+    {
+    public:
+        CURLSetup()
+        {
+            if (curl_global_init(CURL_GLOBAL_ALL) != 0)
+                throw std::runtime_error("failed to initialize curl");
+        }
+
+        ~CURLSetup()
+        {
+            curl_global_cleanup();
+        }
+    };
+
+    static CURLSetup curl_setup;
+
     template <class B>
     std::vector<unsigned char> hex_to_bytes(const B& buffer, std::size_t size) noexcept
     {


### PR DESCRIPTION
Adds correct usage of libcurl which should be initialized and cleanup at the beginning and end, respectively, of `main()`.

WARNING: This specific change relies on the assumption that threads using libcurl are done (aka joined) before the end of `main()`, which is only guaranteed after PR #1637 will be merged, otherwise the behavior is not defined.