### PR TITLE
Order dependencies of `micromamba env export` alphabetically

### DIFF
--- a/libmamba/CMakeLists.txt
+++ b/libmamba/CMakeLists.txt
@@ -14,7 +14,7 @@ set(LIBMAMBA_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/include)
 set(LIBMAMBA_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/src)
 set(LIBMAMBA_DATA_DIR ${CMAKE_CURRENT_SOURCE_DIR}/data)
 
-# Versionning
+# Versioning
 # ===========
 file(STRINGS "${LIBMAMBA_INCLUDE_DIR}/mamba/version.hpp" libmamba_version_defines
      REGEX "#define LIBMAMBA_VERSION_(MAJOR|MINOR|PATCH)")

--- a/libmamba/include/mamba/core/prefix_data.hpp
+++ b/libmamba/include/mamba/core/prefix_data.hpp
@@ -8,7 +8,7 @@
 #define MAMBA_CORE_PREFIX_DATA_HPP
 
 #include <string>
-#include <unordered_map>
+#include <map>
 
 #include "error_handling.hpp"
 #include "history.hpp"
@@ -19,7 +19,7 @@ namespace mamba
     class PrefixData
     {
     public:
-        using package_map = std::unordered_map<std::string, PackageInfo>;
+        using package_map = std::map<std::string, PackageInfo>;
 
         static expected_t<PrefixData> create(const fs::u8path& prefix_path);
 
@@ -36,7 +36,7 @@ namespace mamba
         void load();
 
         History m_history;
-        std::unordered_map<std::string, PackageInfo> m_package_records;
+        package_map m_package_records;
         fs::u8path m_prefix_path;
     };
 }  // namespace mamba

--- a/libmamba/src/core/prefix_data.cpp
+++ b/libmamba/src/core/prefix_data.cpp
@@ -32,7 +32,7 @@ namespace mamba
         catch (...)
         {
             return tl::make_unexpected(
-                mamba_error("Unkown error when trying to load prefix data " + prefix_path.string(),
+                mamba_error("Unknown error when trying to load prefix data " + prefix_path.string(),
                             mamba_error_code::unknown));
         }
     }

--- a/micromamba/src/env.cpp
+++ b/micromamba/src/env.cpp
@@ -5,9 +5,6 @@
 #include "mamba/core/channel.hpp"
 
 #include "mamba/api/configuration.hpp"
-#include "mamba/core/pool.hpp"
-#include "mamba/core/transaction.hpp"
-#include "mamba/core/repo.hpp"
 #include "mamba/api/remove.hpp"
 
 
