### PR TITLE
Add the bzip2 package requirement

### DIFF
--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -73,6 +73,8 @@ For Linux, the default shell is ``bash``:
 
 .. code:: bash
 
+   # If you are using Ubuntu Linux, the bzip2 package is required before running the curl command below.
+   # sudo apt install bzip2
    curl micro.mamba.pm/install.sh | bash
 
 For macOS, the default shell is ``zsh``:


### PR DESCRIPTION
If the user is unaware of this, the install script will fail with:
```
100   889  100   889    0     0    800      0  0:00:01  0:00:01 --:--:--   800
tar (grandchild): bzip2: Cannot exec: No such file or directory
tar (grandchild): Error is not recoverable: exiting now
tar: Child died with signal 13
tar: Error is not recoverable: exiting now
bash: line 42: /home/kozo2/.local/bin/micromamba: No such file or directory
```