### PR TITLE
Faster conda decompress

### DIFF
--- a/libmamba/CMakeLists.txt
+++ b/libmamba/CMakeLists.txt
@@ -426,6 +426,7 @@ macro(libmamba_create_target target_name linkage deps_linkage output_name)
         find_library(LIBSOLVEXT_LIBRARIES NAMES solvext)
         find_package(CURL REQUIRED)
         find_package(LibArchive REQUIRED)
+        find_package(zstd REQUIRED)
         find_package(OpenSSL REQUIRED)
         find_package(yaml-cpp CONFIG REQUIRED)
         find_package(reproc++ CONFIG REQUIRED)
@@ -437,6 +438,7 @@ macro(libmamba_create_target target_name linkage deps_linkage output_name)
             ${LIBSOLV_LIBRARIES}
             ${LIBSOLVEXT_LIBRARIES}
             ${LibArchive_LIBRARIES}
+            zstd::libzstd_shared
             ${CURL_LIBRARIES}
             ${OPENSSL_LIBRARIES}
             yaml-cpp

--- a/libmamba/include/mamba/core/context.hpp
+++ b/libmamba/include/mamba/core/context.hpp
@@ -140,6 +140,7 @@ namespace mamba
 
         std::size_t download_threads = 5;
         int extract_threads = 0;
+        bool extract_sparse = false;
 
         int verbosity = 0;
         void set_verbosity(int lvl);

--- a/libmamba/include/mamba/core/package_handling.hpp
+++ b/libmamba/include/mamba/core/package_handling.hpp
@@ -34,7 +34,6 @@ namespace mamba
                         int compression_level);
 
     void extract_archive(const fs::u8path& file, const fs::u8path& destination);
-    void stream_extract_archive(struct archive* a, const fs::u8path& destination);
     void extract_conda(const fs::u8path& file,
                        const fs::u8path& dest_dir,
                        const std::vector<std::string>& parts = { "info", "pkg" });

--- a/libmamba/include/mamba/core/package_handling.hpp
+++ b/libmamba/include/mamba/core/package_handling.hpp
@@ -34,6 +34,7 @@ namespace mamba
                         int compression_level);
 
     void extract_archive(const fs::u8path& file, const fs::u8path& destination);
+    void stream_extract_archive(struct archive* a, const fs::u8path& destination);
     void extract_conda(const fs::u8path& file,
                        const fs::u8path& dest_dir,
                        const std::vector<std::string>& parts = { "info", "pkg" });

--- a/libmamba/include/mamba/core/util.hpp
+++ b/libmamba/include/mamba/core/util.hpp
@@ -315,6 +315,17 @@ namespace mamba
 
     std::optional<std::string> proxy_match(const std::string& url);
 
+    class non_copyable_base
+    {
+    public:
+        non_copyable_base()
+        {
+        }
+
+    private:
+        non_copyable_base(const non_copyable_base&);
+        non_copyable_base& operator=(const non_copyable_base&);
+    };
 }  // namespace mamba
 
 #endif  // MAMBA_UTIL_HPP

--- a/libmamba/src/core/package_handling.cpp
+++ b/libmamba/src/core/package_handling.cpp
@@ -374,7 +374,7 @@ namespace mamba
         flags |= ARCHIVE_EXTRACT_SECURE_NODOTDOT;
         flags |= ARCHIVE_EXTRACT_SECURE_SYMLINKS;
         flags |= ARCHIVE_EXTRACT_SECURE_NOABSOLUTEPATHS;
-        flags |= ARCHIVE_EXTRACT_SPARSE;
+        // flags |= ARCHIVE_EXTRACT_SPARSE;
         flags |= ARCHIVE_EXTRACT_UNLINK;
 
         a = archive_read_new();
@@ -488,7 +488,7 @@ namespace mamba
         flags |= ARCHIVE_EXTRACT_SECURE_NODOTDOT;
         flags |= ARCHIVE_EXTRACT_SECURE_SYMLINKS;
         flags |= ARCHIVE_EXTRACT_SECURE_NOABSOLUTEPATHS;
