### PR TITLE
Don't create a prefix which is missing conda-meta

### DIFF
--- a/.github/workflows/conda_nightly.yml
+++ b/.github/workflows/conda_nightly.yml
@@ -103,5 +103,5 @@ jobs:
         if: always()
         run: |
           # Do not cache temporary envs with 'cache-env: true'
-          find ~ -iname build_env -maxdepth 3 -type d -exec rm -rf {} \;
-          find ~ -iname conda-bld -maxdepth 3 -type d -exec rm -rf {} \;
+          rm -rf $(micromamba info --json | jq -r '."env location"')/envs
+          rm -rf $(micromamba info --json | jq -r '."env location"')/conda-build/conda-bld

--- a/.github/workflows/conda_nightly.yml
+++ b/.github/workflows/conda_nightly.yml
@@ -103,5 +103,5 @@ jobs:
         if: always()
         run: |
           # Do not cache temporary envs with 'cache-env: true'
-          rm -rf $(micromamba info --json | jq -r '."env location"')/envs
-          rm -rf $(micromamba info --json | jq -r '."env location"')/conda-build/conda-bld
+          find ~ -iname build_env -maxdepth 3 -type d -exec rm -rf {} \;
+          find ~ -iname conda-bld -maxdepth 3 -type d -exec rm -rf {} \;

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,7 +49,7 @@ jobs:
         if: always()
         run: |
           # Do not cache temporary envs with 'cache-env: true'
-          rm -rf $(micromamba info --json | jq -r '."env location"')/envs
+          rm -rf "$(micromamba info --json | jq -r '.\"env location\"')"/envs
 
   libmamba_cpp_tests:
     needs: [libmamba_static]
@@ -92,7 +92,7 @@ jobs:
         if: always()
         run: |
           # Do not cache temporary envs with 'cache-env: true'
-          rm -rf $(micromamba info --json | jq -r '."env location"')/envs
+          rm -rf "$(micromamba info --json | jq -r '.\"env location\"')"/envs
 
   umamba_tests:
     needs: [libmamba_static]
@@ -150,7 +150,7 @@ jobs:
         if: always()
         run: |
           # Do not cache temporary envs with 'cache-env: true'
-          rm -rf $(micromamba info --json | jq -r '."env location"')/envs
+          rm -rf "$(micromamba info --json | jq -r '.\"env location\"')"/envs
 
   mamba_python_tests:
     needs: [libmamba_static]
@@ -264,7 +264,7 @@ jobs:
         if: always()
         run: |
           # Do not cache temporary envs with 'cache-env: true'
-          rm -rf $(micromamba info --json | jq -r '."env location"')/envs
+          rm -rf "$(micromamba info --json | jq -r '.\"env location\"')"/envs
 
   libmamba_static_win:
     runs-on: ${{ matrix.os }}
@@ -308,7 +308,7 @@ jobs:
         if: always()
         run: |
           # Do not cache temporary envs with 'cache-env: true'
-          rm -rf $(micromamba info --json | jq -r '."env location"')/envs
+          rm -rf "$(micromamba info --json | jq -r '.\"env location\"')"/envs
 
   mamba_python_tests_win:
     needs: [libmamba_static_win]
@@ -407,7 +407,7 @@ jobs:
         if: always()
         run: |
           # Do not cache temporary envs with 'cache-env: true'
-          rm -rf $(micromamba info --json | jq -r '."env location"')/envs
+          rm -rf "$(micromamba info --json | jq -r '.\"env location\"')"/envs
 
   libmamba_cpp_tests_win:
     needs: [libmamba_static_win]
@@ -458,7 +458,7 @@ jobs:
         if: always()
         run: |
           # Do not cache temporary envs with 'cache-env: true'
-          rm -rf $(micromamba info --json | jq -r '."env location"')/envs
+          rm -rf "$(micromamba info --json | jq -r '.\"env location\"')"/envs
 
   umamba_tests_win:
     needs: [libmamba_static_win]
