### PR TITLE
Fix issue #1694 external fmt lib

### DIFF
--- a/libmamba/include/mamba/core/util_scope.hpp
+++ b/libmamba/include/mamba/core/util_scope.hpp
@@ -3,7 +3,7 @@
 #define MAMBA_CORE_UTIL_SCOPE_HPP
 
 #include <stdexcept>
-#include "spdlog/fmt/fmt.h"
+#include "spdlog/spdlog.h"
 #include "mamba/core/output.hpp"
 
 namespace mamba

--- a/libmamba/src/core/env_lockfile.cpp
+++ b/libmamba/src/core/env_lockfile.cpp
@@ -7,7 +7,7 @@
 #include "mamba/core/env_lockfile.hpp"
 
 #include <yaml-cpp/yaml.h>
-#include <spdlog/fmt/fmt.h>
+#include <spdlog/spdlog.h>
 
 #include "mamba/core/output.hpp"
 

--- a/libmamba/src/core/progress_bar_impl.cpp
+++ b/libmamba/src/core/progress_bar_impl.cpp
@@ -2,8 +2,6 @@
 
 #include "progress_bar_impl.hpp"
 
-#include "spdlog/fmt/bundled/format.h"
-
 #include <algorithm>
 #include <cmath>
 #include <iostream>

--- a/libmamba/src/core/progress_bar_impl.hpp
+++ b/libmamba/src/core/progress_bar_impl.hpp
@@ -9,9 +9,9 @@
 
 #include "spdlog/spdlog.h"
 #ifdef SPDLOG_FMT_EXTERNAL
-    #include "fmt/color.h"
+#include "fmt/color.h"
 #else
-    #include "spdlog/fmt/bundled/color.h"
+#include "spdlog/fmt/bundled/color.h"
 #endif
 
 #include <iosfwd>

--- a/libmamba/src/core/progress_bar_impl.hpp
+++ b/libmamba/src/core/progress_bar_impl.hpp
@@ -7,8 +7,12 @@
 #ifndef MAMBA_CORE_PROGRESS_BAR_IMPL_HPP
 #define MAMBA_CORE_PROGRESS_BAR_IMPL_HPP
 
-#include "spdlog/fmt/fmt.h"
-#include "spdlog/fmt/bundled/color.h"
+#include "spdlog/spdlog.h"
+#ifdef SPDLOG_FMT_EXTERNAL
+    #include "fmt/color.h"
+#else
+    #include "spdlog/fmt/bundled/color.h"
+#endif
 
 #include <iosfwd>
 #include <mutex>

--- a/libmamba/src/core/query.cpp
+++ b/libmamba/src/core/query.cpp
@@ -11,7 +11,7 @@ extern "C"
 
 #include <iostream>
 #include <stack>
-#include <spdlog/fmt/fmt.h>
+#include <spdlog/spdlog.h>
 #include <spdlog/fmt/chrono.h>
 
 #include "mamba/core/query.hpp"

--- a/micromamba/CMakeLists.txt
+++ b/micromamba/CMakeLists.txt
@@ -66,6 +66,16 @@ message(STATUS "Micromamba linkage: ${MICROMAMBA_LINKAGE}")
 find_package(Threads REQUIRED)
 target_link_libraries(micromamba PRIVATE Threads::Threads)
 
+# Check spdlog C header for external fmt configuration.
+find_file(SPDLOG_TWEAK_H NAMES spdlog/tweakme.h)
+if(SPDLOG_TWEAK_H)
+    file(READ ${SPDLOG_TWEAK_H} SPDLOG_TWEAK_H_STRING)
+    if("${SPDLOG_TWEAK_H_STRING}" MATCHES "\n *#define *SPDLOG_FMT_EXTERNAL *")
+        find_package(fmt REQUIRED)
+        target_link_libraries(micromamba PRIVATE fmt::fmt)
+    endif()
+endif()
+
 if (${MICROMAMBA_LINKAGE} STREQUAL "FULL_STATIC")
     target_link_libraries(micromamba PRIVATE libmamba-full-static)
     if (WIN32)

--- a/micromamba/src/run.cpp
+++ b/micromamba/src/run.cpp
@@ -2,8 +2,12 @@
 #include <exception>
 #include <thread>
 
-#include "spdlog/fmt/fmt.h"
+#include "spdlog/spdlog.h"
+#ifdef SPDLOG_FMT_EXTERNAL
+#include "fmt/color.h"
+#else
 #include "spdlog/fmt/bundled/color.h"
+#endif
 
 #include <reproc++/run.hpp>
 #include "common_options.hpp"


### PR DESCRIPTION
This PR handle issue #1694 to allow fmt to be used as an external library.

- Update headers to use spdlog.h instead of fmt.h (=> include tweakme.h machinery).
- Modify cmake to link with fmt libraries if SDPLOG_FMT_EXTERNAL macro is set/uncommented in tweakme.h.