-        flags |= ARCHIVE_EXTRACT_SPARSE;
+        // flags |= ARCHIVE_EXTRACT_SPARSE;
         flags |= ARCHIVE_EXTRACT_UNLINK;
 
         ext = archive_write_disk_new();

--- a/libmamba/src/core/package_handling.cpp
+++ b/libmamba/src/core/package_handling.cpp
@@ -419,12 +419,7 @@ namespace mamba
             }
             else if (archive_entry_size(entry) > 0)
             {
-                int fd = open(archive_entry_pathname(entry), O_WRONLY);
-                assert(fd > 0);
-                archive_read_data_into_fd(a, fd);
-                assert(close(fd) == 0);
-
-                // r = copy_data(a, ext);
+                r = copy_data(a, ext);
                 if (r < ARCHIVE_OK)
                 {
                     const char* err_str = archive_error_string(ext);
@@ -514,11 +509,7 @@ namespace mamba
             }
             else if (archive_entry_size(entry) > 0)
             {
-                int fd = open(archive_entry_pathname(entry), O_WRONLY);
-                assert(fd > 0);
-                archive_read_data_into_fd(a, fd);
-                assert(close(fd) == 0);
-                // r = copy_data(a, ext);
+                r = copy_data(a, ext);
                 if (r < ARCHIVE_OK)
                 {
                     const char* err_str = archive_error_string(ext);

--- a/libmamba/src/core/package_handling.cpp
+++ b/libmamba/src/core/package_handling.cpp
@@ -419,7 +419,12 @@ namespace mamba
             }
             else if (archive_entry_size(entry) > 0)
             {
-                r = copy_data(a, ext);
+                int fd = open(archive_entry_pathname(entry), O_WRONLY);
+                assert(fd > 0);
+                archive_read_data_into_fd(a, fd);
+                assert(close(fd) == 0);
+
+                // r = copy_data(a, ext);
                 if (r < ARCHIVE_OK)
                 {
                     const char* err_str = archive_error_string(ext);

--- a/libmamba/src/core/package_handling.cpp
+++ b/libmamba/src/core/package_handling.cpp
@@ -7,7 +7,6 @@
 
 #include <archive.h>
 #include <archive_entry.h>
-#include <iostream>
 #include <zstd.h>
 
 #include <sstream>
@@ -468,7 +467,7 @@ namespace mamba
             r = archive_write_finish_entry(ext);
             if (r == ARCHIVE_WARN)
             {
-                std::cout << "libarchive warning: " << archive_error_string(a);
+                LOG_WARNING << "libarchive warning: " << archive_error_string(a);
             }
             else if (r < ARCHIVE_OK)
             {

--- a/libmamba/src/core/package_handling.cpp
+++ b/libmamba/src/core/package_handling.cpp
@@ -58,7 +58,7 @@ namespace mamba
         const fs::u8path& m_file;
     };
 
-    class scoped_archive_read
+    class scoped_archive_read : non_copyable_base
     {
     public:
         scoped_archive_read()
@@ -91,7 +91,7 @@ namespace mamba
         archive* m_archive;
     };
 
-    class scoped_archive_write
+    class scoped_archive_write : non_copyable_base
     {
     public:
         scoped_archive_write()
@@ -127,7 +127,7 @@ namespace mamba
         archive* m_archive;
     };
 
-    class scoped_archive_entry
+    class scoped_archive_entry : non_copyable_base
     {
     public:
         scoped_archive_entry()
@@ -456,16 +456,13 @@ namespace mamba
 
     namespace
     {
-        struct conda_extract_context
+        struct conda_extract_context : non_copyable_base
         {
             conda_extract_context(scoped_archive_read& source)
                 : source(source)
                 , buffer(ZSTD_DStreamOutSize())
             {
             }
-
-            conda_extract_context(const conda_extract_context&) = delete;
-            conda_extract_context& operator=(const conda_extract_context&) = delete;
 
             archive* source;
             std::vector<char> buffer;

--- a/libmamba/src/core/package_handling.cpp
+++ b/libmamba/src/core/package_handling.cpp
@@ -509,10 +509,10 @@ namespace mamba
             }
             else if (archive_entry_size(entry) > 0)
             {
-                std::cout << "Reading data into file: " << archive_entry_pathname(entry) << "\n";
-                
                 int fd = open(archive_entry_pathname(entry), O_WRONLY);
+                assert(fd > 0);
                 archive_read_data_into_fd(a, fd);
+                assert(close(fd) == 0);
                 // r = copy_data(a, ext);
                 if (r < ARCHIVE_OK)
                 {
@@ -587,7 +587,8 @@ namespace mamba
         struct archive* a = archive_read_new();
         assert(archive_read_support_format_zip(a) == ARCHIVE_OK);
 
-        if (archive_read_open_filename(a, file.string().c_str(), BUFFER_SIZE) != ARCHIVE_OK) {
+        if (archive_read_open_filename(a, file.string().c_str(), BUFFER_SIZE) != ARCHIVE_OK)
+        {
             throw std::runtime_error(archive_error_string(a));
         }
 

--- a/libmamba/src/core/package_handling.cpp
+++ b/libmamba/src/core/package_handling.cpp
@@ -459,7 +459,7 @@ namespace mamba
     {
         struct conda_extract_context
         {
-            conda_extract_context(struct archive* source)
+            conda_extract_context(archive* source)
                 : source(source)
                 , buffer(ZSTD_DStreamOutSize())
             {
@@ -553,9 +553,9 @@ namespace mamba
     }
 
 
-    static la_ssize_t file_read(struct archive* a, void* client_data, const void** buff)
+    static la_ssize_t file_read(archive* a, void* client_data, const void** buff)
     {
-        struct conda_extract_context* mine = static_cast<conda_extract_context*>(client_data);
+        conda_extract_context* mine = static_cast<conda_extract_context*>(client_data);
         *buff = mine->buffer.data();
 
         auto read = archive_read_data(mine->source, mine->buffer.data(), mine->buffer.size());
@@ -567,7 +567,7 @@ namespace mamba
         return read;
     }
 
-    int archive_read_open_archive_entry(struct archive* a, conda_extract_context* ctx)
+    int archive_read_open_archive_entry(archive* a, conda_extract_context* ctx)
     {
         archive_clear_error(a);
         archive_read_set_read_callback(a, file_read);

--- a/micromamba/tests/helpers.py
+++ b/micromamba/tests/helpers.py
@@ -17,7 +17,9 @@ import yaml
 def subprocess_run(*args: str) -> str:
     """Execute a command in a subprocess while properly capturing stderr in exceptions."""
     try:
-        p = subprocess.run(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=True)
+        p = subprocess.run(
+            args, stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=True
+        )
     except subprocess.CalledProcessError as e:
         print(f"Command {args} failed with stderr: {e.stderr.decode()}")
         print(f"Command {args} failed with stdout: {e.stdout.decode()}")

--- a/micromamba/tests/helpers.py
+++ b/micromamba/tests/helpers.py
@@ -16,7 +16,12 @@ import yaml
 
 def subprocess_run(*args: str) -> str:
     """Execute a command in a subprocess while properly capturing stderr in exceptions."""
-    p = subprocess.run(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=True)
+    try:
+        p = subprocess.run(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=True)
+    except subprocess.CalledProcessError as e:
+        print(f"Command {args} failed with stderr: {e.stderr.decode()}")
+        print(f"Command {args} failed with stdout: {e.stdout.decode()}")
+        raise e
     return p.stdout
 
 


### PR DESCRIPTION
Implement the `.conda` file extraction in a streaming fashion (instead of extracting to temporary directory first).

This makes it faster. Also disabling the `libarchive` `ARCHIVE_EXTRACT_SPARSE` feature makes it faster (on macOS) because the way it's implemented in `libarchive` results in many more calls to `write`: https://github.com/libarchive/libarchive/issues/1835