### PR TITLE
Add micromamba nightly releases

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,6 +14,7 @@ concurrency:
 
 jobs:
   libmamba_static:
+    if: false
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -267,6 +268,7 @@ jobs:
           rm -rf $(micromamba info --json | jq -r '."env location"')/envs
 
   libmamba_static_win:
+    if: false
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/.github/workflows/static_build.yml
+++ b/.github/workflows/static_build.yml
@@ -178,6 +178,7 @@ jobs:
 
   create_nightly_release:
     name: "Create nightly release"
+    runs-on: ubuntu-latest
 #    depends-on: [conda-build, micromamba-full-static-win]
     steps:
       - run: echo "Hello, world!" >> artifact.txt

--- a/.github/workflows/static_build.yml
+++ b/.github/workflows/static_build.yml
@@ -195,7 +195,7 @@ jobs:
       - name: package-version-to-git-tag
         uses: pkgdeps/git-tag-action@v2
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.MICROMAMBA_NIGHTLIES_TOKEN }}
           github_repo: pavelzw/micromamba-nightlies
           git_commit_sha: e606818dfc0f9ce7d1b0fccdabcfa6822d41cf98
           version: ${{ github.sha }}
@@ -210,5 +210,5 @@ jobs:
           files: |
             artifact.txt
           repository: pavelzw/micromamba-nightlies
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.MICROMAMBA_NIGHTLIES_TOKEN }}
           tag_name: ${{ steps.tag_version.outputs.new_tag }}

--- a/.github/workflows/static_build.yml
+++ b/.github/workflows/static_build.yml
@@ -211,4 +211,4 @@ jobs:
             artifact.txt
           repository: pavelzw/micromamba-nightlies
           token: ${{ secrets.MICROMAMBA_NIGHTLIES_TOKEN }}
-          tag_name: 'sha-${{ steps.tag_version.outputs.new_tag }}'
+          tag_name: 'sha-${{ github.sha }}'

--- a/.github/workflows/static_build.yml
+++ b/.github/workflows/static_build.yml
@@ -95,7 +95,7 @@ jobs:
 
   micromamba-full-static-win:
     # These build instructions are based on https://github.com/conda-forge/micromamba-feedstock
-    if: false
+#    if: false
     name: "micromamba - win-64"
     runs-on: windows-2019
     steps:
@@ -151,6 +151,8 @@ jobs:
               -D BUILD_STATIC_DEPS=ON ^
               -D BUILD_MICROMAMBA=ON ^
               -D MICROMAMBA_LINKAGE=FULL_STATIC ^
+              -D LIBMAMBA_COMMIT_SHA=${{ github.sha }} ^
+              -D UMAMBA_COMMIT_SHA=${{ github.sha }} ^
               -G "Ninja"
           if %errorlevel% neq 0 exit /b %errorlevel%
           ninja install

--- a/.github/workflows/static_build.yml
+++ b/.github/workflows/static_build.yml
@@ -14,6 +14,7 @@ concurrency:
 
 jobs:
   conda-build:
+    if: false
     name: "micromamba - ${{ matrix.platform }}-${{ matrix.arch }}"
     runs-on: ${{ matrix.os }}
     strategy:
@@ -92,8 +93,9 @@ jobs:
           name: micromamba-${{ matrix.platform }}-${{ matrix.arch }}
           path: ${{ github.workspace }}/artifacts/micromamba
 
-  micromamba_full_static_win:
+  micromamba-full-static-win:
     # These build instructions are based on https://github.com/conda-forge/micromamba-feedstock
+    if: false
     name: "micromamba - win-64"
     runs-on: windows-2019
     steps:
@@ -173,3 +175,20 @@ jobs:
         with:
           name: micromamba-win-64
           path: build/micromamba/micromamba.exe
+
+  create_nightly_release:
+    name: "Create nightly release"
+#    depends-on: [conda-build, micromamba-full-static-win]
+    steps:
+      - run: echo "Hello, world!" >> artifact.txt
+      - name: Create release
+        uses: softprops/action-fg-release@v1
+        with:
+          prerelease: true
+          body: |
+            This is a nightly release of mamba.
+          files: |
+            artifact.txt
+          repository: pavelzw/micromamba-nightlies
+          token: ${{ secrets.GITHUB_TOKEN }}
+#          tag_name: nightly-${{ github.sha }}

--- a/.github/workflows/static_build.yml
+++ b/.github/workflows/static_build.yml
@@ -197,7 +197,7 @@ jobs:
         with:
           github_token: ${{ secrets.MICROMAMBA_NIGHTLIES_TOKEN }}
           github_repo: pavelzw/micromamba-nightlies
-          git_commit_sha: e606818dfc0f9ce7d1b0fccdabcfa6822d41cf98
+          git_commit_sha: sha-e606818dfc0f9ce7d1b0fccdabcfa6822d41cf98
           version: ${{ github.sha }}
           git_tag_prefix: ''
 

--- a/.github/workflows/static_build.yml
+++ b/.github/workflows/static_build.yml
@@ -186,12 +186,20 @@ jobs:
           repository: pavelzw/micromamba-nightlies
       - run: ls -la
       - run: echo "Hello, world!" >> artifact.txt
