### PR TITLE
Use xdg schemas for config and data file saving/reading

### DIFF
--- a/libmamba/include/mamba/core/environment.hpp
+++ b/libmamba/include/mamba/core/environment.hpp
@@ -54,6 +54,9 @@ namespace mamba
         std::map<std::string, std::string> copy();
         std::string platform();
         fs::u8path home_directory();
+        fs::u8path user_config_dir();
+        fs::u8path user_data_dir();
+        fs::u8path user_cache_dir();
 
         fs::u8path expand_user(const fs::u8path& path);
         fs::u8path shrink_user(const fs::u8path& path);

--- a/libmamba/include/mamba/core/menuinst.hpp
+++ b/libmamba/include/mamba/core/menuinst.hpp
@@ -5,4 +5,11 @@ namespace mamba
 {
     void remove_menu_from_json(const fs::u8path& json_file, TransactionContext* context);
     void create_menu_from_json(const fs::u8path& json_file, TransactionContext* context);
+#ifdef _WIN32
+    namespace win
+    {
+        fs::u8path get_folder(const std::string& id);
+    }
+
+#endif
 }

--- a/libmamba/src/api/configuration.cpp
+++ b/libmamba/src/api/configuration.cpp
@@ -845,7 +845,6 @@ namespace mamba
         std::vector<fs::u8path> fallback_pkgs_dirs_hook()
         {
             std::vector<fs::u8path> paths = { Context::instance().prefix_params.root_prefix / "pkgs",
-                                              env::user_data_dir() / "pkgs",
                                               env::home_directory() / ".mamba" / "pkgs" };
 #ifdef _WIN32
             auto appdata = env::get("APPDATA");

--- a/libmamba/src/api/configuration.cpp
+++ b/libmamba/src/api/configuration.cpp
@@ -599,7 +599,7 @@ namespace mamba
                 }
                 else
                 {
-                    prefix = env::home_directory() / "micromamba";
+                    prefix = env::user_data_dir() / "micromamba";
                 }
 
                 if (env_name.configured())
@@ -845,6 +845,7 @@ namespace mamba
         std::vector<fs::u8path> fallback_pkgs_dirs_hook()
         {
             std::vector<fs::u8path> paths = { Context::instance().prefix_params.root_prefix / "pkgs",
+                                              env::user_data_dir() / "pkgs",
                                               env::home_directory() / ".mamba" / "pkgs" };
 #ifdef _WIN32
             auto appdata = env::get("APPDATA");
@@ -1776,11 +1777,11 @@ namespace mamba
                                          ctx.prefix_params.root_prefix / "condarc.d",
                                          ctx.prefix_params.root_prefix / ".mambarc" };
 
-        std::vector<fs::u8path> home = { env::home_directory() / ".conda/.condarc",
-                                         env::home_directory() / ".conda/condarc",
-                                         env::home_directory() / ".conda/condarc.d",
-                                         env::home_directory() / ".condarc",
-                                         env::home_directory() / ".mambarc" };
+        std::vector<fs::u8path> home = {
+            env::home_directory() / ".conda/.condarc",  env::home_directory() / ".conda/condarc",
+            env::home_directory() / ".conda/condarc.d", env::home_directory() / ".condarc",
+            env::home_directory() / ".mambarc",         env::user_config_dir() / "mambarc"
+        };
 
         std::vector<fs::u8path> prefix = { ctx.prefix_params.target_prefix / ".condarc",
                                            ctx.prefix_params.target_prefix / "condarc",

--- a/libmamba/src/api/configuration.cpp
+++ b/libmamba/src/api/configuration.cpp
@@ -599,7 +599,7 @@ namespace mamba
                 }
                 else
                 {
-                    prefix = env::user_data_dir() / "micromamba";
+                    prefix = env::home_directory() / "micromamba";
                 }
 
                 if (env_name.configured())