@@ -519,7 +519,7 @@ jobs:
         if: always()
         run: |
           # Do not cache temporary envs with 'cache-env: true'
-          rm -rf $(micromamba info --json | jq -r '."env location"')/envs
+          rm -rf "$(micromamba info --json | jq -r '.\"env location\"')"/envs
 
   umamba_tests_win_cmd:
     needs: [umamba_tests_win]
@@ -586,4 +586,4 @@ jobs:
         if: always()
         run: |
           # Do not cache temporary envs with 'cache-env: true'
-          rm -rf $(micromamba info --json | jq -r '."env location"')/envs
+          rm -rf "$(micromamba info --json | jq -r '.\"env location\"')"/envs

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,8 +49,7 @@ jobs:
         if: always()
         run: |
           # Do not cache temporary envs with 'cache-env: true'
-          rm -rf $(micromamba info --json | jq -r '."env location"')/envs || true
-          rm -rf ~/tmproot* || true
+          rm -rf $(micromamba info --json | jq -r '."env location"' || echo ~/tmproot*)/envs
 
   libmamba_cpp_tests:
     needs: [libmamba_static]
@@ -93,8 +92,7 @@ jobs:
         if: always()
         run: |
           # Do not cache temporary envs with 'cache-env: true'
-          rm -rf $(micromamba info --json | jq -r '."env location"')/envs || true
-          rm -rf ~/tmproot* || true
+          rm -rf $(micromamba info --json | jq -r '."env location"' || echo ~/tmproot*)/envs
 
   umamba_tests:
     needs: [libmamba_static]
@@ -152,8 +150,7 @@ jobs:
         if: always()
         run: |
           # Do not cache temporary envs with 'cache-env: true'
-          rm -rf $(micromamba info --json | jq -r '."env location"')/envs || true
-          rm -rf ~/tmproot* || true
+          rm -rf $(micromamba info --json | jq -r '."env location"' || echo ~/tmproot*)/envs
 
   mamba_python_tests:
     needs: [libmamba_static]
@@ -267,8 +264,7 @@ jobs:
         if: always()
         run: |
           # Do not cache temporary envs with 'cache-env: true'
-          rm -rf $(micromamba info --json | jq -r '."env location"')/envs || true
-          rm -rf ~/tmproot* || true
+          rm -rf $(micromamba info --json | jq -r '."env location"' || echo ~/tmproot*)/envs
 
   libmamba_static_win:
     runs-on: ${{ matrix.os }}
@@ -312,8 +308,7 @@ jobs:
         if: always()
         run: |
           # Do not cache temporary envs with 'cache-env: true'
-          rm -rf $(micromamba info --json | jq -r '."env location"')/envs || true
-          rm -rf ~/tmproot* || true
+          rm -rf $(micromamba info --json | jq -r '."env location"' || echo ~/tmproot*)/envs
 
   mamba_python_tests_win:
     needs: [libmamba_static_win]
@@ -412,8 +407,7 @@ jobs:
         if: always()
         run: |
           # Do not cache temporary envs with 'cache-env: true'
-          rm -rf $(micromamba info --json | jq -r '."env location"')/envs || true
-          rm -rf ~/tmproot* || true
+          rm -rf $(micromamba info --json | jq -r '."env location"' || echo ~/tmproot*)/envs
 
   libmamba_cpp_tests_win:
     needs: [libmamba_static_win]
@@ -464,8 +458,7 @@ jobs:
         if: always()
         run: |
           # Do not cache temporary envs with 'cache-env: true'
-          rm -rf $(micromamba info --json | jq -r '."env location"')/envs || true
-          rm -rf ~/tmproot* || true
+          rm -rf $(micromamba info --json | jq -r '."env location"' || echo ~/tmproot*)/envs
 
   umamba_tests_win:
     needs: [libmamba_static_win]
