### PR TITLE
allow symlinks to folders and empty folders in create_archive

### DIFF
--- a/libmamba/src/core/package_handling.cpp
+++ b/libmamba/src/core/package_handling.cpp
@@ -144,7 +144,8 @@ namespace mamba
 
         for (auto& dir_entry : fs::recursive_directory_iterator("."))
         {
-            if (dir_entry.is_directory())
+            // we only add empty directories to the archive
+            if (dir_entry.is_directory() && !fs::is_empty(dir_entry.path()))
             {
                 continue;
             }


### PR DESCRIPTION
This is an attempt to fix https://github.com/mamba-org/mamba/issues/1932