### PR TITLE
Fix activate/deactivate in fish shell

### DIFF
--- a/mamba/mamba/shell_templates/mamba.fish
+++ b/mamba/mamba/shell_templates/mamba.fish
@@ -13,10 +13,10 @@ function mamba --inherit-variable CONDA_EXE --inherit-variable MAMBA_EXE
     set -e argv[1]
     switch $cmd
       case activate deactivate
-        eval ($CONDA_EXE shell -s fish $cmd $argv)
+        eval ($CONDA_EXE shell.fish $cmd $argv)
       case install update upgrade remove uninstall
         $MAMBA_EXE $cmd $argv || return $status
-        and eval ($CONDA_EXE shell -s fish reactivate)
+        and eval ($CONDA_EXE shell.fish reactivate)
       case '*'
         $MAMBA_EXE $cmd $argv
     end


### PR DESCRIPTION
Fixes https://github.com/mamba-org/mamba/issues/1718
Hopefully for real.
Based on @wolfv comment: https://github.com/mamba-org/mamba/issues/1718#issuecomment-1300536915

Can confirm locally on macOS 12.6 this fixes the issue and mamba activate and deactivate work as expected.