### PR TITLE
Fix libmamba CMake config file after dependency change

### DIFF
--- a/libmamba/libmambaConfig.cmake.in
+++ b/libmamba/libmambaConfig.cmake.in
@@ -22,7 +22,9 @@ set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR};${CMAKE_MODULE_PATH}")
 @LIBMAMBA_CONFIG_CODE@
 
 include(CMakeFindDependencyMacro)
+find_dependency(fmt)
 find_dependency(nlohmann_json)
+find_dependency(spdlog)
 find_dependency(Threads)
 find_dependency(tl-expected)
 


### PR DESCRIPTION
Direct dependency on fmt and spdlog was added in commit b8d7ec97a4324a53e2ed6ca8cff39a349b99c4bd.