### PR TITLE
Fix `micromamba env export` to get channel name instead of full url

### DIFF
--- a/micromamba/src/env.cpp
+++ b/micromamba/src/env.cpp
@@ -120,8 +120,15 @@ set_env_command(CLI::App* com)
                             dependencies << "=" << v.build_string;
                         dependencies << "\n";
                     }
-
-                    channels.insert(make_channel(v.url).base_url());
+                    const auto& chan_name = make_channel(v.url).name();
+                    if (chan_name == "pkgs/main")
+                    {
+                        channels.insert("defaults");
+                    }
+                    else
+                    {
+                        channels.insert(chan_name);
+                    }
                 }
 
                 for (const auto& c : channels)

--- a/micromamba/src/env.cpp
+++ b/micromamba/src/env.cpp
@@ -120,15 +120,8 @@ set_env_command(CLI::App* com)
                             dependencies << "=" << v.build_string;
                         dependencies << "\n";
                     }
-                    const auto& chan_name = make_channel(v.url).name();
-                    if (chan_name == "pkgs/main")
-                    {
-                        channels.insert("defaults");
-                    }
-                    else
-                    {
-                        channels.insert(chan_name);
-                    }
+
+                    channels.insert(make_channel(v.url).name());
                 }
 
                 for (const auto& c : channels)

--- a/micromamba/tests/test_env.py
+++ b/micromamba/tests/test_env.py
@@ -120,7 +120,7 @@ class TestEnv:
         create("", "-n", env_name, "-f", spec_file)
         ret = yaml.safe_load(run_env("export", "-n", env_name))
         assert ret["name"] == env_name
-        assert set(ret["channels"]) == {"https://conda.anaconda.org/conda-forge"}
+        assert set(ret["channels"]) == {"conda-forge"}
         assert "micromamba=0.24.0=0" in ret["dependencies"]
 
     def test_create(self):


### PR DESCRIPTION
Fix #2235
In case of `pkgs/main`, `defaults` is used to be consistent with conda.