### PR TITLE
Install from lockfile by category

### DIFF
--- a/libmamba/include/mamba/api/install.hpp
+++ b/libmamba/include/mamba/api/install.hpp
@@ -33,7 +33,9 @@ namespace mamba
                        int is_retry = 0);
 
     void install_explicit_specs(const std::vector<std::string>& specs, bool create_env = false);
-    void install_lockfile_specs(const fs::u8path& lockfile_specs, bool create_env = false);
+    void install_lockfile_specs(const fs::u8path& lockfile_specs,
+                                const std::vector<std::string>& categories,
+                                bool create_env = false);
 
     namespace detail
     {

--- a/libmamba/include/mamba/core/transaction.hpp
+++ b/libmamba/include/mamba/core/transaction.hpp
@@ -180,6 +180,7 @@ namespace mamba
     MTransaction create_explicit_transaction_from_lockfile(
         MPool& pool,
         const fs::u8path& env_lockfile_path,
+        const std::vector<std::string>& categories,
         MultiPackageCache& package_caches,
         std::vector<detail::other_pkg_mgr_spec>& other_specs);
 }  // namespace mamba

--- a/libmamba/src/api/configuration.cpp
+++ b/libmamba/src/api/configuration.cpp
@@ -1264,6 +1264,10 @@ namespace mamba
                    .group("Solver")
                    .description("Only install dependencies"));
 
+        insert(Configurable("categories", std::vector<std::string>({ "main" }))
+                   .group("Solver")
+                   .description("Package categories to consider"));
+
         insert(Configurable("retry_clean_cache", false)
                    .group("Solver")
                    .set_env_var_names()

--- a/libmamba/src/api/configuration.cpp
+++ b/libmamba/src/api/configuration.cpp
@@ -1266,7 +1266,7 @@ namespace mamba
 
         insert(Configurable("categories", std::vector<std::string>({ "main" }))
                    .group("Solver")
-                   .description("Package categories to consider"));
+                   .description("Package categories to consider when installing from a lock file"));
 
         insert(Configurable("retry_clean_cache", false)
                    .group("Solver")

--- a/libmamba/src/api/create.cpp
+++ b/libmamba/src/api/create.cpp
@@ -63,7 +63,10 @@ namespace mamba
         {
             const auto lockfile_path = Context::instance().env_lockfile.value();
             LOG_DEBUG << "Lockfile: " << lockfile_path.string();
-            install_lockfile_specs(lockfile_path, true);
+            install_lockfile_specs(
+                lockfile_path,
+                Configuration::instance().at("categories").value<std::vector<std::string>>(),
+                true);
         }
         else if (!create_specs.empty())
         {

--- a/libmamba/src/api/install.cpp
+++ b/libmamba/src/api/install.cpp
@@ -359,7 +359,10 @@ namespace mamba
         {
             const auto lockfile_path = Context::instance().env_lockfile.value();
             LOG_DEBUG << "Lockfile: " << lockfile_path.string();
-            install_lockfile_specs(lockfile_path, false);
+            install_lockfile_specs(
+                lockfile_path,
+                Configuration::instance().at("categories").value<std::vector<std::string>>(),
+                false);
         }
         else if (!install_specs.empty())
         {
@@ -594,12 +597,15 @@ namespace mamba
             create_env);
     }
 
-    void install_lockfile_specs(const fs::u8path& lockfile, bool create_env)
+    void install_lockfile_specs(const fs::u8path& lockfile,
+                                const std::vector<std::string>& categories,
+                                bool create_env)
     {
         detail::install_explicit_with_transaction(
-            [&](auto& pool, auto& pkg_caches, auto& others) {
+            [&](auto& pool, auto& pkg_caches, auto& others)
+            {
                 return create_explicit_transaction_from_lockfile(
-                    pool, lockfile, pkg_caches, others);
+                    pool, lockfile, categories, pkg_caches, others);
             },
             create_env);
     }

--- a/libmamba/src/core/transaction.cpp
+++ b/libmamba/src/core/transaction.cpp
@@ -1563,6 +1563,7 @@ namespace mamba
     MTransaction create_explicit_transaction_from_lockfile(
         MPool& pool,
         const fs::u8path& env_lockfile_path,
+        const std::vector<std::string>& categories,
         MultiPackageCache& package_caches,
         std::vector<detail::other_pkg_mgr_spec>& other_specs)
     {
@@ -1573,31 +1574,45 @@ namespace mamba
 
         const auto lockfile_data = maybe_lockfile.value();
 
-        constexpr auto default_category = "main";
         constexpr auto default_manager = "conda";
 
-        const auto packages = lockfile_data.get_packages_for(
-            default_category, Context::instance().platform, default_manager);
-
-        // extract pip packages
+        struct
         {
-            const auto pip_packages = lockfile_data.get_packages_for(
-                default_category, Context::instance().platform, "pip");
-            if (!pip_packages.empty())
-            {
-                std::vector<std::string> pip_specs;
-                for (const auto& package : pip_packages)
-                {
-                    pip_specs.push_back(package.name + " @ " + package.url
-                                        + "#sha256=" + package.sha256);
-                }
-                other_specs.push_back({ "pip --no-deps",
-                                        pip_specs,
-                                        fs::absolute(env_lockfile_path.parent_path()).string() });
-            }
+            std::vector<PackageInfo> conda, pip;
+        } packages;
+
+        for (const auto& category : categories)
+        {
+            std::vector<PackageInfo> selected_packages;
+
+            selected_packages = lockfile_data.get_packages_for(
+                category, Context::instance().platform, default_manager);
+            std::copy(selected_packages.begin(),
+                      selected_packages.end(),
+                      std::back_inserter(packages.conda));
+
+            selected_packages
+                = lockfile_data.get_packages_for(category, Context::instance().platform, "pip");
+            std::copy(selected_packages.begin(),
+                      selected_packages.end(),
+                      std::back_inserter(packages.pip));
         }
 
-        return MTransaction{ pool, packages, package_caches };
+        // extract pip packages
+        if (!packages.pip.empty())
+        {
+            std::vector<std::string> pip_specs;
+            for (const auto& package : packages.pip)
+            {
+                pip_specs.push_back(package.name + " @ " + package.url
+                                    + "#sha256=" + package.sha256);
+            }
+            other_specs.push_back({ "pip --no-deps",
+                                    pip_specs,
+                                    fs::absolute(env_lockfile_path.parent_path()).string() });
+        }
+
+        return MTransaction{ pool, packages.conda, package_caches };
     }
 
 }  // namespace mamba

