### PR TITLE
Add channel specific job with new str

### DIFF
--- a/libmamba/src/core/solver.cpp
+++ b/libmamba/src/core/solver.cpp
@@ -11,6 +11,7 @@
 #include <fmt/ostream.h>
 
 #include "mamba/core/solver.hpp"
+#include "mamba/core/queue.hpp"
 #include "mamba/core/context.hpp"
 #include "mamba/core/channel.hpp"
 #include "mamba/core/match_spec.hpp"
@@ -252,8 +253,7 @@ namespace mamba
     void MSolver::add_channel_specific_job(const MatchSpec& ms, int job_flag)
     {
         Pool* pool = m_pool;
-        Queue selected_pkgs;
-        queue_init(&selected_pkgs);
+        MQueue selected_pkgs;
 
         // conda_build_form does **NOT** contain the channel info
         Id match = pool_conda_matchspec(pool, ms.conda_build_form().c_str());
@@ -263,17 +263,16 @@ namespace mamba
         {
             if (channel_match(pool_id2solvable(pool, *wp), c))
             {
-                queue_push(&selected_pkgs, *wp);
+                selected_pkgs.push(*wp);
             }
         }
-        if (selected_pkgs.count == 0)
+        if (selected_pkgs.count() == 0)
         {
             LOG_ERROR << "Selected channel specific (or force-reinstall) job, but "
                          "package is not available from channel. Solve job will fail.";
         }
-        Id d = pool_queuetowhatprovides(pool, &selected_pkgs);
+        Id d = pool_queuetowhatprovides(pool, selected_pkgs);
         queue_push2(&m_jobs, job_flag | SOLVER_SOLVABLE_ONE_OF, d);
-        queue_free(&selected_pkgs);
     }
 
     void MSolver::add_reinstall_job(MatchSpec& ms, int job_flag)

--- a/libmamba/src/core/solver.cpp
+++ b/libmamba/src/core/solver.cpp
@@ -590,10 +590,11 @@ namespace mamba
                 if (Id const r = problem_rules.elements[j]; r)
                 {
                     Id source, target, dep;
-                    Id const type = solver_ruleinfo(m_solver.get(), r, &source, &target, &dep);
+                    SolverRuleinfo const type
+                        = solver_ruleinfo(m_solver.get(), r, &source, &target, &dep);
                     res.push_back(make_solver_problem(
                         /* solver= */ m_solver.get(),
-                        /* type= */ static_cast<SolverRuleinfo>(type),
+                        /* type= */ type,
                         /* source_id= */ source,
                         /* target_id= */ target,
                         /* dep_id= */ dep));


### PR DESCRIPTION
Currently, using a spec like `conda-forge::python` will segfault in `MSolver::all_problems_structured` because channel specific jobs are added as a queue qith SOLVER_JOB_ONE_OF. In `all_prblem_structured`, the queue `id` is popping back as a `dep` but isn't.
There is not easy way to check for it explicitly, and no way to kepp track of the the fact that it was an explicit channel job.

The fix proposed here is rather to change the implementation of `add_channel_specific_jobs` to dynamically add a spec for the channel specific spec.
