### PR TITLE
Implement `install --export`

### DIFF
--- a/libmamba/include/mamba/core/transaction.hpp
+++ b/libmamba/include/mamba/core/transaction.hpp
@@ -149,6 +149,7 @@ namespace mamba
         bool empty();
         bool prompt();
         void print();
+        void printEnv();
         bool execute(PrefixData& prefix);
         bool filter(Solvable* s);
 

--- a/libmamba/src/api/install.cpp
+++ b/libmamba/src/api/install.cpp
@@ -547,6 +547,8 @@ namespace mamba
                 install_for_other_pkgmgr(other_spec);
             }
         }
+
+        trans.printEnv();
     }
 
     namespace detail


### PR DESCRIPTION
Very early version of https://github.com/mamba-org/mamba/issues/2054.

Mostly here for design feedback from @wolfv @Klaim @AntoinePrv and whoever else is willing to give feedback!

My initial idea was to retrieve the `PrefixData` to construct the environment, as is done in `env.cpp` for `env export`. But that doesn't work if you use dry-run (our primary use case) because it relies on the `conda-meta/*.json` files, which are only present after a non-dry-run installation.

Next idea is to return the `MTransaction` from `install_specs`, but I was incapable of returning it because the solver (and maybe other things?) are stack allocated and the pointers will be invalidated even if `MTransaction` is returned as a shared pointer. Thus, I've added an `printEnv` function to `MTransaction`.

There are a few unrelated cleanup changes to use `pool_id2solvable` where possible.