### PR TITLE
Fix Linux version regex

### DIFF
--- a/libmamba/src/core/util_os.cpp
+++ b/libmamba/src/core/util_os.cpp
@@ -298,7 +298,7 @@ namespace mamba
             return "";
         }
 
-        std::regex re("([0-9]+\\.[0-9]+\\.[0-9]+)-.*");
+        std::regex re("([0-9]+\\.[0-9]+\\.[0-9]+)(?:-.*)?");
         std::smatch m;
 
         if (std::regex_search(out, m, re))
@@ -310,6 +310,8 @@ namespace mamba
                 return linux_version.str();
             }
         }
+
+        LOG_DEBUG << "Could not parse linux version";
 
         return "";
     }


### PR DESCRIPTION
Closes #1851 

Current PR fixes an incorrect regex for detecting Linux kernel versions leading to not being able to create a Linux virtual package on certain distros.