### PR TITLE
remove duplicate console output

### DIFF
--- a/libmamba/src/core/shell_init.cpp
+++ b/libmamba/src/core/shell_init.cpp
@@ -177,10 +177,6 @@ namespace mamba
         // join the list back into a string
         std::wstring new_value = join(L" & ", autorun_list);
 
-        std::cout << "Setting cmd.exe AUTORUN to: " << termcolor::green;
-        std::wcout << new_value;
-        std::cout << termcolor::reset << std::endl;
-
         // set modified registry key
         if (new_value != prev_value)
         {


### PR DESCRIPTION
Duplicate console output: 

[Here](https://github.com/mamba-org/mamba/blob/ae473581380ed64f5dbdea2a25b12a71fb7ea75c/libmamba/src/core/shell_init.cpp#L101) and [here](https://github.com/mamba-org/mamba/blob/ae473581380ed64f5dbdea2a25b12a71fb7ea75c/libmamba/src/core/shell_init.cpp#L180).