### PR TITLE
Fixed error when attempting to get the size of directories. (fix for #1979)

### DIFF
--- a/libmamba/src/api/clean.cpp
+++ b/libmamba/src/api/clean.cpp
@@ -220,7 +220,7 @@ namespace mamba
             std::size_t size = 0;
             for (auto& fp : fs::recursive_directory_iterator(p))
             {
-                if (!fp.is_symlink())
+                if (!fp.is_symlink() && !fp.is_directory())
                 {
                     size += fp.file_size();
                 }

--- a/micromamba/tests/helpers.py
+++ b/micromamba/tests/helpers.py
@@ -195,6 +195,28 @@ def remove(*args, no_dry_run=False):
         raise (e)
 
 
+def clean(*args, no_dry_run=False):
+    umamba = get_umamba()
+    cmd = [umamba, "clean", "-y"] + [arg for arg in args if arg]
+
+    if "--print-config-only" in args:
+        cmd += ["--debug"]
+    if (dry_run_tests == DryRun.DRY) and "--dry-run" not in args and not no_dry_run:
+        cmd += ["--dry-run"]
+
+    try:
+        res = subprocess.check_output(cmd)
+        if "--json" in args:
+            j = json.loads(res)
+            return j
+        if "--print-config-only" in args:
+            return yaml.load(res, Loader=yaml.FullLoader)
+        return res.decode()
+    except subprocess.CalledProcessError as e:
+        print(f"Error when executing '{' '.join(cmd)}'")
+        raise (e)
+
+
 def update(*args, default_channel=True, no_rc=True, no_dry_run=False):
     umamba = get_umamba()
     cmd = [umamba, "update", "-y"] + [arg for arg in args if arg]

--- a/micromamba/tests/test_remove.py
+++ b/micromamba/tests/test_remove.py
@@ -242,6 +242,16 @@ class TestRemoveConfig:
         assert res["env_name"] == ""
         assert res["specs"] == specs
 
+    def test_remove_then_clean(self, env_created):
+        from .test_create import test_env_requires_pip_install_path
+
+        env_name = "env_to_clean"
+        create(
+            "-n", env_name, "-f", test_env_requires_pip_install_path, no_dry_run=True
+        )
+        remove("-n", env_name, "pip", no_dry_run=True)
+        clean("-ay", no_dry_run=True)
+
     @pytest.mark.parametrize("root_prefix", (None, "env_var", "cli"))
     @pytest.mark.parametrize("target_is_root", (False, True))
     @pytest.mark.parametrize("cli_prefix", (False, True))


### PR DESCRIPTION
This should fix  #1979 (well it does fix it for me)

The standard filesystem library cannot guarantee that attempting to get the size of a directory with result in a value or an error, because of the wild differences in implementations. So we need to check if it's a directory and don't count sum it's size to the whole if it is.

I'll add a repro in-project.