--- a/libmamba/src/core/transaction.cpp
+++ b/libmamba/src/core/transaction.cpp
@@ -1574,8 +1574,6 @@ namespace mamba
 
         const auto lockfile_data = maybe_lockfile.value();
 
-        constexpr auto default_manager = "conda";
-
         struct
         {
             std::vector<PackageInfo> conda, pip;
@@ -1585,8 +1583,8 @@ namespace mamba
         {
             std::vector<PackageInfo> selected_packages;
 
-            selected_packages = lockfile_data.get_packages_for(
-                category, Context::instance().platform, default_manager);
+            selected_packages
+                = lockfile_data.get_packages_for(category, Context::instance().platform, "conda");
             std::copy(selected_packages.begin(),
                       selected_packages.end(),
                       std::back_inserter(packages.conda));

--- a/libmamba/tests/env_lockfile_test/good_multiple_categories-lock.yaml
+++ b/libmamba/tests/env_lockfile_test/good_multiple_categories-lock.yaml
@@ -1,0 +1,483 @@
+
+metadata:
+  channels:
+  - url: conda-forge
+    used_env_vars: []
+  content_hash:
+    linux-64: 3e6ffafafc28a0beefa39dbfa354f3aa1972ce9c8de32e68ab099ad7f5e9dc43
+  platforms:
+  - linux-64
+  sources:
+  - main.yaml
+  - dev.yaml
+package:
+- category: dev
+  dependencies: {}
+  hash:
+    md5: d7c89558ba9fa0495403155b64376d81
+    sha256: fe51de6107f9edc7aa4f786a70f4a883943bc9d39b3bb7307c04c41410990726
+  manager: conda
+  name: _libgcc_mutex
+  optional: true
+  platform: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
+  version: '0.1'
+- category: dev
+  dependencies: {}
+  hash:
+    md5: 2be128ae4d5e44803720d43644ce3e3e
+    sha256: 27a6442ae7ef10d7935cd60aac9f3b33f687cd926ff2559e6bf05c02d8b189e1
+  manager: conda
+  name: ca-certificates
+  optional: true
+  platform: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/ca-certificates-2022.6.15.1-ha878542_0.tar.bz2
+  version: 2022.6.15.1
+- category: dev
+  dependencies: {}
+  hash:
+    md5: bd4f2e711b39af170e7ff15163fe87ee
+    sha256: ad7985a9ff622880cf87c42db1ffe2dfb040d8175c1bb352fc8f3705c7e0962f
+  manager: conda
+  name: ld_impl_linux-64
+  optional: true
+  platform: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.36.1-hea4e1c9_2.tar.bz2
+  version: 2.36.1
+- category: dev
+  dependencies: {}
+  hash:
+    md5: a56386ad31a7322940dd7d03fb3a9979
+    sha256: 8a6a7c6217c79f1afaf0fea71463a5577e2a165a743a04afd45b200d344d6de9
+  manager: conda
+  name: tzdata
+  optional: true
+  platform: linux-64
+  url: https://conda.anaconda.org/conda-forge/noarch/tzdata-2022c-h191b570_0.tar.bz2
+  version: 2022c
+- category: dev
+  dependencies:
+    _libgcc_mutex: 0.1 conda_forge
+  hash:
+    md5: f013cf7749536ce43d82afbffdf499ab
+    sha256: 499fab15d3897a7bf7a1d82dd44c76dad1ceeaec0b71e348e77fb8a753ff898d
+  manager: conda
+  name: libgomp
+  optional: true
+  platform: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgomp-12.1.0-h8d9b700_16.tar.bz2
+  version: 12.1.0
+- category: dev
+  dependencies:
+    _libgcc_mutex: 0.1 conda_forge
+    libgomp: '>=7.5.0'
+  hash:
+    md5: 73aaf86a425cc6e73fcf236a5a46396d
+    sha256: fbe2c5e56a653bebb982eda4876a9178aedfc2b545f25d0ce9c4c0b508253d22
+  manager: conda
+  name: _openmp_mutex
+  optional: true
+  platform: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-2_gnu.tar.bz2
+  version: '4.5'
+- category: dev
+  dependencies:
+    _libgcc_mutex: 0.1 conda_forge
+    _openmp_mutex: '>=4.5'
+  hash:
+    md5: 4f05bc9844f7c101e6e147dab3c88d5c
+    sha256: 2fde3d9f0199bf4f5447b35d3fd74d058c17ef2b6c68815eb1b469f2aec138b9
+  manager: conda
+  name: libgcc-ng
+  optional: true
+  platform: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-12.1.0-h8d9b700_16.tar.bz2
+  version: 12.1.0
+- category: dev
+  dependencies:
+    libgcc-ng: '>=9.3.0'
+  hash:
+    md5: a1fd65c7ccbf10880423d82bca54eb54
+    sha256: cb521319804640ff2ad6a9f118d972ed76d86bea44e5626c09a13d38f562e1fa
+  manager: conda
+  name: bzip2
+  optional: true
+  platform: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-h7f98852_4.tar.bz2
+  version: 1.0.8
+- category: dev
+  dependencies:
+    libgcc-ng: '>=9.4.0'
+  hash:
+    md5: d645c6d2ac96843a2bfaccd2d62b3ac3
+    sha256: ab6e9856c21709b7b517e940ae7028ae0737546122f83c2aa5d692860c3b149e
+  manager: conda
+  name: libffi
+  optional: true
+  platform: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.4.2-h7f98852_5.tar.bz2
+  version: 3.4.2
+- category: dev
+  dependencies:
+    libgcc-ng: '>=9.4.0'
+  hash:
+    md5: 39b1328babf85c7c3a61636d9cd50206
+    sha256: 32f4fb94d99946b0dabfbbfd442b25852baf909637f2eed1ffe3baea15d02aad
+  manager: conda
+  name: libnsl
+  optional: true
+  platform: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libnsl-2.0.0-h7f98852_0.tar.bz2
+  version: 2.0.0
+- category: dev
+  dependencies:
+    libgcc-ng: '>=9.3.0'
+  hash:
+    md5: 772d69f030955d9646d3d0eaf21d859d
+    sha256: 54f118845498353c936826f8da79b5377d23032bcac8c4a02de2019e26c3f6b3
+  manager: conda
+  name: libuuid
+  optional: true
+  platform: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.32.1-h7f98852_1000.tar.bz2
+  version: 2.32.1
+- category: dev
+  dependencies:
+    libgcc-ng: '>=12'
+  hash:
+    md5: 29b2d63b0e21b765da0418bc452538c9
+    sha256: 864e4de308644dc5f5b88da185bb65e4e437ffe56299bffec9eba496c04758f3
+  manager: conda
+  name: libzlib
+  optional: true
+  platform: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.2.12-h166bdaf_3.tar.bz2
+  version: 1.2.12
+- category: dev
+  dependencies:
+    libgcc-ng: '>=10.3.0'
+  hash:
+    md5: 4acfc691e64342b9dae57cf2adc63238
+    sha256: b801e8cf4b2c9a30bce5616746c6c2a4e36427f045b46d9fc08a4ed40a9f7065
+  manager: conda
+  name: ncurses
+  optional: true
+  platform: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.3-h27087fc_1.tar.bz2
+  version: '6.3'
+- category: dev
+  dependencies:
+    ca-certificates: ''
+    libgcc-ng: '>=12'
+  hash:
+    md5: e772305877e7e57021916886d8732137
+    sha256: d358b5e5187695748961fc06c380668ba1b9a67d5880f94d1ae2757c523f2a52
+  manager: conda
+  name: openssl
+  optional: true
+  platform: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.0.5-h166bdaf_2.tar.bz2
+  version: 3.0.5
+- category: dev
+  dependencies:
+    libgcc-ng: '>=12'
+  hash:
+    md5: 2161070d867d1b1204ea749c8eec4ef0
+    sha256: 03a6d28ded42af8a347345f82f3eebdd6807a08526d47899a42d62d319609162
+  manager: conda
+  name: xz
+  optional: true
+  platform: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/xz-5.2.6-h166bdaf_0.tar.bz2
+  version: 5.2.6
+- category: dev
+  dependencies:
+    libgcc-ng: '>=12'
+    libzlib: '>=1.2.12,<1.3.0a0'
+  hash:
+    md5: ccb2457c73609f2622b8a4b3e42e5d8b
+    sha256: aa579bad433c481f9b0e3df473c4b9f4455787c0c439e921d0caa26affb205e3
+  manager: conda
+  name: libsqlite
+  optional: true
+  platform: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.39.3-h753d276_0.tar.bz2
+  version: 3.39.3
+- category: dev
+  dependencies:
+    libgcc-ng: '>=12'
+    ncurses: '>=6.3,<7.0a0'
+  hash:
+    md5: db2ebbe2943aae81ed051a6a9af8e0fa
+    sha256: f5f383193bdbe01c41cb0d6f99fec68e820875e842e6e8b392dbe1a9b6c43ed8
+  manager: conda
+  name: readline
+  optional: true
+  platform: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/readline-8.1.2-h0f457ee_0.tar.bz2
+  version: 8.1.2
+- category: dev
+  dependencies:
+    libgcc-ng: '>=9.4.0'
+    libzlib: '>=1.2.11,<1.3.0a0'
+  hash:
+    md5: 5b8c42eb62e9fc961af70bdd6a26e168
+    sha256: 032fd769aad9d4cad40ba261ab222675acb7ec951a8832455fce18ef33fa8df0
+  manager: conda
+  name: tk
+  optional: true
+  platform: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.12-h27826a3_0.tar.bz2
+  version: 8.6.12
+- category: dev
+  dependencies:
+    bzip2: '>=1.0.8,<2.0a0'
+    ld_impl_linux-64: '>=2.36.1'
+    libffi: '>=3.4.2,<3.5.0a0'
+    libgcc-ng: '>=12'
+    libnsl: '>=2.0.0,<2.1.0a0'
+    libsqlite: '>=3.39.2,<4.0a0'
+    libuuid: '>=2.32.1,<3.0a0'
+    libzlib: '>=1.2.12,<1.3.0a0'
+    ncurses: '>=6.3,<7.0a0'
+    openssl: '>=3.0.5,<4.0a0'
+    readline: '>=8.1.2,<9.0a0'
+    tk: '>=8.6.12,<8.7.0a0'
+    tzdata: ''
+    xz: '>=5.2.6,<5.3.0a0'
+  hash:
+    md5: 98d77e6496f7516d6b3c508f71c102fc
+    sha256: 51858b574a043bd0f7225880ecb11624c0545ef04865f848cd5a54c487bc637f
+  manager: conda
+  name: python
+  optional: true
+  platform: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/python-3.10.6-ha86cf86_0_cpython.tar.bz2
+  version: 3.10.6
+- category: dev
+  dependencies:
+    python: '>=3.5'
+  hash:
+    md5: 6d3ccbc56256204925bfa8378722792f
+    sha256: 86133878250874b3823bae7369bcad90187132537726cb1b546d88a0552d24de
+  manager: conda
+  name: attrs
+  optional: true
+  platform: linux-64
+  url: https://conda.anaconda.org/conda-forge/noarch/attrs-22.1.0-pyh71513ae_1.tar.bz2
+  version: 22.1.0
+- category: dev
+  dependencies:
+    python: ''
+  hash:
+    md5: 39161f81cc5e5ca45b8226fbb06c6905
+    sha256: 9423ded508ebda87dae21d7876134e406ffeb88e6059f3fe1a909d180c351959
+  manager: conda
+  name: iniconfig
+  optional: true
+  platform: linux-64
+  url: https://conda.anaconda.org/conda-forge/noarch/iniconfig-1.1.1-pyh9f0ad1d_0.tar.bz2
+  version: 1.1.1
+- category: dev
+  dependencies:
+    python: '>=2.7'
+  hash:
+    md5: b4613d7e7a493916d867842a6a148054
+    sha256: 268be33a290e3d51467ab29cbb5a80cf79f69dade2f2dead25d7f80d76c3543a
+  manager: conda
+  name: py
+  optional: true
+  platform: linux-64
+  url: https://conda.anaconda.org/conda-forge/noarch/py-1.11.0-pyh6c4a22f_0.tar.bz2
+  version: 1.11.0
+- category: dev
+  dependencies:
+    python: '>=3.6'
+  hash:
+    md5: e8fbc1b54b25f4b08281467bc13b70cc
+    sha256: 4acc7151cef5920d130f2e0a7615559cce8bfb037aeecb14d4d359ae3d9bc51b
+  manager: conda
+  name: pyparsing
+  optional: true
+  platform: linux-64
+  url: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.0.9-pyhd8ed1ab_0.tar.bz2
+  version: 3.0.9
+- category: dev
+  dependencies:
+    python: 3.10.*
+  hash:
+    md5: 9e7160cd0d865e98f6803f1fe15c8b61
+    sha256: e7e52aaec7cba6e17e45d731f9d38ede007aea0d72aee66670ab71016f5783ed
+  manager: conda
+  name: python_abi
+  optional: true
+  platform: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/python_abi-3.10-2_cp310.tar.bz2
+  version: '3.10'
+- category: main
+  dependencies:
+    python: '>=3.8'
+  hash:
+    md5: a64c8af7be7a6348c1d9e530f88fa4da
+    sha256: 54d2d1480c6f01a9b0a368276b95a71062eb3995183b10de04ec26d5e2571fcd
+  manager: conda
+  name: setuptools
+  optional: false
+  platform: linux-64
+  url: https://conda.anaconda.org/conda-forge/noarch/setuptools-65.3.0-pyhd8ed1ab_1.tar.bz2
+  version: 65.3.0
+- category: dev
+  dependencies:
+    python: '>=3.7'
+  hash:
+    md5: 5844808ffab9ebdb694585b50ba02a96
+    sha256: 4cd48aba7cd026d17e86886af48d0d2ebc67ed36f87f6534f4b67138f5a5a58f
+  manager: conda
+  name: tomli
+  optional: true
+  platform: linux-64
+  url: https://conda.anaconda.org/conda-forge/noarch/tomli-2.0.1-pyhd8ed1ab_0.tar.bz2
+  version: 2.0.1
+- category: main
+  dependencies:
+    python: '!=3.0,!=3.1,!=3.2,!=3.3,!=3.4'
+  hash:
+    md5: 1ca02aaf78d9c70d9a81a3bed5752022
+    sha256: aede66e6370f3b936164a703e48362f9080d7162234058fb2ee63cc84d528afc
+  manager: conda
+  name: wheel
+  optional: false
+  platform: linux-64
+  url: https://conda.anaconda.org/conda-forge/noarch/wheel-0.37.1-pyhd8ed1ab_0.tar.bz2
+  version: 0.37.1
+- category: dev
+  dependencies:
+    pyparsing: '>=2.0.2,!=3.0.5'
+    python: '>=3.6'
+  hash:
+    md5: 71f1ab2de48613876becddd496371c85
+    sha256: 8322a9e93e2e09fbf2103f0d37c9287b7b97387125abadd6db26686084893540
+  manager: conda
+  name: packaging
+  optional: true
+  platform: linux-64
+  url: https://conda.anaconda.org/conda-forge/noarch/packaging-21.3-pyhd8ed1ab_0.tar.bz2
+  version: '21.3'
+- category: main
+  dependencies:
+    python: '>=3.7'
+    setuptools: ''
+    wheel: ''
+  hash:
+    md5: 0b43abe4d3ee93e82742d37def53a836
+    sha256: 507ae896a2f9ccc7bbedc2f7fd10dc2ac666575769b55b5e94ca44b86db193e0
+  manager: conda
+  name: pip
+  optional: false
+  platform: linux-64
+  url: https://conda.anaconda.org/conda-forge/noarch/pip-22.2.2-pyhd8ed1ab_0.tar.bz2
+  version: 22.2.2
+- category: dev
+  dependencies:
+    python: '>=3.10,<3.11.0a0'
+    python_abi: 3.10.* *_cp310
+  hash:
+    md5: 97f9a22577338f91a94dfac5c1a65a50
+    sha256: 98f4c14b45066616a2e82b18a541190e4315396b8cfbeb8bdb6ce4db1d131c76
+  manager: conda
+  name: pluggy
+  optional: true
+  platform: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/pluggy-1.0.0-py310hff52083_3.tar.bz2
+  version: 1.0.0
+- category: dev
+  dependencies:
+    attrs: '>=19.2.0'
+    iniconfig: ''
+    packaging: ''
+    pluggy: '>=0.12,<2.0'
+    py: '>=1.8.2'
+    python: '>=3.10,<3.11.0a0'
+    python_abi: 3.10.* *_cp310
+    tomli: '>=1.0.0'
+  hash:
+    md5: 18ef27d620d67af2feef22acfd42cf4a
+    sha256: 7caab18204cccb2f43afd52cec61755c4cc5c0224d01eeaed3a3c8b720cc6926
+  manager: conda
+  name: pytest
+  optional: true
+  platform: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/pytest-7.1.3-py310hff52083_0.tar.bz2
+  version: 7.1.3
+- category: main
+  dependencies: {}
+  hash:
+    sha256: 43dadad18a7f168740e66944e4fa82c6611848ff9056ad910f8f7a3e46ab89e0
+  manager: pip
+  name: certifi
+  optional: false
+  platform: linux-64
+  source: null
+  url: https://files.pythonhosted.org/packages/ac/80/e0df41f336f21d35befa4ff15348eb3e8b2483e131922e8427223b52e688/certifi-2022.6.15.1-py3-none-any.whl
+  version: 2022.6.15.1
+- category: main
+  dependencies: {}
+  hash:
+    sha256: 83e9a75d1911279afd89352c68b45348559d1fc0506b054b346651b5e7fee29f
+  manager: pip
+  name: charset-normalizer
+  optional: false
+  platform: linux-64
+  source: null
+  url: https://files.pythonhosted.org/packages/db/51/a507c856293ab05cdc1db77ff4bc1268ddd39f29e7dc4919aa497f0adbec/charset_normalizer-2.1.1-py3-none-any.whl
+  version: 2.1.1
+- category: main
+  dependencies: {}
+  hash:
+    sha256: 84d9dd047ffa80596e0f246e2eab0b391788b0503584e8945f2368256d2735ff
+  manager: pip
+  name: idna
+  optional: false
+  platform: linux-64
+  source: null
+  url: https://files.pythonhosted.org/packages/04/a2/d918dcd22354d8958fe113e1a3630137e0fc8b44859ade3063982eacd2a4/idna-3.3-py3-none-any.whl
+  version: '3.3'
+- category: main
+  dependencies: {}
+  hash:
+    sha256: b930dd878d5a8afb066a637fbb35144fe7901e3b209d1cd4f524bd0e9deee997
+  manager: pip
+  name: urllib3
+  optional: false
+  platform: linux-64
+  source: null
+  url: https://files.pythonhosted.org/packages/6f/de/5be2e3eed8426f871b170663333a0f627fc2924cc386cd41be065e7ea870/urllib3-1.26.12-py2.py3-none-any.whl
+  version: 1.26.12
+- category: dev
+  dependencies:
+    pytest: '>=5.0'
+  hash:
+    sha256: 8a9e226d6c0ef09fcf20c94eb3405c388af438a90f3e39687f84166da82d5948
+  manager: pip
+  name: pytest-mock
+  optional: true
+  platform: linux-64
+  source: null
+  url: https://files.pythonhosted.org/packages/64/ec/e21d6a5c31df566847de2dc7e7c1870c67cf10cb97cb0a1ea0e389446e60/pytest_mock-3.8.2-py3-none-any.whl
+  version: 3.8.2
+- category: main
+  dependencies:
+    certifi: '>=2017.4.17'
+    charset-normalizer: '>=2,<3'
+    idna: '>=2.5,<4'
+    urllib3: '>=1.21.1,<1.27'
+  hash:
+    sha256: 8fefa2a1a1365bf5520aac41836fbee479da67864514bdb821f31ce07ce65349
+  manager: pip
+  name: requests
+  optional: false
+  platform: linux-64
+  source: null
+  url: https://files.pythonhosted.org/packages/ca/91/6d9b8ccacd0412c08820f72cebaa4f0c0441b5cda699c90f618b6f8a1b42/requests-2.28.1-py3-none-any.whl
+  version: 2.28.1
+version: 1

--- a/micromamba/src/common_options.cpp
+++ b/micromamba/src/common_options.cpp
@@ -402,4 +402,9 @@ init_install_options(CLI::App* subcom)
     subcom->add_flag("--no-deps", no_deps.get_cli_config<bool>(), no_deps.description());
     auto& only_deps = config.at("only_deps");
     subcom->add_flag("--only-deps", only_deps.get_cli_config<bool>(), only_deps.description());
+
+    auto& categories = config.at("categories");
+    subcom->add_option("--category",
+                       categories.get_cli_config<string_list>(),
+                       "Categories of package to install from environment lockfile");
 }


### PR DESCRIPTION
Add a `--category` flag to restrict which category of package should be installed from an environment lockfile. Defaults to "main".

Closes #1883.