### PR TITLE
Add fully static micromamba build for Windows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,6 @@ jobs:
           environment-file: ./libmamba/environment-dev.yml
           environment-name: build_env
           cache-env: true
-          micromamba-version: "0.23.0"
       - uses: hendrikmuhs/ccache-action@main
         with:
           variant: sccache
@@ -66,7 +65,6 @@ jobs:
           environment-file: ./libmamba/environment-dev.yml
           environment-name: build_env
           cache-env: true
-          micromamba-version: "0.23.0"
       - uses: hendrikmuhs/ccache-action@main
         with:
           variant: sccache
@@ -110,7 +108,6 @@ jobs:
           environment-file: ./micromamba/environment-dev.yml
           environment-name: build_env
           cache-env: true
-          micromamba-version: "0.23.0"
       - uses: hendrikmuhs/ccache-action@main
         with:
           variant: sccache
@@ -171,7 +168,6 @@ jobs:
           environment-file: ./mamba/environment-dev.yml
           environment-name: build_env
           cache-env: true
-          micromamba-version: "0.23.0"
           extra-specs: |
             conda-build
             python=${{ matrix.python_version }}
@@ -278,7 +274,6 @@ jobs:
         with:
           environment-file: ./libmamba/environment-dev.yml
           environment-name: build_env
-          micromamba-version: "0.23.0"
           cache-env: true
       - uses: hendrikmuhs/ccache-action@main
         with:
@@ -321,7 +316,6 @@ jobs:
         with:
           environment-file: ./mamba/environment-dev.yml
           environment-name: build_env
-          micromamba-version: "0.23.0"
           cache-env: true
           extra-specs: |
             conda-build
@@ -416,7 +410,6 @@ jobs:
         with:
           environment-file: ./libmamba/environment-dev.yml
           environment-name: build_env
-          micromamba-version: "0.23.0"
           cache-env: true
       - uses: hendrikmuhs/ccache-action@main
         with:
@@ -463,7 +456,6 @@ jobs:
         with:
           environment-file: ./micromamba/environment-dev.yml
           environment-name: build_env
-          micromamba-version: "0.23.0"
           cache-env: true
       - uses: hendrikmuhs/ccache-action@main
         with:
@@ -530,7 +522,6 @@ jobs:
         with:
           environment-file: ./micromamba/environment-dev.yml
           environment-name: build_env
-          micromamba-version: "0.23.0"
           extra-specs: menuinst
 
       - name: micromamba python based tests with pwsh
@@ -581,7 +572,6 @@ jobs:
           environment-file: ./micromamba/environment-dev.yml
           environment-name: build_env
           cache-env: true
-          micromamba-version: "0.23.0"
       - name: create build environment
         run: micromamba install -y -n build_env -f ./libmamba/environment-static-dev.yml
       - uses: hendrikmuhs/ccache-action@main

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -283,14 +283,18 @@ jobs:
         shell: cmd /C call {0}
         run: |
           call micromamba activate build_env
+          if %errorlevel% neq 0 exit /b %errorlevel%
           mkdir build
+          if %errorlevel% neq 0 exit /b %errorlevel%
           cd build
+          if %errorlevel% neq 0 exit /b %errorlevel%
           cmake .. -DCMAKE_INSTALL_PREFIX=%CONDA_PREFIX%\Library ^
                    -DBUILD_LIBMAMBA=ON ^
                    -DBUILD_STATIC=ON ^
                    -DCMAKE_CXX_COMPILER_LAUNCHER=sccache ^
                    -DCMAKE_C_COMPILER_LAUNCHER=sccache ^
                    -GNinja
+          if %errorlevel% neq 0 exit /b %errorlevel%
           ninja
       - name: build cache statistics
         run: sccache --show-stats
@@ -333,8 +337,11 @@ jobs:
         shell: cmd /C call {0}
         run: |
           call micromamba activate build_env
+          if %errorlevel% neq 0 exit /b %errorlevel%
           mkdir build
+          if %errorlevel% neq 0 exit /b %errorlevel%
           cd build
+          if %errorlevel% neq 0 exit /b %errorlevel%
           cmake .. -DCMAKE_INSTALL_PREFIX=%CONDA_PREFIX%\Library ^
                    -DBUILD_LIBMAMBAPY=ON ^
                    -DBUILD_LIBMAMBA=ON ^
@@ -343,7 +350,9 @@ jobs:
                    -DCMAKE_CXX_COMPILER_LAUNCHER=sccache ^
                    -DCMAKE_C_COMPILER_LAUNCHER=sccache ^
                    -GNinja
+          if %errorlevel% neq 0 exit /b %errorlevel%
           ninja
