### PR TITLE
Add support for nodefaults channel

### DIFF
--- a/libmamba/include/mamba/api/install.hpp
+++ b/libmamba/include/mamba/api/install.hpp
@@ -43,6 +43,8 @@ namespace mamba
 
         void file_specs_hook(std::vector<std::string>& file_specs);
 
+        void channels_hook(std::vector<std::string>& channels);
+
         bool download_explicit(const std::vector<PackageInfo>& pkgs, MultiPackageCache& pkg_caches);
 
         struct other_pkg_mgr_spec

--- a/libmamba/src/api/configuration.cpp
+++ b/libmamba/src/api/configuration.cpp
@@ -1079,7 +1079,8 @@ namespace mamba
                    .needs({ "file_specs" })
                    .long_description(unindent(R"(
                         The list of channels where the packages will be searched for.
-                        See also 'channel_priority'.)")));
+                        See also 'channel_priority'.)"))
+                   .set_post_merge_hook(detail::channels_hook));
 
         insert(Configurable("channel_alias", &ctx.channel_alias)
                    .group("Channels")

--- a/libmamba/src/api/install.cpp
+++ b/libmamba/src/api/install.cpp
@@ -719,17 +719,17 @@ namespace mamba
         void channels_hook(std::vector<std::string>& channels)
         {
             auto& config = Configuration::instance();
+            auto& config_channels = config.at("channels");
+            std::vector<std::string> cli_channels;
 
-            if (find(channels.begin(), channels.end(), "nodefaults") != channels.end())
+            if (config_channels.cli_configured())
             {
-                if (config.at("channels").cli_configured())
+                cli_channels = config_channels.cli_value<std::vector<std::string>>();
+                auto it = find(cli_channels.begin(), cli_channels.end(), "nodefaults");
+                if (it != cli_channels.end())
                 {
-                    channels = config.at("channels").cli_value<std::vector<std::string>>();
-                    channels.erase(find(channels.begin(), channels.end(), "nodefaults"));
-                }
-                else
-                {
-                    channels.clear();
+                    cli_channels.erase(it);
+                    channels = cli_channels;
                 }
             }
         }

--- a/libmamba/src/api/install.cpp
+++ b/libmamba/src/api/install.cpp
@@ -715,5 +715,23 @@ namespace mamba
                 }
             }
         }
+
+        void channels_hook(std::vector<std::string>& channels)
+        {
+            auto& config = Configuration::instance();
+
+            if (find(channels.begin(), channels.end(), "nodefaults") != channels.end())
+            {
+                if (config.at("channels").cli_configured())
+                {
+                    channels = config.at("channels").cli_value<std::vector<std::string>>();
+                    channels.erase(find(channels.begin(), channels.end(), "nodefaults"));
+                }
+                else
+                {
+                    channels.clear();
+                }
+            }
+        }
     }  // detail
 }  // mamba

--- a/micromamba/tests/test_create.py
+++ b/micromamba/tests/test_create.py
@@ -543,6 +543,42 @@ class TestCreate:
                 assert l["url"].startswith(f"{ca}/conda-forge/")
                 assert l["version"].startswith("0.22.")
 
+    def test_channel_nodefaults(self):
+        f_name = random_string() + ".yaml"
+        rc_file = os.path.join(TestCreate.spec_files_location, f_name)
+
+        content = [
+            "channels:",
+            "  - rc",
+        ]
+        with open(rc_file, "w") as f:
+            f.write("\n".join(content))
+
+        f_name = random_string() + ".yaml"
+        spec_file = os.path.join(TestCreate.spec_files_location, f_name)
+        contents = [
+            "channels:",
+            "  - yaml",
+            "  - nodefaults",
+            "dependencies:",
+            "  - xframe",
+        ]
+        with open(spec_file, "w") as f:
+            f.write("\n".join(contents))
+
+        res = create(
+            "-n",
+            TestCreate.env_name,
+            "-f",
+            spec_file,
+            "--print-config-only",
+            f"--rc-file={rc_file}",
+            default_channel=False,
+            no_rc=False,
+        )
+
+        assert res["channels"] == ["yaml"]
+
     def test_set_platform(self, existing_cache):
         # test a dummy platform/arch
         create("-n", TestCreate.env_name, "--platform", "ptf-128")


### PR DESCRIPTION
Closes #1107

This PR adds support for the nodefaults channel to micromamba.

In contrast to conda this implementation also allows passing the `nodefaults` channel on the command line. This is because the internal design of libmamba's configuration handler doesn't allow differentiating between channels passed on the command line and channels specified in the environments.yml file.

Because the configuration handler only allows adding a single hook to an option I had to remove the channels hook from micromamba to add it to libmamba. Instead of directly handling `--override-channels` micromamba now adds `nodefaults` to the channels when it encounters `--override-channels` and lets libmamba handle the rest.