### PR TITLE
Fix segmentation fault in case of an invalid package name

### DIFF
--- a/libmamba/src/core/match_spec.cpp
+++ b/libmamba/src/core/match_spec.cpp
@@ -17,14 +17,14 @@ namespace mamba
 {
     std::vector<std::string> parse_legacy_dist(std::string dist_str)
     {
-        try
+        dist_str = strip_package_extension(dist_str).string();
+        auto split_str = rsplit(dist_str, "-", 2);
+        if (split_str.size() != 3)
         {
-            dist_str = strip_package_extension(dist_str).string();
+            LOG_ERROR << "dist_str " << dist_str << " did not split into a correct version info.";
+            throw std::runtime_error("Invalid package filename");
         }
-        catch (...)
-        {
-        }
-        return rsplit(dist_str, "-", 2);
+        return split_str;
     }
 
 

--- a/micromamba/tests/test_install.py
+++ b/micromamba/tests/test_install.py
@@ -524,3 +524,12 @@ class TestInstall:
         pkg = pkgs[0]
         assert pkg["version"] == "1.4.4"
         assert pkg["build_string"] == "pyh9f0ad1d_0"
+
+    def test_broken_package_name(self):
+        non_existing_url = (
+            "https://026e9ab9-6b46-4285-ae0d-427553801720.de/mypackage.tar.bz2"
+        )
+        try:
+            res = install(non_existing_url, default_channel=False)
+        except subprocess.CalledProcessError as e:
+            assert "Invalid package filename" in e.stderr.decode("utf-8")


### PR DESCRIPTION
Issue #2250 says that trying to install a not existing package from a URL leads to a bad alloc. I cannot reproduce this. I can however produce a segfault with a non existing package:

    micromamba install  https://www.heise.de/not_existing_package.tar.bz2
    Segmentation fault (core dumped)

The error is not that the package does not exist in this case, but rather that the version information from the package is being parsed, even though it is not present (the error is the package name not_existing_package.tar.bz2).

For example, this crashes correctly:

    micromamba install  https://www.heise.de/linux-64/fbBss-gpu-1.7.3-py3.9_h28a55e0_0_cuda11.3.tar.bz2
    https://www.heise.de/linux-64                       37.0kB @ 121.3kB/s 404 failed  0.3s
    https://www.heise.de/noarch                         37.0kB @ 120.4kB/s 404 failed  0.3s
    critical libmamba Multiple errors occured:
     Multi-download failed. Reason: Transfer finalized, status: 404 [https://www.heise.de/noarch/repodata.json] 36966 bytes
     Subdir https://www.heise.de/noarch not loaded!

In this PR, I removed an unnecessary try except block and instead verified the existence of the version information in the file string. In this case, mamba now errors out without a segfault:

    ./build/micromamba/micromamba install  https://www.heise.de/not_existing_package.tar.bz2
    error    libmamba dist_str not_existing_package did not split into a correct version info.
    critical libmamba Invalid package filename


- [ ] @jonashaag Please verify, if this covers your issue #2250.