### PR TITLE
Use `fish_add_path` instead of modifying `$PATH`

### DIFF
--- a/libmamba/data/mamba.fish
+++ b/libmamba/data/mamba.fish
@@ -1,6 +1,6 @@
 if not set -q MAMBA_SHLVL
   set -gx MAMBA_SHLVL "0"
-  set -gx PATH $MAMBA_ROOT_PREFIX/condabin $PATH
+  fish_add_path $MAMBA_ROOT_PREFIX/condabin
 end
 
 if not set -q MAMBA_NO_PROMPT

--- a/libmamba/data/mamba.fish
+++ b/libmamba/data/mamba.fish
@@ -1,6 +1,6 @@
 if not set -q MAMBA_SHLVL
   set -gx MAMBA_SHLVL "0"
-  fish_add_path $MAMBA_ROOT_PREFIX/condabin
+  fish_add_path --move $MAMBA_ROOT_PREFIX/condabin
 end
 
 if not set -q MAMBA_NO_PROMPT


### PR DESCRIPTION
```fish
set -gx MAMBA_EXE "/usr/bin/micromamba"
set -gx MAMBA_ROOT_PREFIX "/home/raj/.local/share/micromamba"
eval $MAMBA_EXE shell hook --shell fish --prefix $MAMBA_ROOT_PREFIX | source
```

Adding the above to the end of my `config.fish` (as recommended by `micromamba` when I try `micromamba activate <environment>` without initializing the `fish` shell) messes up my `PATH`:

```
/home/raj/.local/share/micromamba/envs/temp/bin /home/raj/.local/bin /home/raj/.local/share/micromamba/condabin /usr/local/sbin /usr/local/bin /usr/bin /usr/lib/jvm/default/bin /usr/bin/site_perl /usr/bin/vendor_perl /usr/bin/core_perl set -gx CONDA_PREFIX /home/raj/.local/share/micromamba/envs/temp set -gx CONDA_SHLVL 1 set -gx CONDA_DEFAULT_ENV temp set -gx CONDA_PROMPT_MODIFIER (temp)
```

A similar problem was reported here: https://github.com/mamba-org/mamba/pull/2079

Instead of adding that to `config.fish` directly, if I just add this, it also reproduces the issue:

```fish
set -gx MAMBA_EXE "/usr/bin/micromamba"
set -gx MAMBA_ROOT_PREFIX "/home/raj/.local/share/micromamba"

if not set -q MAMBA_SHLVL
  set -gx MAMBA_SHLVL "0"
  fish_add_path $MAMBA_ROOT_PREFIX/condabin
end

function micromamba --inherit-variable MAMBA_EXE
  if test (count $argv) -lt 1 || contains -- --help $argv
    $MAMBA_EXE $argv
  else
    set -l cmd $argv[1]
    set -e argv[1]
    switch $cmd
      case activate deactivate
        eval ($MAMBA_EXE shell -s fish $cmd $argv)
      case install update upgrade remove uninstall
        $MAMBA_EXE $cmd $argv || return $status
        and eval ($MAMBA_EXE shell -s fish reactivate)
      case '*'
        $MAMBA_EXE $cmd $argv
    end
  end
end
```

I'm not sure exactly where the `PATH` is changing, so I replaced the manual path update with `fish_add_path` as a first step, but that doesn't change things, suggesting that `micromamba shell -s fish activate <environment>` is the issue. Not sure how to debug this further.