@@ -61,7 +58,7 @@ set_env_command(CLI::App* com)
     export_subcom->callback(
         []()
         {
-            auto& ctx = Context::instance();
+            auto const& ctx = Context::instance();
             auto& config = Configuration::instance();
             config.at("show_banner").set_value(false);
             config.load();
@@ -76,7 +73,7 @@ set_env_command(CLI::App* com)
                           << "# platform: " << Context::instance().platform << "\n"
                           << "@EXPLICIT\n";
 
-                for (auto& record : records)
+                for (const auto& record : records)
                 {
                     std::string clean_url, token;
                     split_anaconda_token(record.url, clean_url, token);
@@ -93,7 +90,7 @@ set_env_command(CLI::App* com)
                 auto pd = PrefixData::create(ctx.target_prefix).value();
                 History& hist = pd.history();
 
-                auto versions_map = pd.records();
+                const auto& versions_map = pd.records();
 
                 std::cout << "name: " << get_env_name(ctx.target_prefix) << "\n";
                 std::cout << "channels:\n";
@@ -101,7 +98,7 @@ set_env_command(CLI::App* com)
                 auto requested_specs_map = hist.get_requested_specs_map();
                 std::stringstream dependencies;
                 std::set<std::string> channels;
-                for (auto& [k, v] : versions_map)
+                for (const auto& [k, v] : versions_map)
                 {
                     if (from_history && requested_specs_map.find(k) == requested_specs_map.end())
                         continue;
@@ -121,7 +118,7 @@ set_env_command(CLI::App* com)
                     channels.insert(make_channel(v.url).base_url());
                 }
 
-                for (auto& c : channels)
+                for (const auto& c : channels)
                     std::cout << "- " << c << "\n";
                 std::cout << "dependencies:\n" << dependencies.str() << std::endl;
                 std::cout.flush();
@@ -131,7 +128,7 @@ set_env_command(CLI::App* com)
     list_subcom->callback(
         []()
         {
-            auto& ctx = Context::instance();
+            const auto& ctx = Context::instance();
             auto& config = Configuration::instance();
             config.load();
 
@@ -176,10 +173,10 @@ set_env_command(CLI::App* com)
             // Remove specs if exist
             remove(MAMBA_REMOVE_ALL);
 
-            auto& ctx = Context::instance();
+            const auto& ctx = Context::instance();
             if (!ctx.dry_run)
             {
-                auto& prefix = ctx.target_prefix;
+                const auto& prefix = ctx.target_prefix;
                 // Remove env directory or rename it (e.g. if used)
                 remove_or_rename(env::expand_user(prefix));
 


### PR DESCRIPTION
This PR makes the `micromamba env export` command print the `dependencies` section in alphabetical order. This arguably both easier for humans to read, and helps avoid git merge conflicts when committing the environment to a repo. 

Before:
```
name: cpp
channels:
- https://conda.anaconda.org/conda-forge
- https://conda.anaconda.org/memfault
dependencies:
- libcxx=14.0.6=hccf4f1f_0
- llvm-openmp=14.0.4=ha654fa7_0
- wheel=0.37.1=pyhd8ed1ab_0
- libnghttp2=1.47.0=h5aae05b_1
- ncurses=6.3=h96cf925_1
- ca-certificates=2022.9.24=h033912b_0
- clang=15.0.3=h694c41f_0
- libuv=1.44.2=hac89ed1_0
- zstd=1.5.2=hfa58983_4
- libzlib=1.2.13=hfd90126_4
- xz=5.2.6=h775f41a_0
- rhash=1.4.3=hac89ed1_0
- libxml2=2.9.14=hea49891_4
- clang-15=15.0.3=default_h20dc2f0_0
- libgfortran5=11.3.0=h082f757_25
- libsqlite=3.39.4=ha978bb4_0
- setuptools=65.5.0=pyhd8ed1ab_0
- zlib=1.2.13=hfd90126_4
- ccache=4.7.1=h2822714_0
- krb5=1.19.3=hb98e516_0
- gcc-arm-none-eabi=10.3.2021.10=0
- python=3.10.6=hc14f532_0_cpython
- libedit=3.1.20191231=h0678c8f_2
- perl=5.32.1=2_h0d85af4_perl5
- libssh2=1.10.0=h47af595_3
- ninja=1.11.0=h1b54a9f_0
- expat=2.4.9=hf0c8a7f_0
- make=4.3=h22f3db7_1
- libhiredis=1.0.2=h2beb688_0
- c-ares=1.18.1=h0d85af4_0
- libllvm15=15.0.3=hb04caa8_0
- readline=8.1.2=h3899abd_0
- libcurl=7.85.0=h581aaea_0
- libffi=3.4.2=h0d85af4_5
- libgfortran=5.0.0=10_4_0_h97931a8_25
- libclang-cpp15=15.0.3=default_h20dc2f0_0
- bzip2=1.0.8=h0d85af4_4
- pip=22.3=pyhd8ed1ab_0
- icu=70.1=h96cf925_0
- openssl=3.0.5=hfd90126_2
- cmake=3.24.2=h5291bba_0
- tzdata=2022e=h191b570_0
- libiconv=1.17=hac89ed1_0
- tk=8.6.12=h5dbffcc_0
- libev=4.33=haf1e3a3_1
- lcov=1.16=h694c41f_0
```


After
```

- bzip2=1.0.8=h0d85af4_4
- c-ares=1.18.1=h0d85af4_0
- ca-certificates=2022.9.24=h033912b_0
- ccache=4.7.1=h2822714_0
- clang=15.0.3=h694c41f_0
- clang-15=15.0.3=default_h20dc2f0_0
- cmake=3.24.2=h5291bba_0
- expat=2.4.9=hf0c8a7f_0
- gcc-arm-none-eabi=10.3.2021.10=0
- icu=70.1=h96cf925_0
- krb5=1.19.3=hb98e516_0
- lcov=1.16=h694c41f_0
- libclang-cpp15=15.0.3=default_h20dc2f0_0
- libcurl=7.85.0=h581aaea_0
- libcxx=14.0.6=hccf4f1f_0
- libedit=3.1.20191231=h0678c8f_2
- libev=4.33=haf1e3a3_1
- libffi=3.4.2=h0d85af4_5
- libgfortran=5.0.0=10_4_0_h97931a8_25
- libgfortran5=11.3.0=h082f757_25
- libhiredis=1.0.2=h2beb688_0
- libiconv=1.17=hac89ed1_0
- libllvm15=15.0.3=hb04caa8_0
- libnghttp2=1.47.0=h5aae05b_1
- libsqlite=3.39.4=ha978bb4_0
- libssh2=1.10.0=h47af595_3
- libuv=1.44.2=hac89ed1_0
- libxml2=2.9.14=hea49891_4
- libzlib=1.2.13=hfd90126_4
- llvm-openmp=14.0.4=ha654fa7_0
- make=4.3=h22f3db7_1
- ncurses=6.3=h96cf925_1
- ninja=1.11.0=h1b54a9f_0
- openssl=3.0.5=hfd90126_2
- perl=5.32.1=2_h0d85af4_perl5
- pip=22.3=pyhd8ed1ab_0
- python=3.10.6=hc14f532_0_cpython
- readline=8.1.2=h3899abd_0
- rhash=1.4.3=hac89ed1_0
- setuptools=65.5.0=pyhd8ed1ab_0
- tk=8.6.12=h5dbffcc_0
- tzdata=2022e=h191b570_0
- wheel=0.37.1=pyhd8ed1ab_0
- xz=5.2.6=h775f41a_0
- zlib=1.2.13=hfd90126_4
- zstd=1.5.2=hfa58983_4

```

