### PR TITLE
fix rename or remove

### DIFF
--- a/libmamba/include/mamba/core/fsutil.hpp
+++ b/libmamba/include/mamba/core/fsutil.hpp
@@ -136,6 +136,10 @@ namespace mamba
     namespace mamba_fs
     {
         // Like std::rename, but works across file systems by moving the file instead
+        // if the rename fails.
+        // if both rename and move fail, the error code is set to the error code of the
+        // copy_file operation and the `to` file is removed. You will have to handle removal
+        // of the `from` file yourself.
         inline void rename_or_move(const fs::u8path& from,
                                    const fs::u8path& to,
                                    std::error_code& ec)
@@ -145,9 +149,10 @@ namespace mamba
             {
                 ec.clear();
                 fs::copy_file(from, to, ec);
-                if (!ec)
+                if (ec)
                 {
-                    fs::remove(from, ec);
+                    std::error_code ec2;
+                    fs::remove(to, ec2);
                 }
             }
         }


### PR DESCRIPTION
This fixes the usage of the confusing `ec` boolean values :)

It would be much nicer if the `error_code` had a `has_error()` function to make it easier to understand what we're testing.

Maybe @JohanMabille or @Klaim can give this a review to make sure it's correct this time around.