### PR TITLE
Hotfix #1649 : progress-manager termination function was never called on errors

### DIFF
--- a/libmamba/src/core/progress_bar_impl.hpp
+++ b/libmamba/src/core/progress_bar_impl.hpp
@@ -12,6 +12,7 @@
 
 #include <iosfwd>
 #include <mutex>
+#include <atomic>
 #include <set>
 #include <string_view>
 #include <vector>
@@ -201,7 +202,8 @@ namespace mamba
         duration_t m_period = std::chrono::milliseconds(100);
         std::vector<progress_bar_ptr> m_progress_bars = {};
         std::map<std::string, std::vector<ProgressBar*>> m_labels;
-        bool m_marked_to_terminate = false, m_watch_print_started = false;
+        std::atomic<bool> m_marked_to_terminate { false };
+        std::atomic<bool> m_watch_print_started { false };
         bool m_sort_bars = false;
         std::size_t m_width = 0;
 

--- a/libmamba/src/core/progress_bar_impl.hpp
+++ b/libmamba/src/core/progress_bar_impl.hpp
@@ -202,8 +202,8 @@ namespace mamba
         duration_t m_period = std::chrono::milliseconds(100);
         std::vector<progress_bar_ptr> m_progress_bars = {};
         std::map<std::string, std::vector<ProgressBar*>> m_labels;
-        std::atomic<bool> m_marked_to_terminate { false };
-        std::atomic<bool> m_watch_print_started { false };
+        std::atomic<bool> m_marked_to_terminate{ false };
+        std::atomic<bool> m_watch_print_started{ false };
         bool m_sort_bars = false;
         std::size_t m_width = 0;
 

--- a/micromamba/src/main.cpp
+++ b/micromamba/src/main.cpp
@@ -15,6 +15,8 @@
 #include "mamba/core/thread_utils.hpp"
 #include "mamba/core/execution.hpp"
 #include "mamba/core/util_os.hpp"
+#include "mamba/core/util_scope.hpp"
+#include "../src/core/progress_bar_impl.hpp" // FIXME: HACK HACK HACK
 
 #include <CLI/CLI.hpp>
 
@@ -26,6 +28,9 @@ int
 main(int argc, char** argv)
 {
     mamba::MainExecutor scoped_threads;
+    mamba::on_scope_exit _cleanup{ []{
+        Console::instance().progress_bar_manager().terminate();
+    }};
 
     init_console();
     auto& ctx = Context::instance();

--- a/micromamba/src/main.cpp
+++ b/micromamba/src/main.cpp
@@ -16,7 +16,7 @@
 #include "mamba/core/execution.hpp"
 #include "mamba/core/util_os.hpp"
 #include "mamba/core/util_scope.hpp"
-#include "../src/core/progress_bar_impl.hpp" // FIXME: HACK HACK HACK
+#include "../src/core/progress_bar_impl.hpp"  // FIXME: HACK HACK HACK
 
 #include <CLI/CLI.hpp>
 
@@ -28,9 +28,7 @@ int
 main(int argc, char** argv)
 {
     mamba::MainExecutor scoped_threads;
-    mamba::on_scope_exit _cleanup{ []{
-        Console::instance().progress_bar_manager().terminate();
-    }};
+    mamba::on_scope_exit _cleanup{ [] { Console::instance().progress_bar_manager().terminate(); } };
 
     init_console();
     auto& ctx = Context::instance();


### PR DESCRIPTION
Also made the signaling boolean as atomic, otherwise this is a data race (false sharing would happen).