### PR TITLE
Fix Python version in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -158,7 +158,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: ["3.8"]
+        python_version: ["3.8"]
 
     steps:
       - uses: actions/checkout@v3
@@ -169,7 +169,9 @@ jobs:
           environment-name: build_env
           cache-env: true
           micromamba-version: "0.23.0"
-          extra-specs: conda-build
+          extra-specs: |
+            conda-build
+            python=${{ matrix.python_version }}
       - uses: hendrikmuhs/ccache-action@main
         with:
           variant: sccache


### PR DESCRIPTION
CI tests are not run with the expected Python version (seeing 3.10 in the logs).