### PR TITLE
repoquery: Implemented recursive dependency printout. Closes: #1242

### DIFF
--- a/docs/source/user_guide/mamba.rst
+++ b/docs/source/user_guide/mamba.rst
@@ -68,10 +68,14 @@ Here are some examples:
     # you can also specify more constraints on this search query
     $ mamba repoquery search "xtensor>=0.18"
 
-    # will show you a list of the dependencies of xtensor.
+    # will show you a list of the direct dependencies of xtensor.
     $ mamba repoquery depends xtensor
 
-With the ``-t,--tree`` flag, you can get the same information in a tree.
+    # will show you a list of the dependencies (including dependencies of dependencies).
+    $ mamba repoquery depends xtensor --recursive
+
+The flag ``--recursive`` shows also recursive (i.e. transitive) dependencies of dependent packages instead of only direct dependencies.
+With the ``-t,--tree`` flag, you can get the same information of a recursive query in a tree.
 
 .. code::
 

--- a/libmamba/include/mamba/core/query.hpp
+++ b/libmamba/include/mamba/core/query.hpp
@@ -58,10 +58,11 @@ namespace mamba
 
     enum class QueryResultFormat
     {
-        kJSON,
-        kTREE,
-        kTABLE,
-        kPRETTY
+        kJSON = 0,
+        kTREE = 1,
+        kTABLE = 2,
+        kPRETTY = 3,
+        kRECURSIVETABLE = 4,
     };
 
     class query_result