+          if %errorlevel% neq 0 exit /b %errorlevel%
           ninja install
       - name: install libmambapy
         shell: cmd /C call {0}
@@ -421,8 +430,11 @@ jobs:
         shell: cmd /C call {0}
         run: |
           call micromamba activate build_env
+          if %errorlevel% neq 0 exit /b %errorlevel%
           mkdir build
+          if %errorlevel% neq 0 exit /b %errorlevel%
           cd build
+          if %errorlevel% neq 0 exit /b %errorlevel%
           cmake .. -DCMAKE_INSTALL_PREFIX=%CONDA_PREFIX%\Library ^
                    -DBUILD_LIBMAMBA_TESTS=ON ^
                    -DBUILD_LIBMAMBA=ON ^
@@ -430,7 +442,9 @@ jobs:
                    -DCMAKE_CXX_COMPILER_LAUNCHER=sccache ^
                    -DCMAKE_C_COMPILER_LAUNCHER=sccache ^
                    -GNinja
+          if %errorlevel% neq 0 exit /b %errorlevel%
           ninja install
+          if %errorlevel% neq 0 exit /b %errorlevel%
           ninja test
       - name: build cache statistics
         run: sccache --show-stats
@@ -467,8 +481,11 @@ jobs:
         shell: cmd /C call {0}
         run: |
           call micromamba activate build_env
+          if %errorlevel% neq 0 exit /b %errorlevel%
           mkdir build
+          if %errorlevel% neq 0 exit /b %errorlevel%
           cd build
+          if %errorlevel% neq 0 exit /b %errorlevel%
           cmake .. -DCMAKE_INSTALL_PREFIX=%CONDA_PREFIX%\Library ^
                    -DBUILD_MICROMAMBA=ON ^
                    -DMICROMAMBA_LINKAGE=STATIC ^
@@ -477,6 +494,7 @@ jobs:
                    -DCMAKE_CXX_COMPILER_LAUNCHER=sccache ^
                    -DCMAKE_C_COMPILER_LAUNCHER=sccache ^
                    -GNinja
+          if %errorlevel% neq 0 exit /b %errorlevel%
           ninja install
       - name: check that micromamba runs
         shell: cmd /C call {0}
@@ -536,10 +554,15 @@ jobs:
       # - name: micromamba python based tests
       #   shell: cmd /C call {0}
       #   run: |
+      #     if %errorlevel% neq 0 exit /b %errorlevel%
       #     set PYTHONIOENCODING=UTF-8
+      #     if %errorlevel% neq 0 exit /b %errorlevel%
       #     set MAMBA_ROOT_PREFIX=%cd%\mambaroot
+      #     if %errorlevel% neq 0 exit /b %errorlevel%
       #     set MAMBA_TEST_SHELL_TYPE=cmd.exe
+      #     if %errorlevel% neq 0 exit /b %errorlevel%
       #     reg delete "HKEY_CURRENT_USER\Software\Microsoft\Command Processor" /v AutoRun /f
+      #     if %errorlevel% neq 0 exit /b %errorlevel%
       #
       #     pytest -v --capture=tee-sys micromamba/tests/test_shell.py
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -572,7 +572,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]  # Windows: missing yaml-cpp-static
+        os: [ubuntu-latest, macos-latest]
     steps:
       - uses: actions/checkout@v3
       - name: create build environment
@@ -615,3 +615,79 @@ jobs:
         with:
           name: micromamba_fully_static_binary
           path: build/micromamba/micromamba