@@ -526,8 +519,7 @@ jobs:
         if: always()
         run: |
           # Do not cache temporary envs with 'cache-env: true'
-          rm -rf $(micromamba info --json | jq -r '."env location"')/envs || true
-          rm -rf ~/tmproot* || true
+          rm -rf $(micromamba info --json | jq -r '."env location"' || echo ~/tmproot*)/envs
 
   umamba_tests_win_cmd:
     needs: [umamba_tests_win]
@@ -594,5 +586,4 @@ jobs:
         if: always()
         run: |
           # Do not cache temporary envs with 'cache-env: true'
-          rm -rf $(micromamba info --json | jq -r '."env location"')/envs || true
-          rm -rf ~/tmproot* || true
+          rm -rf $(micromamba info --json | jq -r '."env location"' || echo ~/tmproot*)/envs

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,7 +49,8 @@ jobs:
         if: always()
         run: |
           # Do not cache temporary envs with 'cache-env: true'
-          rm -rf $(micromamba info --json | jq -r '."env location"')/envs
+          rm -rf $(micromamba info --json | jq -r '."env location"')/envs || true
+          rm -rf ~/tmproot* || true
 
   libmamba_cpp_tests:
     needs: [libmamba_static]
@@ -92,7 +93,8 @@ jobs:
         if: always()
         run: |
           # Do not cache temporary envs with 'cache-env: true'
-          rm -rf $(micromamba info --json | jq -r '."env location"')/envs
+          rm -rf $(micromamba info --json | jq -r '."env location"')/envs || true
+          rm -rf ~/tmproot* || true
 
   umamba_tests:
     needs: [libmamba_static]
@@ -150,7 +152,8 @@ jobs:
         if: always()
         run: |
           # Do not cache temporary envs with 'cache-env: true'
-          rm -rf $(micromamba info --json | jq -r '."env location"')/envs
+          rm -rf $(micromamba info --json | jq -r '."env location"')/envs || true
+          rm -rf ~/tmproot* || true
 
   mamba_python_tests:
     needs: [libmamba_static]
@@ -264,7 +267,8 @@ jobs:
         if: always()
         run: |
           # Do not cache temporary envs with 'cache-env: true'
-          rm -rf $(micromamba info --json | jq -r '."env location"')/envs
+          rm -rf $(micromamba info --json | jq -r '."env location"')/envs || true
+          rm -rf ~/tmproot* || true
 
   libmamba_static_win:
     runs-on: ${{ matrix.os }}
@@ -308,7 +312,8 @@ jobs:
         if: always()
         run: |
           # Do not cache temporary envs with 'cache-env: true'
-          rm -rf $(micromamba info --json | jq -r '."env location"')/envs
+          rm -rf $(micromamba info --json | jq -r '."env location"')/envs || true
+          rm -rf ~/tmproot* || true
 
   mamba_python_tests_win:
     needs: [libmamba_static_win]
@@ -407,7 +412,8 @@ jobs:
         if: always()
         run: |
           # Do not cache temporary envs with 'cache-env: true'
-          rm -rf $(micromamba info --json | jq -r '."env location"')/envs
+          rm -rf $(micromamba info --json | jq -r '."env location"')/envs || true
+          rm -rf ~/tmproot* || true
 
   libmamba_cpp_tests_win:
     needs: [libmamba_static_win]
@@ -458,7 +464,8 @@ jobs:
         if: always()
         run: |
           # Do not cache temporary envs with 'cache-env: true'
-          rm -rf $(micromamba info --json | jq -r '."env location"')/envs
+          rm -rf $(micromamba info --json | jq -r '."env location"')/envs || true
+          rm -rf ~/tmproot* || true
 
   umamba_tests_win:
     needs: [libmamba_static_win]
@@ -519,7 +526,8 @@ jobs:
         if: always()
         run: |
           # Do not cache temporary envs with 'cache-env: true'