@@ -1778,9 +1778,10 @@ namespace mamba
                                          ctx.prefix_params.root_prefix / ".mambarc" };
 
         std::vector<fs::u8path> home = {
-            env::home_directory() / ".conda/.condarc",  env::home_directory() / ".conda/condarc",
-            env::home_directory() / ".conda/condarc.d", env::home_directory() / ".condarc",
-            env::home_directory() / ".mambarc",         env::user_config_dir() / "mambarc"
+            env::home_directory() / ".conda/.condarc",   env::home_directory() / ".conda/condarc",
+            env::home_directory() / ".conda/condarc.d",  env::home_directory() / ".condarc",
+            env::user_config_dir() / "../conda/condarc", env::home_directory() / ".mambarc",
+            env::user_config_dir() / "mambarc"
         };
 
         std::vector<fs::u8path> prefix = { ctx.prefix_params.target_prefix / ".condarc",

--- a/libmamba/src/api/info.cpp
+++ b/libmamba/src/api/info.cpp
@@ -136,8 +136,7 @@ namespace mamba
             items.push_back({ "env location", location });
 
             // items.insert( { "shell level", { 1 } });
-            items.push_back({ "user config files",
-                              { (env::home_directory() / ".mambarc").string() } });
+            items.push_back({ "user config files", { env::user_config_dir() / "mambarc" } });
 
             std::vector<std::string> sources;
             for (auto s : config.valid_sources())

--- a/libmamba/src/core/context.cpp
+++ b/libmamba/src/core/context.cpp
@@ -219,7 +219,7 @@ namespace mamba
         }
 
         std::map<std::string, AuthenticationInfo> res;
-        fs::u8path auth_loc(mamba::env::home_directory() / ".mamba" / "auth" / "authentication.json");
+        fs::u8path auth_loc(mamba::env::user_data_dir() / "auth" / "authentication.json");
         try
         {
             if (fs::exists(auth_loc))

--- a/libmamba/src/core/environment.cpp
+++ b/libmamba/src/core/environment.cpp
@@ -5,11 +5,13 @@
 // The full license is in the file LICENSE, distributed with this software.
 
 #include "mamba/core/environment.hpp"
+#include "mamba/core/util.hpp"
 #include "mamba/core/util_string.hpp"
 
 #ifdef _WIN32
 #include <mutex>
 
+#include "mamba/core/menuinst.hpp"
 #include "mamba/core/output.hpp"
 #include "mamba/core/util_os.hpp"
 #endif
@@ -268,6 +270,69 @@ namespace mamba
             }
 #endif
             return maybe_home;
+        }
+
+        fs::u8path user_config_dir()
+        {
+            std::string maybe_user_config_dir = env::get("XDG_CONFIG_HOME").value_or("");
+            if (maybe_user_config_dir.empty())
+            {
+#ifdef _WIN32
+                maybe_user_config_dir = ::mamba::win::get_folder("roamingappdata");
+#else
+                if (on_mac)
+                {
+                    maybe_user_config_dir = home_directory() / "Library" / "Application Support";
+                }
+                else
+                {
+                    maybe_user_config_dir = home_directory() / ".config";
+                }
+#endif
+            }
+            return fs::u8path(maybe_user_config_dir) / "mamba";
+        }
+
+        fs::u8path user_data_dir()
+        {
+            std::string maybe_user_data_dir = env::get("XDG_DATA_HOME").value_or("");
+            if (maybe_user_data_dir.empty())
+            {
+#ifdef _WIN32
+                maybe_user_data_dir = ::mamba::win::get_folder("roamingappdata");
+#else
+                if (on_mac)
+                {
+                    maybe_user_data_dir = home_directory() / "Library" / "Application Support";
+                }
+                else
+                {
+                    maybe_user_data_dir = home_directory() / ".local" / "share";
+                }
+#endif
+            }
+            return fs::u8path(maybe_user_data_dir) / "mamba";
+        }
+
+        fs::u8path user_cache_dir()
+        {
+            std::string maybe_user_cache_dir = env::get("XDG_CACHE_HOME").value_or("");
+            if (maybe_user_cache_dir.empty())
+            {
+#ifdef _WIN32
+                maybe_user_cache_dir = ::mamba::win::get_folder("localappdata");
+#else
+                if (on_mac)
+                {
+                    maybe_user_cache_dir = home_directory() / "Library" / "Caches";
+                }
+                else
+                {
+                    maybe_user_cache_dir = home_directory() / ".cache";
+                }
+#endif
+            }
+            return fs::u8path(maybe_user_cache_dir) / "mamba";
         }
 
         fs::u8path expand_user(const fs::u8path& path)

