### PR TITLE
[micromamba] Stop run command when given prefix does not exist

### DIFF
--- a/libmamba/src/core/run.cpp
+++ b/libmamba/src/core/run.cpp
@@ -254,7 +254,8 @@ namespace mamba
     {
         if (!fs::exists(Context::instance().target_prefix))
         {
-            LOG_CRITICAL << "The given prefix does not exist: " << Context::instance().target_prefix;
+            LOG_CRITICAL << "The given prefix does not exist: "
+                         << Context::instance().target_prefix;
             return 1;
         }
         std::vector<std::string> raw_command = command;

--- a/libmamba/src/core/run.cpp
+++ b/libmamba/src/core/run.cpp
@@ -252,6 +252,11 @@ namespace mamba
                            const std::vector<std::string>& env_vars,
                            const std::string& specific_process_name)
     {
+        if (!fs::exists(Context::instance().target_prefix))
+        {
+            LOG_CRITICAL << "The given prefix does not exist: " << Context::instance().target_prefix;
+            return 1;
+        }
         std::vector<std::string> raw_command = command;
         // Make sure the proc directory is always existing and ready.
         std::error_code ec;

--- a/micromamba/tests/test_run.py
+++ b/micromamba/tests/test_run.py
@@ -99,6 +99,16 @@ class TestRun:
             )
         assert subprocess.run(test_script_path, shell=True).returncode == 0
 
+    def test_run_non_existing_env(self):
+        env_name = random_string()
+        try:
+            run_res = umamba_run("-n", env_name, "python")
+        except subprocess.CalledProcessError as e:
+            assert (
+                "critical libmamba The given prefix does not exist:"
+                in e.stderr.decode()
+            )
+
 
 @pytest.fixture()
 def temp_env_prefix():


### PR DESCRIPTION
Fix #2084 
The exception thrown during env activation is indeed not caught. Since `reproc` has the upper hand and doesn't catch it, I added a check at the beginning of `run_in_environment` function.