-          rm -rf $(micromamba info --json | jq -r '."env location"')/envs
+          rm -rf $(micromamba info --json | jq -r '."env location"')/envs || true
+          rm -rf ~/tmproot* || true
 
   umamba_tests_win_cmd:
     needs: [umamba_tests_win]
@@ -586,4 +594,5 @@ jobs:
         if: always()
         run: |
           # Do not cache temporary envs with 'cache-env: true'
-          rm -rf $(micromamba info --json | jq -r '."env location"')/envs
+          rm -rf $(micromamba info --json | jq -r '."env location"')/envs || true
+          rm -rf ~/tmproot* || true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,11 +45,11 @@ jobs:
       - name: build cache statistics
         run: sccache --show-stats
       - name: Cleanup
-        shell: bash -l {0}
+        shell: bash
         if: always()
         run: |
           # Do not cache temporary envs with 'cache-env: true'
-          find ~ -iname build_env -maxdepth 3 -type d -exec rm -rf {} \;
+          rm -rf $(micromamba info --json | jq -r '."env location"')/envs
 
   libmamba_cpp_tests:
     needs: [libmamba_static]
@@ -88,11 +88,11 @@ jobs:
       - name: build cache statistics
         run: sccache --show-stats
       - name: Cleanup
-        shell: bash -l {0}
+        shell: bash
         if: always()
         run: |
           # Do not cache temporary envs with 'cache-env: true'
-          find ~ -iname build_env -maxdepth 3 -type d -exec rm -rf {} \;
+          rm -rf $(micromamba info --json | jq -r '."env location"')/envs
 
   umamba_tests:
     needs: [libmamba_static]
@@ -146,11 +146,11 @@ jobs:
           micromamba activate build_env
           pytest -v --capture=tee-sys micromamba/tests/
       - name: Cleanup
-        shell: bash -l {0}
+        shell: bash
         if: always()
         run: |
           # Do not cache temporary envs with 'cache-env: true'
-          find ~ -iname build_env -maxdepth 3 -type d -exec rm -rf {} \;
+          rm -rf $(micromamba info --json | jq -r '."env location"')/envs
 
   mamba_python_tests:
     needs: [libmamba_static]
@@ -260,11 +260,11 @@ jobs:
 
           ./testserver.sh
       - name: Cleanup
-        shell: bash -l {0}
+        shell: bash
         if: always()
         run: |
           # Do not cache temporary envs with 'cache-env: true'
-          find ~ -iname build_env -maxdepth 3 -type d -exec rm -rf {} \;
+          rm -rf $(micromamba info --json | jq -r '."env location"')/envs
 
   libmamba_static_win:
     runs-on: ${{ matrix.os }}
@@ -304,11 +304,11 @@ jobs:
       - name: build cache statistics
         run: sccache --show-stats
       - name: Cleanup
-        shell: bash -l {0}
+        shell: bash
         if: always()
         run: |
           # Do not cache temporary envs with 'cache-env: true'
-          find ~ -iname build_env -maxdepth 3 -type d -exec rm -rf {} \;
+          rm -rf $(micromamba info --json | jq -r '."env location"')/envs
 
   mamba_python_tests_win:
     needs: [libmamba_static_win]
@@ -403,11 +403,11 @@ jobs:
             exit 1
           fi
       - name: Cleanup
-        shell: bash -l {0}
+        shell: bash
         if: always()
         run: |
           # Do not cache temporary envs with 'cache-env: true'
-          find ~ -iname build_env -maxdepth 3 -type d -exec rm -rf {} \;
+          rm -rf $(micromamba info --json | jq -r '."env location"')/envs
 
   libmamba_cpp_tests_win:
     needs: [libmamba_static_win]
@@ -454,11 +454,11 @@ jobs:
       - name: build cache statistics
         run: sccache --show-stats
       - name: Cleanup