--- a/libmamba/src/core/environment.cpp
+++ b/libmamba/src/core/environment.cpp
@@ -280,14 +280,7 @@ namespace mamba
 #ifdef _WIN32
                 maybe_user_config_dir = ::mamba::win::get_folder("roamingappdata");
 #else
-                if (on_mac)
-                {
-                    maybe_user_config_dir = home_directory() / "Library" / "Application Support";
-                }
-                else
-                {
-                    maybe_user_config_dir = home_directory() / ".config";
-                }
+                maybe_user_config_dir = home_directory() / ".config";
 #endif
             }
             return fs::u8path(maybe_user_config_dir) / "mamba";
@@ -301,14 +294,7 @@ namespace mamba
 #ifdef _WIN32
                 maybe_user_data_dir = ::mamba::win::get_folder("roamingappdata");
 #else
-                if (on_mac)
-                {
-                    maybe_user_data_dir = home_directory() / "Library" / "Application Support";
-                }
-                else
-                {
-                    maybe_user_data_dir = home_directory() / ".local" / "share";
-                }
+                maybe_user_data_dir = home_directory() / ".local" / "share";
 #endif
             }
             return fs::u8path(maybe_user_data_dir) / "mamba";
@@ -322,14 +308,7 @@ namespace mamba
 #ifdef _WIN32
                 maybe_user_cache_dir = ::mamba::win::get_folder("localappdata");
 #else
-                if (on_mac)
-                {
-                    maybe_user_cache_dir = home_directory() / "Library" / "Caches";
-                }
-                else
-                {
-                    maybe_user_cache_dir = home_directory() / ".cache";
-                }
+                maybe_user_cache_dir = home_directory() / ".cache";
 #endif
             }
             return fs::u8path(maybe_user_cache_dir) / "mamba";

--- a/libmamba/src/core/environments_manager.cpp
+++ b/libmamba/src/core/environments_manager.cpp
@@ -23,7 +23,7 @@ namespace mamba
 
     void EnvironmentsManager::register_env(const fs::u8path& location)
     {
-        fs::u8path env_txt_file = get_environments_txt_file(env::home_directory());
+        fs::u8path env_txt_file = get_environments_txt_file(env::user_data_dir());
         fs::u8path final_location = fs::absolute(location);
         fs::u8path folder = final_location.parent_path();
 
@@ -96,7 +96,7 @@ namespace mamba
             }
         }
 
-        clean_environments_txt(get_environments_txt_file(env::home_directory()), location);
+        clean_environments_txt(get_environments_txt_file(env::user_data_dir()), location);
     }
 
     std::set<fs::u8path> EnvironmentsManager::list_all_known_prefixes()
@@ -121,7 +121,7 @@ namespace mamba
         // }
         // else
         {
-            search_dirs = std::vector<fs::u8path>{ env::home_directory() };
+            search_dirs = std::vector<fs::u8path>{ env::user_data_dir() };
         }
 
         std::set<fs::u8path> all_env_paths;
@@ -207,9 +207,9 @@ namespace mamba
         return p;
     }
 
-    fs::u8path EnvironmentsManager::get_environments_txt_file(const fs::u8path& home) const
+    fs::u8path EnvironmentsManager::get_environments_txt_file(const fs::u8path& user_data_dir_in) const
     {
-        return home / ".conda" / "environments.txt";
+        return user_data_dir_in / "environments.txt";
     }
 
 }  // namespace mamba

