### PR TITLE
Fix doc code snippet layout

### DIFF
--- a/docs/source/developer_zone/build_locally.rst
+++ b/docs/source/developer_zone/build_locally.rst
@@ -149,6 +149,7 @@ Build ``libmambapy``
 The Python bindings of ``libmamba``, ``libmambapy`` can be built by using the ``BUILD_LIBMAMBAPY`` ``cmake`` option.
 
 You can either rely on ``libmamba`` package already installed in your environment and run:
+
 .. code:: bash
 
     mkdir -p build


### PR DESCRIPTION
Missing blank line breaks the code snippet.
<img width="827" alt="Screenshot 2022-07-11 at 10 21 39" src="https://user-images.githubusercontent.com/11088808/178220589-fd8ae19a-fb45-4369-a85c-116cf2082282.png">

