### PR TITLE
fix: Don't print banner in quiet mode

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ discuss the change you wish to make via issue, email, or any other method with
 the owners of this repository before making a change.
 
 We welcome all kinds of contribution -- code or non-code -- and value them
-highly. We pledge to treat everyones contribution fairly and with respect and
+highly. We pledge to treat everyone's contribution fairly and with respect and
 we are here to help awesome pull requests over the finish line.
 
 Please note we have a code of conduct, and follow it in all your interactions with the project.

--- a/mamba/mamba/mamba.py
+++ b/mamba/mamba/mamba.py
@@ -877,6 +877,7 @@ def _wrapped_main(*args, **kwargs):
     if (
         not found_no_banner
         and os.isatty(sys.stdout.fileno())
+        and not context.quiet
         and not ("MAMBA_NO_BANNER" in os.environ or parsed_args.cmd in ("list", "run"))
     ):
         print(banner, file=sys.stderr)


### PR DESCRIPTION
Resolves https://github.com/mamba-org/mamba/issues/2089

- fix: do not print banner in quiet mode
- typo(contributing.md): everyones -> everyone's