-        shell: bash -l {0}
+        shell: bash
         if: always()
         run: |
           # Do not cache temporary envs with 'cache-env: true'
-          find ~ -iname build_env -maxdepth 3 -type d -exec rm -rf {} \;
+          rm -rf $(micromamba info --json | jq -r '."env location"')/envs
 
   umamba_tests_win:
     needs: [libmamba_static_win]
@@ -515,11 +515,11 @@ jobs:
           name: _internal_micromamba_binary
           path: umamba.tar
       - name: Cleanup
-        shell: bash -l {0}
+        shell: bash
         if: always()
         run: |
           # Do not cache temporary envs with 'cache-env: true'
-          find ~ -iname build_env -maxdepth 3 -type d -exec rm -rf {} \;
+          rm -rf $(micromamba info --json | jq -r '."env location"')/envs
 
   umamba_tests_win_cmd:
     needs: [umamba_tests_win]
@@ -582,8 +582,8 @@ jobs:
       #     pytest -v --capture=tee-sys micromamba/tests/test_shell.py
 
       - name: Cleanup
-        shell: bash -l {0}
+        shell: bash
         if: always()
         run: |
           # Do not cache temporary envs with 'cache-env: true'
-          find ~ -iname build_env -maxdepth 3 -type d -exec rm -rf {} \;
+          rm -rf $(micromamba info --json | jq -r '."env location"')/envs

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,7 +49,7 @@ jobs:
         if: always()
         run: |
           # Do not cache temporary envs with 'cache-env: true'
-          rm -rf $(micromamba info --json | jq -r '."env location"' || echo ~/tmproot*)/envs
+          find ~ -iname build_env -maxdepth 3 -type d -exec rm -rf {} \;
 
   libmamba_cpp_tests:
     needs: [libmamba_static]
@@ -92,7 +92,7 @@ jobs:
         if: always()
         run: |
           # Do not cache temporary envs with 'cache-env: true'
-          rm -rf $(micromamba info --json | jq -r '."env location"' || echo ~/tmproot*)/envs
+          find ~ -iname build_env -maxdepth 3 -type d -exec rm -rf {} \;
 
   umamba_tests:
     needs: [libmamba_static]
@@ -150,7 +150,7 @@ jobs:
         if: always()
         run: |
           # Do not cache temporary envs with 'cache-env: true'
-          rm -rf $(micromamba info --json | jq -r '."env location"' || echo ~/tmproot*)/envs
+          find ~ -iname build_env -maxdepth 3 -type d -exec rm -rf {} \;
 
   mamba_python_tests:
     needs: [libmamba_static]
@@ -264,7 +264,7 @@ jobs:
         if: always()
         run: |
           # Do not cache temporary envs with 'cache-env: true'
-          rm -rf $(micromamba info --json | jq -r '."env location"' || echo ~/tmproot*)/envs
+          find ~ -iname build_env -maxdepth 3 -type d -exec rm -rf {} \;
 
   libmamba_static_win:
     runs-on: ${{ matrix.os }}
@@ -308,7 +308,7 @@ jobs:
         if: always()
         run: |
           # Do not cache temporary envs with 'cache-env: true'
-          rm -rf $(micromamba info --json | jq -r '."env location"' || echo ~/tmproot*)/envs
+          find ~ -iname build_env -maxdepth 3 -type d -exec rm -rf {} \;
 
   mamba_python_tests_win:
     needs: [libmamba_static_win]
@@ -407,7 +407,7 @@ jobs:
         if: always()
         run: |
           # Do not cache temporary envs with 'cache-env: true'
-          rm -rf $(micromamba info --json | jq -r '."env location"' || echo ~/tmproot*)/envs
+          find ~ -iname build_env -maxdepth 3 -type d -exec rm -rf {} \;
 
   libmamba_cpp_tests_win:
     needs: [libmamba_static_win]
