### PR TITLE
Use CONDA_PKGS_DIRS even in explicit installation trasactions

### DIFF
--- a/libmamba/src/api/install.cpp
+++ b/libmamba/src/api/install.cpp
@@ -565,8 +565,7 @@ namespace mamba
             }
             PrefixData& prefix_data = exp_prefix_data.value();
 
-            fs::u8path pkgs_dirs(Context::instance().root_prefix / "pkgs");
-            MultiPackageCache pkg_caches({ pkgs_dirs });
+            MultiPackageCache pkg_caches(ctx.pkgs_dirs);
             prefix_data.add_packages(get_virtual_packages());
             MRepo::create(
                 pool, prefix_data);  // Potentially re-alloc (moves in memory) Solvables in the pool


### PR DESCRIPTION
Closes https://github.com/mamba-org/mamba/issues/2187

I've gone through the exercise of:

1. Updating micromamba in miniforge. Ensuring that the new build (built locally) recreates the issues https://github.com/conda-forge/miniforge/issues/420 and https://github.com/conda-forge/miniforge/issues/419
2. Using this patched version. Verifying that the issues go away (and because all the pkgs are already available, the installer completes much more quickly!)

