### PR TITLE
Fix conda-forge required test conflict

### DIFF
--- a/libmamba/tests/test_satisfiability_error.cpp
+++ b/libmamba/tests/test_satisfiability_error.cpp
@@ -394,7 +394,7 @@ namespace mamba
 
     auto create_jupyterlab()
     {
-        return create_conda_forge({ "jupyterlab>3", "openssl=3.*" });
+        return create_conda_forge({ "jupyterlab=3.4", "openssl=3.0.0" });
     }
 
     class Problem : public testing::TestWithParam<decltype(&create_basic_conflict)>


### PR DESCRIPTION
This test is failing (or will fail) since the conflict has disappeared.
This is a more specific pin.