### PR TITLE
Fixed libmamba crash when using `pip`

### DIFF
--- a/libmamba/include/mamba/core/activation.hpp
+++ b/libmamba/include/mamba/core/activation.hpp
@@ -63,7 +63,6 @@ namespace mamba
                                         const std::string& conda_default_env,
                                         int old_conda_shlvl);
 
-        std::vector<fs::path> get_path_dirs(const fs::path& prefix);
         std::vector<fs::path> get_clean_dirs();
 
         std::string add_prefix_to_path(const fs::path& prefix, int old_conda_shlvl);
@@ -181,6 +180,10 @@ namespace mamba
         std::string hook_postamble() override;
         fs::path hook_source_path() override;
     };
+
+
+    std::vector<fs::path> get_path_dirs(const fs::path& prefix);
+
 }  // namespace mamba
 
 #endif

--- a/libmamba/include/mamba/core/environment.hpp
+++ b/libmamba/include/mamba/core/environment.hpp
@@ -50,6 +50,7 @@ namespace mamba
         void unset(const std::string& key);
 
         fs::path which(const std::string& exe, const std::string& override_path = "");
+        fs::path which(const std::string& exe, const std::vector<fs::path>& search_paths);
         std::map<std::string, std::string> copy();
         std::string platform();
         fs::path home_directory();

--- a/libmamba/src/core/activation.cpp
+++ b/libmamba/src/core/activation.cpp
@@ -172,7 +172,7 @@ namespace mamba
         }
     }
 
-    std::vector<fs::path> Activator::get_path_dirs(const fs::path& prefix)
+    std::vector<fs::path> get_path_dirs(const fs::path& prefix)
     {
         if (on_win)
         {

--- a/libmamba/src/core/environment.cpp
+++ b/libmamba/src/core/environment.cpp
@@ -81,22 +81,11 @@ namespace mamba
             if (env_path)
             {
                 std::string path = env_path.value();
-                auto parts = mamba::split(path, pathsep());
-                for (auto& p : parts)
-                {
-                    if (!fs::exists(p) || !fs::is_directory(p))
-                    {
-                        continue;
-                    }
-                    for (const auto& entry : fs::directory_iterator(p))
-                    {
-                        if (entry.path().filename() == exe)
-                        {
-                            return entry.path();
-                        }
-                    }
-                }
+                const auto parts = mamba::split(path, pathsep());
+                const std::vector<fs::path> search_paths(parts.begin(), parts.end());
+                return which(exe, search_paths);
             }
+
 
 #ifndef _WIN32
             if (override_path == "")
@@ -111,6 +100,37 @@ namespace mamba
                 }
             }
 #endif
+
+            return "";  // empty path
+        }
+
+        fs::path which(const std::string& exe, const std::vector<fs::path>& search_paths)
+        {
+            for (auto& p : search_paths)
+            {
+                if (!fs::exists(p) || !fs::is_directory(p))
+                {
+                    continue;
+                }
+
+#ifdef _WIN32
+                const auto exe_with_extension = exe + ".exe";
+#endif
+                for (const auto& entry : fs::directory_iterator(p))
+                {
+                    const auto filename = entry.path().filename();
+                    if (filename == exe
+
+#ifdef _WIN32
+                        || filename == exe_with_extension
+#endif
+                    )
+                    {
+                        return entry.path();
+                    }
+                }
+            }
+
 
             return "";  // empty path
         }


### PR DESCRIPTION
Also added an overload of `env::which` taking a list of search paths for the executable to find.