+
+  micromamba_full_static_win:
+    # These build instructions are based on https://github.com/conda-forge/micromamba-feedstock
+    runs-on: windows-2019
+    steps:
+      - uses: actions/checkout@v3
+      - name: create build environment
+        uses: mamba-org/provision-with-micromamba@main
+        with:
+          environment-file: ./libmamba/environment-static-dev-win.yml
+          environment-name: build_env
+          cache-env: true  # this also caches the vcpkg builds
+      - name: build static windows dependencies with vcpkg
+        shell: cmd /C CALL {0}
+        run: |
+          call micromamba activate build_env
+          if %errorlevel% neq 0 exit /b %errorlevel%
+          mkdir build
+          if %errorlevel% neq 0 exit /b %errorlevel%
+          cd build
+          if %errorlevel% neq 0 exit /b %errorlevel%
+          git clone https://github.com/conda-forge/micromamba-feedstock.git
+          if %errorlevel% neq 0 exit /b %errorlevel%
+          ROBOCOPY micromamba-feedstock/recipe/libsolv %VCPKG_ROOT%/ports/libsolv
+          @rem ROBOCOPY has 0 and 1 as successfull exit codes
+          if %errorlevel% neq 0 if %errorlevel% neq 1 exit /b %errorlevel%
+          SET VCPKG_BUILD_TYPE=release && vcpkg install libsolv[conda] --triplet x64-windows-static
+          if %errorlevel% neq 0 exit /b %errorlevel%
+          vcpkg install "libarchive[bzip2,lz4,lzma,lzo,openssl,zstd]" --triplet x64-windows-static
+          if %errorlevel% neq 0 exit /b %errorlevel%
+          vcpkg install curl --triplet x64-windows-static
+          if %errorlevel% neq 0 exit /b %errorlevel%
+          vcpkg install yaml-cpp --triplet x64-windows-static
+          if %errorlevel% neq 0 exit /b %errorlevel%
+          vcpkg install reproc --triplet x64-windows-static
+          if %errorlevel% neq 0 exit /b %errorlevel%
+          set CMAKE_PREFIX_PATH=%VCPKG_ROOT%\installed\x64-windows-static\;%CMAKE_PREFIX_PATH%
+          if %errorlevel% neq 0 exit /b %errorlevel%
+      - name: Apply libmamba.patch
+        run: |
+          cd libmamba
+          patch < ../build/micromamba-feedstock/recipe/libmamba.patch
+        shell: bash
+      - uses: hendrikmuhs/ccache-action@main
+        with:
+          variant: sccache
+          key: ${{ github.job }}-windows-2019
+      - name: build micromamba
+        shell: cmd /C CALL {0}
+        run: |
+          call micromamba activate build_env
+          if %errorlevel% neq 0 exit /b %errorlevel%
+          cd build
+          if %errorlevel% neq 0 exit /b %errorlevel%
+          cmake .. ^
+              -D CMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% ^
+              -D CMAKE_PREFIX_PATH="%VCPKG_ROOT%\installed\x64-windows-static;%CMAKE_PREFIX_PATH%" ^
+              -D CMAKE_BUILD_TYPE="Release" ^
+              -D BUILD_LIBMAMBA=ON ^
+              -D BUILD_STATIC_DEPS=ON ^
+              -D BUILD_MICROMAMBA=ON ^
+              -D MICROMAMBA_LINKAGE=FULL_STATIC ^
+              -G "Ninja"
+          if %errorlevel% neq 0 exit /b %errorlevel%
+          ninja install
+          if %errorlevel% neq 0 exit /b %errorlevel%
+          sccache --show-stats
+          if %errorlevel% neq 0 exit /b %errorlevel%
+          .\micromamba\micromamba.exe --version
+          if %errorlevel% neq 0 exit /b %errorlevel%
+          .\micromamba\micromamba.exe --help
+          if %errorlevel% neq 0 exit /b %errorlevel%
+      - uses: actions/upload-artifact@v3
+        with:
+          name: micromamba_fully_static_binary
+          path: build/micromamba/micromamba.exe

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -507,7 +507,7 @@ jobs:
         run: tar -cvf umamba.tar build/micromamba/micromamba.exe
       - uses: actions/upload-artifact@v2
         with:
-          name: micromamba_binary
+          name: _internal_micromamba_binary
           path: umamba.tar
       - name: Cleanup
         shell: bash -l {0}
@@ -528,7 +528,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/download-artifact@v2
         with:
-          name: micromamba_binary
+          name: _internal_micromamba_binary
 
       - name: untar micromamba artifact
         shell: bash -l -eo pipefail {0}
@@ -626,7 +626,7 @@ jobs:
         run: sccache --show-stats
       - uses: actions/upload-artifact@v3
         with:
-          name: micromamba_fully_static_binary
+          name: Fully static binary (${{ matrix.os }})
           path: build/micromamba/micromamba
 
   micromamba_full_static_win:
@@ -702,5 +702,5 @@ jobs:
           if %errorlevel% neq 0 exit /b %errorlevel%
       - uses: actions/upload-artifact@v3
         with:
-          name: micromamba_fully_static_binary
+          name: Fully static binary (windows-2019)
           path: build/micromamba/micromamba.exe

--- a/libmamba/environment-static-dev-win.yml
+++ b/libmamba/environment-static-dev-win.yml
@@ -1,0 +1,17 @@
+name: mamba-dev
+channels:
+  - conda-forge
+dependencies:
+  - vs2019_win-64
+  - ninja
+  - vcpkg
+  - python
+  - curl
+  - cli11 >=2.2,<3
+  - cpp-expected
+  - cpp-filesystem
+  - nlohmann_json
+  - spdlog
+  - termcolor-cpp
+  - zlib
+  - winreg


### PR DESCRIPTION
- Add fully static micromamba build in CI
- Add errorlevel checks since `cmd.exe` doesn't automatically fail if a command fails
- Remove `micromamba-version: "0.23.0"` since we are way past #1670

Closes #1860.