@@ -458,7 +458,7 @@ jobs:
         if: always()
         run: |
           # Do not cache temporary envs with 'cache-env: true'
-          rm -rf $(micromamba info --json | jq -r '."env location"' || echo ~/tmproot*)/envs
+          find ~ -iname build_env -maxdepth 3 -type d -exec rm -rf {} \;
 
   umamba_tests_win:
     needs: [libmamba_static_win]
@@ -519,7 +519,7 @@ jobs:
         if: always()
         run: |
           # Do not cache temporary envs with 'cache-env: true'
-          rm -rf $(micromamba info --json | jq -r '."env location"' || echo ~/tmproot*)/envs
+          find ~ -iname build_env -maxdepth 3 -type d -exec rm -rf {} \;
 
   umamba_tests_win_cmd:
     needs: [umamba_tests_win]
@@ -586,4 +586,4 @@ jobs:
         if: always()
         run: |
           # Do not cache temporary envs with 'cache-env: true'
-          rm -rf $(micromamba info --json | jq -r '."env location"' || echo ~/tmproot*)/envs
+          find ~ -iname build_env -maxdepth 3 -type d -exec rm -rf {} \;

--- a/libmamba/src/core/shell_init.cpp
+++ b/libmamba/src/core/shell_init.cpp
@@ -654,6 +654,11 @@ namespace mamba
     {
         Context::instance().root_prefix = root_prefix;
 
+        if (!fs::exists(root_prefix))
+        {
+            fs::create_directories(root_prefix / "conda-meta");
+        }
+
         if (shell == "zsh" || shell == "bash" || shell == "posix")
         {
             PosixActivator a;

--- a/micromamba/tests/test_shell.py
+++ b/micromamba/tests/test_shell.py
@@ -7,7 +7,14 @@ from pathlib import Path
 
 import pytest
 
-from .helpers import MAMBA_NO_PREFIX_CHECK, create, get_umamba, random_string, shell
+from .helpers import (
+    MAMBA_NO_PREFIX_CHECK,
+    create,
+    get_umamba,
+    random_string,
+    shell,
+    umamba_list,
+)
 
 
 def skip_if_shell_incompat(shell_type):
@@ -262,3 +269,15 @@ class TestShell:
         skip_if_shell_incompat("dash")
         subprocess.check_call(["dash", "-c", "eval $(micromamba shell hook -s dash)"])
         subprocess.check_call(["dash", "-c", "eval $(micromamba shell hook -s posix)"])
+
+    def test_implicitly_created_environment(self):
+        """If a shell implicitly creates an environment, confirm that it's valid.
+
+        See <https://github.com/mamba-org/mamba/pull/2162>.
+        """
+        skip_if_shell_incompat("bash")
+        shutil.rmtree(TestShell.root_prefix)
+        assert shell("init", "--shell=bash")
+        assert (Path(TestShell.root_prefix) / "conda-meta").exists()
+        # Check, for example, that "list" works.
+        assert umamba_list("-p", TestShell.root_prefix)


### PR DESCRIPTION
To illustrate the problem, run the following:

```bash
docker run --rm -it mambaorg/micromamba:1.1.0
unset MAMBA_ROOT_PREFIX
micromamba shell init
micromamba shell init
```

The first `shell init` command creates a root prefix `~/micromamba` which contains the single file `~/micromamba/etc/profile.d/micromamba.sh`. The second `shell init` validates the root prefix by checking for `~/micromamba/conda-meta`, which is missing, causing the following error:

```
critical libmamba Could not use default 'root_prefix': /home/mambauser/micromamba: Directory exists, is not empty and not a conda prefix.
```

Workaround with Bash:
```bash
docker run --rm -it mambaorg/micromamba:1.1.0
unset MAMBA_ROOT_PREFIX
micromamba shell init
mkdir -p ~/micromamba/conda-meta
micromamba shell init
```

This PR which I'm submitting is untested, but it should at least convey what I believe the fix should be.