### PR TITLE
Add explicit channels to update

### DIFF
--- a/libmamba/src/api/install.cpp
+++ b/libmamba/src/api/install.cpp
@@ -403,10 +403,9 @@ namespace mamba
         MultiPackageCache package_caches(ctx.pkgs_dirs);
 
         // add channels from specs
-        std::vector<mamba::MatchSpec> match_specs(specs.begin(), specs.end());
-        for (const auto& m : match_specs)
+        for (const auto& s : specs)
         {
-            if (!m.channel.empty())
+            if (auto m = MatchSpec{ s }; !m.channel.empty())
             {
                 ctx.channels.push_back(m.channel);
             }

--- a/libmamba/src/api/update.cpp
+++ b/libmamba/src/api/update.cpp
@@ -29,6 +29,15 @@ namespace mamba
 
         auto update_specs = config.at("specs").value<std::vector<std::string>>();
 
+        // add channels from specs
+        for (const auto& s : update_specs)
+        {
+            if (auto m = MatchSpec{ s }; !m.channel.empty())
+            {
+                ctx.channels.push_back(m.channel);
+            }
+        }
+
         int solver_flag = SOLVER_UPDATE;
 
         MPool pool;


### PR DESCRIPTION
Closes #1846

This should to be enough to solve the issue.

@wolfv 
- This piece of code is duplicated from `install_specs` so there should be a better place to put it.  Perhaps we could do it in `add_channel_specifc_job`, but we do not have access to the context there; or perhaps we change the order of the instruction in `mamba::update` (not sure what an `MTransaction` is).
  It seems that
  - running `micromamba install` we go through it order `install_specs` then `add_job>add_channel_specifc_job`;
  - running `micromamba update`  we go through it order `add_job>add_channel_specifc_job` then `MTransaction>install_specs`;
- Where do you think would be a good place to add a test for this? It is a `libmamba` change, but high-level tests seems to rather be done in `mamba` or `micromamba`
