### PR TITLE
Improvement: Log the exception that caused a failure to parse configuration

### DIFF
--- a/libmamba/include/mamba/api/configuration.hpp
+++ b/libmamba/include/mamba/api/configuration.hpp
@@ -532,7 +532,7 @@ namespace mamba
             catch (const YAML::Exception& e)
             {
                 LOG_ERROR << "Bad conversion of configurable '" << this->m_name << "' with value '"
-                          << value << "'";
+                          << value << "' : " << e.what();
                 throw e;
             }
         }
@@ -643,7 +643,8 @@ namespace mamba
                         {
                             LOG_ERROR << "Bad conversion of configurable '" << this->m_name
                                       << "' from environment variable '" << env_var
-                                      << "' with value '" << env_var_value.value() << "'";
+                                      << "' with value '" << env_var_value.value()
+                                      << "' : " << e.what();
                             throw e;
                         }
                     }


### PR DESCRIPTION
### Before this PR

When I run
```
MAMBA_LOG_PATTERN='%v' micromamba create -n base numpy --dry-run -y --json --log-level info -vvv
```
I get 
```
trace    libmamba Compute configurable 'log_pattern'
error    libmamba Bad conversion of configurable 'log_pattern' from environment variable 'MAMBA_LOG_PATTERN' with value '%v'
critical libmamba bad conversion
```
but there's no way for me to find out why it failed to parse the pattern.

### After this PR

The exception will be logged so the client can adjust their configuration.