### PR TITLE
Fix #1751: Better error message if root prefix is not a directory

### DIFF
--- a/libmamba/src/api/configuration.cpp
+++ b/libmamba/src/api/configuration.cpp
@@ -532,13 +532,20 @@ namespace mamba
                     LOG_WARNING << "'root_prefix' set with default value: " << prefix.string();
                 }
 
-                if (fs::exists(prefix) && !fs::is_empty(prefix))
+                if (fs::exists(prefix))
                 {
-                    if (!(fs::exists(prefix / "pkgs") || fs::exists(prefix / "conda-meta")
-                          || fs::exists(prefix / "envs")))
+                    if (fs::is_directory(prefix))
                     {
+                        if (!fs::is_empty(prefix) && (!(fs::exists(prefix / "pkgs") || fs::exists(prefix / "conda-meta")
+                                  || fs::exists(prefix / "envs"))))
+                        {
+                            LOG_ERROR << "Could not use default 'root_prefix': " << prefix.string();
+                            LOG_ERROR << "Directory exists, is not empty and not a conda prefix.";
+                            exit(1);
+                        }
+                    } else {
                         LOG_ERROR << "Could not use default 'root_prefix': " << prefix.string();
-                        LOG_ERROR << "Directory exists, is not empty and not a conda prefix.";
+                        LOG_ERROR << "File is not a directory.";
                         exit(1);
                     }
                 }

--- a/libmamba/src/api/configuration.cpp
+++ b/libmamba/src/api/configuration.cpp
@@ -536,17 +536,20 @@ namespace mamba
                 {
                     if (fs::is_directory(prefix))
                     {
-                        if (!fs::is_empty(prefix) && (!(fs::exists(prefix / "pkgs") || fs::exists(prefix / "conda-meta")
+                        if (!fs::is_empty(prefix)
+                            && (!(fs::exists(prefix / "pkgs") || fs::exists(prefix / "conda-meta")
                                   || fs::exists(prefix / "envs"))))
                         {
-                            LOG_ERROR << "Could not use default 'root_prefix': " << prefix.string();
-                            LOG_ERROR << "Directory exists, is not empty and not a conda prefix.";
-                            exit(1);
+                            throw std::runtime_error(fmt::format(
+                                "Could not use default 'root_prefix': {}: Directory exists, is not empty and not a conda prefix.",
+                                prefix.string()));
                         }
-                    } else {
-                        LOG_ERROR << "Could not use default 'root_prefix': " << prefix.string();
-                        LOG_ERROR << "File is not a directory.";
-                        exit(1);
+                    }
+                    else
+                    {
+                        throw std::runtime_error(fmt::format(
+                            "Could not use default 'root_prefix': {}: File is not a directory.",
+                            prefix.string()));
                     }
                 }
 

--- a/libmamba/src/api/install.cpp
+++ b/libmamba/src/api/install.cpp
@@ -6,6 +6,7 @@
 
 #include <reproc/reproc.h>
 #include <reproc++/run.hpp>
+#include <stdexcept>
 
 #include "mamba/api/configuration.hpp"
 #include "mamba/api/install.hpp"
@@ -371,8 +372,8 @@ namespace mamba
         }
         if (!fs::exists(ctx.target_prefix) && create_env == false)
         {
-            LOG_ERROR << "Prefix does not exist at: " << ctx.target_prefix;
-            exit(1);
+            throw std::runtime_error(
+                fmt::format("Prefix does not exist at: {}", ctx.target_prefix.string()));
         }
 
         MultiPackageCache package_caches(ctx.pkgs_dirs);

--- a/libmamba/src/api/shell.cpp
+++ b/libmamba/src/api/shell.cpp
@@ -140,7 +140,7 @@ namespace mamba
         {
             if (!enable_long_paths_support(true))
             {
-                exit(1);
+                throw std::runtime_error("Error enabling Windows long-path support");
             }
         }
 #endif

--- a/libmamba/src/core/shell_init.cpp
+++ b/libmamba/src/core/shell_init.cpp
@@ -19,6 +19,7 @@
 #include "termcolor/termcolor.hpp"
 
 #include <reproc++/run.hpp>
+#include <stdexcept>
 
 #ifdef _WIN32
 #include "WinReg.hpp"
@@ -169,11 +170,8 @@ namespace mamba
         }
         catch (...)
         {
-            std::cout
-                << termcolor::red
-                << "ERROR: Could not find bash, or use cygpath to convert Windows path to Unix."
-                << termcolor::reset << std::endl;
-            exit(1);
+            throw std::runtime_error(
+                "Could not find bash, or use cygpath to convert Windows path to Unix.");
         }
     }
 

--- a/libmamba/src/core/solver.cpp
+++ b/libmamba/src/core/solver.cpp
@@ -13,6 +13,7 @@
 #include "mamba/core/pool.hpp"
 #include "mamba/core/repo.hpp"
 #include "mamba/core/util.hpp"
+#include <stdexcept>
 
 namespace mamba
 {
@@ -307,8 +308,7 @@ namespace mamba
 
         if (all_solvables.size() != 0 && matching_solvables.size() == 0)
         {
-            LOG_ERROR << "No package can be installed for pin: " << pin;
-            exit(1);
+            throw std::runtime_error(fmt::format("No package can be installed for pin: {}", pin));
         }
         m_pinned_specs.push_back(ms);
 

--- a/libmamba/src/core/subdirdata.cpp
+++ b/libmamba/src/core/subdirdata.cpp
@@ -12,6 +12,7 @@
 #include "mamba/core/util.hpp"
 
 #include "progress_bar_impl.hpp"
+#include <stdexcept>
 
 namespace decompress
 {
@@ -558,8 +559,7 @@ namespace mamba
 
         if (!final_file.is_open())
         {
-            LOG_ERROR << "Could not open file '" << json_file.string() << "'";
-            exit(1);
+            throw std::runtime_error(fmt::format("Could not open file '{}'", json_file.string()));
         }
 
         if (ends_with(m_repodata_url, ".bz2"))
@@ -587,10 +587,9 @@ namespace mamba
 
         if (!temp_file)
         {
-            LOG_ERROR << "Could not write out repodata file '" << json_file
-                      << "': " << strerror(errno);
             fs::remove(json_file);
-            exit(1);
+            throw std::runtime_error(fmt::format(
+                "Could not write out repodata file '{}': {}", json_file.string(), strerror(errno)));
         }
 
         if (m_progress_bar)


### PR DESCRIPTION
Fixes https://github.com/mamba-org/mamba/issues/1751

@adriendelsalle it seems like these lines cause the error messages I improved not to be shown. Is it on purpose that only critical errors are printed in this case? https://github.com/mamba-org/mamba/blob/f2ac46b1c478668ed09463cf5b88d4802af7661b/libmamba/src/api/configuration.cpp#L1636-L1637