### PR TITLE
Test isolation

### DIFF
--- a/mamba/tests/reposerver.py
+++ b/mamba/tests/reposerver.py
@@ -18,11 +18,6 @@ try:
 except ImportError:
     conda_content_trust_available = False
 
-if os.environ.get("TESTPWD"):
-    default_user, default_password = os.environ.get("TESTPWD").split(":")
-else:
-    default_user, default_password = None, None
-
 parser = argparse.ArgumentParser(description="Start a simple conda package server.")
 parser.add_argument("-p", "--port", type=int, default=8000, help="Port to use.")
 parser.add_argument(
@@ -53,13 +48,13 @@ parser.add_argument(
 parser.add_argument(
     "--user",
     type=str,
-    default=default_user,
+    default=None,
     help="Use token as API Key",
 )
 parser.add_argument(
     "--password",
     type=str,
-    default=default_password,
+    default=None,
     help="Use token as API Key",
 )
 args = parser.parse_args()

--- a/mamba/tests/testserver.sh
+++ b/mamba/tests/testserver.sh
@@ -1,48 +1,61 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail -x
 
-rm -rf $CONDA_PREFIX/pkgs/test-package*
-ENV_NAME=testauth
+# Directory of this file
+readonly __DIR__="$(cd "$(dirname "${BASH_SOURCE[0]:?}")" && pwd)"
+# reposerver python script
+readonly reposerver="${__DIR__}/reposerver.py"
+# Conda mock repository
+readonly repo="${__DIR__}/repo/"
 
-python reposerver.py -d repo/ --auth none & PID=$!
-mamba create -y -q -n $ENV_NAME --override-channels -c http://localhost:8000/ test-package --json
+# Set up a temporary space for Conda environment and packages
+readonly test_dir="$(mktemp -d -t mamba-test-reposerver-XXXXXXXXXX)"
+export CONDA_ENVS_PATH="${test_dir}/envs"
+export CONDA_PKGS_DIRS="${test_dir}/pkgs"
+readonly this_pid="$$"
+# On exit, kill all subprocess and cleanup test directory.
+trap 'rm -rf "${test_dir}"; pkill -P ${this_pid} || true' EXIT
+
+# 10 random characters
+function make-name {
+	LC_ALL=C tr -dc A-Za-z0-9 </dev/urandom | head -c 10
+}
+
+
+python "${reposerver}" -d "${repo}" --auth none & PID=$!
+mamba create -y -q -n "$(make-name)" --override-channels -c http://localhost:8000/ test-package --json
 kill -TERM $PID
-rm -rf $CONDA_PREFIX/envs/$ENV_NAME
 
 export TESTPWD="user:test"
-python reposerver.py -d repo/ --auth basic & PID=$!
-mamba create -y -q -n $ENV_NAME --override-channels -c http://user:test@localhost:8000/ test-package --json
+python "${reposerver}" -d "${repo}" --auth basic & PID=$!
+mamba create -y -q -n "$(make-name)" --override-channels -c http://user:test@localhost:8000/ test-package --json
 kill -TERM $PID
-rm -rf $CONDA_PREFIX/envs/$ENV_NAME
 
 export TESTPWD="user@email.com:test"
-python reposerver.py -d repo/ --auth basic & PID=$!
-mamba create -y -q -n $ENV_NAME --override-channels -c http://user@email.com:test@localhost:8000/ test-package --json
+python "${reposerver}" -d "${repo}" --auth basic & PID=$!
+mamba create -y -q -n "$(make-name)" --override-channels -c http://user@email.com:test@localhost:8000/ test-package --json
 kill -TERM $PID
-rm -rf $CONDA_PREFIX/envs/$ENV_NAME
 
 unset TESTPWD
-python reposerver.py -d repo/ --token xy-12345678-1234-1234-1234-123456789012 & PID=$!
-mamba create -y -q -n $ENV_NAME --override-channels -c http://localhost:8000/t/xy-12345678-1234-1234-1234-123456789012 test-package --json
+python "${reposerver}" -d "${repo}" --token xy-12345678-1234-1234-1234-123456789012 & PID=$!
+mamba create -y -q -n "$(make-name)" --override-channels -c http://localhost:8000/t/xy-12345678-1234-1234-1234-123456789012 test-package --json
 kill -TERM $PID
-rm -rf $CONDA_PREFIX/envs/$ENV_NAME
 
 if [[ "$(uname -s)" == "Linux" ]]; then
 	export KEY1=$(gpg --fingerprint "MAMBA1")
 	export KEY2=$(gpg --fingerprint "MAMBA2")
 
-	python reposerver.py -d repo/ --auth none --sign & PID=$!
+	python "${reposerver}" -d "${repo}" --auth none --sign & PID=$!
 	sleep 5s
 	kill -TERM $PID
 fi
 
 export TESTPWD=":test"
-python reposerver.py -d repo/ --auth basic --port 8005 & PID=$!
-python reposerver.py -d repo/ --auth basic --port 8006 & PID2=$!
-python reposerver.py -d repo/ --auth basic --port 8007 & PID3=$!
-mamba create -y -q -n $ENV_NAME --override-channels -c http://:test@localhost:8005/ -c http://:test@localhost:8006/ -c http://:test@localhost:8007/ test-package --json
+python "${reposerver}" -d "${repo}" --auth basic --port 8005 & PID=$!
+python "${reposerver}" -d "${repo}" --auth basic --port 8006 & PID2=$!
+python "${reposerver}" -d "${repo}" --auth basic --port 8007 & PID3=$!
+mamba create -y -q -n "$(make-name)" --override-channels -c http://:test@localhost:8005/ -c http://:test@localhost:8006/ -c http://:test@localhost:8007/ test-package --json
 kill -TERM $PID
 kill -TERM $PID2
 kill -TERM $PID3
-rm -rf $CONDA_PREFIX/envs/$ENV_NAME

--- a/mamba/tests/testserver.sh
+++ b/mamba/tests/testserver.sh
@@ -27,17 +27,14 @@ python "${reposerver}" -d "${repo}" --auth none & PID=$!
 mamba create -y -q -n "$(make-name)" --override-channels -c http://localhost:8000/ test-package --json
 kill -TERM $PID
 
-export TESTPWD="user:test"
-python "${reposerver}" -d "${repo}" --auth basic & PID=$!
+python "${reposerver}" -d "${repo}" --auth basic --user user --password test & PID=$!
 mamba create -y -q -n "$(make-name)" --override-channels -c http://user:test@localhost:8000/ test-package --json
 kill -TERM $PID
 
-export TESTPWD="user@email.com:test"
-python "${reposerver}" -d "${repo}" --auth basic & PID=$!
+python "${reposerver}" -d "${repo}" --auth basic --user user@email.com --password test & PID=$!
 mamba create -y -q -n "$(make-name)" --override-channels -c http://user@email.com:test@localhost:8000/ test-package --json
 kill -TERM $PID
 
-unset TESTPWD
 python "${reposerver}" -d "${repo}" --token xy-12345678-1234-1234-1234-123456789012 & PID=$!
 mamba create -y -q -n "$(make-name)" --override-channels -c http://localhost:8000/t/xy-12345678-1234-1234-1234-123456789012 test-package --json
 kill -TERM $PID
@@ -51,10 +48,9 @@ if [[ "$(uname -s)" == "Linux" ]]; then
 	kill -TERM $PID
 fi
 
-export TESTPWD=":test"
-python "${reposerver}" -d "${repo}" --auth basic --port 8005 & PID=$!
-python "${reposerver}" -d "${repo}" --auth basic --port 8006 & PID2=$!
-python "${reposerver}" -d "${repo}" --auth basic --port 8007 & PID3=$!
+python "${reposerver}" -d "${repo}" --auth basic --user '' --password test --port 8005 & PID=$!
+python "${reposerver}" -d "${repo}" --auth basic --user '' --password test --port 8006 & PID2=$!
+python "${reposerver}" -d "${repo}" --auth basic --user '' --password test --port 8007 & PID3=$!
 mamba create -y -q -n "$(make-name)" --override-channels -c http://:test@localhost:8005/ -c http://:test@localhost:8006/ -c http://:test@localhost:8007/ test-package --json
 kill -TERM $PID
 kill -TERM $PID2

--- a/mamba/tests/testserver.sh
+++ b/mamba/tests/testserver.sh
@@ -17,26 +17,21 @@ readonly this_pid="$$"
 # On exit, kill all subprocess and cleanup test directory.
 trap 'rm -rf "${test_dir}"; pkill -P ${this_pid} || true' EXIT
 
-# 10 random characters
-function make-name {
-	LC_ALL=C tr -dc A-Za-z0-9 </dev/urandom | head -c 10
-}
-
 
 python "${reposerver}" -d "${repo}" --auth none & PID=$!
-mamba create -y -q -n "$(make-name)" --override-channels -c http://localhost:8000/ test-package --json
+mamba create -y -q -n "env-${RANDOM}" --override-channels -c http://localhost:8000/ test-package --json
 kill -TERM $PID
 
 python "${reposerver}" -d "${repo}" --auth basic --user user --password test & PID=$!
-mamba create -y -q -n "$(make-name)" --override-channels -c http://user:test@localhost:8000/ test-package --json
+mamba create -y -q -n "env-${RANDOM}" --override-channels -c http://user:test@localhost:8000/ test-package --json
 kill -TERM $PID
 
 python "${reposerver}" -d "${repo}" --auth basic --user user@email.com --password test & PID=$!
-mamba create -y -q -n "$(make-name)" --override-channels -c http://user@email.com:test@localhost:8000/ test-package --json
+mamba create -y -q -n "env-${RANDOM}" --override-channels -c http://user@email.com:test@localhost:8000/ test-package --json
 kill -TERM $PID
 
 python "${reposerver}" -d "${repo}" --token xy-12345678-1234-1234-1234-123456789012 & PID=$!
-mamba create -y -q -n "$(make-name)" --override-channels -c http://localhost:8000/t/xy-12345678-1234-1234-1234-123456789012 test-package --json
+mamba create -y -q -n "env-${RANDOM}" --override-channels -c http://localhost:8000/t/xy-12345678-1234-1234-1234-123456789012 test-package --json
 kill -TERM $PID
 
 if [[ "$(uname -s)" == "Linux" ]]; then
@@ -51,7 +46,7 @@ fi
 python "${reposerver}" -d "${repo}" --auth basic --user '' --password test --port 8005 & PID=$!
 python "${reposerver}" -d "${repo}" --auth basic --user '' --password test --port 8006 & PID2=$!
 python "${reposerver}" -d "${repo}" --auth basic --user '' --password test --port 8007 & PID3=$!
-mamba create -y -q -n "$(make-name)" --override-channels -c http://:test@localhost:8005/ -c http://:test@localhost:8006/ -c http://:test@localhost:8007/ test-package --json
+mamba create -y -q -n "env-${RANDOM}" --override-channels -c http://:test@localhost:8005/ -c http://:test@localhost:8006/ -c http://:test@localhost:8007/ test-package --json
 kill -TERM $PID
 kill -TERM $PID2
 kill -TERM $PID3

--- a/micromamba/tests/conftest.py
+++ b/micromamba/tests/conftest.py
@@ -16,13 +16,18 @@ def env_name(N: int = 10) -> str:
 @pytest.fixture
 def tmp_home(tmp_path: pathlib.Path) -> Generator[pathlib.Path, None, None]:
     """Change the home directory to a tmp folder for the duration of a test."""
-    old_home = os.environ.get("HOME")
-    new_home = tmp_path / "home"
-    new_home.mkdir(parents=True, exist_ok=True)
-    if old_home is not None:
-        os.environ["HOME"] = str(new_home)
+    # Try multiple combination for Unix/Windows
+    home_envs = [k for k in ("HOME", "USERPROFILE") if k in os.environ]
+    old_homes = {name: os.environ[name] for name in home_envs}
+
+    if len(home_envs) > 0:
+        new_home = tmp_path / "home"
+        new_home.mkdir(parents=True, exist_ok=True)
+        for env in home_envs:
+            os.environ[env] = str(new_home)
         yield new_home
-        os.environ["HOME"] = old_home
+        for env, home in old_homes.items():
+            os.environ[env] = home
     else:
         yield pathlib.Path.home()
 

--- a/micromamba/tests/conftest.py
+++ b/micromamba/tests/conftest.py
@@ -1,0 +1,57 @@
+import os
+import pathlib
+import random
+import string
+from typing import Generator
+
+import pytest
+
+
+@pytest.fixture
+def env_name(N: int = 10) -> str:
+    """Return Ten random characters."""
+    return "".join(random.choices(string.ascii_uppercase + string.digits, k=N))
+
+
+@pytest.fixture
+def tmp_home(tmp_path: pathlib.Path) -> Generator[pathlib.Path, None, None]:
+    """Change the home directory to a tmp folder for the duration of a test."""
+    old_home = os.environ.get("HOME")
+    new_home = tmp_path / "home"
+    new_home.mkdir(parents=True, exist_ok=True)
+    if old_home is not None:
+        os.environ["HOME"] = str(new_home)
+        yield new_home
+        os.environ["HOME"] = old_home
+    else:
+        yield pathlib.Path.home()
+
+
+@pytest.fixture
+def tmp_root_prefix(tmp_path: pathlib.Path) -> Generator[pathlib.Path, None, None]:
+    """Change the micromamba root directory to a tmp folder for the duration of a test."""
+    old_root_prefix = os.environ.get("MAMBA_ROOT_PREFIX")
+    new_root_prefix = tmp_path / "mamba"
+    new_root_prefix.mkdir(parents=True, exist_ok=True)
+    os.environ["MAMBA_ROOT_PREFIX"] = str(new_root_prefix)
+    yield new_root_prefix
+    if old_root_prefix is not None:
+        os.environ["MAMBA_ROOT_PREFIX"] = old_root_prefix
+    else:
+        del os.environ["MAMBA_ROOT_PREFIX"]
+
+
+@pytest.fixture
+def tmp_prefix(
+    tmp_root_prefix: pathlib.Path, env_name: str
+) -> Generator[pathlib.Path, None, None]:
+    """Change the conda prefix to a tmp folder for the duration of a test."""
+    old_prefix = os.environ.get("CONDA_PREFIX")
+    new_prefix = tmp_root_prefix / "envs" / env_name
+    new_prefix.mkdir(parents=True, exist_ok=True)
+    os.environ["CONDA_PREFIX"] = str(new_prefix)
+    yield new_prefix
+    if old_prefix is not None:
+        os.environ["CONDA_PREFIX"] = old_prefix
+    else:
+        del os.environ["CONDA_PREFIX"]


### PR DESCRIPTION
This PR (hopefully) improves tests isolation by creating temporary directories for `$HOME` `$MAMBA_ROOT_PREFIX` `$CONDA_PREFIX`
- Reusable fixtures across tests and test files
- Always start test in an empty directory (as opposed to `$HOME` potentially populated with user configs)
- Safely cleanup (Pytest fixtures and OS tmp dir)
