### PR TITLE
Fix ci deprecation warnings

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -16,33 +16,18 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
-    - name: Set up Python 3.8
-      uses: actions/setup-python@v1
+    - uses: actions/checkout@v3
+    - name: Install pre-commit
+      uses: mamba-org/provision-with-micromamba@main
       with:
-        python-version: 3.8
-    - name: Setup Miniconda
-      uses: conda-incubator/setup-miniconda@v2
-      with:
-        miniconda-version: 'latest'
-        activate-environment: linters
-        python-version: 3.8
-        auto-update-conda: true
-    - name: Config Channels
-      shell: pwsh
+        environment-name: linters
+        extra-specs: pre-commit
+    - name: Micromamba info
+      shell: bash -el {0}
       run: |
-        conda config --set always_yes yes
-        conda config --add channels conda-forge
-    - name: Install dependencies
-      shell: pwsh
-      run: |
-        conda install pre-commit
-    - name: Conda info
-      shell: pwsh
-      run: |
-        conda info -a
-        conda list
+        micromamba info -a
+        micromamba list
     - name: Run all linters
-      shell: pwsh
+      shell: bash -el {0}
       run: |
         pre-commit run --all-files --verbose --show-diff-on-failure

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -510,7 +510,7 @@ jobs:
         run: sccache --show-stats
       - name: tar micromamba artifact
         run: tar -cvf umamba.tar build/micromamba/micromamba.exe
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: _internal_micromamba_binary
           path: umamba.tar
@@ -531,7 +531,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: _internal_micromamba_binary
 


### PR DESCRIPTION
- `actions/upload-artifact@v2` -> `actions/upload-artifact@v3`
- `actions/download-artifact@v2` -> `actions/download-artifact@v3`
- use `mamba-org/provision-with-micromamba` instead of `conda-incubator/setup-miniconda` in `linters.yml`

The CI warnings in `static_build.yml` already get fixed by #2058.