### PR TITLE
Expliclity point to libmamba test data independently of cwd

### DIFF
--- a/libmamba/tests/CMakeLists.txt
+++ b/libmamba/tests/CMakeLists.txt
@@ -1,11 +1,17 @@
 cmake_minimum_required(VERSION 3.1)
 
+
+add_executable(testing_libmamba_lock testing/lock.cpp)
+
+target_link_libraries(testing_libmamba_lock PUBLIC libmamba)
+
+target_compile_features(testing_libmamba_lock PUBLIC cxx_std_17)
+
+
 find_package(GTest)
 find_package(Threads REQUIRED)
 
-include_directories(${GTEST_INCLUDE_DIRS} SYSTEM)
-
-set(TEST_SRCS
+set(LIBMAMBA_TEST_SRCS
     ../longpath.manifest
     test_activation.cpp
     test_channel.cpp
@@ -36,34 +42,27 @@ set(TEST_SRCS
 )
 
 message(STATUS "Building libmamba C++ tests")
-add_executable(test_libmamba ${TEST_SRCS})
 
-file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/history_test/parse/conda-meta/history
-     DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/history_test/parse/conda-meta/)
-file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/history_test/parse/conda-meta/aux_file
-     DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/history_test/parse/conda-meta/)
-file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/history_test/parse_segfault/conda-meta/history
-     DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/history_test/parse_segfault/conda-meta/)
-file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/config_test/.condarc
-     DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/config_test/)
-file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/config_test/.condarc
-     DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/config_test/)
-file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/env_file_test
-     DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/)
-file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/validation_data
-     DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/)
-file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/repodata_json_cache
-     DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/)
-file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/env_lockfile_test
-     DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/)
+add_executable(test_libmamba ${LIBMAMBA_TEST_SRCS})
 
+target_include_directories(
+    test_libmamba
+    PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}"
+)
 
-target_link_libraries(test_libmamba PRIVATE GTest::GTest GTest::Main Threads::Threads)
-target_link_libraries(test_libmamba PUBLIC libmamba)
-set_property(TARGET test_libmamba PROPERTY CXX_STANDARD 17)
+target_link_libraries(
+    test_libmamba
+    PUBLIC libmamba
+    PRIVATE GTest::GTest GTest::Main Threads::Threads
+)
+
+target_compile_definitions(
+    test_libmamba
+    PRIVATE
+        MAMBA_TEST_DATA_DIR="${CMAKE_CURRENT_SOURCE_DIR}"
+        MAMBA_TEST_LOCK_EXE="${CMAKE_CURRENT_BINARY_DIR}/testing_libmamba_lock"
+)
+
+target_compile_features(test_libmamba PUBLIC cxx_std_17)
 
 add_custom_target(test COMMAND test_libmamba DEPENDS test_libmamba)
-
-add_executable(testing_libmamba_lock testing/lock.cpp)
-target_link_libraries(testing_libmamba_lock PUBLIC libmamba)
-set_property(TARGET testing_libmamba_lock PROPERTY CXX_STANDARD 17)

--- a/libmamba/tests/history_test/test_history.cpp
+++ b/libmamba/tests/history_test/test_history.cpp
@@ -1,15 +1,19 @@
-#include <gtest/gtest.h>
-
 #include <string>
 
+#include <gtest/gtest.h>
+
 #include "mamba/core/history.hpp"
