### PR TITLE
Fixed invalid reinstall count display. Fixes: #2210

### DIFF
--- a/libmamba/src/core/transaction.cpp
+++ b/libmamba/src/core/transaction.cpp
@@ -1536,7 +1536,7 @@ namespace mamba
         if (reinstalled.size())
         {
             t.add_rows("Reinstall:", reinstalled);
-            summary << "  Reinstall: " << reinstalled.size() / 2 << " packages\n";
+            summary << "  Reinstall: " << reinstalled.size() << " packages\n";
         }
         if (upgraded.size())
         {


### PR DESCRIPTION
Issue #2210 assumes that the reinstall count is off by one. However, when checking with more than one package, it seems it is off by a factor of two, as shown here:

    micromamba install zstd=1.5.2 cmake libsodium krb5 ninja=1.11.0  libiconv=1.17 --force-reinstall -c conda-forge
    (...)
      Package      Version  Build       Channel          Size
     Reinstall:


      o cmake       3.25.2  h077f3f9_0  conda-forge      16MB
      o krb5        1.20.1  h81ceb04_0  conda-forge       1MB
      o libiconv      1.17  h166bdaf_0  conda-forge       1MB
      o libsodium   1.0.18  h36c2ea0_1  conda-forge     375kB
      o ninja       1.11.0  h924138e_0  conda-forge       3MB
      o zstd         1.5.2  h3eb15da_6  conda-forge     420kB
    
      Summary:
    
      Reinstall: 3 packages
    
      Total download: 23MB

This factor of 2 seems to be only caused by a copy and paste error. Reinstall only lists the packages once (only one format_row occurence), like install, whereas changed has two format_row occurences.