### PR TITLE
Fix micromamba shell completion when running 'shell hook' directly

### DIFF
--- a/libmamba/data/mamba_completion.posix
+++ b/libmamba/data/mamba_completion.posix
@@ -10,7 +10,7 @@ if [ -n "${ZSH_VERSION:+x}" ]; then
 
   _umamba_zsh_completions()
   {
-    COMPREPLY=($($MAMBA_EXE completer "${(@s: :)${(@s: :)COMP_LINE}:1}"))
+    COMPREPLY=($(__mamba_exe completer "${(@s: :)${(@s: :)COMP_LINE}:1}"))
   }
 
   complete -o default -F _umamba_zsh_completions micromamba
@@ -18,7 +18,7 @@ fi
 if [ -n "${BASH_VERSION:+x}" ]; then
   _umamba_bash_completions()
   {
-    COMPREPLY=($($MAMBA_EXE completer "${COMP_WORDS[@]:1}"))
+    COMPREPLY=($(__mamba_exe completer "${COMP_WORDS[@]:1}"))
   }
   complete -o default -F _umamba_bash_completions micromamba
 fi


### PR DESCRIPTION
Fixes #1748.

Note: I didn't test this at all.

Caveat: With this patch, old users will most likely have to rerun "micromamba shell init" or "micromamba shell reinit" after doing a manual update. Otherwise the old script will stay cached in ~/micromamba/etc/profile.d/micromamba.sh and their bash/zsh completion will break. It would be good to document this. But at least users on 1.0.0+ can just use "micromamba self-update", which runs shell reinit automatically.