### PR TITLE
log warnings but ignore cyclic symlinks

### DIFF
--- a/libmamba/src/core/link.cpp
+++ b/libmamba/src/core/link.cpp
@@ -571,7 +571,8 @@ namespace mamba
             fs::create_directories(dst.parent_path());
         }
 
-        if (fs::exists(dst))
+        std::error_code ec;
+        if (fs::exists(dst, ec) && !ec)
         {
             // Sometimes we might want to raise here ...
             m_clobber_warnings.push_back(rel_dst.string());
@@ -579,6 +580,9 @@ namespace mamba
             return std::make_tuple(validate::sha256sum(dst), rel_dst.string());
 #endif
             fs::remove(dst);
+        }
+        if (ec) {
+            LOG_WARNING << "Could not check file existence: " << ec.message() << " (" << dst << ")";
         }
 
 #ifdef __APPLE__
@@ -914,7 +918,12 @@ namespace mamba
                 }
                 if (!found)
                 {
-                    if (fs::exists(m_context->target_prefix / files_record[i]))
+                    bool exists = fs::exists(m_context->target_prefix / files_record[i], ec);
+                    if (ec) {
+                        LOG_WARNING << "Could not check existence " << ec.message() << " (" << files_record[i] << ")";
+                        exists = false;
+                    }
+                    if (exists)
                     {
                         paths_json["paths"][i]["sha256_in_prefix"]
                             = validate::sha256sum(m_context->target_prefix / files_record[i]);

--- a/libmamba/src/core/link.cpp
+++ b/libmamba/src/core/link.cpp
@@ -572,7 +572,7 @@ namespace mamba
         }
 
         std::error_code ec;
-        if (fs::exists(dst, ec) && !ec)
+        if (lexists(dst, ec) && !ec)
         {
             // Sometimes we might want to raise here ...
             m_clobber_warnings.push_back(rel_dst.string());
@@ -581,7 +581,8 @@ namespace mamba
 #endif
             fs::remove(dst);
         }
-        if (ec) {
+        if (ec)
+        {
             LOG_WARNING << "Could not check file existence: " << ec.message() << " (" << dst << ")";
         }
 
@@ -919,10 +920,13 @@ namespace mamba
                 if (!found)
                 {
                     bool exists = fs::exists(m_context->target_prefix / files_record[i], ec);
-                    if (ec) {
-                        LOG_WARNING << "Could not check existence " << ec.message() << " (" << files_record[i] << ")";
+                    if (ec)
+                    {
+                        LOG_WARNING << "Could not check existence for " << files_record[i] << ": "
+                                    << ec.message();
                         exists = false;
                     }
+
                     if (exists)
                     {
                         paths_json["paths"][i]["sha256_in_prefix"]

--- a/libmamba/src/core/package_handling.cpp
+++ b/libmamba/src/core/package_handling.cpp
@@ -769,8 +769,17 @@ namespace mamba
                 // "exists" follows symlink so if the symlink doesn't link to existing target it
                 // will return false. There is such symlink in _openmp_mutex package. So if the file
                 // is a symlink we don't want to follow the symlink. The "paths_data" should include
-                // path of all the files and we shound't need to follow symlink.
-                if (!(fs::exists(full_path) || fs::is_symlink(full_path)))
+                // path of all the files and we should not need to follow symlink.
+                std::error_code ec;
+                auto exists = fs::exists(full_path, ec);
+                if (ec) {
+                    LOG_WARNING << "Could not check existence: " << ec.message() << " (" << p.path << ")";
+                }
+                auto is_symlink = fs::is_symlink(full_path, ec);
+                if (ec) {
+                    LOG_WARNING << "Could not check if symlink: " << ec.message() << " (" << p.path << ")";
+                }
+                if (!(exists || is_symlink))
                 {
                     if (is_warn || is_fail)
                     {
@@ -808,10 +817,10 @@ namespace mamba
                 }
             }
         }
-        catch (...)
+        catch (const std::exception& e)
         {
             LOG_WARNING << "Invalid package cache, could not read 'paths.json' from '"
-                        << pkg_folder.string() << "'" << std::endl;
+                        << pkg_folder.string() << "': " << e.what() << std::endl;
             return false;
         }
         return true;

--- a/libmamba/src/core/package_handling.cpp
+++ b/libmamba/src/core/package_handling.cpp
@@ -771,15 +771,13 @@ namespace mamba
                 // is a symlink we don't want to follow the symlink. The "paths_data" should include
                 // path of all the files and we should not need to follow symlink.
                 std::error_code ec;
-                auto exists = fs::exists(full_path, ec);
-                if (ec) {
-                    LOG_WARNING << "Could not check existence: " << ec.message() << " (" << p.path << ")";
+                auto exists = lexists(full_path, ec);
+                if (ec)
+                {
+                    LOG_WARNING << "Could not check existence: " << ec.message() << " (" << p.path
+                                << ")";
                 }
-                auto is_symlink = fs::is_symlink(full_path, ec);
-                if (ec) {
-                    LOG_WARNING << "Could not check if symlink: " << ec.message() << " (" << p.path << ")";
-                }
-                if (!(exists || is_symlink))
+                if (!exists)
                 {
                     if (is_warn || is_fail)
                     {

--- a/libmamba/src/core/util.cpp
+++ b/libmamba/src/core/util.cpp
@@ -69,8 +69,13 @@ namespace mamba
     // lexists(emptylink) == true
     bool lexists(const fs::u8path& path, std::error_code& ec)
     {
-        auto status = fs::symlink_status(path, ec);
-        return status.type() != fs::file_type::not_found || status.type() == fs::file_type::symlink;
+        auto status = fs::symlink_status(path, ec).type();
+        if (status != fs::file_type::none)
+        {
+            ec.clear();
+            return status != fs::file_type::not_found || status == fs::file_type::symlink;
+        }
+        return false;
     }
 
     bool lexists(const fs::u8path& path)

--- a/libmamba/tests/test_cpp.cpp
+++ b/libmamba/tests/test_cpp.cpp
@@ -499,6 +499,13 @@ namespace mamba
         fs::remove("emptytestfile");
         EXPECT_FALSE(fs::exists("emptytestfile"));
         EXPECT_FALSE(lexists("emptytestfile"));
+
+        std::error_code ec;
+        EXPECT_FALSE(lexists("completelyinexistent", ec));
+        EXPECT_FALSE(ec);
+
+        EXPECT_FALSE(fs::exists("completelyinexistent", ec));
+        EXPECT_FALSE(ec);
     }
 
     namespace detail


### PR DESCRIPTION
This allows the installation of the slightly broken package `libcufile=1.5.0.59=0 -c nvidia` from the NVidia channel.