### PR TITLE
Fix an infinite loop in replace_all() when the search string is empty

### DIFF
--- a/libmamba/src/core/util.cpp
+++ b/libmamba/src/core/util.cpp
@@ -321,6 +321,10 @@ namespace mamba
     template <class S>
     void replace_all_impl(S& data, const S& search, const S& replace)
     {
+        if (search.empty())
+        {
+            return;
+        }
         std::size_t pos = data.find(search);
         while (pos != std::string::npos)
         {

--- a/libmamba/tests/test_string_methods.cpp
+++ b/libmamba/tests/test_string_methods.cpp
@@ -61,6 +61,10 @@ namespace mamba
         replace_all(prefix, "/I/am/a/PREFIX", "/Yes/Thats/great/");
         EXPECT_TRUE(starts_with(prefix, "/Yes/Thats/great/\n"));
 
+        std::string testbuf2 = "this is another test wow";
+        replace_all(testbuf2, "", "somereplacement");
+        EXPECT_EQ(testbuf2, "this is another test wow");
+
         std::string prefix_unicode = "/I/am/Dörteæœ©æ©fðgb®/PREFIX\n\nabcdefg\nxyz";
         replace_all(
             prefix_unicode, "/I/am/Dörteæœ©æ©fðgb®/PREFIX", "/home/åéäáßðæœ©ðfßfáðß/123123123");


### PR DESCRIPTION
The empty string is found at the start of the string, pos = 0, and replaced over and over again.  If the replacement string is also empty, the size of the data string will not change.  If the replacement string is not empty, it will be repeatedly prepended to the data string.

While most callers are careful to ensure the search string is not empty, PosixActivator::update_prompt() lost this property in "Micromamba: Substitute env vars in .condarc (#1423)" (9e5f8fd).  Rather than restore the check in the caller, fix the root of the issue in replace_all() itself.

I ran into this bug as a Micromamba user in a particular set of circumstances where the CONDA_PROMPT_MODIFIER env var was the empty string.¹  It manifested to me the user as a `micromamba create` invocation hanging at the linking phase for any package with a post-link script (such as openmpi).  The generated post-link script wrapper invoked, indirectly, `micromamba shell --shell bash activate <path>` which was hanging during update_prompt().

¹ https://github.com/nextstrain/cli/pull/223#issuecomment-1270806302