### PR TITLE
LockFile as a testable type - no need to try_lock or use pointers.

### DIFF
--- a/libmamba/include/mamba/core/error_handling.hpp
+++ b/libmamba/include/mamba/core/error_handling.hpp
@@ -27,6 +27,7 @@ namespace mamba
         env_lockfile_parsing_failed,
         openssl_failed,
         internal_failure,
+        lockfile_failure,
     };
 
     class mamba_error : public std::runtime_error

--- a/libmamba/include/mamba/core/util.hpp
+++ b/libmamba/include/mamba/core/util.hpp
@@ -121,6 +121,11 @@ namespace mamba
         fs::u8path path() const;
         fs::u8path lockfile_path() const;
 
+        std::size_t count_lock_owners() const
+        {
+            return impl.use_count();
+        }
+
 #ifdef _WIN32
         // Using file descriptor on Windows may cause false negative
         static bool is_locked(const fs::u8path& path);

--- a/libmamba/include/mamba/core/util.hpp
+++ b/libmamba/include/mamba/core/util.hpp
@@ -117,10 +117,32 @@ namespace mamba
         static std::unique_ptr<LockFile> create_lock(const fs::u8path& path);
         static std::unique_ptr<LockFile> try_lock(const fs::u8path& path) noexcept;
 
+        // Returns true if this LockFile is currently maintaining a lock on the target path.
+        // Returns false if this instance have been moved-from without being re-assigned,
+        // or if the lock acquisition failed.
+        bool is_locked() const
+        {
+            return impl ? true: false;
+        }
+
+        // Convenient operator to check if a lockfile is actually locking a path.
+        explicit operator bool() const
+        {
+            return is_locked();
+        }
+
+        // Returns the fd of the path being locked if `is_locked() == true`.
         int fd() const;
+
+        // Returns the path being locked if `is_locked() == true`.
         fs::u8path path() const;
+
+        // Returns the path of the lock-file being locked if `is_locked() == true`.
         fs::u8path lockfile_path() const;
 
