### PR TITLE
Add `brew` installation option to micromamba

### DIFF
--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -146,7 +146,7 @@ Manual
 
 Otherwise, you can use the download script; here, instructions are mostly the same as with :ref:`linux<umamba-install-linux>`.
 
-However, you need to download a different `micromamba`` binary depending if you are using an Apple Silicon or an Intel Mac.need to download a different `micromamba` binary depending if you are using an Apple Silicon or an Intel Mac.
+However, you need to download a different `micromamba`` binary depending if you are using an Apple Silicon or an Intel Mac.
 
 Apple Silicon:
 

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -128,12 +128,25 @@ Now you can activate the base environment and install new packages, or create ot
 
 .. _umamba-install-osx:
 
-OS X
-****
+macOS
+*****
+``micromamba`` has macOS support as well.
 
-``micromamba`` has OS X support as well. Instructions are largely the same as :ref:`linux<umamba-install-linux>`:
+brew
+^^^^
+If you have ``brew`` installed you can get ``micromamba`` as a cask with
 
-You need to download a different `micromamba` binary depending if you are using an Apple Silicon or an Intel Mac.
+.. code::
+
+ brew install --cask micromamba
+
+
+Manual
+^^^^^^
+
+Otherwise, you can use the download script; here, instructions are mostly the same as with :ref:`linux<umamba-install-linux>`.
+
+However, you need to download a different `micromamba`` binary depending if you are using an Apple Silicon or an Intel Mac.need to download a different `micromamba` binary depending if you are using an Apple Silicon or an Intel Mac.
 
 Apple Silicon:
 


### PR DESCRIPTION
Hey, 

Recently, I have added a formula to `homebrew`, the beloved package manager, and wanted to include this in the docs.
I have also changed the reference from `OS X` to `macOS` here since it's the official name now, but that should probably be also done in some other place.s

I hope it's okay for documentation additions to go the direct PR route since the changes are often so straightforward.

Thanks for the review!