### PR TITLE
Fix `custom_channels` parsing

### DIFF
--- a/libmamba/src/core/channel.cpp
+++ b/libmamba/src/core/channel.cpp
@@ -844,8 +844,7 @@ namespace mamba
             if (!starts_with(url, "http"))
                 url = path_to_url(url);
 
-            auto channel
-                = ChannelBuilder::make_simple_channel(m_channel_alias, join_url(url, n), "", n);
+            auto channel = ChannelBuilder::make_simple_channel(m_channel_alias, url, n, "");
             m_custom_channels.emplace(n, std::move(channel));
         }
 

--- a/libmamba/tests/test_channel.cpp
+++ b/libmamba/tests/test_channel.cpp
@@ -147,8 +147,8 @@ namespace mamba
             std::string value = "test_channel";
             const Channel& c = make_channel(value);
             EXPECT_EQ(c.scheme(), "file");
-            EXPECT_EQ(c.location(), "");
-            EXPECT_EQ(c.name(), "tmp/test_channel");
+            EXPECT_EQ(c.location(), "/tmp");
+            EXPECT_EQ(c.name(), "test_channel");
             EXPECT_EQ(c.canonical_name(), "test_channel");
             EXPECT_EQ(c.platforms(), std::vector<std::string>({ platform, "noarch" }));
             std::vector<std::string> exp_urls({ std::string("file:///tmp/test_channel/") + platform,
@@ -334,8 +334,8 @@ namespace mamba
             std::string value = "test_channel";
             const Channel& c = make_channel(value);
             EXPECT_EQ(c.scheme(), "https");
-            EXPECT_EQ(c.location(), "server.com");
-            EXPECT_EQ(c.name(), "private/channels/test_channel");
+            EXPECT_EQ(c.location(), "server.com/private/channels");
+            EXPECT_EQ(c.name(), "test_channel");
             EXPECT_EQ(c.canonical_name(), "test_channel");
             EXPECT_EQ(c.platforms(), std::vector<std::string>({ platform, "noarch" }));
             std::vector<std::string> exp_urls(
@@ -348,8 +348,8 @@ namespace mamba
             std::string value = "test_channel/mylabel/xyz";
             const Channel& c = make_channel(value);
             EXPECT_EQ(c.scheme(), "https");
-            EXPECT_EQ(c.location(), "server.com");
-            EXPECT_EQ(c.name(), "private/channels/test_channel/mylabel/xyz");
+            EXPECT_EQ(c.location(), "server.com/private/channels");
+            EXPECT_EQ(c.name(), "test_channel/mylabel/xyz");
             EXPECT_EQ(c.canonical_name(), "test_channel/mylabel/xyz");
             EXPECT_EQ(c.platforms(), std::vector<std::string>({ platform, "noarch" }));
             std::vector<std::string> exp_urls(


### PR DESCRIPTION
Fixes #2204

- #2204

In [`conda`](https://github.com/conda/conda), `custom_channels`:

```yaml
# condarc

custom_channels:
  name1: https://domain1.com/long/suffix
  name2: https://domain2.com
```

are resolved as:

```python
Channel.make_simple_channel(Channel(""), "https://domain1.com/long/suffix", "name1")
Channel.make_simple_channel(Channel(""), "https://domain2.com", "name2")
```

https://github.com/conda/conda/blob/f474462658ef6e3763c1193db0f8edbea01fa5fe/conda/base/context.py#L756-L769

```python
    @memoizedproperty
    def custom_channels(self):
        from ..models.channel import Channel


        return odict(
            (channel.name, channel)
            for channel in (
                *chain.from_iterable(channel for channel in self.custom_multichannels.values()),
                *(
                    Channel.make_simple_channel(self.channel_alias, url, name)
                    for name, url in self._custom_channels.items()
                ),
            )
        )
```

------

While `mamba` resolves them as:

```cpp
ChannelBuilder::make_simple_channel(Channel(""), join_url("https://domain1.com/long/suffix", "name1"), "", "name1");
ChannelBuilder::make_simple_channel(Channel(""), join_url("https://domain2.com", "name2"), "", "name2");
```

It set joined URL as the `channel_url`, set `channel_name` as an empty string, and set the true name as `multi_name`.

In `make_simple_channel` (line 366), the empty `channel_name` will be set as URLs without the top-domain component:

```cpp
channel_name = "long/suffix/name1"
channel_name = "name2"
```

https://github.com/mamba-org/mamba/blob/10a63f125a67b948b4d8fe7f65cd23818cc0a561/libmamba/src/core/channel.cpp#L337-L377

https://github.com/mamba-org/mamba/blob/10a63f125a67b948b4d8fe7f65cd23818cc0a561/libmamba/src/core/channel.cpp#L847-L848

In this PR, the `join_url` is removed, and set the `channel_name` directly:

```diff
- auto channel = ChannelBuilder::make_simple_channel(m_channel_alias, join_url(url, n), "", n);
+ auto channel = ChannelBuilder::make_simple_channel(m_channel_alias, url, n, "");
```