--- a/libmamba/src/api/repoquery.cpp
+++ b/libmamba/src/api/repoquery.cpp
@@ -76,7 +76,9 @@ namespace mamba
         }
         else if (type == QueryType::kDEPENDS)
         {
-            auto res = q.depends(query, format == QueryResultFormat::kTREE);
+            auto res = q.depends(query,
+                                 format == QueryResultFormat::kTREE
+                                     || format == QueryResultFormat::kRECURSIVETABLE);
             switch (format)
             {
                 case QueryResultFormat::kTREE:
@@ -87,12 +89,15 @@ namespace mamba
                     std::cout << res.json().dump(4);
                     break;
                 case QueryResultFormat::kTABLE:
+                case QueryResultFormat::kRECURSIVETABLE:
                     res.sort("name").table(std::cout);
             }
         }
         else if (type == QueryType::kWHONEEDS)
         {
-            auto res = q.whoneeds(query, format == QueryResultFormat::kTREE);
+            auto res = q.whoneeds(query,
+                                  format == QueryResultFormat::kTREE
+                                      || format == QueryResultFormat::kRECURSIVETABLE);
             switch (format)
             {
                 case QueryResultFormat::kTREE:
@@ -103,6 +108,7 @@ namespace mamba
                     std::cout << res.json().dump(4);
                     break;
                 case QueryResultFormat::kTABLE:
+                case QueryResultFormat::kRECURSIVETABLE:
                     res.sort("name").table(
                         std::cout,
                         { "Name", "Version", "Build", concat("Depends:", query), "Channel" });

--- a/libmambapy/libmambapy/__init__.pyi
+++ b/libmambapy/libmambapy/__init__.pyi
@@ -1122,6 +1122,8 @@ class QueryFormat:
       TABLE
 
       PRETTY
+
+      RECURSIVETABLE
     """
 
     def __eq__(self, other: object) -> bool: ...
@@ -1145,9 +1147,10 @@ class QueryFormat:
         """
     JSON: libmambapy.bindings.QueryFormat  # value = <QueryFormat.JSON: 0>
     PRETTY: libmambapy.bindings.QueryFormat  # value = <QueryFormat.PRETTY: 3>
+    RECURSIVETABLE: libmambapy.bindings.QueryFormat  # value = <QueryFormat.RECURSIVETABLE: 4>
     TABLE: libmambapy.bindings.QueryFormat  # value = <QueryFormat.TABLE: 2>
     TREE: libmambapy.bindings.QueryFormat  # value = <QueryFormat.TREE: 1>
-    __members__: dict  # value = {'JSON': <QueryFormat.JSON: 0>, 'TREE': <QueryFormat.TREE: 1>, 'TABLE': <QueryFormat.TABLE: 2>, 'PRETTY': <QueryFormat.PRETTY: 3>}
+    __members__: dict  # value = {'JSON': <QueryFormat.JSON: 0>, 'TREE': <QueryFormat.TREE: 1>, 'TABLE': <QueryFormat.TABLE: 2>, 'PRETTY': <QueryFormat.PRETTY: 3>, 'RECURSIVETABLE': <QueryFormat.RECURSIVETABLE: 4>}
     pass
 
 class Repo:

--- a/libmambapy/src/main.cpp
+++ b/libmambapy/src/main.cpp
@@ -43,10 +43,11 @@ namespace query
 {
     enum RESULT_FORMAT
     {
-        JSON,
-        TREE,
-        TABLE,
-        PRETTY
+        JSON = 0,
+        TREE = 1,
+        TABLE = 2,
+        PRETTY = 3,
+        RECURSIVETABLE = 4,
     };
 }
 
@@ -332,7 +333,8 @@ PYBIND11_MODULE(bindings, m)
         .value("JSON", query::RESULT_FORMAT::JSON)
         .value("TREE", query::RESULT_FORMAT::TREE)
         .value("TABLE", query::RESULT_FORMAT::TABLE)
-        .value("PRETTY", query::RESULT_FORMAT::PRETTY);
+        .value("PRETTY", query::RESULT_FORMAT::PRETTY)
+        .value("RECURSIVETABLE", query::RESULT_FORMAT::RECURSIVETABLE);
 
     py::class_<Query>(m, "Query")
         .def(py::init<MPool&>())
@@ -349,6 +351,7 @@ PYBIND11_MODULE(bindings, m)
                          break;
                      case query::TREE:
                      case query::TABLE:
+                     case query::RECURSIVETABLE:
                          q.find(query).groupby("name").table(res_stream);
                          break;
                      case query::PRETTY:
@@ -374,6 +377,7 @@ PYBIND11_MODULE(bindings, m)
                          res_stream << res.json().dump(4);
                          break;
                      case query::TABLE:
+                     case query::RECURSIVETABLE:
                          res.table(
                              res_stream,
                              { "Name", "Version", "Build", concat("Depends:", query), "Channel" });
@@ -385,7 +389,8 @@ PYBIND11_MODULE(bindings, m)
                 const std::string& query,
                 const query::RESULT_FORMAT format) -> std::string
              {
-                 query_result res = q.depends(query, (format == query::TREE));
+                 query_result res
+                     = q.depends(query, (format == query::TREE || format == query::RECURSIVETABLE));
                  std::stringstream res_stream;
                  switch (format)
                  {
@@ -397,6 +402,7 @@ PYBIND11_MODULE(bindings, m)
                          res_stream << res.json().dump(4);
                          break;
                      case query::TABLE:
+                     case query::RECURSIVETABLE:
                          // res.table(res_stream, {"Name", "Version", "Build", concat("Depends:",
                          // query), "Channel"});
                          res.table(res_stream);

--- a/mamba/mamba/mamba.py
+++ b/mamba/mamba/mamba.py
@@ -694,6 +694,8 @@ def repoquery(args, parser):
         fmt = api.QueryFormat.JSON
     elif hasattr(args, "tree") and args.tree:
         fmt = api.QueryFormat.TREE
+    elif hasattr(args, "recursive") and args.recursive:
+        fmt = api.QueryFormat.RECURSIVETABLE
     elif hasattr(args, "pretty") and args.pretty:
         fmt = api.QueryFormat.PRETTY
     else:
@@ -818,6 +820,7 @@ Examples:
 
     view_cmds = argparse.ArgumentParser(add_help=False)
     view_cmds.add_argument("-t", "--tree", action="store_true")
+    view_cmds.add_argument("--recursive", action="store_true")
 
     c1 = subsub_parser.add_parser(
         "whoneeds",

--- a/micromamba/src/repoquery.cpp
+++ b/micromamba/src/repoquery.cpp
@@ -50,6 +50,10 @@ set_common_search(CLI::App* subcom, bool is_repoquery)
     static bool show_as_tree = false;
     subcom->add_flag("-t,--tree", show_as_tree, "Show result as a tree");
 
+    static bool recursive = false;
+    subcom->add_flag(
+        "--recursive", recursive, "Show dependencies recursively (i.e. transitive dependencies).");
+
     static bool pretty_print = false;
     subcom->add_flag("--pretty", pretty_print, "Pretty print result (only for search)");
 
@@ -83,6 +87,9 @@ set_common_search(CLI::App* subcom, bool is_repoquery)
                     local = (local == 0) ? true : local > 0;
                     break;
             }
+            if (qtype == QueryType::kDEPENDS && recursive)
+                format = QueryResultFormat::kRECURSIVETABLE;
+
             if (qtype == QueryType::kDEPENDS && show_as_tree)
                 format = QueryResultFormat::kTREE;
 


### PR DESCRIPTION
https://github.com/mamba-org/mamba/issues/1242 describes a way to get recursive dependency information from repoquery depends.

I implemented it as specified in the issue:

    mamba repoquery depends cmake --recursive 

behaves exactly like 

    mamba repoquery depends cmake --tree

but lists the packages in a table. --tree overrides --recursive. Both mamba and micromamba have been updated. Please let me know if I should write additional tests and where.