### PR TITLE
Implement --use-index-cache

### DIFF
--- a/libmamba/src/core/subdirdata.cpp
+++ b/libmamba/src/core/subdirdata.cpp
@@ -332,7 +332,8 @@ namespace mamba
 
                     auto cache_age_seconds
                         = std::chrono::duration_cast<std::chrono::seconds>(cache_age).count();
-                    if ((max_age > cache_age_seconds || Context::instance().offline))
+                    if ((max_age > cache_age_seconds || Context::instance().offline
+                         || Context::instance().use_index_cache))
                     {
                         // valid json cache found
                         if (!m_loaded)


### PR DESCRIPTION
This makes the --use-index-cache option work in mamba.

Fixes #74.

Note that this still isn't quite the same as conda's behavior:
In case no index cache is present conda returns an empty index. Mamba will still download the index.