### PR TITLE
[MER][T31] join_trunc and string_util improvements

### DIFF
--- a/libmamba/include/mamba/core/util_string.hpp
+++ b/libmamba/include/mamba/core/util_string.hpp
@@ -131,9 +131,10 @@ namespace mamba
         std::size_t size(const wchar_t* s);
         std::size_t size(const char c);
         template <class T>
-        inline std::size_t size(T const& s)
+        std::size_t size(T const& s)
         {
-            return s.size();
+            using std::size;
+            return size(s);
         }
     }
 
@@ -236,11 +237,17 @@ namespace mamba
         };
 
         auto const [show_head, show_tail] = show;
-        join_for_each_func(first, first + show_head, sep);
-        func(sep);
+        if (show_head > 0)
+        {
+            join_for_each_func(first, first + show_head, sep);
+            func(sep);
+        }
         func(etc);
-        func(sep);
-        join_for_each_func(last - show_tail, last, sep);
+        if (show_tail)
+        {
+            func(sep);
+            join_for_each_func(last - show_tail, last, sep);
+        }
         return func;
     }
 
@@ -279,13 +286,12 @@ namespace mamba
         return out;
     }
 
-
     void replace_all(std::string& data, const std::string& search, const std::string& replace);
 
     void replace_all(std::wstring& data, const std::wstring& search, const std::wstring& replace);
 
     template <typename T>
-    auto without_duplicates(std::vector<T> values)
+    std::vector<T> without_duplicates(std::vector<T> values)
     {
         const auto end_it = std::unique(values.begin(), values.end());
         values.erase(end_it, values.end());
@@ -297,7 +303,7 @@ namespace mamba
     std::string to_lower(const std::string_view& input);
 
     template <typename... Args>
-    inline std::string concat(const Args&... args)
+    std::string concat(const Args&... args)
     {
         std::string result;
         result.reserve((details::size(args) + ...));
@@ -306,7 +312,7 @@ namespace mamba
     }
 
     template <class B>
-    inline std::string hex_string(const B& buffer, std::size_t size)
+    std::string hex_string(const B& buffer, std::size_t size)
     {
         std::ostringstream oss;
         oss << std::hex;
@@ -318,7 +324,7 @@ namespace mamba
     }
 
     template <class B>
-    inline std::string hex_string(const B& buffer)
+    std::string hex_string(const B& buffer)
     {
         return hex_string(buffer, buffer.size());
     }

--- a/libmamba/include/mamba/core/util_string.hpp
+++ b/libmamba/include/mamba/core/util_string.hpp
@@ -127,16 +127,11 @@ namespace mamba
         template <typename T>
         inline constexpr bool has_reserve_v = has_reserve<T>::value;
 
-        inline std::size_t size(const char* s)
-        {
-            return strlen(s);
-        }
-        inline std::size_t size(const char /*c*/)
-        {
-            return 1;
-        }
+        std::size_t size(const char* s);
+        std::size_t size(const wchar_t* s);
+        std::size_t size(const char c);
         template <class T>
-        inline std::size_t size(T& s)
+        inline std::size_t size(T const& s)
         {
             return s.size();
         }

--- a/libmamba/include/mamba/core/util_string.hpp
+++ b/libmamba/include/mamba/core/util_string.hpp
@@ -147,51 +147,27 @@ namespace mamba
 
     namespace concat_impl
     {
+        inline std::size_t size(const char* s)
+        {
+            return strlen(s);
+        }
+        inline std::size_t size(const char /*c*/)
+        {
+            return 1;
+        }
         template <class T>
-        inline void concat_foreach(std::string& result, const T& rhs)
+        inline std::size_t size(T& s)
         {
-            result += rhs;
+            return s.size();
         }
-
-        template <class T, class... Rest>
-        inline void concat_foreach(std::string& result, const T& rhs, const Rest&... rest)
-        {
-            result += rhs;
-            concat_foreach(result, rest...);
-        }
-
-        struct sizer
-        {
-            inline sizer(const char* s)
-                : size(strlen(s))
-            {
-            }
-
-            inline sizer(const char /*s*/)
-                : size(1)
-            {
-            }
-
-            template <class T>
-            inline sizer(T& s)
-                : size(s.size())
-            {
-            }
-
-            std::size_t size;
-        };
     }  // namespace concat_impl
 
     template <typename... Args>
     inline std::string concat(const Args&... args)
     {
-        size_t len = 0;
-        for (auto s : std::initializer_list<concat_impl::sizer>{ args... })
-            len += s.size;
-
         std::string result;
-        result.reserve(len);
-        concat_impl::concat_foreach(result, args...);
+        result.reserve((concat_impl::size(args) + ...));
+        ((result += args), ...);
         return result;
     }
 

--- a/libmamba/include/mamba/core/util_string.hpp
+++ b/libmamba/include/mamba/core/util_string.hpp
@@ -137,6 +137,13 @@ namespace mamba
         }
     }
 
