### PR TITLE
Fixed create/install requiring pip install failing when the prefix have whitespaces on Windows

### DIFF
--- a/micromamba/tests/env-requires-pip-install-with-spaces.yaml
+++ b/micromamba/tests/env-requires-pip-install-with-spaces.yaml
@@ -1,0 +1,8 @@
+name: test env with spaces
+channels:
+- conda-forge
+dependencies:
+- python=3.9
+- pip
+- pip:
+  - pydantic

--- a/micromamba/tests/env-requires-pip-install.yaml
+++ b/micromamba/tests/env-requires-pip-install.yaml
@@ -1,0 +1,9 @@
+name: test_env
+channels:
+- conda-forge
+dependencies:
+- python=3.9
+- pip
+- pip:
+  - pydantic
+  

--- a/micromamba/tests/env-requires-pip-install.yaml
+++ b/micromamba/tests/env-requires-pip-install.yaml
@@ -6,4 +6,3 @@ dependencies:
 - pip
 - pip:
   - pydantic
-  

--- a/micromamba/tests/test_create.py
+++ b/micromamba/tests/test_create.py
@@ -13,6 +13,20 @@ from .helpers import *
 
 source_dir_path = os.path.dirname(os.path.realpath(__file__))
 
+this_source_file_dir_path = Path(__file__).parent.resolve()
+
+test_env_requires_pip_install_path = os.path.join(
+    this_source_file_dir_path, "env-requires-pip-install.yaml"
+)
+
+test_env_requires_pip_install_path_with_whitespaces = os.path.join(
+    this_source_file_dir_path, "env-requires-pip-install-with-spaces.yaml"
+)
+
+test_envs = [
+    test_env_requires_pip_install_path,
+    test_env_requires_pip_install_path_with_whitespaces
+]
 
 class TestCreate:
 
@@ -642,16 +656,14 @@ class TestCreate:
         assert (site_packages / pyc_fn).exists()
         assert pyc_fn.name in six_meta
 
-    test_env_requires_pip_install_path = os.path.join(
-        Path(__file__).parent.resolve(), "env-requires-pip-install.yaml"
-    )
-
-    def test_requires_pip_install(self):
+    @pytest.mark.parametrize("env_file", test_envs)
+    def test_requires_pip_install(self, env_file):
         prefix = Path(TestCreate.prefix)
-        cmd = ["-p", prefix, "-f", self.test_env_requires_pip_install_path]
+        cmd = ["-p", f"{prefix}", "-f", env_file]
         create(*cmd)
 
-    def test_requires_pip_install_prefix_spaces(self):
+    @pytest.mark.parametrize("env_file", test_envs)
+    def test_requires_pip_install_prefix_spaces(self, env_file):
         prefix = Path(f"{TestCreate.prefix} with space")
-        cmd = ["-p", prefix, "-f", self.test_env_requires_pip_install_path]
+        cmd = ["-p", f"{prefix}", "-f", env_file]
         create(*cmd)

--- a/micromamba/tests/test_create.py
+++ b/micromamba/tests/test_create.py
@@ -641,3 +641,18 @@ class TestCreate:
         create(*cmd)
         assert (site_packages / pyc_fn).exists()
         assert pyc_fn.name in six_meta
+
+    test_env_requires_pip_install_path = os.path.join(
+        Path(__file__).parent.resolve(), "env-requires-pip-install.yaml"
+    )
+    
+    def test_requires_pip_install(self):
+        prefix = Path(TestCreate.prefix)
+        cmd = ["-p", f"{prefix}", "-f", self.test_env_requires_pip_install_path]
+        create(*cmd)
+
+    def test_requires_pip_install_prefix_spaces(self):
+        prefix = Path(f"{TestCreate.prefix} with space")
+        cmd = ["-p", f"{prefix}", "-f", self.test_env_requires_pip_install_path]
+        create(*cmd)
+

--- a/micromamba/tests/test_create.py
+++ b/micromamba/tests/test_create.py
@@ -645,7 +645,7 @@ class TestCreate:
     test_env_requires_pip_install_path = os.path.join(
         Path(__file__).parent.resolve(), "env-requires-pip-install.yaml"
     )
-    
+
     def test_requires_pip_install(self):
         prefix = Path(TestCreate.prefix)
         cmd = ["-p", f"{prefix}", "-f", self.test_env_requires_pip_install_path]
@@ -655,4 +655,3 @@ class TestCreate:
         prefix = Path(f"{TestCreate.prefix} with space")
         cmd = ["-p", f"{prefix}", "-f", self.test_env_requires_pip_install_path]
         create(*cmd)
-

--- a/micromamba/tests/test_create.py
+++ b/micromamba/tests/test_create.py
@@ -25,8 +25,9 @@ test_env_requires_pip_install_path_with_whitespaces = os.path.join(
 
 test_envs = [
     test_env_requires_pip_install_path,
-    test_env_requires_pip_install_path_with_whitespaces
+    test_env_requires_pip_install_path_with_whitespaces,
 ]
+
 
 class TestCreate:
 

--- a/micromamba/tests/test_create.py
+++ b/micromamba/tests/test_create.py
@@ -653,5 +653,5 @@ class TestCreate:
 
     def test_requires_pip_install_prefix_spaces(self):
         prefix = Path(f"{TestCreate.prefix} with space")
-        cmd = ["-p", f"{prefix}", "-f", self.test_env_requires_pip_install_path]
+        cmd = ["-p", prefix, "-f", self.test_env_requires_pip_install_path]
         create(*cmd)

--- a/micromamba/tests/test_create.py
+++ b/micromamba/tests/test_create.py
@@ -648,7 +648,7 @@ class TestCreate:
 
     def test_requires_pip_install(self):
         prefix = Path(TestCreate.prefix)
-        cmd = ["-p", f"{prefix}", "-f", self.test_env_requires_pip_install_path]
+        cmd = ["-p", prefix, "-f", self.test_env_requires_pip_install_path]
         create(*cmd)
 
     def test_requires_pip_install_prefix_spaces(self):


### PR DESCRIPTION
Also adds tests checking this issue in the first commit. They fail for me on Windows 11 without the fix provided in the second commit.

I believe this should fix #1805  which was re-opened after #1828 re-introduced the issue.
