### PR TITLE
Fix pip execution in environments with spaces in path (#1805)

### DIFF
--- a/libmamba/src/api/install.cpp
+++ b/libmamba/src/api/install.cpp
@@ -28,7 +28,7 @@ namespace mamba
     namespace
     {
         std::map<std::string, std::string> other_pkg_mgr_install_instructions
-            = { { "pip", "pip install -r {0} --no-input" } };
+            = { { "pip", "python -m pip install -r {0} --no-input" } };
     }
 
     bool reproc_killed(int status)


### PR DESCRIPTION
Conda executes pip via `python -m pip install ...` when installing pip dependencies into the environment. Mamba is using `pip install` directly, but that does not work in environments with spaces in the path. This PR makes sure mamba als uses `python -m pip install ...` during the package installation process.

See #1805 for a longer discussion.