### PR TITLE
Do not crash when permissions cannot be changed, instead log warning (#2004)

### DIFF
--- a/libmamba/src/core/link.cpp
+++ b/libmamba/src/core/link.cpp
@@ -698,7 +698,11 @@ namespace mamba
             fo << buffer;
             fo.close();
 
-            fs::permissions(dst, fs::status(src).permissions());
+            std::error_code ec;
+            fs::permissions(dst, fs::status(src).permissions(), ec);
+            if (ec)
+                LOG_WARNING << "Could not set permissions on [" << dst << "]: " << ec.message();
+
 #if defined(__APPLE__)
             if (binary_changed && m_pkg_info.subdir == "osx-arm64")
             {


### PR DESCRIPTION
As discussed in #2004. 

Tested locally on the misbehaving filesystem, it works.