--- a/libmamba/src/core/menuinst.cpp
+++ b/libmamba/src/core/menuinst.cpp
@@ -168,9 +168,9 @@ namespace mamba
         }
 
         const std::map<std::string, KNOWNFOLDERID> knownfolders = {
-            { "programs", FOLDERID_Programs },
-            { "profile", FOLDERID_Profile },
-            { "documents", FOLDERID_Documents },
+            { "programs", FOLDERID_Programs },       { "profile", FOLDERID_Profile },
+            { "documents", FOLDERID_Documents },     { "roamingappdata", FOLDERID_RoamingAppData },
+            { "programdata", FOLDERID_ProgramData }, { "localappdata", FOLDERID_LocalAppData },
         };
 
         fs::u8path get_folder(const std::string& id)

--- a/libmamba/src/core/run.cpp
+++ b/libmamba/src/core/run.cpp
@@ -114,7 +114,7 @@ namespace mamba
 
     const fs::u8path& proc_dir()
     {
-        static const auto path = env::home_directory() / ".mamba" / "proc";
+        static auto path = env::user_cache_dir() / "proc";
         return path;
     }
 

--- a/libmamba/tests/src/core/test_configuration.cpp
+++ b/libmamba/tests/src/core/test_configuration.cpp
@@ -560,10 +560,12 @@ namespace mamba
                         { "pkgs_dirs" }
                     ),
                     unindent((R"(
-                                    pkgs_dirs:
-                                      - )"
+                                pkgs_dirs:
+                                  - )"
                               + (fs::u8path(root_prefix_str) / "pkgs").string() + R"(  # 'fallback'
-                                      - )"
+                                  - )"
+                              + (env::user_data_dir() / "pkgs").string() + R"(  # 'fallback'
+                                  - )"
                               + (env::home_directory() / ".mamba" / "pkgs").string()
                               + R"(  # 'fallback')" + extra_cache)
                                  .c_str())

--- a/libmamba/tests/src/core/test_configuration.cpp
+++ b/libmamba/tests/src/core/test_configuration.cpp
@@ -564,8 +564,6 @@ namespace mamba
                                   - )"
                               + (fs::u8path(root_prefix_str) / "pkgs").string() + R"(  # 'fallback'
                                   - )"
-                              + (env::user_data_dir() / "pkgs").string() + R"(  # 'fallback'
-                                  - )"
                               + (env::home_directory() / ".mamba" / "pkgs").string()
                               + R"(  # 'fallback')" + extra_cache)
                                  .c_str())

--- a/micromamba/src/config.cpp
+++ b/micromamba/src/config.cpp
@@ -60,7 +60,7 @@ compute_config_path(Configuration& config, bool touch_if_not_exists)
     auto& env_path = config.at("config_set_env_path");
     auto& system_path = config.at("config_set_system_path");
 