+    /**
+     * Execute the function @p func on each element of a join iteration.
+     *
+     * The join iteration of an iterator pair (@p first, @p last) with a separator @p sep is
+     * defined by iterating through the ``n`` elements of the iterator pair, interleaving the
+     * separator in between the elements (thus appearing ``n-1`` times).
+     */
     // TODO(C++20) Take an input range and return a range
     template <typename InputIt, typename UnaryFunction, typename Value>
     UnaryFunction join_for_each(InputIt first, InputIt last, UnaryFunction func, Value const& sep)
@@ -153,6 +160,15 @@ namespace mamba
         return func;
     }
 
+    /**
+     * Concatenate the elements of the container @p container by interleaving a separator.
+     *
+     * Joining is done by successively joining (using the provided @p joiner) the aggregate with
+     * element of the container and the separator, such that the separator only appears
+     * in-between two elements of the range.
+     *
+     * @see join_for_each
+     */
     template <class Range, class Value, class Joiner = details::PlusEqual>
     auto join(Value const& sep, const Range& container, Joiner joiner = details::PlusEqual{}) ->
         typename Range::value_type
@@ -171,6 +187,26 @@ namespace mamba
         return out;
     }
 
+    /**
+     * Execute the function @p func on each element of a tuncated join iteration.
+     *
+     * The join iteration of an iterator pair (@p first, @p last) with a separator @p sep
+     * and a trunction symbol @p etc is define by the join iteration of either all the elements
+     * in the iterator pair if they are less than @p threshold, a limited number of elements, with
+     * middle elements represented by @p etc.
+     * defined by iterating through the ``n`` elements of the iterator pair, interleaving the
+     * separator in between the elements (thus appearing ``n-1`` times).
+     *
+     * @param first The iterator pointing to the begining of the range of elements to join.
+     * @param last The iterator pointing to past the end of the range of elements to join.
+     * @param func The unary function to apply to all elements (separation and truncation included).
+     * @param sep The separator used in between elements.
+     * @param etc The value used to represent the truncation of the elements.
+     * @param threshold Distance between the iterator pair beyond which truncation is preformed.
+     * @param show Number of elements to keep at the begining/end when truncation is preformed.
+     *
+     * @see join_for_each
+     */
     // TODO(C++20) Take an input range and return a range
     template <typename InputIt, typename UnaryFunction, typename Value>
     UnaryFunction join_trunc_for_each(InputIt first,
@@ -208,6 +244,18 @@ namespace mamba
         return func;
     }
 
