### PR TITLE
Set compiler optimization level

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,9 @@ option(BUILD_LIBMAMBA_TESTS "Build libmamba C++ tests" OFF)
 option(BUILD_MICROMAMBA "Build micromamba" OFF)
 option(BUILD_MAMBA_PACKAGE "Build mamba package utility" OFF)
 
+set(CMAKE_CXX_FLAGS "-Os -g" ${CMAKE_CXX_FLAGS}")
+set(CMAKE_C_FLAGS "-Os -g" ${CMAKE_C_FLAGS}")
+
 if (MSVC)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /DNOMINMAX")
     set(CMAKE_BUILD_TYPE Release)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,15 +24,15 @@ option(BUILD_LIBMAMBA_TESTS "Build libmamba C++ tests" OFF)
 option(BUILD_MICROMAMBA "Build micromamba" OFF)
 option(BUILD_MAMBA_PACKAGE "Build mamba package utility" OFF)
 
-set(CMAKE_CXX_FLAGS "-Os -g" ${CMAKE_CXX_FLAGS}")
-set(CMAKE_C_FLAGS "-Os -g" ${CMAKE_C_FLAGS}")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Os -g")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Os -g")
 
 if (MSVC)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /DNOMINMAX")
     set(CMAKE_BUILD_TYPE Release)
     # add_definitions("-DUNICODE -D_UNICODE")
 else()
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
+    set(CMAKE_CXX_FLAGS "-Wall ${CMAKE_CXX_FLAGS}")
 endif()
 
 # Variants


### PR DESCRIPTION
Closes #1644

I chose `-Os` assuming that no performance critical code exists in Mamba.

Also change the order of default settings to it's possible to overwrite them.