+        // Returns the count of LockFile instances which are currently locking
+        // the same path/file from the same process.
+        // Returns 0 if `is_locked() == false`.
         std::size_t count_lock_owners() const
         {
             return impl.use_count();

--- a/libmamba/include/mamba/core/util.hpp
+++ b/libmamba/include/mamba/core/util.hpp
@@ -147,8 +147,8 @@ namespace mamba
     //          {
     //              if(auto error = lock.error) print(error); // some error happened while
     //              attempting the lock, maybe some other process already locks the path else
-    //              print("didn't attempt locking {}") // locking didn't happen for some other
-    //              reason, maybe a configuration option
+    //              print("didn't attempt locking {}", some_path); // locking didn't happen for some
+    //              other reason, maybe a configuration option
     //          }
     //          some_more_work(some_path); // do this that the lock failed or not
     //          return lock; // The locking ownership can be transfered to another function if

--- a/libmamba/include/mamba/core/util.hpp
+++ b/libmamba/include/mamba/core/util.hpp
@@ -12,6 +12,7 @@
 #include "mamba/core/util_string.hpp"
 
 #include "nlohmann/json.hpp"
+#include "tl/expected.hpp"
 
 #include <array>
 #include <limits>
@@ -46,6 +47,14 @@ namespace mamba
 #else
 #error "no supported OS detected"
 #endif
+
+    // Used when we want a callback which does nothing.
+    struct no_op
+    {
+        void operator()() const noexcept
+        {
+        }
+    };
 
     bool is_package_file(const std::string_view& fn);
 
@@ -103,9 +112,62 @@ namespace mamba
 
     class LockFileOwner;
 
+    // This is a non-throwing file-locking mechanism.
+    // It can be used on a file or directory path. In the case of a directory path a file will be
+    // created to be locked. The locking will be implemented using the OS's filesystem locking
+    // capabilities, if available.
+    //
+    // Once constructed, use `is_locked()` or `operator bool` to check if the lock did happen
+    // successfully. When locking fails because of an error, the error can be retrieved using
+    // `error()`. When attempting to lock a path which is already locked by another process, the
+    // attempt will fail and `is_locked()` will return false.
+    //
+    // When the same process attempts to lock the same path more than once (multiple instances of
+    // `LockFile` target the same path), creating a new `LockFile` for that path will always succeed
+    // and increment the lock owner count which can be retrieved using `count_lock_owners()`.
+    // Basically, all instacnes of `LockFile` locking the same path are sharing the lock, which will
+    // only be released once there is no instance alive.
+    //
+    // Use `Context::instance().use_lockfiles = false` to never have locking happen, in which case
+    // the created `LockFile` instance will not be locked (`is_locked()` will return false) but will
+    // have no error either (`error()` will return `noopt`).
+    //
+    // Example:
+    //
+    //      LockFile some_work_on(some_path)
+    //      {
+    //          LockFile lock{ some_path, timeout };
+    //          if(lock) // make sure the locking happened
+    //          {
+    //              print("locked file {}, locking counts: {}", some_path,
+    //              lock.count_lock_owners()); // success might mean we are locking the same path
+    //              from multiple threads do_something(som_path); // locking was a success
+    //          }
+    //          else // locking didnt succeed for some reason
+    //          {
+    //              if(auto error = lock.error) print(error); // some error happened while
+    //              attempting the lock, maybe some other process already locks the path else
+    //              print("didn't attempt locking {}") // locking didn't happen for some other
+    //              reason, maybe a configuration option
+    //          }
+    //          some_more_work(some_path); // do this that the lock failed or not
+    //          return lock; // The locking ownership can be transfered to another function if
+    //          necessary
+    //      }
+    //
     class LockFile
     {
     public:
+        // Non-throwing constructors, attempting lock on the provided path, file or directory.
+        // In case of a directory, a lock-file will be created, located at `this->lockfile_path()`
+        // and `this->is_locked()` (and `if(*this))` will always return true (unless this instance
+        // is moved-from). If the lock acquisition failed or `Context::instance().use_lockfiles ==
+        // false` and until re-assigned:
+        // - `this->is_locked() == false` and `if(*this) ...` will go in the `false` branch.
+        // - accessors will throw, except `is_locked()`, `count_lock_owners()`, and `error()`
+        LockFile(const fs::u8path& path);
+        LockFile(const fs::u8path& path, const std::chrono::seconds& timeout);
+
         ~LockFile();
 
         LockFile(const LockFile&) = delete;
@@ -114,15 +176,13 @@ namespace mamba
         LockFile(LockFile&&);
         LockFile& operator=(LockFile&&);
 
-        static std::unique_ptr<LockFile> create_lock(const fs::u8path& path);
-        static std::unique_ptr<LockFile> try_lock(const fs::u8path& path) noexcept;
-
         // Returns true if this LockFile is currently maintaining a lock on the target path.
         // Returns false if this instance have been moved-from without being re-assigned,
         // or if the lock acquisition failed.
         bool is_locked() const
         {
-            return impl ? true: false;
+            return impl.has_value()                   // we have a owner
+                   && (impl.value() ? true : false);  // it's not null
         }
 
         // Convenient operator to check if a lockfile is actually locking a path.
@@ -131,13 +191,13 @@ namespace mamba
             return is_locked();
         }
 
-        // Returns the fd of the path being locked if `is_locked() == true`.
+        // Returns the fd of the path being locked, throws if `is_locked() == false`.
         int fd() const;
 
-        // Returns the path being locked if `is_locked() == true`.
+        // Returns the path being locked, throws if `is_locked() == false`.
         fs::u8path path() const;
 
-        // Returns the path of the lock-file being locked if `is_locked() == true`.
+        // Returns the path of the lock-file being locked, throws if `is_locked() == false`.
         fs::u8path lockfile_path() const;
 
         // Returns the count of LockFile instances which are currently locking
@@ -145,7 +205,7 @@ namespace mamba
         // Returns 0 if `is_locked() == false`.
         std::size_t count_lock_owners() const
         {
-            return impl.use_count();
+            return impl.has_value() ? impl.value().use_count() : 0;
         }
 
 #ifdef _WIN32
@@ -158,18 +218,25 @@ namespace mamba
 
         static bool is_locked(const LockFile& lockfile)
         {
+            return lockfile.is_locked() &&
 #ifdef _WIN32
-            return is_locked(lockfile.lockfile_path());
+                   is_locked(lockfile.lockfile_path());
 #else
-            // Opening a new file descriptor on Unix would clear locks
-            return is_locked(lockfile.fd());
+                   // Opening a new file descriptor on Unix would clear locks
+                   is_locked(lockfile.fd());
 #endif
         }
 
+        std::optional<mamba_error> error() const
+        {
+            if (impl.has_value())
+                return {};
+            else
+                return impl.error();
+        }
+
     private:
-        LockFile(const fs::u8path& path);
-        LockFile(const fs::u8path& path, const std::chrono::seconds& timeout);
-        std::shared_ptr<LockFileOwner> impl;
+        tl::expected<std::shared_ptr<LockFileOwner>, mamba_error> impl;
     };
 
 

