### PR TITLE
Fix zsh for micro.mamba.pm ci

### DIFF
--- a/.github/workflows/test_micro.mamba.pm.yml
+++ b/.github/workflows/test_micro.mamba.pm.yml
@@ -22,11 +22,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-        shell: [bash]
-        # TODO: Fix zsh support
-        # include:
-        #   - {os: macos-latest, shell: zsh}
+        include:
+          - {os: ubuntu-latest, shell: bash, shell-source-param: -i}
+          - {os: macos-latest, shell: zsh, shell-source-param: -i}
+          - {os: macos-latest, shell: bash, shell-source-param: -l}
+          - {os: windows-latest, shell: bash, shell-source-param: -l}
     steps:
       - name: Install Micromamba (${{ matrix.os }}, ${{ matrix.shell }})
         run: |
@@ -39,7 +39,13 @@ jobs:
             curl http://micro.mamba.pm/install.sh | ${{ matrix.shell }}
           fi
       - name: Test Micromamba
-        run: ${{ matrix.shell }} -elc "micromamba --version"
+        # remove /home/runner/.local/bin because the micromamba executable is located
+        # there and this would overwrite the micromamba function defined
+        # by the mamba activate block
+        # use either -l or -i to source .bash_profile or .bashrc/.zshrc
+        run: |
+          export PATH=${PATH/':/home/runner/.local/bin'/}
+          ${{ matrix.shell }} ${{ matrix.shell-source-param }} -ec micromamba
       - uses: dblock/create-a-github-issue@2c9fa0d32c24d651281c37d21e5b49e333500fe8
         #if: failure()
         if: false


### PR DESCRIPTION
Okay, so this probably needs a bit of explanation, I'm going to be a bit more detailed since I think that one can learn a thing or two here about how `bash` and `zsh` sourcing works...

Before, the `micromamba --version` command was tested using `${{ matrix.shell }} -elc "micromamba --version"`. 

This worked on bash + Ubuntu, bash + macOS and bash + Windows. But actually, it only should work on the latter two. 

For this, we need to take a quick™ detour into login and interactive shells. 

`bash -l` (as used before in the action) is used to make bash act as if it had been invoked as a login shell. This means that the `.bash_profile` is loaded. 
`bash -i` is used to make bash as an interactive shell. _Only then_, the `.bashrc` is loaded. 

Since the mamba initialize block is in the `.bash_profile` under Windows and macOS, the action works there without problems. But the mamba initialize block is in the `.bashrc` under Ubuntu. So why did it still [work](https://github.com/mamba-org/mamba/runs/7743626601?check_suite_focus=true) there in the action? 

For this, we will take a look at what `PATH` looks like in our runner.

```bash
runner@fv-az214-585:~/work/mamba/mamba$ echo $PATH
/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin:/home/runner/.local/bin:/opt/pipx_bin:/home/runner/.cargo/bin:/home/runner/.config/composer/vendor/bin:/usr/local/.ghcup/bin:/home/runner/.dotnet/tools:/snap/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin
```

The answer is because the `/home/runner/.local/bin` was in the `PATH` variable in the GitHub runner. The `micromamba` executable is in this folder, thus Ubuntu doesn't complain when executing `micromamba --version`. Also, this path variable overrides the `micromamba` function that gets defined in the mamba initialize block in the `.bashrc`. This leads to numerous errors when actually wanting to use `micromamba` (not just `--version`).

The problem, in general, is that using only `micromamba --version` does not check that `micromamba` got initialized correctly. `micromamba --version` still works when executing the binary directly. Since the [micro.mamba.pm/install.sh](http://micro.mamba.pm/install.sh) script also includes some logic for the shell initialization, I think it makes sense to still check here that `micromamba` got inialized correctly. So let's execute `micromamba` instead of `micromamba --version` (like this, the version also gets printed out).

A solution to the path problem mentioned above would be to strip the `PATH` variable of `/home/runner/.local/bin`. On the other systems, the `/home/runner/.local/bin` would get deleted too which should be no problem if they just don't exist in their `$PATH`...

Now to the actual fix of the `zsh` issue: Since `zsh` only has a `.zshrc` that gets written to by `micromamba shell init`, we need `zsh -i` instead of `zsh -l`. 
Unfortunately, when executing `bash -il`, `bash` doesn't source both the `.bashrc` and the `.bash_profile` but only the `.bash_profile` which still leaves us at the problem that it would now crash for Ubuntu + bash. 

So I would suggest we just add the different `-i` and `-l` parameters in the matrix and call it a day...

Btw @wolfv is there a reason why we use different locations for the mamba initialize block?



~~This should work, I still need to test it one last time... For some reason, my CI is not letting any new jobs through because an old one is not able to cancel...~~ The CI Job is tested [here](https://github.com/pavelzw/mamba/runs/7757630056?check_suite_focus=true).