### PR TITLE
also split platform if it is the currently used platform

### DIFF
--- a/libmamba/src/api/create.cpp
+++ b/libmamba/src/api/create.cpp
@@ -80,6 +80,9 @@ namespace mamba
     {
         void store_platform_config(const fs::path& prefix, const std::string& platform)
         {
+            if (!fs::exists(prefix))
+                fs::create_directories(prefix);
+
             auto out = open_ofstream(prefix / ".mambarc");
             out << "platform: " << platform;
         }

--- a/libmamba/src/core/channel.cpp
+++ b/libmamba/src/core/channel.cpp
@@ -627,14 +627,22 @@ namespace mamba
                             std::string& platform)
         {
             platform = "";
-            size_t pos = std::string::npos;
-            for (auto it = known_platforms.begin(); it != known_platforms.end(); ++it)
+
+            size_t pos = url.find(Context::instance().platform);
+            if (pos != std::string::npos)
             {
-                pos = url.find(*it);
-                if (pos != std::string::npos)
+                platform = Context::instance().platform;
+            }
+            else
+            {
+                for (auto it = known_platforms.begin(); it != known_platforms.end(); ++it)
                 {
-                    platform = *it;
-                    break;
+                    pos = url.find(*it);
+                    if (pos != std::string::npos)
+                    {
+                        platform = *it;
+                        break;
+                    }
                 }
             }
 


### PR DESCRIPTION
@martinRenou this shall make the latest micromamba work properly with unknown platforms such as `emscripten-32` :)