+    /**
+     * Join elements of a range, with possible truncation.
+     *
+     * @param range Elements to join.
+     * @param sep The separator used in between elements.
+     * @param etc The value used to represent the truncation of the elements.
+     * @param threshold Distance between the iterator pair beyond which truncation is preformed.
+     * @param show Number of elements to keep at the begining/end when truncation is preformed.
+     *
+     * @see join_trunc_for_each
+     * @see join
+     */
     template <typename Range, typename Joiner = details::PlusEqual>
     auto join_trunc(Range const& range,
                     std::string_view sep = ", ",

--- a/libmamba/include/mamba/core/util_string.hpp
+++ b/libmamba/include/mamba/core/util_string.hpp
@@ -142,6 +142,7 @@ namespace mamba
         }
     }
 
+    // TODO(C++20) Take an input range and return a range
     template <typename InputIt, typename UnaryFunction, typename Value>
     UnaryFunction join_for_each(InputIt first, InputIt last, UnaryFunction func, Value const& sep)
     {
@@ -175,6 +176,7 @@ namespace mamba
         return out;
     }
 
+    // TODO(C++20) Take an input range and return a range
     template <typename InputIt, typename UnaryFunction, typename Value>
     UnaryFunction join_trunc_for_each(InputIt first,
                                       InputIt last,

--- a/libmamba/include/mamba/core/util_string.hpp
+++ b/libmamba/include/mamba/core/util_string.hpp
@@ -9,6 +9,7 @@
 #include <cstring>
 #include <sstream>
 #include <algorithm>
+#include <iomanip>
 
 namespace mamba
 {

--- a/libmamba/src/core/util.cpp
+++ b/libmamba/src/core/util.cpp
@@ -27,8 +27,6 @@ extern "C"
 #include <fcntl.h>
 }
 
-#include "mamba/core/shell_init.hpp"
-
 #endif
 
 #include <cerrno>
@@ -38,6 +36,9 @@ extern "C"
 #include <optional>
 #include <unordered_map>
 #include <memory>
+#include <cstring>
+#include <cwchar>
+
 #include <openssl/evp.h>
 
 #include "mamba/core/environment.hpp"
@@ -50,6 +51,8 @@ extern "C"
 #include "mamba/core/util_random.hpp"
 #include "mamba/core/fsutil.hpp"
 #include "mamba/core/url.hpp"
+#include "mamba/core/shell_init.hpp"
+
 
 namespace mamba
 {
@@ -316,6 +319,22 @@ namespace mamba
         std::reverse(result.begin(), result.end());
 
         return result;
+    }
+
+    namespace details
+    {
+        std::size_t size(const char* s)
+        {
+            return std::strlen(s);
+        }
+        std::size_t size(const wchar_t* s)
+        {
+            return std::wcslen(s);
+        }
+        std::size_t size(const char /*c*/)
+        {
+            return 1;
+        }
     }
 
     template <class S>

--- a/libmamba/tests/CMakeLists.txt
+++ b/libmamba/tests/CMakeLists.txt
@@ -20,13 +20,13 @@ set(TEST_SRCS
     test_output.cpp
     test_progress_bar.cpp
     test_shell_init.cpp
-    test_string_methods.cpp
     test_thread_utils.cpp
     test_transfer.cpp
     test_url.cpp
     test_validate.cpp
     test_virtual_packages.cpp
     test_util.cpp
+    test_util_string.cpp
     test_env_lockfile.cpp
     test_execution.cpp
     test_invoke.cpp

--- a/libmamba/tests/test_util_string.cpp
+++ b/libmamba/tests/test_util_string.cpp
@@ -1,16 +1,83 @@
 #include <gtest/gtest.h>
 
+#include "mamba/core/mamba_fs.hpp"
 #include "mamba/core/util_string.hpp"
 
 namespace mamba
 {
-    TEST(util_string, to_upper_lower)
+    TEST(util_string, starts_with)
     {
-        std::string a = "ThisIsARandomTTTeeesssT";
-        EXPECT_EQ(to_upper(a), "THISISARANDOMTTTEEESSST");
-        // std::wstring b = "áäáœ©gþhëb®hüghœ©®xb";
-        // EXPECT_EQ(to_upper(b), "ÁÄÁŒ©GÞHËB®HÜGHŒ©®XB");
-        // EXPECT_EQ(to_lower(a), "thisisarandomttteeessst");
+        EXPECT_TRUE(starts_with(":hello", ""));
+        EXPECT_TRUE(starts_with(":hello", ":"));
+        EXPECT_TRUE(starts_with(":hello", ":h"));
+        EXPECT_TRUE(starts_with(":hello", ":hello"));
+        EXPECT_FALSE(starts_with(":hello", "lo"));
+        EXPECT_TRUE(starts_with("áäáœ©gþhëb®hüghœ©®xb", "áäáœ©"));
+    }
+
+    TEST(util_string, ends_with)
+    {
+        EXPECT_TRUE(ends_with("hello&", ""));
+        EXPECT_TRUE(ends_with("hello&", "&"));
+        EXPECT_TRUE(ends_with("hello&", "o&"));
+        EXPECT_TRUE(ends_with("hello&", "hello&"));
+        EXPECT_FALSE(ends_with("hello&", "he"));
+        EXPECT_TRUE(ends_with("áäáœ©gþhëb®hüghœ©®xb", "©®xb"));
+    }
+
+    TEST(util_string, contains)
+    {
+        EXPECT_TRUE(contains(":hello&", ""));
+        EXPECT_TRUE(contains(":hello&", "&"));
+        EXPECT_TRUE(contains(":hello&", ":"));
+        EXPECT_TRUE(contains(":hello&", "ll"));
+        EXPECT_FALSE(contains(":hello&", "eo"));
+        EXPECT_TRUE(contains("áäáœ©gþhëb®hüghœ©®xb", "ëb®"));
+    }
+
+    TEST(util_string, any_starts_with)
+    {
+        EXPECT_FALSE(any_starts_with({}, "not"));
+        EXPECT_FALSE(any_starts_with({}, ""));
+        EXPECT_TRUE(any_starts_with({ ":hello", "world" }, ""));
+        EXPECT_TRUE(any_starts_with({ ":hello", "world" }, ":"));
+        EXPECT_TRUE(any_starts_with({ ":hello", "world" }, ":h"));
+        EXPECT_TRUE(any_starts_with({ ":hello", "world" }, ":hello"));
+        EXPECT_FALSE(any_starts_with({ ":hello", "world" }, "orld"));
+        EXPECT_TRUE(any_starts_with({ "áäáœ©gþhëb", "®hüghœ©®xb" }, "áäá"));
+    }
+
+    TEST(util_string, starts_with_any)
+    {
+        EXPECT_TRUE(starts_with_any(":hello", { "", "not" }));
+        EXPECT_TRUE(starts_with_any(":hello", { ":hello", "not" }));
+        EXPECT_FALSE(starts_with_any(":hello", {}));
+        EXPECT_FALSE(starts_with_any(":hello", { "not", "any" }));
+        EXPECT_TRUE(starts_with_any("áäáœ©gþhëb®hüghœ©®xb", { "áäáœ©gþhëb", "®hüghœ©®xb" }));
+    }
+
+    TEST(util_string, strip)
+    {
+        EXPECT_EQ(strip("  hello \t\n"), "hello");
+        EXPECT_EQ(strip(":::hello%:%", ":%"), "hello");
+        EXPECT_EQ(strip(":::hello%:%", ":"), "hello%:%");
+        EXPECT_EQ(strip(":::hello%:%", ":"), "hello%:%");
+    }
+
+    TEST(util_string, lstrip)
+    {
+        EXPECT_EQ(lstrip("\n \thello \t\n"), "hello \t\n");
+        EXPECT_EQ(lstrip(":::hello%:%", ":%"), "hello%:%");
+        EXPECT_EQ(lstrip(":::hello%:%", ":"), "hello%:%");
+        EXPECT_EQ(lstrip(":::hello%:%", "%"), ":::hello%:%");
+    }
+
+    TEST(util_string, rstrip)
+    {
+        EXPECT_EQ(rstrip("\n \thello \t\n"), "\n \thello");
+        EXPECT_EQ(rstrip(":::hello%:%", "%"), ":::hello%:");
+        EXPECT_EQ(rstrip(":::hello%:%", ":%"), ":::hello");
+        EXPECT_EQ(rstrip(":::hello%:%", ":"), ":::hello%:%");
     }
 
     TEST(util_string, split)
@@ -46,6 +113,22 @@ namespace mamba
         EXPECT_EQ(rsplit("conda-forge/linux64::xtensor==0.12.3", ":", 1), v21);
     }
 
+    TEST(util_string, join)
+    {
+        {
+            std::vector<std::string> to_join = { "a", "bc", "d" };
+            auto joined = join("-", to_join);
+            testing::StaticAssertTypeEq<decltype(joined), decltype(to_join)::value_type>();
+            EXPECT_EQ(joined, "a-bc-d");
+        }
+        {
+            std::vector<fs::u8path> to_join = { "/a", "bc", "d" };
+            auto joined = join("/", to_join);
+            testing::StaticAssertTypeEq<decltype(joined), decltype(to_join)::value_type>();
+            EXPECT_EQ(joined, "/a/bc/d");
+        }
+    }
+
     TEST(util_string, replace_all)
     {
         std::string testbuf = "this is just a test a just a a abc bca";
@@ -70,4 +153,19 @@ namespace mamba
             prefix_unicode, "/I/am/Dörteæœ©æ©fðgb®/PREFIX", "/home/åéäáßðæœ©ðfßfáðß/123123123");
         EXPECT_EQ(prefix_unicode, "/home/åéäáßðæœ©ðfßfáðß/123123123\n\nabcdefg\nxyz");
     }
+
+    TEST(util_string, to_upper_lower)
+    {
+        std::string a = "ThisIsARandomTTTeeesssT";
+        EXPECT_EQ(to_upper(a), "THISISARANDOMTTTEEESSST");
+        // std::wstring b = "áäáœ©gþhëb®hüghœ©®xb";
+        // EXPECT_EQ(to_upper(b), "ÁÄÁŒ©GÞHËB®HÜGHŒ©®XB");
+        // EXPECT_EQ(to_lower(a), "thisisarandomttteeessst");
+    }
+
+    TEST(util_string, concat)
+    {
+        EXPECT_EQ(concat("aa", std::string("bb"), std::string_view("cc"), 'd'), "aabbccd");
+    }
+
 }  // namespace mamba