+
+#include "test_data.hpp"
 
 namespace mamba
 {
     TEST(history, parse)
     {
-        static const auto history_file_path = fs::absolute("history_test/parse/conda-meta/history");
-        static const auto aux_file_path = fs::absolute("history_test/parse/conda-meta/aux_file");
+        static const auto history_file_path
+            = fs::absolute(test_data_dir / "history_test/parse/conda-meta/history");
+        static const auto aux_file_path
+            = fs::absolute(test_data_dir / "history_test/parse/conda-meta/aux_file");
 
         // Backup history file and restore it at the end of the test, whatever the output.
         struct ScopedHistoryFileBackup
@@ -27,7 +31,7 @@ namespace mamba
         } scoped_history_file_backup;
 
         // Gather history from current history file.
-        History history_instance("history_test/parse");
+        History history_instance(test_data_dir / "history_test/parse");
         std::vector<History::UserRequest> user_reqs = history_instance.get_user_requests();
 
         // Extract raw history file content into buffer.

--- a/libmamba/tests/test_configuration.cpp
+++ b/libmamba/tests/test_configuration.cpp
@@ -4,6 +4,8 @@
 #include "mamba/core/context.hpp"
 #include "mamba/core/util.hpp"
 
+#include "test_data.hpp"
+
 namespace mamba
 {
     namespace detail
@@ -981,10 +983,13 @@ namespace mamba
         {
             using namespace detail;
 
-            fs::u8path p = "config_test/.condarc";
+            fs::u8path p = test_data_dir / "config_test/.condarc";
 
             std::vector<fs::u8path> wrong_paths = {
-                "config_test", "conf_test", "config_test/condarc", "history_test/conda-meta/history"
+                test_data_dir / "config_test",
+                test_data_dir / "conf_test",
+                test_data_dir / "config_test/condarc",
+                test_data_dir / "history_test/conda-meta/history",
             };
 
             EXPECT_TRUE(is_config_file(p));

--- a/libmamba/tests/test_cpp.cpp
+++ b/libmamba/tests/test_cpp.cpp
@@ -1,7 +1,7 @@
-#include <gtest/gtest.h>
-
 #include <sstream>
 #include <tuple>
+
+#include <gtest/gtest.h>
 
 #include "mamba/core/context.hpp"
 #include "mamba/core/fsutil.hpp"
@@ -9,6 +9,8 @@
 #include "mamba/core/link.hpp"
 #include "mamba/core/match_spec.hpp"
 #include "mamba/core/output.hpp"
+
+#include "test_data.hpp"
 
 namespace mamba
 {
@@ -507,7 +509,7 @@ namespace mamba
 
     TEST(subdirdata, parse_mod_etag)
     {
-        fs::u8path cache_folder = fs::u8path("repodata_json_cache");
+        fs::u8path cache_folder = fs::u8path(test_data_dir / "repodata_json_cache");
         auto j = detail::read_mod_and_etag(cache_folder / "test_1.json");
         EXPECT_EQ(j["_mod"], "Fri, 11 Feb 2022 13:52:44 GMT");
         EXPECT_EQ(

--- a/libmamba/tests/test_data.hpp
+++ b/libmamba/tests/test_data.hpp
@@ -15,7 +15,7 @@ namespace mamba
 #ifndef MAMBA_TEST_DATA_DIR
 #error "MAMBA_TEST_DATA_DIR must be defined pointing to test data"
 #endif
-    static const fs::u8path test_data_dir = MAMBA_TEST_DATA_DIR;
+    inline static const fs::u8path test_data_dir = MAMBA_TEST_DATA_DIR;
 
 }
 

--- a/libmamba/tests/test_data.hpp
+++ b/libmamba/tests/test_data.hpp
@@ -1,0 +1,22 @@
+// Copyright (c) 2022, QuantStack and Mamba Contributors
+//
+// Distributed under the terms of the BSD 3-Clause License.
+//
+// The full license is in the file LICENSE, distributed with this software.
+
+#ifndef MAMBA_CORE_URL_HPP
+#define MAMBA_CORE_URL_HPP
+
+#include "mamba/core/fsutil.hpp"
+
+namespace mamba
+{
+
+#ifndef MAMBA_TEST_DATA_DIR
+#error "MAMBA_TEST_DATA_DIR must be defined pointing to test data"
+#endif
+    static const fs::u8path test_data_dir = MAMBA_TEST_DATA_DIR;
+
+}
+
+#endif

--- a/libmamba/tests/test_env_file_reading.cpp
+++ b/libmamba/tests/test_env_file_reading.cpp
@@ -2,6 +2,8 @@
 
 #include "mamba/api/install.hpp"
 
+#include "test_data.hpp"
+
 namespace mamba
 {
     TEST(env_file_reading, selector)
@@ -34,13 +36,13 @@ namespace mamba
     TEST(env_file_reading, specs_selection)
     {
         using V = std::vector<std::string>;
-        auto res = detail::read_yaml_file("env_file_test/env_1.yaml");
+        auto res = detail::read_yaml_file(test_data_dir / "env_file_test/env_1.yaml");
         EXPECT_EQ(res.name, "env_1");
         EXPECT_EQ(res.channels, V({ "conda-forge", "bioconda" }));
         EXPECT_EQ(res.dependencies, V({ "test1", "test2", "test3" }));
         EXPECT_FALSE(res.others_pkg_mgrs_specs.size());
 
-        auto res2 = detail::read_yaml_file("env_file_test/env_2.yaml");
+        auto res2 = detail::read_yaml_file(test_data_dir / "env_file_test/env_2.yaml");
         EXPECT_EQ(res2.name, "env_2");
         EXPECT_EQ(res2.channels, V({ "conda-forge", "bioconda" }));
 #ifdef __linux__
@@ -56,7 +58,7 @@ namespace mamba
     TEST(env_file_reading, external_pkg_mgrs)
     {
         using V = std::vector<std::string>;
-        auto res = detail::read_yaml_file("env_file_test/env_3.yaml");
+        auto res = detail::read_yaml_file(test_data_dir / "env_file_test/env_3.yaml");
         EXPECT_EQ(res.name, "env_3");
         EXPECT_EQ(res.channels, V({ "conda-forge", "bioconda" }));
         EXPECT_EQ(res.dependencies, V({ "test1", "test2", "test3", "pip" }));
@@ -65,7 +67,7 @@ namespace mamba
         auto o = res.others_pkg_mgrs_specs[0];
         EXPECT_EQ(o.pkg_mgr, "pip");
         EXPECT_EQ(o.deps, V({ "pytest", "numpy" }));
-        EXPECT_EQ(o.cwd, fs::absolute("env_file_test"));
+        EXPECT_EQ(o.cwd, fs::absolute(test_data_dir / "env_file_test"));
     }
 
 }  // namespace mamba

--- a/libmamba/tests/test_env_lockfile.cpp
+++ b/libmamba/tests/test_env_lockfile.cpp
@@ -1,10 +1,11 @@
 #include <gtest/gtest.h>
-
 #include <yaml-cpp/exceptions.h>
 
 #include "mamba/core/env_lockfile.hpp"
 #include "mamba/core/fsutil.hpp"
 #include "mamba/core/transaction.hpp"
+
+#include "test_data.hpp"
 
 namespace mamba
 {
@@ -29,7 +30,9 @@ namespace mamba
 
     TEST(env_lockfile, invalid_version_fails)
     {
-        const fs::u8path invalid_version_lockfile_path{ "env_lockfile_test/bad_version-lock.yaml" };
+        const fs::u8path invalid_version_lockfile_path{
+            test_data_dir / "env_lockfile_test/bad_version-lock.yaml"
+        };
         const auto maybe_lockfile = read_environment_lockfile(invalid_version_lockfile_path);
         ASSERT_FALSE(maybe_lockfile);
         const auto error = maybe_lockfile.error();
@@ -40,7 +43,8 @@ namespace mamba
 
     TEST(env_lockfile, valid_no_package_succeed)
     {
-        const fs::u8path lockfile_path{ "env_lockfile_test/good_no_package-lock.yaml" };
+        const fs::u8path lockfile_path{ test_data_dir
+                                        / "env_lockfile_test/good_no_package-lock.yaml" };
         const auto maybe_lockfile = read_environment_lockfile(lockfile_path);
         ASSERT_TRUE(maybe_lockfile) << maybe_lockfile.error().what();
         const auto lockfile = maybe_lockfile.value();
@@ -49,7 +53,7 @@ namespace mamba
 
     TEST(env_lockfile, invalid_package_fails)
     {
-        const fs::u8path lockfile_path{ "env_lockfile_test/bad_package-lock.yaml" };
+        const fs::u8path lockfile_path{ test_data_dir / "env_lockfile_test/bad_package-lock.yaml" };
         const auto maybe_lockfile = read_environment_lockfile(lockfile_path);
         ASSERT_FALSE(maybe_lockfile);
         const auto error = maybe_lockfile.error();
@@ -60,7 +64,8 @@ namespace mamba
 
     TEST(env_lockfile, valid_one_package_succeed)
     {
-        const fs::u8path lockfile_path{ "env_lockfile_test/good_one_package-lock.yaml" };
+        const fs::u8path lockfile_path{ test_data_dir
+                                        / "env_lockfile_test/good_one_package-lock.yaml" };
         const auto maybe_lockfile = read_environment_lockfile(lockfile_path);
         ASSERT_TRUE(maybe_lockfile) << maybe_lockfile.error().what();
         const auto lockfile = maybe_lockfile.value();
@@ -70,7 +75,7 @@ namespace mamba
     TEST(env_lockfile, valid_one_package_implicit_category)
     {
         const fs::u8path lockfile_path{
-            "env_lockfile_test/good_one_package_missing_category-lock.yaml"
+            test_data_dir / "env_lockfile_test/good_one_package_missing_category-lock.yaml"
         };
         const auto maybe_lockfile = read_environment_lockfile(lockfile_path);
         ASSERT_TRUE(maybe_lockfile) << maybe_lockfile.error().what();
@@ -80,7 +85,8 @@ namespace mamba
 
     TEST(env_lockfile, valid_multiple_packages_succeed)
     {
-        const fs::u8path lockfile_path{ "env_lockfile_test/good_multiple_packages-lock.yaml" };
+        const fs::u8path lockfile_path{ test_data_dir
+                                        / "env_lockfile_test/good_multiple_packages-lock.yaml" };
         const auto maybe_lockfile = read_environment_lockfile(lockfile_path);
         ASSERT_TRUE(maybe_lockfile) << maybe_lockfile.error().what();
         const auto lockfile = maybe_lockfile.value();
@@ -89,7 +95,8 @@ namespace mamba
 
     TEST(env_lockfile, get_specific_packages)
     {
-        const fs::u8path lockfile_path{ "env_lockfile_test/good_multiple_packages-lock.yaml" };
+        const fs::u8path lockfile_path{ test_data_dir
+                                        / "env_lockfile_test/good_multiple_packages-lock.yaml" };
         const auto lockfile = read_environment_lockfile(lockfile_path).value();
         EXPECT_TRUE(lockfile.get_packages_for("", "", "").empty());
         {
@@ -106,7 +113,8 @@ namespace mamba
 
     TEST(env_lockfile, create_transaction_with_categories)
     {
-        const fs::u8path lockfile_path{ "env_lockfile_test/good_multiple_categories-lock.yaml" };
+        const fs::u8path lockfile_path{ test_data_dir
+                                        / "env_lockfile_test/good_multiple_categories-lock.yaml" };
         MPool pool;
         mamba::MultiPackageCache pkg_cache({ "/tmp/" });
 

--- a/libmamba/tests/test_lockfile.cpp
+++ b/libmamba/tests/test_lockfile.cpp
@@ -27,10 +27,8 @@ namespace mamba
 #ifndef MAMBA_TEST_LOCK_EXE
 #error "MAMBA_TEST_LOCK_EXE must be defined pointing to testing_libmamba_lock"
 #endif
-    static const fs::u8path testing_libmamba_lock_exe = MAMBA_TEST_LOCK_EXE;
+    inline static const fs::u8path testing_libmamba_lock_exe = MAMBA_TEST_LOCK_EXE;
 
-
-    static const fs::u8path test_data_dir = MAMBA_TEST_DATA_DIR;
     namespace testing
     {
 

--- a/libmamba/tests/test_lockfile.cpp
+++ b/libmamba/tests/test_lockfile.cpp
@@ -20,8 +20,17 @@ extern "C"
 }
 #endif
 
+
 namespace mamba
 {
+
+#ifndef MAMBA_TEST_LOCK_EXE
+#error "MAMBA_TEST_LOCK_EXE must be defined pointing to testing_libmamba_lock"
+#endif
+    static const fs::u8path testing_libmamba_lock_exe = MAMBA_TEST_LOCK_EXE;
+
+
+    static const fs::u8path test_data_dir = MAMBA_TEST_DATA_DIR;
     namespace testing
     {
 
@@ -110,15 +119,9 @@ namespace mamba
 
         TEST_F(LockDirTest, different_pid)
         {
-            std::string lock_cli;
+            std::string const lock_exe = testing_libmamba_lock_exe.string();
             std::string out, err;
             std::vector<std::string> args;
-
-#ifdef _WIN32
-            lock_cli = "testing_libmamba_lock";
-#else
-            lock_cli = "./testing_libmamba_lock";
-#endif
 
             {
                 auto lock = LockFile(tempdir_path);
@@ -128,7 +131,7 @@ namespace mamba
                 EXPECT_TRUE(mamba::LockFile::is_locked(lock));
 
                 // Check lock status from another process
-                args = { lock_cli, "is-locked", lock.lockfile_path().string() };
+                args = { lock_exe, "is-locked", lock.lockfile_path().string() };
                 out.clear();
                 err.clear();
                 reproc::run(
@@ -146,7 +149,7 @@ namespace mamba
                 EXPECT_TRUE(is_locked);
 
                 // Try to lock from another process
-                args = { lock_cli, "lock", "--timeout=1", tempdir_path.string() };
+                args = { lock_exe, "lock", "--timeout=1", tempdir_path.string() };
                 out.clear();
                 err.clear();
                 reproc::run(
@@ -167,7 +170,7 @@ namespace mamba
             fs::u8path lock_path = tempdir_path / (tempdir_path.filename().string() + ".lock");
             EXPECT_FALSE(fs::exists(lock_path));
 
-            args = { lock_cli, "is-locked", lock_path.string() };
+            args = { lock_exe, "is-locked", lock_path.string() };
             out.clear();
             err.clear();
             reproc::run(
@@ -229,15 +232,9 @@ namespace mamba
 
         TEST_F(LockFileTest, different_pid)
         {
-            std::string lock_cli;
+            std::string const lock_exe = testing_libmamba_lock_exe.string();
             std::string out, err;
             std::vector<std::string> args;
-
-#ifdef _WIN32
-            lock_cli = "testing_libmamba_lock";
-#else
-            lock_cli = "./testing_libmamba_lock";
-#endif
             {
                 // Create a lock
                 auto lock = LockFile(tempfile_path);
@@ -247,7 +244,7 @@ namespace mamba
                 EXPECT_TRUE(mamba::LockFile::is_locked(lock));
 
                 // Check lock status from another process
-                args = { lock_cli, "is-locked", lock.lockfile_path().string() };
+                args = { lock_exe, "is-locked", lock.lockfile_path().string() };
                 out.clear();
                 err.clear();
                 reproc::run(
@@ -265,7 +262,7 @@ namespace mamba
                 EXPECT_TRUE(is_locked);
 
                 // Try to lock from another process
-                args = { lock_cli, "lock", "--timeout=1", tempfile_path.string() };
+                args = { lock_exe, "lock", "--timeout=1", tempfile_path.string() };
                 out.clear();
                 err.clear();
                 reproc::run(
@@ -286,7 +283,7 @@ namespace mamba
             fs::u8path lock_path = tempfile_path.string() + ".lock";
             EXPECT_FALSE(fs::exists(lock_path));
 
-            args = { lock_cli, "is-locked", lock_path.string() };
+            args = { lock_exe, "is-locked", lock_path.string() };
             out.clear();
             err.clear();
             reproc::run(

--- a/libmamba/tests/test_validate.cpp
+++ b/libmamba/tests/test_validate.cpp
@@ -1,17 +1,23 @@
+// Copyright (c) 2022, QuantStack and Mamba Contributors
+//
+// Distributed under the terms of the BSD 3-Clause License.
+//
+// The full license is in the file LICENSE, distributed with this software.
+
+#include <algorithm>
+#include <map>
+
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+#include <nlohmann/json.hpp>
+#include <spdlog/spdlog.h>
+
 #include "mamba/core/environment.hpp"
 #include "mamba/core/fsutil.hpp"
 #include "mamba/core/validate.hpp"
 #include "mamba/core/util.hpp"
 
-#include <gtest/gtest.h>
-#include <gmock/gmock.h>
-
-#include <nlohmann/json.hpp>
-
-#include <algorithm>
-#include <map>
-
-#include "spdlog/spdlog.h"
+#include "test_data.hpp"
 
 namespace validate
 {
@@ -324,7 +330,7 @@ namespace validate
                 }
 
             protected:
-                fs::u8path root1_pgp = "validation_data/1.sv0.6.root.json";
+                fs::u8path root1_pgp = test_data_dir / "validation_data/1.sv0.6.root.json";
                 json root1_json, root1_pgp_json;
 
                 secrets_type secrets;
@@ -1504,7 +1510,7 @@ namespace validate
                 }
 
             protected:
-                fs::u8path root1 = "validation_data/root.json";
+                fs::u8path root1 = test_data_dir / "validation_data/root.json";
                 json root1_json;
 
                 std::unique_ptr<TemporaryDirectory> channel_dir;


### PR DESCRIPTION
This makes it possible to run tests from the project root directory, without changing into the test build directory.