### PR TITLE
Fix CI by pointing to updated feedstock

### DIFF
--- a/.github/workflows/static_build.yml
+++ b/.github/workflows/static_build.yml
@@ -31,7 +31,8 @@ jobs:
       - name: Checkout micromamba-feedstock
         uses: actions/checkout@v3
         with:
-          repository: conda-forge/micromamba-feedstock
+          repository: AntoinePrv/micromamba-feedstock
+          ref: spdlog
           path: micromamba-feedstock
       # replace the url: ... until the libmamba.patch line with git_url: ../..
       - name: Patch micromamba-feedstock

--- a/.github/workflows/static_build.yml
+++ b/.github/workflows/static_build.yml
@@ -38,14 +38,13 @@ jobs:
       - name: Patch micromamba-feedstock
         if: ${{ matrix.platform == 'linux' }}
         run: |
-          sed -i -E -z 's/url:.*libmamba.patch/git_url: ..\/..\//g' micromamba-feedstock/recipe/meta.yaml
+          sed -i -E 's/url:.*$/git_url: ..\/..\//' micromamba-feedstock/recipe/meta.yaml
+          sed -i '/sha256:/d' micromamba-feedstock/recipe/meta.yaml
       - name: Patch micromamba-feedstock
         if: ${{ matrix.platform == 'osx' }}
         run: |
           sed -i '' -E 's/url:.*/git_url: ..\/..\//' micromamba-feedstock/recipe/meta.yaml
           sed -i '' '/sha256:/d' micromamba-feedstock/recipe/meta.yaml
-          sed -i '' '/patches:/d' micromamba-feedstock/recipe/meta.yaml
-          sed -i '' '/libmamba.patch/d' micromamba-feedstock/recipe/meta.yaml
       - uses: mamba-org/provision-with-micromamba@main
         with:
           channels: conda-forge

--- a/micromamba/tests/test_update.py
+++ b/micromamba/tests/test_update.py
@@ -52,7 +52,9 @@ class TestUpdate:
         shutil.rmtree(TestUpdate.prefix)
 
     def test_constrained_update(self, env_created):
-        update_res = update("xtensor<=" + self.medium_old_version, "-n", env_created, "--json")
+        update_res = update(
+            "xtensor<=" + self.medium_old_version, "-n", env_created, "--json"
+        )
         xtensor_link = [
             l for l in update_res["actions"]["LINK"] if l["name"] == "xtensor"
         ][0]


### PR DESCRIPTION
Pointing the micromamba static feedstock to https://github.com/conda-forge/micromamba-feedstock/pull/97.