### PR TITLE
Fix Windows CI

### DIFF
--- a/micromamba/environment-dev.yml
+++ b/micromamba/environment-dev.yml
@@ -23,3 +23,4 @@ dependencies:
   - pyyaml
   - spdlog
   - sel(win): winreg
+  - sel(win): pywin32


### PR DESCRIPTION
Windows CI currently gives the following error
```
micromamba\tests\test_menuinst.py:15: in <module>
    import win32com.client
E   ModuleNotFoundError: No module named 'win32com'
```