-      - name: Tag repository
-        id: tag_version
-        uses: anothrNick/github-tag-action@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          CUSTOM_TAG: ${{ github.sha }}
+#      - name: Tag repository
+#        id: tag_version
+#        uses: anothrNick/github-tag-action@v1
+#        env:
+#          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#          CUSTOM_TAG: ${{ github.sha }}
+      - name: package-version-to-git-tag
+        uses: pkgdeps/git-tag-action@v2
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_repo: pavelzw/micromamba-nightlies
+          git_commit_sha: e606818dfc0f9ce7d1b0fccdabcfa6822d41cf98
+          version: ${{ github.sha }}
+          git_tag_prefix: ''
 
       - name: Create release
         uses: softprops/action-gh-release@v1

--- a/.github/workflows/static_build.yml
+++ b/.github/workflows/static_build.yml
@@ -198,8 +198,8 @@ jobs:
           github_token: ${{ secrets.MICROMAMBA_NIGHTLIES_TOKEN }}
           github_repo: pavelzw/micromamba-nightlies
           git_commit_sha: e606818dfc0f9ce7d1b0fccdabcfa6822d41cf98
-          version: sha-${{ github.sha }}
-          git_tag_prefix: ''
+          version: ${{ github.sha }}
+          git_tag_prefix: 'sha-'
 
       - name: Create release
         uses: softprops/action-gh-release@v1
@@ -211,4 +211,4 @@ jobs:
             artifact.txt
           repository: pavelzw/micromamba-nightlies
           token: ${{ secrets.MICROMAMBA_NIGHTLIES_TOKEN }}
-          tag_name: ${{ steps.tag_version.outputs.new_tag }}
+          tag_name: 'sha-${{ steps.tag_version.outputs.new_tag }}'

--- a/.github/workflows/static_build.yml
+++ b/.github/workflows/static_build.yml
@@ -183,7 +183,7 @@ jobs:
     steps:
       - run: echo "Hello, world!" >> artifact.txt
       - name: Create release
-        uses: softprops/action-fg-release@v1
+        uses: softprops/action-gh-release@v1
         with:
           prerelease: true
           body: |

--- a/.github/workflows/static_build.yml
+++ b/.github/workflows/static_build.yml
@@ -181,13 +181,17 @@ jobs:
     runs-on: ubuntu-latest
 #    depends-on: [conda-build, micromamba-full-static-win]
     steps:
+      - uses: actions/checkout@v3
+        with:
+          repository: pavelzw/micromamba-nightlies
       - run: echo "Hello, world!" >> artifact.txt
       - name: Tag repository
         id: tag_version
-        uses: mathieudutour/github-tag-action@v6.1
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          custom_tag: ${{ github.sha }}
+        uses: anothrNick/github-tag-action@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CUSTOM_TAG: ${{ github.sha }}
+
       - name: Create release
         uses: softprops/action-gh-release@v1
         with:

--- a/.github/workflows/static_build.yml
+++ b/.github/workflows/static_build.yml
@@ -184,6 +184,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           repository: pavelzw/micromamba-nightlies
+      - run: ls -la
       - run: echo "Hello, world!" >> artifact.txt
       - name: Tag repository
         id: tag_version

--- a/.github/workflows/static_build.yml
+++ b/.github/workflows/static_build.yml
@@ -197,8 +197,8 @@ jobs:
         with:
           github_token: ${{ secrets.MICROMAMBA_NIGHTLIES_TOKEN }}
           github_repo: pavelzw/micromamba-nightlies
-          git_commit_sha: sha-e606818dfc0f9ce7d1b0fccdabcfa6822d41cf98
-          version: ${{ github.sha }}
+          git_commit_sha: e606818dfc0f9ce7d1b0fccdabcfa6822d41cf98
+          version: sha-${{ github.sha }}
           git_tag_prefix: ''
 
       - name: Create release

--- a/.github/workflows/static_build.yml
+++ b/.github/workflows/static_build.yml
@@ -182,6 +182,12 @@ jobs:
 #    depends-on: [conda-build, micromamba-full-static-win]
     steps:
       - run: echo "Hello, world!" >> artifact.txt
+      - name: Tag repository
+        id: tag_version
+        uses: mathieudutour/github-tag-action@v6.1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          custom_tag: ${{ github.sha }}
       - name: Create release
         uses: softprops/action-gh-release@v1
         with:
@@ -192,4 +198,4 @@ jobs:
             artifact.txt
           repository: pavelzw/micromamba-nightlies
           token: ${{ secrets.GITHUB_TOKEN }}
-#          tag_name: nightly-${{ github.sha }}
+          tag_name: ${{ steps.tag_version.outputs.new_tag }}

--- a/libmamba/CMakeLists.txt
+++ b/libmamba/CMakeLists.txt
@@ -46,6 +46,8 @@ message(STATUS "libmamba binary version: v${LIBMAMBA_BINARY_VERSION}")
 # Build options
 # =============
 