-    fs::u8path rc_source = env::expand_user(env::home_directory() / ".condarc");
+    fs::u8path rc_source = env::expand_user(env::user_config_dir() / "mambarc");
 
     if (file_path.configured())
     {
@@ -68,7 +68,7 @@ compute_config_path(Configuration& config, bool touch_if_not_exists)
     }
     else if (env_path.configured())
     {
-        rc_source = fs::u8path{ ctx.prefix_params.target_prefix / ".condarc" };
+        rc_source = fs::u8path(ctx.prefix_params.target_prefix / ".mambarc");
     }
     else if (system_path.configured())
     {

--- a/micromamba/src/login.cpp
+++ b/micromamba/src/login.cpp
@@ -65,7 +65,7 @@ set_logout_command(CLI::App* subcom)
     subcom->callback(
         []()
         {
-            static auto path = mamba::env::home_directory() / ".mamba" / "auth";
+            static auto path = mamba::env::user_data_dir() / "auth";
             fs::u8path auth_file = path / "authentication.json";
 
             if (all)
@@ -159,7 +159,7 @@ set_login_command(CLI::App* subcom)
                 bearer = read_stdin();
             }
 
-            static auto path = mamba::env::home_directory() / ".mamba" / "auth";
+            static auto path = mamba::env::user_data_dir() / "auth";
             fs::create_directories(path);
 
 

--- a/micromamba/tests/conftest.py
+++ b/micromamba/tests/conftest.py
@@ -192,9 +192,7 @@ def user_config_dir(tmp_home: pathlib.Path) -> Generator[pathlib.Path, None, Non
     if maybe_xdg_config:
         yield pathlib.Path(maybe_xdg_config)
     system = platform.system()
-    if system == "Darwin":
-        yield tmp_home / "Library/Application Support/mamba"
-    elif system == "Linux":
+    if system == "Linux" or system == "Darwin":
         yield tmp_home / ".config/mamba"
     elif system == "Windows":
         yield pathlib.Path(os.environ["APPDATA"]) / "mamba"
@@ -209,9 +207,7 @@ def user_data_dir(tmp_home: pathlib.Path) -> Generator[pathlib.Path, None, None]
     if maybe_xdg_data:
         yield pathlib.Path(maybe_xdg_data)
     system = platform.system()
-    if system == "Darwin":
-        yield tmp_home / "Library/Application Support/mamba"
-    elif system == "Linux":
+    if system == "Linux" or system == "Darwin":
         yield tmp_home / ".local/share/mamba"
     elif system == "Windows":
         yield pathlib.Path(os.environ["APPDATA"]) / "mamba"
@@ -226,9 +222,7 @@ def user_cache_dir(tmp_home: pathlib.Path) -> Generator[pathlib.Path, None, None
     if maybe_xdg_cache:
         yield pathlib.Path(maybe_xdg_cache)
     system = platform.system()
-    if system == "Darwin":
-        yield tmp_home / "Library/Caches/mamba"
-    elif system == "Linux":
+    if system == "Linux" or system == "Darwin":
         yield tmp_home / ".cache/mamba"
     elif system == "Windows":
         yield pathlib.Path(os.environ["LOCALAPPDATA"]) / "mamba"

--- a/micromamba/tests/test_config.py
+++ b/micromamba/tests/test_config.py
@@ -45,7 +45,15 @@ def rc_file_text(rc_file_args):
 
 
 @pytest.fixture
-def rc_file(request, rc_file_text, tmp_home, tmp_root_prefix, tmp_prefix, tmp_path):
+def rc_file(
+    request,
+    rc_file_text,
+    tmp_home,
+    tmp_root_prefix,
+    tmp_prefix,
+    tmp_path,
+    user_config_dir,
+):
     """Parametrizable fixture to create an rc file at the desired location.
 
     The file is created in an isolated folder and set as the prefix, root prefix, or
@@ -59,6 +67,11 @@ def rc_file(request, rc_file_text, tmp_home, tmp_root_prefix, tmp_prefix, tmp_pa
             rc_file = tmp_root_prefix / rc_filename
         elif where == "prefix":
             rc_file = tmp_prefix / rc_filename
+        elif where == "user_config_dir":
+            rc_file = user_config_dir / rc_filename
+        elif where == "env_set_xdg":
+            os.environ["XDG_CONFIG_HOME"] = str(tmp_home / "custom_xdg_config_dir")
+            rc_file = tmp_home / "custom_xdg_config_dir" / "mamba" / rc_filename
         elif where == "absolute":
             rc_file = Path(rc_filename)
         else:
@@ -114,7 +127,6 @@ class TestConfigSources:
             res = config("sources", quiet_flag)
             assert res.startswith("Configuration files (by precedence order):")
 
-    # TODO: test OS specific sources
     # TODO: test system located sources?
     @pytest.mark.parametrize(
         "rc_file",
@@ -127,6 +139,8 @@ class TestConfigSources:
             # "/var/lib/conda/condarc",
             # "/var/lib/conda/condarc.d/",
             # "/var/lib/conda/.mambarc",
+            ("user_config_dir", "mambarc"),
+            ("env_set_xdg", "mambarc"),
             ("home", ".conda/.condarc"),
             ("home", ".conda/condarc"),
             ("home", ".conda/condarc.d"),

--- a/micromamba/tests/test_env.py
+++ b/micromamba/tests/test_env.py
@@ -78,10 +78,10 @@ def test_create():
 
 
 @pytest.mark.parametrize("shared_pkgs_dirs", [True], indirect=True)
-def test_env_remove(tmp_home, tmp_root_prefix):
+def test_env_remove(tmp_home, tmp_root_prefix, user_data_dir):
     env_name = "env-create-remove"
     env_fp = tmp_root_prefix / "envs" / env_name
-    conda_env_file = tmp_home / ".conda/environments.txt"
+    conda_env_file = user_data_dir / "environments.txt"
 
     # Create env with xtensor
     helpers.create("xtensor", "-n", env_name, "--json", no_dry_run=True)

--- a/micromamba/tests/test_info.py
+++ b/micromamba/tests/test_info.py
@@ -6,7 +6,7 @@ from . import helpers
 
 
 @pytest.mark.parametrize("prefix_selection", [None, "prefix", "name"])
-def test_base(tmp_home, tmp_root_prefix, prefix_selection):
+def test_base(tmp_home, tmp_root_prefix, prefix_selection, user_config_dir):
     os.environ["CONDA_PREFIX"] = str(tmp_root_prefix)
 
     if prefix_selection == "prefix":
@@ -15,31 +15,40 @@ def test_base(tmp_home, tmp_root_prefix, prefix_selection):
         infos = helpers.info("-n", "base")
     else:
         infos = helpers.info()
-
+    user_config = user_config_dir / "mambarc"
     assert "environment : base (active)" in infos
     assert f"env location : {tmp_root_prefix}" in infos
-    assert f"user config files : {tmp_home / '.mambarc' }" in infos
+    assert f"user config files : {user_config}" in infos
     assert f"base environment : {tmp_root_prefix}" in infos
 
 
 @pytest.mark.parametrize("prefix_selection", [None, "prefix", "name"])
-def test_env(tmp_home, tmp_root_prefix, tmp_env_name, tmp_prefix, prefix_selection):
+def test_env(
+    tmp_home,
+    tmp_root_prefix,
+    tmp_env_name,
+    tmp_prefix,
+    prefix_selection,
+    user_config_dir,
+):
     if prefix_selection == "prefix":
         infos = helpers.info("-p", tmp_prefix)
     elif prefix_selection == "name":
         infos = helpers.info("-n", tmp_env_name)
     else:
         infos = helpers.info()
-
+    user_config = user_config_dir / "mambarc"
     assert f"environment : {tmp_env_name} (active)" in infos
     assert f"env location : {tmp_prefix}" in infos
-    assert f"user config files : {tmp_home / '.mambarc' }" in infos
+    assert f"user config files : {user_config}" in infos
     assert f"base environment : {tmp_root_prefix}" in infos
 
 
 @pytest.mark.parametrize("existing_prefix", [False, True])
 @pytest.mark.parametrize("prefix_selection", [None, "env_var", "prefix", "name"])
-def test_not_env(tmp_home, tmp_root_prefix, prefix_selection, existing_prefix):
+def test_not_env(
+    tmp_home, tmp_root_prefix, prefix_selection, existing_prefix, user_config_dir
+):
     name = "not_an_env"
     prefix = tmp_root_prefix / "envs" / name
 
@@ -69,9 +78,10 @@ def test_not_env(tmp_home, tmp_root_prefix, prefix_selection, existing_prefix):
         else:
             expected_name = name + " (not found)"
         location = prefix
+    user_config = user_config_dir / "mambarc"
     print(infos)
 
     assert f"environment : {expected_name}" in infos
     assert f"env location : {location}" in infos
-    assert f"user config files : {tmp_home / '.mambarc' }" in infos
+    assert f"user config files : {user_config}" in infos
     assert f"base environment : {tmp_root_prefix}" in infos


### PR DESCRIPTION
This PR added some helper functions in addition to moving a few things around in order to support the xdg directory schema.   I think following the xdg_ dirs keeps my home directory much cleaner so I added support for it in this PR.

possibly breaking -- config right now uses a condarc, this would change it to use a mambarc... I'm not sure what the roadmap is for mambarc/condarc, but I feel like for mamba it makes sense to use mambarc.

Fixes: #1787

This is still untested and is a work in progress -- just posting to help keep track now.