--- a/libmamba/src/core/package_handling.cpp
+++ b/libmamba/src/core/package_handling.cpp
@@ -305,7 +305,7 @@ namespace mamba
         archive_write_disk_set_options(ext, flags);
         archive_write_disk_set_standard_lookup(ext);
 
-        auto lock = LockFile::try_lock(file);
+        auto lock = LockFile(file);
         r = archive_read_open_filename(a, file.string().c_str(), 10240);
 
         if (r != ARCHIVE_OK)

--- a/libmamba/src/core/repo.cpp
+++ b/libmamba/src/core/repo.cpp
@@ -317,7 +317,7 @@ namespace mamba
 
         if (is_solv)
         {
-            auto lock = LockFile::try_lock(m_solv_file);
+            auto lock = LockFile(m_solv_file);
 #ifdef _WIN32
             auto fp = _wfopen(m_solv_file.wstring().c_str(), L"rb");
 #else
@@ -393,7 +393,7 @@ namespace mamba
             fclose(fp);
         }
 
-        auto lock = LockFile::try_lock(m_json_file);
+        auto lock = LockFile(m_json_file);
 #ifdef _WIN32
         auto fp = _wfopen(m_json_file.wstring().c_str(), L"r");
 #else

--- a/libmamba/src/core/subdirdata.cpp
+++ b/libmamba/src/core/subdirdata.cpp
@@ -309,7 +309,7 @@ namespace mamba
             if (!fs::exists(json_file, ec))
                 continue;
 
-            auto lock = LockFile::try_lock(cache_path / "cache");
+            auto lock = LockFile(cache_path / "cache");
             auto cache_age = check_cache(json_file, now);
 
             if (cache_age != fs::file_time_type::duration::max() && !forbid_cache())
@@ -480,7 +480,7 @@ namespace mamba
                 LOG_DEBUG << "Copying repodata cache files from '" << m_expired_cache_path.string()
                           << "' to '" << m_writable_pkgs_dir.string() << "'";
                 fs::u8path writable_cache_dir = create_cache_dir(m_writable_pkgs_dir);
-                auto lock = LockFile::create_lock(writable_cache_dir);
+                auto lock = LockFile(writable_cache_dir);
 
                 auto copied_json_file = writable_cache_dir / m_json_fn;
                 if (fs::exists(copied_json_file))
@@ -502,13 +502,13 @@ namespace mamba
 
             {
                 LOG_TRACE << "Refreshing '" << json_file.string() << "'";
-                auto lock = LockFile::create_lock(json_file);
+                auto lock = LockFile(json_file);
                 fs::last_write_time(json_file, now);
             }
             if (fs::exists(solv_file) && solv_age.count() <= json_age.count())
             {
                 LOG_TRACE << "Refreshing '" << solv_file.string() << "'";
-                auto lock = LockFile::create_lock(solv_file);
+                auto lock = LockFile(solv_file);
                 fs::last_write_time(solv_file, now);
                 m_solv_cache_valid = true;
             }
@@ -545,7 +545,7 @@ namespace mamba
 
         fs::u8path writable_cache_dir = create_cache_dir(m_writable_pkgs_dir);
         json_file = writable_cache_dir / m_json_fn;
-        auto lock = LockFile::create_lock(writable_cache_dir);
+        auto lock = LockFile(writable_cache_dir);
 
         m_mod_etag.clear();
         m_mod_etag["_url"] = m_repodata_url;

--- a/libmamba/src/core/transaction.cpp
+++ b/libmamba/src/core/transaction.cpp
@@ -921,7 +921,7 @@ namespace mamba
             return true;
         }
 
-        auto lf = LockFile::create_lock(ctx.target_prefix / "conda-meta");
+        auto lf = LockFile(ctx.target_prefix / "conda-meta");
         clean_trash_files(ctx.target_prefix, false);
 
         Console::stream() << "\nTransaction starting";

