### PR TITLE
fix pytest-xprocess issue

### DIFF
--- a/micromamba/environment-dev.yml
+++ b/micromamba/environment-dev.yml
@@ -21,6 +21,9 @@ dependencies:
   - pytest
   - pytest-asyncio
   - pytest-lazy-fixture
+  # explicitly require `py` until this issue is closed:
+  # https://github.com/pytest-dev/pytest-xprocess/issues/110
+  - py
   - pytest-xprocess
   - pyyaml
   - spdlog


### PR DESCRIPTION
Unfortunately, a dropped dependency on `py` forces us to install it explicitly: https://github.com/pytest-dev/pytest-xprocess/issues/110