+add_definitions("-DLIBMAMBA_COMMIT_SHA=unknown sha")
+
 option(BUILD_TESTS "Build libmamba C++ tests" OFF)
 option(BUILD_SHARED "Build shared libmamba library" OFF)
 option(BUILD_STATIC "Build static libmamba library" OFF)

--- a/libmamba/environment-static-dev-win.yml
+++ b/libmamba/environment-static-dev-win.yml
@@ -10,6 +10,8 @@ dependencies:
   - cli11 >=2.2,<3
   - cpp-expected
   - cpp-filesystem
+  - fmt
+  - spdlog
   - nlohmann_json
   - spdlog
   - fmt

--- a/libmamba/include/mamba/version.hpp
+++ b/libmamba/include/mamba/version.hpp
@@ -27,7 +27,7 @@
 #define LIBMAMBA_VERSION_STRING                                                                    \
     __LIBMAMBA_STRINGIZE(LIBMAMBA_VERSION_MAJOR)                                                   \
     "." __LIBMAMBA_STRINGIZE(LIBMAMBA_VERSION_MINOR) "." __LIBMAMBA_STRINGIZE(                     \
-        LIBMAMBA_VERSION_PATCH)
+        LIBMAMBA_VERSION_PATCH) " (" __LIBMAMBA_STRINGIZE(LIBMAMBA_COMMIT_SHA) ")"
 
 namespace mamba
 {

--- a/micromamba/CMakeLists.txt
+++ b/micromamba/CMakeLists.txt
@@ -51,6 +51,8 @@ set(MICROMAMBA_HEADERS
     ${CMAKE_CURRENT_SOURCE_DIR}/src/version.hpp
 )
 
+add_definitions("-DUMAMBA_COMMIT_SHA=unknown sha")
+
 add_executable(micromamba ${MICROMAMBA_SRCS} ${MICROMAMBA_HEADERS})
 
 if(NOT (TARGET libmamba OR TARGET libmamba-static OR TARGET libmamba-full-static))

--- a/micromamba/src/version.hpp
+++ b/micromamba/src/version.hpp
@@ -26,8 +26,8 @@
     (UMAMBA_VERSION_MAJOR * 10000 + UMAMBA_VERSION_MINOR * 100 + UMAMBA_VERSION_PATCH)
 #define UMAMBA_VERSION_STRING                                                                      \
     __UMAMBA_STRINGIZE(UMAMBA_VERSION_MAJOR)                                                       \
-    "." __UMAMBA_STRINGIZE(UMAMBA_VERSION_MINOR) "." __UMAMBA_STRINGIZE(UMAMBA_VERSION_PATCH)
-
+    "." __UMAMBA_STRINGIZE(UMAMBA_VERSION_MINOR) "." __UMAMBA_STRINGIZE(UMAMBA_VERSION_PATCH)      \
+        " (" __UMAMBA_STRINGIZE(UMAMBA_COMMIT_SHA) ")"
 namespace umamba
 {
     std::string version();

--- a/micromamba/src/version.hpp
+++ b/micromamba/src/version.hpp
@@ -26,8 +26,8 @@
     (UMAMBA_VERSION_MAJOR * 10000 + UMAMBA_VERSION_MINOR * 100 + UMAMBA_VERSION_PATCH)
 #define UMAMBA_VERSION_STRING                                                                      \
     __UMAMBA_STRINGIZE(UMAMBA_VERSION_MAJOR)                                                       \
-    "." __UMAMBA_STRINGIZE(UMAMBA_VERSION_MINOR) "." __UMAMBA_STRINGIZE(UMAMBA_VERSION_PATCH)      \
-        " (" __UMAMBA_STRINGIZE(UMAMBA_COMMIT_SHA) ")"
+    "." __UMAMBA_STRINGIZE(UMAMBA_VERSION_MINOR) "." __UMAMBA_STRINGIZE(                           \
+        UMAMBA_VERSION_PATCH) " (" __UMAMBA_STRINGIZE(UMAMBA_COMMIT_SHA) ")"
 namespace umamba
 {
     std::string version();


### PR DESCRIPTION
For each `main` commit where the `static-build.yml` workflow succeeds, the workflow will afterwards create a new tag on a separate repository (for example `mamba-org/micromamba-nightlies`) where the built artifacts get uploaded. This fixes the issue of static build artifacts being deleted after 90 days.

Since every release needs to point to a specific commit sha in this new repository, we need to pin each release to a specific commit. We have two options here:

1. For each run, create a new commit that modifies the readme in the nightlies repo (for example displaying the current SHA and commit details) and create a release on this commit. 
2. Create a tag every time on `HEAD` leading to hundreds of tags on `HEAD`.

Still to do:

- [ ] add counter to version number to show (for example make releases like this: `v0.26.0-<counter-increment>-<first-letters-of-sha>`)
- [ ] Add new version string to `micromamba --version` (this closes #1929)

Proof of concept can be seen in [`pavelzw/micromamba-releases`](https://github.com/pavelzw/micromamba-nightlies/releases) with corresponding workflow runs in [`pavelzw/mamba #7`](https://github.com/pavelzw/mamba/pull/7). 