--- a/libmamba/src/core/util.cpp
+++ b/libmamba/src/core/util.cpp
@@ -1166,7 +1166,6 @@ namespace mamba
     LockFile::LockFile(const fs::u8path& path, const std::chrono::seconds& timeout)
         : impl{ files_locked_by_this_process.acquire_lock(path, timeout) }
     {
-        assert(impl);
     }
 
     LockFile::LockFile(const fs::u8path& path)

--- a/libmamba/src/core/util.cpp
+++ b/libmamba/src/core/util.cpp
@@ -1047,7 +1047,7 @@ namespace mamba
     namespace
     {
 
-        bool log_duplicate_lockfile_in_process(const fs::u8path& path)
+        void log_duplicate_lockfile_in_process(const fs::u8path& path)
         {
             LOG_DEBUG << "Path already locked by the same process: '" << fs::absolute(path).string()
                       << "'";

--- a/libmamba/tests/test_lockfile.cpp
+++ b/libmamba/tests/test_lockfile.cpp
@@ -62,9 +62,16 @@ namespace mamba
         {
             {
                 auto lock = LockFile::create_lock(tempdir_path);
+                EXPECT_EQ(lock->count_lock_owners(), 1);
                 EXPECT_TRUE(fs::exists(lock->lockfile_path()));
 
-                EXPECT_THROW(LockFile::create_lock(tempdir_path), std::logic_error);
+                {
+                    auto other_lock = LockFile::create_lock(tempdir_path);
+                    EXPECT_EQ(other_lock->count_lock_owners(), 2);
+                    EXPECT_EQ(lock->count_lock_owners(), 2);
+                }
+
+                EXPECT_EQ(lock->count_lock_owners(), 1);
 
                 // check the first lock is still locked
                 EXPECT_TRUE(fs::exists(lock->lockfile_path()));
@@ -179,8 +186,15 @@ namespace mamba
             {
                 auto lock = LockFile::create_lock(tempfile_path);
                 EXPECT_TRUE(fs::exists(lock->lockfile_path()));
+                EXPECT_EQ(lock->count_lock_owners(), 1);
 
-                EXPECT_THROW(LockFile::create_lock(tempfile_path), std::logic_error);
+                {
+                    auto other_lock = LockFile::create_lock(tempfile_path);
+                    EXPECT_EQ(other_lock->count_lock_owners(), 2);
+                    EXPECT_EQ(lock->count_lock_owners(), 2);
+                }
+
+                EXPECT_EQ(lock->count_lock_owners(), 1);
 
                 // check the first lock is still locked
                 EXPECT_TRUE(fs::exists(lock->lockfile_path()));

--- a/libmamba/tests/test_lockfile.cpp
+++ b/libmamba/tests/test_lockfile.cpp
@@ -62,11 +62,13 @@ namespace mamba
         {
             {
                 auto lock = LockFile::create_lock(tempdir_path);
+                EXPECT_TRUE(lock->is_locked());
                 EXPECT_EQ(lock->count_lock_owners(), 1);
                 EXPECT_TRUE(fs::exists(lock->lockfile_path()));
 
                 {
                     auto other_lock = LockFile::create_lock(tempdir_path);
+                    EXPECT_TRUE(other_lock->is_locked());
                     EXPECT_EQ(other_lock->count_lock_owners(), 2);
                     EXPECT_EQ(lock->count_lock_owners(), 2);
                 }
@@ -185,11 +187,13 @@ namespace mamba
         {
             {
                 auto lock = LockFile::create_lock(tempfile_path);
+                EXPECT_TRUE(lock->is_locked());
                 EXPECT_TRUE(fs::exists(lock->lockfile_path()));
                 EXPECT_EQ(lock->count_lock_owners(), 1);
 
                 {
                     auto other_lock = LockFile::create_lock(tempfile_path);
+                    EXPECT_TRUE(other_lock->is_locked());
                     EXPECT_EQ(other_lock->count_lock_owners(), 2);
                     EXPECT_EQ(lock->count_lock_owners(), 2);
                 }

--- a/libmamba/tests/test_lockfile.cpp
+++ b/libmamba/tests/test_lockfile.cpp
@@ -49,6 +49,20 @@ namespace mamba
             }
         };
 
+
+        TEST_F(LockDirTest, basics)
+        {
+            mamba::LockFile lock{ tempdir_path };
+            EXPECT_TRUE(lock);
+            {
+                auto new_lock = std::move(lock);
+                EXPECT_FALSE(lock);
+                EXPECT_TRUE(new_lock);
+            }
+            EXPECT_FALSE(lock);
+        }
+
+
         TEST_F(LockDirTest, disable_locking)
         {
             {
@@ -193,13 +207,13 @@ namespace mamba
         TEST_F(LockFileTest, same_pid)
         {
             {
-                auto lock = LockFile(tempfile_path);
+                LockFile lock{ tempfile_path };
                 EXPECT_TRUE(lock.is_locked());
                 EXPECT_TRUE(fs::exists(lock.lockfile_path()));
                 EXPECT_EQ(lock.count_lock_owners(), 1);
 
                 {
-                    auto other_lock = LockFile(tempfile_path);
+                    LockFile other_lock{ tempfile_path };
                     EXPECT_TRUE(other_lock.is_locked());
                     EXPECT_EQ(other_lock.count_lock_owners(), 2);
                     EXPECT_EQ(lock.count_lock_owners(), 2);

--- a/libmamba/tests/testing/lock.cpp
+++ b/libmamba/tests/testing/lock.cpp
@@ -42,8 +42,11 @@ main(int argc, char** argv)
             mamba::Context::instance().lock_timeout = timeout;
             try
             {
-                auto lock = mamba::LockFile::create_lock(path);
-                std::cout << 1;
+                auto lock = mamba::LockFile(path);
+                if (lock)
+                    std::cout << 1;
+                else
+                    std::cout << 0;
             }
             catch (...)
             {

--- a/libmambapy/src/main.cpp
+++ b/libmambapy/src/main.cpp
@@ -69,7 +69,7 @@ PYBIND11_MODULE(bindings, m)
              { return fmt::format("fs::u8path[{}]", self.string()); });
     py::implicitly_convertible<std::string, fs::u8path>();
 
-    py::class_<mamba::LockFile>(m, "LockFile").def(py::init(&mamba::LockFile::create_lock));
+    py::class_<mamba::LockFile>(m, "LockFile").def(py::init<fs::u8path>());
 
     py::register_exception<mamba_error>(m, "MambaNativeException");
 

--- a/micromamba/src/run.hpp
+++ b/micromamba/src/run.hpp
@@ -10,7 +10,7 @@ namespace mamba
     bool is_process_name_running(const std::string& name);
     std::string generate_unique_process_name(std::string_view program_name);
     const fs::u8path& proc_dir();
-    std::unique_ptr<LockFile> lock_proc_dir();
+    LockFile lock_proc_dir();
 
     nlohmann::json get_all_running_processes_info(
         const std::function<bool(const nlohmann::json&)>& filter


### PR DESCRIPTION
This change was discussed/designed with @JohanMabille mainly. There are alternative designs to this but we can now test this one.

The goal is to simplify most of the handling of `LockFile` objects. Instead of having factory functions that might or not catch errors, we just maek `LockFile` itself not throw on construction and let the user decide if testing if it's locked is important or not.
Basically, this version of `LockFile` acts both as a lockfile and as an `expected`, which can hold an error if locking failed.

For example, from the documentation (added in the `LockFile` definition):
```c++
LockFile some_work_on(some_path)
{
    LockFile lock{ some_path, timeout };
    if(lock) // make sure the locking happened
    {
        print("locked file {}, locking counts: {}", some_path, lock.count_lock_owners()); // success might mean we are locking the same path from multiple threads
        do_something(som_path); // locking was a success
    }
    else // locking didnt succeed for some reason
    {
        if(auto error = lock.error) print(error); // some error happened while attempting the lock, maybe some other process already locks the path
        else print("didn't attempt locking {}") // locking didn't happen for some other reason, maybe a configuration option
    }
    some_more_work(some_path); // do this that the lock failed or not
    return lock; // The locking ownership can be transfered to another function if necessary
}
```

The main alternative to this design is to keep `LockFile` throwing constructors, keep `try_lock` but make it return an expected, and rationalize more clearly what `try_lock` does allow or not. Feel free to provide some arguments and guidance for alternative designs such as this one, we are open to discuss this.