### PR TITLE
add `use_lockfiles` to libmambapy bindings

### DIFF
--- a/libmambapy/libmambapy/__init__.pyi
+++ b/libmambapy/libmambapy/__init__.pyi
@@ -638,20 +638,20 @@ class Context:
     def use_index_cache(self, arg0: bool) -> None:
         pass
     @property
-    def use_only_tar_bz2(self) -> bool:
-        """
-        :type: bool
-        """
-    @use_only_tar_bz2.setter
-    def use_only_tar_bz2(self, arg0: bool) -> None:
-        pass
-    @property
     def use_lockfiles(self) -> bool:
         """
         :type: bool
         """
     @use_lockfiles.setter
     def use_lockfiles(self, arg0: bool) -> None:
+        pass
+    @property
+    def use_only_tar_bz2(self) -> bool:
+        """
+        :type: bool
+        """
+    @use_only_tar_bz2.setter
+    def use_only_tar_bz2(self, arg0: bool) -> None:
         pass
     @property
     def user_agent(self) -> str:

--- a/libmambapy/libmambapy/__init__.pyi
+++ b/libmambapy/libmambapy/__init__.pyi
@@ -646,6 +646,14 @@ class Context:
     def use_only_tar_bz2(self, arg0: bool) -> None:
         pass
     @property
+    def use_lockfiles(self) -> bool:
+        """
+        :type: bool
+        """
+    @use_lockfiles.setter
+    def use_lockfiles(self, arg0: bool) -> None:
+        pass
+    @property
     def user_agent(self) -> str:
         """
         :type: str

--- a/libmambapy/src/main.cpp
+++ b/libmambapy/src/main.cpp
@@ -487,6 +487,7 @@ PYBIND11_MODULE(bindings, m)
         .def_readwrite("use_only_tar_bz2", &Context::use_only_tar_bz2)
         .def_readwrite("channel_priority", &Context::channel_priority)
         .def_readwrite("experimental_sat_error_message", &Context::experimental_sat_error_message)
+        .def_readwrite("use_lockfiles", &Context::use_lockfiles)
         .def("set_verbosity", &Context::set_verbosity)
         .def("set_log_level", &Context::set_log_level);
 


### PR DESCRIPTION
Comes from findings in https://github.com/conda/conda-libmamba-solver/issues/116