--- a/libmamba/tests/test_util_string.cpp
+++ b/libmamba/tests/test_util_string.cpp
@@ -129,6 +129,23 @@ namespace mamba
         }
     }
 
+    TEST(util_string, join_trunc)
+    {
+        std::vector<std::string> to_join = { "a", "bc", "d", "e", "f" };
+        {
+            auto joined = join_trunc(to_join);
+            testing::StaticAssertTypeEq<decltype(joined), decltype(to_join)::value_type>();
+        }
+        {
+            auto joined = join_trunc(to_join, "-", "..", 5, { 2, 1 });
+            EXPECT_EQ(joined, "a-bc-d-e-f");
+        }
+        {
+            auto joined = join_trunc(to_join, ",", "..", 4, { 2, 1 });
+            EXPECT_EQ(joined, "a,bc,..,f");
+        }
+    }
+
     TEST(util_string, replace_all)
     {
         std::string testbuf = "this is just a test a just a a abc bca";

--- a/libmamba/tests/test_util_string.cpp
+++ b/libmamba/tests/test_util_string.cpp
@@ -1,10 +1,10 @@
 #include <gtest/gtest.h>
 
-#include "mamba/core/util.hpp"
+#include "mamba/core/util_string.hpp"
 
 namespace mamba
 {
-    TEST(util, to_upper_lower)
+    TEST(util_string, to_upper_lower)
     {
         std::string a = "ThisIsARandomTTTeeesssT";
         EXPECT_EQ(to_upper(a), "THISISARANDOMTTTEEESSST");
@@ -13,7 +13,7 @@ namespace mamba
         // EXPECT_EQ(to_lower(a), "thisisarandomttteeessst");
     }
 
-    TEST(util, split)
+    TEST(util_string, split)
     {
         std::string a = "hello.again.it's.me.mario";
         std::vector<std::string> e1 = { "hello", "again", "it's", "me", "mario" };
@@ -46,7 +46,7 @@ namespace mamba
         EXPECT_EQ(rsplit("conda-forge/linux64::xtensor==0.12.3", ":", 1), v21);
     }
 
-    TEST(util, replace_all)
+    TEST(util_string, replace_all)
     {
         std::string testbuf = "this is just a test a just a a abc bca";
 

--- a/libmamba/tests/test_util_string.cpp
+++ b/libmamba/tests/test_util_string.cpp
@@ -139,17 +139,12 @@ namespace mamba
             auto joined = join_trunc(to_join);
             testing::StaticAssertTypeEq<decltype(joined), decltype(to_join)::value_type>();
         }
-        {
-            auto joined = join_trunc(to_join, "-", "..", 5, { 2, 1 });
-            EXPECT_EQ(joined, "a-bc-d-e-f");
-        }
-        {
-            auto joined = join_trunc(to_join, ",", "..", 4, { 2, 1 });
-            EXPECT_EQ(joined, "a,bc,..,f");
-        }
-        {
-            EXPECT_EQ(join_trunc(std::vector<std::string>()), "");
-        }
+        EXPECT_EQ(join_trunc(to_join, "-", "..", 5, { 2, 1 }), "a-bc-d-e-f");
+        EXPECT_EQ(join_trunc(to_join, ",", "..", 4, { 2, 1 }), "a,bc,..,f");
+        EXPECT_EQ(join_trunc(to_join, ",", "..", 4, { 0, 1 }), "..,f");
+        EXPECT_EQ(join_trunc(to_join, ",", "..", 4, { 2, 0 }), "a,bc,..");
+        EXPECT_EQ(join_trunc(to_join, ",", "..", 4, { 0, 0 }), "..");
+        EXPECT_EQ(join_trunc(std::vector<std::string>()), "");
     }
 
     TEST(util_string, replace_all)

--- a/libmamba/tests/test_util_string.cpp
+++ b/libmamba/tests/test_util_string.cpp
@@ -127,6 +127,9 @@ namespace mamba
             testing::StaticAssertTypeEq<decltype(joined), decltype(to_join)::value_type>();
             EXPECT_EQ(joined, "/a/bc/d");
         }
+        {
+            EXPECT_EQ(join(",", std::vector<std::string>()), "");
+        }
     }
 
     TEST(util_string, join_trunc)
@@ -143,6 +146,9 @@ namespace mamba
         {
             auto joined = join_trunc(to_join, ",", "..", 4, { 2, 1 });
             EXPECT_EQ(joined, "a,bc,..,f");
+        }
+        {
+            EXPECT_EQ(join_trunc(std::vector<std::string>()), "");
         }
     }
 


### PR DESCRIPTION
``join_trunc`` for #1878 and other ``string_util`` improvements.

The diffs are not easy to follow, basically this PR do
- Rename `test_string_methods.cpp` > `test_util_string.cpp` to align with header name;
- Add a number of tests for previously untested functions (`strip`, `concat`, `starts_with`, `contains`, `join`, ...)
- Refactor `join`
  - for reusing it in `join_trunc` (new)
  - for calling `reserve` when possible.
- Add a new `join_trunc`, similar to `join` but truncates the middle of the string if too long.