### PR TITLE
Retry on 413/429 HTTP response codes

### DIFF
--- a/libmamba/src/core/fetch.cpp
+++ b/libmamba/src/core/fetch.cpp
@@ -344,7 +344,8 @@ namespace mamba
 
     bool DownloadTarget::can_retry()
     {
-        return m_retries < size_t(Context::instance().max_retries) && http_status >= 500
+        return m_retries < size_t(Context::instance().max_retries)
+               && (http_status == 413 || http_status == 429 || http_status >= 500)
                && !starts_with(m_url, "file://");
     }
 
@@ -652,7 +653,7 @@ namespace mamba
         LOG_INFO << "Transfer finalized, status " << http_status << " [" << effective_url << "] "
                  << downloaded_size << " bytes";
 
-        if (http_status >= 500 && can_retry())
+        if (can_retry())
         {
             // this request didn't work!
             m_next_retry

--- a/libmamba/src/core/fetch.cpp
+++ b/libmamba/src/core/fetch.cpp
@@ -656,6 +656,14 @@ namespace mamba
         if (can_retry())
         {
             // this request didn't work!
+
+            // respect Retry-After header if present, otherwise use default timeout
+            curl_easy_getinfo(m_handle, CURLINFO_RETRY_AFTER, &m_retry_wait_seconds);
+            if (!m_retry_wait_seconds)
+            {
+                m_retry_wait_seconds = get_default_retry_timeout();
+            }
+
             m_next_retry
                 = std::chrono::steady_clock::now() + std::chrono::seconds(m_retry_wait_seconds);
             std::stringstream msg;


### PR DESCRIPTION
Resolves #262

There are 3 parts to the retry logic in `conda`:
1. Retrying on 413, 429, 500, and 503 HTTP response codes (see [`conda.gateways.connection.session`](https://github.com/conda/conda/blob/51d89f89c4eb1a93d2934fb8d5b6e7611060f781/conda/gateways/connection/session.py#L84-L87))
2. Respecting the `Retry-After` header if present (see [`urllib3` implementation](https://urllib3.readthedocs.io/en/stable/reference/urllib3.util.html#urllib3.util.Retry.sleep))
3. A backoff algorithm to calculate the retry sleep time (see [`backoff_factor` in `urllib3`](https://urllib3.readthedocs.io/en/stable/reference/urllib3.util.html?highlight=backoff_factor#urllib3.util.Retry))

This PR only addresses the first two items.