### PR TITLE
Isolate solv::ObjQueue

### DIFF
--- a/libmamba/CMakeLists.txt
+++ b/libmamba/CMakeLists.txt
@@ -123,6 +123,8 @@ endforeach()
 set(LIBMAMBA_SOURCES
     longpath.manifest
     ${LIBMAMBA_SOURCE_DIR}/version.cpp
+    # C++ wrapping of libsolv
+    ${LIBMAMBA_INCLUDE_DIR}/mamba/solv-cpp/queue.hpp
     # Core API (low-level)
     ${LIBMAMBA_SOURCE_DIR}/core/singletons.cpp
     ${LIBMAMBA_SOURCE_DIR}/core/activation.cpp
@@ -212,7 +214,6 @@ set(LIBMAMBA_HEADERS
     ${LIBMAMBA_INCLUDE_DIR}/mamba/core/progress_bar.hpp
     ${LIBMAMBA_INCLUDE_DIR}/mamba/core/pinning.hpp
     ${LIBMAMBA_INCLUDE_DIR}/mamba/core/query.hpp
-    ${LIBMAMBA_INCLUDE_DIR}/mamba/core/queue.hpp
     ${LIBMAMBA_INCLUDE_DIR}/mamba/core/repo.hpp
     ${LIBMAMBA_INCLUDE_DIR}/mamba/core/run.hpp
     ${LIBMAMBA_INCLUDE_DIR}/mamba/core/shell_init.hpp

--- a/libmamba/CMakeLists.txt
+++ b/libmamba/CMakeLists.txt
@@ -124,7 +124,8 @@ set(LIBMAMBA_SOURCES
     longpath.manifest
     ${LIBMAMBA_SOURCE_DIR}/version.cpp
     # C++ wrapping of libsolv
-    ${LIBMAMBA_INCLUDE_DIR}/mamba/solv-cpp/queue.hpp
+    ${LIBMAMBA_SOURCE_DIR}/solv-cpp/queue.hpp
+    ${LIBMAMBA_SOURCE_DIR}/solv-cpp/queue.cpp
     # Core API (low-level)
     ${LIBMAMBA_SOURCE_DIR}/core/singletons.cpp
     ${LIBMAMBA_SOURCE_DIR}/core/activation.cpp

--- a/libmamba/CMakeLists.txt
+++ b/libmamba/CMakeLists.txt
@@ -124,7 +124,6 @@ set(LIBMAMBA_SOURCES
     longpath.manifest
     ${LIBMAMBA_SOURCE_DIR}/version.cpp
     # C++ wrapping of libsolv
-    ${LIBMAMBA_SOURCE_DIR}/solv-cpp/queue.hpp
     ${LIBMAMBA_SOURCE_DIR}/solv-cpp/queue.cpp
     # Core API (low-level)
     ${LIBMAMBA_SOURCE_DIR}/core/singletons.cpp
@@ -186,7 +185,7 @@ foreach(script ${SHELL_SCRIPTS})
     list(APPEND LIBMAMBA_SOURCES shell_scripts/${script}.cpp)
 endforeach()
 
-set(LIBMAMBA_HEADERS
+set(LIBMAMBA_PUBLIC_HEADERS
     ${LIBMAMBA_INCLUDE_DIR}/mamba/version.hpp
     # Core API (low-level)
     ${LIBMAMBA_INCLUDE_DIR}/mamba/core/activation.hpp
@@ -254,6 +253,10 @@ set(LIBMAMBA_HEADERS
     ${LIBMAMBA_INCLUDE_DIR}/mamba/api/update.hpp
 )
 
+set(LIBMAMBA_PRIVATE_HEADERS
+    ${LIBMAMBA_SOURCE_DIR}/solv-cpp/queue.hpp
+)
+
 # Targets and link
 # ================
 
@@ -270,7 +273,12 @@ macro(libmamba_create_target target_name linkage deps_linkage output_name)
 
     # Output
     # ======
-    add_library(${target_name} ${linkage_upper} ${LIBMAMBA_SOURCES} ${LIBMAMBA_HEADERS})
+    add_library(
+        ${target_name} ${linkage_upper}
+        ${LIBMAMBA_PUBLIC_HEADERS}
+        ${LIBMAMBA_PRIVATE_HEADERS}
+        ${LIBMAMBA_SOURCES}
+    )
 
     mamba_target_add_compile_warnings(
         ${target_name}
@@ -471,7 +479,7 @@ macro(libmamba_create_target target_name linkage deps_linkage output_name)
                               ${MAMBA_FORCE_DYNAMIC_LIBS})
     endif ()
 
-    set_property(TARGET ${target_name} PROPERTY CXX_STANDARD 17)
+    target_compile_features(${target_name} PUBLIC cxx_std_17)
 
     target_include_directories(
         ${target_name}
@@ -496,7 +504,7 @@ macro(libmamba_create_target target_name linkage deps_linkage output_name)
         set_target_properties(
             ${target_name}
             PROPERTIES
-            PUBLIC_HEADER "${LIBMAMBA_HEADERS}"
+            PUBLIC_HEADER "${LIBMAMBA_PUBLIC_HEADERS}"
             COMPILE_DEFINITIONS "LIBMAMBA_EXPORTS"
             PREFIX ""
             VERSION "${LIBMAMBA_BINARY_COMPATIBLE}.${LIBMAMBA_BINARY_REVISION}.${LIBMAMBA_BINARY_AGE}"
@@ -507,7 +515,7 @@ macro(libmamba_create_target target_name linkage deps_linkage output_name)
         set_target_properties(
             ${target_name}
             PROPERTIES
-            PUBLIC_HEADER "${LIBMAMBA_HEADERS}"
+            PUBLIC_HEADER "${LIBMAMBA_PUBLIC_HEADERS}"
             COMPILE_DEFINITIONS "LIBMAMBA_EXPORTS"
             PREFIX ""
             VERSION ${LIBMAMBA_BINARY_VERSION}

--- a/libmamba/include/mamba/api/install.hpp
+++ b/libmamba/include/mamba/api/install.hpp
@@ -11,6 +11,7 @@
 #include <vector>
 
 #include <nlohmann/json.hpp>
+#include <solv/solver.h>
 #include <yaml-cpp/yaml.h>
 
 #include "mamba/core/context.hpp"
@@ -20,7 +21,6 @@
 #include "mamba/core/pool.hpp"
 #include "mamba/core/repo.hpp"
 #include "mamba/core/solver.hpp"
-
 
 namespace mamba
 {

--- a/libmamba/include/mamba/core/package_info.hpp
+++ b/libmamba/include/mamba/core/package_info.hpp
@@ -7,19 +7,15 @@
 #ifndef MAMBA_CORE_PACKAGE_INFO
 #define MAMBA_CORE_PACKAGE_INFO
 
-extern "C"
-{
-#include <solv/pool.h>
-#include <solv/poolid.h>
-#include <solv/repo.h>
-#include <solv/solvable.h>
-}
-
 #include <set>
 #include <string>
 #include <vector>
 
-#include "nlohmann/json.hpp"
+#include <nlohmann/json.hpp>
+#include <solv/pool.h>
+#include <solv/poolid.h>
+#include <solv/repo.h>
+#include <solv/solvable.h>
 
 namespace mamba
 {

--- a/libmamba/include/mamba/core/query.hpp
+++ b/libmamba/include/mamba/core/query.hpp
@@ -11,18 +11,18 @@
 #include <string>
 #include <vector>
 
+#include <solv/pool.h>
+#include <solv/repo.h>
+#include <solv/selection.h>
+#include <solv/solver.h>
+extern "C"  // Incomplete header
+{
+#include <solv/conda.h>
+}
+
 #include "mamba/core/package_info.hpp"
 #include "mamba/core/pool.hpp"
 #include "mamba/core/util_graph.hpp"
-
-extern "C"
-{
-#include "solv/conda.h"
-#include "solv/repo.h"
-#include "solv/selection.h"
-#include "solv/solver.h"
-}
-
 
 namespace mamba
 {

--- a/libmamba/include/mamba/core/repo.hpp
+++ b/libmamba/include/mamba/core/repo.hpp
@@ -9,16 +9,16 @@
 
 #include <string>
 #include <tuple>
+#include <utility>
+
+#include <solv/pooltypes.h>
 
 #include "channel.hpp"
 #include "prefix_data.hpp"
 
 extern "C"
 {
-#include "solv/conda.h"
-#include "solv/repo.h"
-#include "solv/repo_conda.h"
-#include "solv/repo_solv.h"
+    typedef struct s_Repo Repo;
 }
 
 namespace mamba

--- a/libmamba/include/mamba/core/solver.hpp
+++ b/libmamba/include/mamba/core/solver.hpp
@@ -14,8 +14,10 @@
 #include <utility>
 #include <vector>
 
-#include <solv/queue.h>
-#include <solv/solver.h>
+#include <solv/pooltypes.h>
+#include <solv/solvable.h>
+// Incomplete header
+#include <solv/rules.h>
 
 #include "mamba/core/package_info.hpp"
 #include "mamba/core/pool.hpp"
@@ -25,6 +27,16 @@
 #define MAMBA_NO_DEPS 0b0001
 #define MAMBA_ONLY_DEPS 0b0010
 #define MAMBA_FORCE_REINSTALL 0b0100
+
+extern "C"
+{
+    typedef struct s_Solver Solver;
+}
+
+namespace mamba::solv
+{
+    class ObjQueue;
+}
 
 namespace mamba
 {
@@ -43,12 +55,13 @@ namespace mamba
         std::string description;
     };
 
+
     class MSolver
     {
     public:
 
         MSolver(MPool pool, std::vector<std::pair<int, int>> flags = {});
-        ~MSolver() = default;
+        ~MSolver();
 
         MSolver(const MSolver&) = delete;
         MSolver& operator=(const MSolver&) = delete;
@@ -103,7 +116,7 @@ namespace mamba
         // Order of m_pool and m_solver is critical since m_pool must outlive m_solver.
         MPool m_pool;
         std::unique_ptr<::Solver, void (*)(::Solver*)> m_solver;
-        Queue m_jobs;
+        std::unique_ptr<solv::ObjQueue> m_jobs;
     };
 }  // namespace mamba
 

--- a/libmamba/include/mamba/core/transaction.hpp
+++ b/libmamba/include/mamba/core/transaction.hpp
@@ -14,9 +14,10 @@
 #include <tuple>
 #include <vector>
 
-#include "mamba/api/install.hpp"
+#include <nlohmann/json.hpp>
+#include <solv/transaction.h>
 
-#include "nlohmann/json.hpp"
+#include "mamba/api/install.hpp"
 
 #include "env_lockfile.hpp"
 #include "fetch.hpp"
@@ -27,15 +28,9 @@
 #include "prefix_data.hpp"
 #include "progress_bar.hpp"
 #include "repo.hpp"
+#include "solver.hpp"
 #include "thread_utils.hpp"
 #include "transaction_context.hpp"
-
-extern "C"
-{
-#include "solv/transaction.h"
-}
-
-#include "solver.hpp"
 
 
 namespace mamba

--- a/libmamba/include/mamba/solv-cpp/queue.hpp
+++ b/libmamba/include/mamba/solv-cpp/queue.hpp
@@ -1,0 +1,294 @@
+// Copyright (c) 2019, QuantStack and Mamba Contributors
+//
+// Distributed under the terms of the BSD 3-Clause License.
+//
+// The full license is in the file LICENSE, distributed with this software.
+
+#ifndef MAMBA_SOLV_QUEUE_HPP
+#define MAMBA_SOLV_QUEUE_HPP
+
+#include <cassert>
+#include <iterator>
+#include <limits>
+#include <utility>
+
+#include <solv/queue.h>
+
+namespace mamba::solv
+{
+    /**
+     * A ``std::vector`` like structure used in libsolv.
+     *
+     * This is used privately within libsolv, hence the direct use of ``Queue`` as an attribute
+     * (for performances).
+     */
+    class ObjQueue
+    {
+    public:
+
+        using value_type = ::Id;
+        using reference = value_type&;
+        using const_reference = const value_type&;
+        using pointer = ::Id*;
+        using const_pointer = const ::Id*;
+        using size_type = std::size_t;
+        using difference_type = std::ptrdiff_t;
+        using iterator = pointer;
+        using const_iterator = const_pointer;
+        using reverse_iterator = std::reverse_iterator<iterator>;
+        using const_reverse_iterator = std::reverse_iterator<const_iterator>;
+
+        ObjQueue();
+        template <typename InputIt>
+        ObjQueue(InputIt first, InputIt last);
+        ObjQueue(std::initializer_list<value_type> elems);
+        ~ObjQueue();
+
+        /**
+         * Move and copy operations are disabled for simplicity but could be added if needed.
+         */
+        ObjQueue(const ObjQueue&) = delete;
+        ObjQueue(ObjQueue&&) = delete;
+        ObjQueue& operator=(const ObjQueue&) = delete;
+        ObjQueue& operator=(ObjQueue&&) = delete;
+
+        auto size() const -> size_type;
+        auto capacity() const -> size_type;
+        auto empty() const -> bool;
+
+        auto insert(const_iterator pos, value_type id) -> iterator;
+        template <typename InputIt>
+        auto insert(const_iterator pos, InputIt first, InputIt last) -> iterator;
+        void push_back(value_type id);
+        void push_back(value_type id1, value_type id2);
+        auto erase(const_iterator pos) -> iterator;
+        void reserve(size_type new_cap);
+        void clear();
+
+        auto front() -> reference;
+        auto front() const -> const_reference;
+        auto back() -> reference;
+        auto back() const -> const_reference;
+        auto operator[](int idx) -> reference;
+        auto operator[](int idx) const -> const_reference;
+        auto begin() -> iterator;
+        auto begin() const -> const_iterator;
+        auto end() -> iterator;
+        auto end() const -> const_iterator;
+        auto rbegin() -> reverse_iterator;
+        auto rbegin() const -> const_reverse_iterator;
+        auto rend() -> reverse_iterator;
+        auto rend() const -> const_reverse_iterator;
+
+        template <template <typename, typename...> class C>
+        auto as() -> C<value_type>;
+
+        auto get() -> ::Queue*;
+        auto get() const -> const ::Queue*;
+
+    private:
+
+        ::Queue m_queue = {};
+    };
+
+    /********************************
+     *  Implementation of ObjQueue  *
+     ********************************/
+
+    inline ObjQueue::ObjQueue()
+    {
+        queue_init(get());
+    }
+
+    template <typename InputIt>
+    inline ObjQueue::ObjQueue(InputIt first, InputIt last)
+        : ObjQueue()
+    {
+        insert(begin(), first, last);
+    }
+
+    inline ObjQueue::ObjQueue(std::initializer_list<value_type> elems)
+        : ObjQueue(elems.begin(), elems.end())
+    {
+    }
+
+    inline ObjQueue::~ObjQueue()
+    {
+        queue_free(get());
+    }
+
+    inline void ObjQueue::push_back(value_type id)
+    {
+        queue_push(get(), id);
+    }
+
+    inline void ObjQueue::push_back(value_type id1, value_type id2)
+    {
+        queue_push2(get(), id1, id2);
+    }
+
+    inline auto ObjQueue::insert(const_iterator pos, value_type id) -> iterator
+    {
+        const difference_type offset = pos - begin();
+        assert(offset >= 0);
+        assert(offset <= std::numeric_limits<int>::max());
+        queue_insert(get(), static_cast<int>(offset), id);
+        return begin() + offset;
+    }
+
+    template <typename InputIt>
+    auto ObjQueue::insert(const_iterator pos, InputIt first, InputIt last) -> iterator
+    {
+        const difference_type offset = pos - begin();
+        assert(offset >= 0);
+        assert(offset <= std::numeric_limits<int>::max());
+        const auto n = std::distance(first, last);
+        assert(n >= 0);
+
+        if constexpr (std::is_same_v<InputIt, iterator> || std::is_same_v<InputIt, const_iterator>)
+        {
+            assert(n <= std::numeric_limits<int>::max());
+            queue_insertn(get(), static_cast<int>(offset), static_cast<int>(n), first);
+        }
+        else
+        {
+            reserve(size() + n);
+            for (; first != last; ++first)
+            {
+                pos = insert(pos, *first);
+                ++pos;
+            }
+        }
+        return begin() + offset;
+    }
+
+    inline auto ObjQueue::capacity() const -> size_type
+    {
+        return static_cast<size_type>(m_queue.count + m_queue.left);
+    }
+
+    inline auto ObjQueue::size() const -> size_type
+    {
+        assert(m_queue.count >= 0);
+        return static_cast<std::size_t>(m_queue.count);
+    }
+
+    inline auto ObjQueue::empty() const -> bool
+    {
+        return size() == 0;
+    }
+
+    inline auto ObjQueue::erase(const_iterator pos) -> iterator
+    {
+        const difference_type offset = pos - begin();
+        assert(offset >= 0);
+        assert(offset <= std::numeric_limits<int>::max());
+        queue_delete(get(), static_cast<int>(offset));
+        return begin() + offset;
+    }
+
+    inline void ObjQueue::reserve(size_type new_cap)
+    {
+        if (new_cap < capacity())
+        {
+            return;
+        }
+        size_type cap_diff = new_cap - capacity();
+        assert(cap_diff <= std::numeric_limits<int>::max());
+        queue_prealloc(get(), static_cast<int>(cap_diff));
+    }
+
+    inline void ObjQueue::clear()
+    {
+        queue_empty(get());
+    }
+
+    inline auto ObjQueue::front() -> reference
+    {
+        return *begin();
+    }
+
+    inline auto ObjQueue::front() const -> const_reference
+    {
+        return *begin();
+    }
+
+    inline auto ObjQueue::back() -> reference
+    {
+        return *rbegin();
+    }
+
+    inline auto ObjQueue::back() const -> const_reference
+    {
+        return *rbegin();
+    }
+
+    inline auto ObjQueue::operator[](int idx) -> reference
+    {
+        return m_queue.elements[idx];
+    }
+
+    inline auto ObjQueue::operator[](int idx) const -> const_reference
+    {
+        return m_queue.elements[idx];
+    }
+
+    inline auto ObjQueue::begin() -> iterator
+    {
+        return m_queue.elements;
+    }
+
+    inline auto ObjQueue::begin() const -> const_iterator
+    {
+        return m_queue.elements;
+    }
+
+    inline auto ObjQueue::end() -> iterator
+    {
+        return m_queue.elements + size();
+    }
+
+    inline auto ObjQueue::end() const -> const_iterator
+    {
+        return m_queue.elements + size();
+    }
+
+    inline auto ObjQueue::rbegin() -> reverse_iterator
+    {
+        return std::reverse_iterator{ end() };
+    }
+
+    inline auto ObjQueue::rbegin() const -> const_reverse_iterator
+    {
+        return std::reverse_iterator{ end() };
+    }
+
+    inline auto ObjQueue::rend() -> reverse_iterator
+    {
+        return std::reverse_iterator{ begin() };
+    }
+
+    inline auto ObjQueue::rend() const -> const_reverse_iterator
+    {
+        return std::reverse_iterator{ begin() };
+    }
+
+    template <template <typename, typename...> class C>
+    auto ObjQueue::as() -> C<value_type>
+    {
+        return C<value_type>(begin(), end());
+    }
+
+    inline const ::Queue* ObjQueue::get() const
+    {
+        return &m_queue;
+    }
+
+    inline ::Queue* ObjQueue::get()
+    {
+        return &m_queue;
+    }
+
+}  // namespace mamba
+
+#endif

--- a/libmamba/src/core/package_info.cpp
+++ b/libmamba/src/core/package_info.cpp
@@ -14,7 +14,8 @@
 
 #include "mamba/core/channel.hpp"
 #include "mamba/core/util.hpp"
-#include "mamba/solv-cpp/queue.hpp"
+
+#include "solv-cpp/queue.hpp"
 
 namespace mamba
 {

--- a/libmamba/src/core/package_info.cpp
+++ b/libmamba/src/core/package_info.cpp
@@ -160,7 +160,7 @@ namespace mamba
 
         solv::ObjQueue q = {};
 
-        if (!solvable_lookup_deparray(s, SOLVABLE_REQUIRES, q.get(), -1))
+        if (!solvable_lookup_deparray(s, SOLVABLE_REQUIRES, q.raw(), -1))
         {
             defaulted_keys.insert("depends");
         }
@@ -173,7 +173,7 @@ namespace mamba
         );
 
         q.clear();
-        if (!solvable_lookup_deparray(s, SOLVABLE_CONSTRAINS, q.get(), -1))
+        if (!solvable_lookup_deparray(s, SOLVABLE_CONSTRAINS, q.raw(), -1))
         {
             defaulted_keys.insert("constrains");
         }
@@ -186,7 +186,7 @@ namespace mamba
         );
 
         q.clear();
-        solvable_lookup_idarray(s, SOLVABLE_TRACK_FEATURES, q.get());
+        solvable_lookup_idarray(s, SOLVABLE_TRACK_FEATURES, q.raw());
         for (auto iter = q.begin(), end = q.end(); iter < end; ++iter)
         {
             track_features += pool_id2str(pool, *iter);
@@ -203,7 +203,7 @@ namespace mamba
         {
             // Get extra signed keys
             q.clear();
-            solvable_lookup_idarray(s, extra_keys_id, q.get());
+            solvable_lookup_idarray(s, extra_keys_id, q.raw());
             std::vector<std::string> extra_keys = {};
             extra_keys.reserve(q.size());
             std::transform(
@@ -215,7 +215,7 @@ namespace mamba
 
             // Get extra signed values
             q.clear();
-            solvable_lookup_idarray(s, extra_values_id, q.get());
+            solvable_lookup_idarray(s, extra_values_id, q.raw());
             std::vector<std::string> extra_values = {};
             extra_values.reserve(q.size());
             std::transform(

--- a/libmamba/src/core/pool.cpp
+++ b/libmamba/src/core/pool.cpp
@@ -4,19 +4,22 @@
 //
 // The full license is in the file LICENSE, distributed with this software.
 
-#include "mamba/core/pool.hpp"
-
 #include <list>
 
 #include <solv/evr.h>
 #include <solv/pool.h>
 #include <solv/selection.h>
 #include <solv/solver.h>
+extern "C"  // Incomplete header
+{
+#include <solv/conda.h>
+}
 #include <spdlog/spdlog.h>
 
 #include "mamba/core/context.hpp"
 #include "mamba/core/output.hpp"
-#include "mamba/core/queue.hpp"
+#include "mamba/core/pool.hpp"
+#include "mamba/solv-cpp/queue.hpp"
 
 namespace mamba
 {
@@ -116,9 +119,9 @@ namespace mamba
 
     std::vector<Id> MPool::select_solvables(Id matchspec, bool sorted) const
     {
-        MQueue job, solvables;
-        job.push(SOLVER_SOLVABLE_PROVIDES, matchspec);
-        selection_solvables(const_cast<Pool*>(pool()), job, solvables);
+        solv::ObjQueue job = { SOLVER_SOLVABLE_PROVIDES, matchspec };
+        solv::ObjQueue solvables = {};
+        selection_solvables(const_cast<Pool*>(pool()), job.get(), solvables.get());
 
         if (sorted)
         {

--- a/libmamba/src/core/pool.cpp
+++ b/libmamba/src/core/pool.cpp
@@ -122,7 +122,7 @@ namespace mamba
     {
         solv::ObjQueue job = { SOLVER_SOLVABLE_PROVIDES, matchspec };
         solv::ObjQueue solvables = {};
-        selection_solvables(const_cast<Pool*>(pool()), job.get(), solvables.get());
+        selection_solvables(const_cast<Pool*>(pool()), job.raw(), solvables.raw());
 
         if (sorted)
         {

--- a/libmamba/src/core/pool.cpp
+++ b/libmamba/src/core/pool.cpp
@@ -19,7 +19,8 @@ extern "C"  // Incomplete header
 #include "mamba/core/context.hpp"
 #include "mamba/core/output.hpp"
 #include "mamba/core/pool.hpp"
-#include "mamba/solv-cpp/queue.hpp"
+
+#include "solv-cpp/queue.hpp"
 
 namespace mamba
 {

--- a/libmamba/src/core/prefix_data.cpp
+++ b/libmamba/src/core/prefix_data.cpp
@@ -11,7 +11,8 @@
 #include "mamba/core/output.hpp"
 #include "mamba/core/pool.hpp"
 #include "mamba/core/repo.hpp"
-#include "mamba/solv-cpp/queue.hpp"
+
+#include "solv-cpp/queue.hpp"
 
 namespace mamba
 {

--- a/libmamba/src/core/prefix_data.cpp
+++ b/libmamba/src/core/prefix_data.cpp
@@ -4,16 +4,14 @@
 //
 // The full license is in the file LICENSE, distributed with this software.
 
-extern "C"
-{
+#include "mamba/core/prefix_data.hpp"
+
 #include <solv/transaction.h>
-}
 
 #include "mamba/core/output.hpp"
 #include "mamba/core/pool.hpp"
-#include "mamba/core/prefix_data.hpp"
-#include "mamba/core/queue.hpp"
 #include "mamba/core/repo.hpp"
+#include "mamba/solv-cpp/queue.hpp"
 
 namespace mamba
 {
@@ -79,7 +77,7 @@ namespace mamba
         std::vector<PackageInfo> result;
         MPool pool;
 
-        MQueue q;
+        solv::ObjQueue q;
         {
             // TODO check prereq marker to `pip` if it's part of the installed packages
             // so that it gets installed after Python.
@@ -91,14 +89,14 @@ namespace mamba
 
             FOR_REPO_SOLVABLES(repo.repo(), pkg_id, s)
             {
-                q.push(pkg_id);
+                q.push_back(pkg_id);
             }
         }
 
         Pool* pp = pool;
         pp->installed = nullptr;
 
-        Transaction* t = transaction_create_decisionq(pool, q, nullptr);
+        Transaction* t = transaction_create_decisionq(pool, q.get(), nullptr);
         transaction_order(t, 0);
 
         for (int i = 0; i < t->steps.count; i++)

--- a/libmamba/src/core/prefix_data.cpp
+++ b/libmamba/src/core/prefix_data.cpp
@@ -97,7 +97,7 @@ namespace mamba
         Pool* pp = pool;
         pp->installed = nullptr;
 
-        Transaction* t = transaction_create_decisionq(pool, q.get(), nullptr);
+        Transaction* t = transaction_create_decisionq(pool, q.raw(), nullptr);
         transaction_order(t, 0);
 
         for (int i = 0; i < t->steps.count; i++)

--- a/libmamba/src/core/query.cpp
+++ b/libmamba/src/core/query.cpp
@@ -54,7 +54,7 @@ namespace mamba
                 solv::ObjQueue rec_solvables = {};
                 // the following prints the requested version
                 solv::ObjQueue job = { SOLVER_SOLVABLE_PROVIDES, req };
-                selection_solvables(pool, job.get(), rec_solvables.get());
+                selection_solvables(pool, job.raw(), rec_solvables.raw());
 
                 if (rec_solvables.size() != 0)
                 {
@@ -116,7 +116,7 @@ namespace mamba
             // figure out who requires `s`
             solv::ObjQueue solvables = {};
 
-            pool_whatmatchesdep(pool, SOLVABLE_REQUIRES, s->name, solvables.get(), -1);
+            pool_whatmatchesdep(pool, SOLVABLE_REQUIRES, s->name, solvables.raw(), -1);
 
             if (solvables.size() != 0)
             {
@@ -214,7 +214,7 @@ namespace mamba
         }
         job.push_back(SOLVER_SOLVABLE_PROVIDES, id);
 
-        selection_solvables(m_pool.get(), job.get(), solvables.get());
+        selection_solvables(m_pool.get(), job.raw(), solvables.raw());
         query_result::dependency_graph g;
 
         Pool* pool = m_pool.get();
@@ -255,7 +255,7 @@ namespace mamba
 
         if (tree)
         {
-            selection_solvables(m_pool.get(), job.get(), solvables.get());
+            selection_solvables(m_pool.get(), job.raw(), solvables.raw());
             if (solvables.size() > 0)
             {
                 Solvable* latest = pool_id2solvable(m_pool.get(), solvables[0]);
@@ -266,7 +266,7 @@ namespace mamba
         }
         else
         {
-            pool_whatmatchesdep(m_pool.get(), SOLVABLE_REQUIRES, id, solvables.get(), -1);
+            pool_whatmatchesdep(m_pool.get(), SOLVABLE_REQUIRES, id, solvables.raw(), -1);
             for (auto& el : solvables)
             {
                 Solvable* s = pool_id2solvable(m_pool.get(), el);
@@ -288,7 +288,7 @@ namespace mamba
         job.push_back(SOLVER_SOLVABLE_PROVIDES, id);
 
         query_result::dependency_graph g;
-        selection_solvables(m_pool.get(), job.get(), solvables.get());
+        selection_solvables(m_pool.get(), job.raw(), solvables.raw());
 
         int depth = tree ? -1 : 1;
 

--- a/libmamba/src/core/query.cpp
+++ b/libmamba/src/core/query.cpp
@@ -22,7 +22,8 @@
 #include "mamba/core/package_info.hpp"
 #include "mamba/core/url.hpp"
 #include "mamba/core/util.hpp"
-#include "mamba/solv-cpp/queue.hpp"
+
+#include "solv-cpp/queue.hpp"
 
 namespace mamba
 {

--- a/libmamba/src/core/query.cpp
+++ b/libmamba/src/core/query.cpp
@@ -20,9 +20,9 @@
 #include "mamba/core/match_spec.hpp"
 #include "mamba/core/output.hpp"
 #include "mamba/core/package_info.hpp"
-#include "mamba/core/queue.hpp"
 #include "mamba/core/url.hpp"
 #include "mamba/core/util.hpp"
+#include "mamba/solv-cpp/queue.hpp"
 
 namespace mamba
 {
@@ -50,12 +50,12 @@ namespace mamba
 
             while (req != 0)
             {
-                MQueue job, rec_solvables;
+                solv::ObjQueue rec_solvables = {};
                 // the following prints the requested version
-                job.push(SOLVER_SOLVABLE_PROVIDES, req);
-                selection_solvables(pool, job, rec_solvables);
+                solv::ObjQueue job = { SOLVER_SOLVABLE_PROVIDES, req };
+                selection_solvables(pool, job.get(), rec_solvables.get());
 
-                if (rec_solvables.count() != 0)
+                if (rec_solvables.size() != 0)
                 {
                     Solvable* rs = nullptr;
                     for (auto& el : rec_solvables)
@@ -113,11 +113,11 @@ namespace mamba
         {
             auto* pool = s->repo->pool;
             // figure out who requires `s`
-            MQueue solvables;
+            solv::ObjQueue solvables = {};
 
-            pool_whatmatchesdep(pool, SOLVABLE_REQUIRES, s->name, solvables, -1);
+            pool_whatmatchesdep(pool, SOLVABLE_REQUIRES, s->name, solvables.get(), -1);
 
-            if (solvables.count() != 0)
+            if (solvables.size() != 0)
             {
                 Solvable* rs;
                 for (auto& el : solvables)
@@ -204,19 +204,16 @@ namespace mamba
 
     query_result Query::find(const std::string& query) const
     {
-        MQueue job, solvables;
+        solv::ObjQueue job, solvables;
 
-        Id id = pool_conda_matchspec(m_pool.get(), query.c_str());
-        if (id)
-        {
-            job.push(SOLVER_SOLVABLE_PROVIDES, id);
-        }
-        else
+        const Id id = pool_conda_matchspec(m_pool.get(), query.c_str());
+        if (!id)
         {
             throw std::runtime_error("Could not generate query for " + query);
         }
+        job.push_back(SOLVER_SOLVABLE_PROVIDES, id);
 
-        selection_solvables(m_pool.get(), job, solvables);
+        selection_solvables(m_pool.get(), job.get(), solvables.get());
         query_result::dependency_graph g;
 
         Pool* pool = m_pool.get();
@@ -244,24 +241,21 @@ namespace mamba
 
     query_result Query::whoneeds(const std::string& query, bool tree) const
     {
-        MQueue job, solvables;
+        solv::ObjQueue job, solvables;
 
-        Id id = pool_conda_matchspec(m_pool.get(), query.c_str());
-        if (id)
-        {
-            job.push(SOLVER_SOLVABLE_PROVIDES, id);
-        }
-        else
+        const Id id = pool_conda_matchspec(m_pool.get(), query.c_str());
+        if (!id)
         {
             throw std::runtime_error("Could not generate query for " + query);
         }
+        job.push_back(SOLVER_SOLVABLE_PROVIDES, id);
 
         query_result::dependency_graph g;
 
         if (tree)
         {
-            selection_solvables(m_pool.get(), job, solvables);
-            if (solvables.count() > 0)
+            selection_solvables(m_pool.get(), job.get(), solvables.get());
+            if (solvables.size() > 0)
             {
                 Solvable* latest = pool_id2solvable(m_pool.get(), solvables[0]);
                 const auto node_id = g.add_node(PackageInfo(latest));
@@ -271,7 +265,7 @@ namespace mamba
         }
         else
         {
-            pool_whatmatchesdep(m_pool.get(), SOLVABLE_REQUIRES, id, solvables, -1);
+            pool_whatmatchesdep(m_pool.get(), SOLVABLE_REQUIRES, id, solvables.get(), -1);
             for (auto& el : solvables)
             {
                 Solvable* s = pool_id2solvable(m_pool.get(), el);
@@ -283,29 +277,26 @@ namespace mamba
 
     query_result Query::depends(const std::string& query, bool tree) const
     {
-        MQueue job, solvables;
+        solv::ObjQueue job, solvables;
 
-        Id id = pool_conda_matchspec(m_pool.get(), query.c_str());
-        if (id)
-        {
-            job.push(SOLVER_SOLVABLE_PROVIDES, id);
-        }
-        else
+        const Id id = pool_conda_matchspec(m_pool.get(), query.c_str());
+        if (!id)
         {
             throw std::runtime_error("Could not generate query for " + query);
         }
+        job.push_back(SOLVER_SOLVABLE_PROVIDES, id);
 
         query_result::dependency_graph g;
-        selection_solvables(m_pool.get(), job, solvables);
+        selection_solvables(m_pool.get(), job.get(), solvables.get());
 
         int depth = tree ? -1 : 1;
 
-        auto find_latest = [&](MQueue& solvables) -> Solvable*
+        auto find_latest_in_non_empty = [&](solv::ObjQueue& solvables) -> Solvable*
         {
-            Solvable* latest = pool_id2solvable(m_pool.get(), solvables[0]);
-            for (int i = 1; i < solvables.count(); ++i)
+            Solvable* latest = pool_id2solvable(m_pool.get(), solvables.front());
+            for (Id const solv : solvables)
             {
-                Solvable* s = pool_id2solvable(m_pool.get(), solvables[i]);
+                Solvable* s = pool_id2solvable(m_pool.get(), solv);
                 if (pool_evrcmp(m_pool.get(), s->evr, latest->evr, 0) > 0)
                 {
                     latest = s;
@@ -314,9 +305,9 @@ namespace mamba
             return latest;
         };
 
-        if (solvables.count() != 0)
+        if (solvables.size() > 0)
         {
-            Solvable* latest = find_latest(solvables);
+            Solvable* latest = find_latest_in_non_empty(solvables);
             const auto node_id = g.add_node(PackageInfo(latest));
             std::map<Solvable*, size_t> visited = { { latest, node_id } };
             std::map<std::string, size_t> not_found;

--- a/libmamba/src/core/repo.cpp
+++ b/libmamba/src/core/repo.cpp
@@ -4,17 +4,21 @@
 //
 // The full license is in the file LICENSE, distributed with this software.
 
-#include "mamba/core/repo.hpp"
+#include <solv/repo.h>
+#include <solv/repo_solv.h>
+#include <solv/repo_write.h>
+extern "C"  // Incomplete header
+{
+#include <solv/conda.h>
+#include <solv/repo_conda.h>
+}
 
 #include "mamba/core/context.hpp"
 #include "mamba/core/output.hpp"
 #include "mamba/core/package_info.hpp"
 #include "mamba/core/pool.hpp"
+#include "mamba/core/repo.hpp"
 
-extern "C"
-{
-#include "solv/repo_write.h"
-}
 
 #define MAMBA_TOOL_VERSION "1.1"
 

--- a/libmamba/src/core/solver.cpp
+++ b/libmamba/src/core/solver.cpp
@@ -26,7 +26,8 @@ extern "C"  // Incomplete header
 #include "mamba/core/satisfiability_error.hpp"
 #include "mamba/core/solver.hpp"
 #include "mamba/core/util.hpp"
-#include "mamba/solv-cpp/queue.hpp"
+
+#include "solv-cpp/queue.hpp"
 
 namespace mamba
 {

--- a/libmamba/src/core/solver.cpp
+++ b/libmamba/src/core/solver.cpp
@@ -286,7 +286,7 @@ namespace mamba
             LOG_ERROR << "Selected channel specific (or force-reinstall) job, but "
                          "package is not available from channel. Solve job will fail.";
         }
-        Id offset = pool_queuetowhatprovides(pool, selected_pkgs.get());
+        Id offset = pool_queuetowhatprovides(pool, selected_pkgs.raw());
         // Poor man's ms repr to match waht the user provided
         std::string const repr = fmt::format("{}::{}", ms.channel, ms.conda_build_form());
         Id repr_id = pool_str2id(pool, repr.c_str(), 1);
@@ -501,7 +501,7 @@ namespace mamba
             }
         }
 
-        Id d = pool_queuetowhatprovides(pool, selected_pkgs.get());
+        Id d = pool_queuetowhatprovides(pool, selected_pkgs.raw());
         m_jobs->push_back(SOLVER_LOCK | SOLVER_SOLVABLE_ONE_OF, d);
     }
 
@@ -585,7 +585,7 @@ namespace mamba
         m_solver.reset(solver_create(m_pool));
         set_flags(m_flags);
 
-        solver_solve(m_solver.get(), m_jobs->get());
+        solver_solve(m_solver.get(), m_jobs->raw());
         m_is_solved = true;
         LOG_INFO << "Problem count: " << solver_problem_count(m_solver.get());
         const bool success = solver_problem_count(m_solver.get()) == 0;
@@ -613,7 +613,7 @@ namespace mamba
         const Id count = solver_problem_count(m_solver.get());
         for (Id i = 1; i <= count; ++i)
         {
-            solver_findallproblemrules(m_solver.get(), i, problem_rules.get());
+            solver_findallproblemrules(m_solver.get(), i, problem_rules.raw());
             for (const Id r : problem_rules)
             {
                 if (r != 0)
@@ -642,7 +642,7 @@ namespace mamba
         Id count = solver_problem_count(m_solver.get());
         for (Id i = 1; i <= count; ++i)
         {
-            solver_findallproblemrules(m_solver.get(), i, problem_rules.get());
+            solver_findallproblemrules(m_solver.get(), i, problem_rules.raw());
             for (const Id r : problem_rules)
             {
                 Id source, target, dep;

--- a/libmamba/src/core/solver.cpp
+++ b/libmamba/src/core/solver.cpp
@@ -4,13 +4,17 @@
 //
 // The full license is in the file LICENSE, distributed with this software.
 
-#include "mamba/core/solver.hpp"
-
 #include <sstream>
 #include <stdexcept>
 
 #include <fmt/format.h>
 #include <fmt/ostream.h>
+#include <solv/pool.h>
+#include <solv/solver.h>
+extern "C"  // Incomplete header
+{
+#include <solv/conda.h>
+}
 
 #include "mamba/core/channel.hpp"
 #include "mamba/core/context.hpp"
@@ -18,10 +22,11 @@
 #include "mamba/core/output.hpp"
 #include "mamba/core/package_info.hpp"
 #include "mamba/core/pool.hpp"
-#include "mamba/core/queue.hpp"
 #include "mamba/core/repo.hpp"
 #include "mamba/core/satisfiability_error.hpp"
+#include "mamba/core/solver.hpp"
 #include "mamba/core/util.hpp"
+#include "mamba/solv-cpp/queue.hpp"
 
 namespace mamba
 {
@@ -215,10 +220,12 @@ namespace mamba
         , m_is_solved(false)
         , m_pool(std::move(pool))
         , m_solver(nullptr, &delete_libsolve_solver)
+        , m_jobs(std::make_unique<solv::ObjQueue>())
     {
-        queue_init(&m_jobs);
         pool_createwhatprovides(m_pool);
     }
+
+    MSolver::~MSolver() = default;
 
     inline bool channel_match(Solvable* s, const Channel& needle)
     {
@@ -254,13 +261,13 @@ namespace mamba
 
     void MSolver::add_global_job(int job_flag)
     {
-        queue_push2(&m_jobs, job_flag, 0);
+        m_jobs->push_back(job_flag, 0);
     }
 
     void MSolver::add_channel_specific_job(const MatchSpec& ms, int job_flag)
     {
         Pool* pool = m_pool;
-        MQueue selected_pkgs;
+        solv::ObjQueue selected_pkgs;
 
         // conda_build_form does **NOT** contain the channel info
         Id match = pool_conda_matchspec(pool, ms.conda_build_form().c_str());
@@ -270,22 +277,22 @@ namespace mamba
         {
             if (channel_match(pool_id2solvable(pool, *wp), c))
             {
-                selected_pkgs.push(*wp);
+                selected_pkgs.push_back(*wp);
             }
         }
-        if (selected_pkgs.count() == 0)
+        if (selected_pkgs.size() == 0)
         {
             LOG_ERROR << "Selected channel specific (or force-reinstall) job, but "
                          "package is not available from channel. Solve job will fail.";
         }
-        Id offset = pool_queuetowhatprovides(pool, selected_pkgs);
+        Id offset = pool_queuetowhatprovides(pool, selected_pkgs.get());
         // Poor man's ms repr to match waht the user provided
         std::string const repr = fmt::format("{}::{}", ms.channel, ms.conda_build_form());
         Id repr_id = pool_str2id(pool, repr.c_str(), 1);
         // We add a new entry into the whatprovides to reflect the channel specific job
         pool_set_whatprovides(pool, repr_id, offset);
-        // We ask to isntall that new entry
-        queue_push2(&m_jobs, job_flag, repr_id);
+        // We ask to install that new entry
+        m_jobs->push_back(job_flag, repr_id);
     }
 
     void MSolver::add_reinstall_job(MatchSpec& ms, int job_flag)
@@ -346,7 +353,7 @@ namespace mamba
             }
         }
         Id inst_id = pool_conda_matchspec(m_pool, ms.conda_build_form().c_str());
-        queue_push2(&m_jobs, job_flag | SOLVER_SOLVABLE_PROVIDES, inst_id);
+        m_jobs->push_back(job_flag | SOLVER_SOLVABLE_PROVIDES, inst_id);
     }
 
     void MSolver::add_jobs(const std::vector<std::string>& jobs, int job_flag)
@@ -377,12 +384,12 @@ namespace mamba
                 if (!ms.is_simple())
                 {
                     Id inst_id = pool_conda_matchspec(m_pool, ms.conda_build_form().c_str());
-                    queue_push2(&m_jobs, SOLVER_INSTALL | SOLVER_SOLVABLE_PROVIDES, inst_id);
+                    m_jobs->push_back(SOLVER_INSTALL | SOLVER_SOLVABLE_PROVIDES, inst_id);
                 }
                 if (ms.channel.empty())
                 {
                     Id update_id = pool_conda_matchspec(m_pool, ms.name.c_str());
-                    queue_push2(&m_jobs, job_flag | SOLVER_SOLVABLE_PROVIDES, update_id);
+                    m_jobs->push_back(job_flag | SOLVER_SOLVABLE_PROVIDES, update_id);
                 }
                 else
                 {
@@ -409,7 +416,7 @@ namespace mamba
                 // Todo remove double parsing?
                 LOG_INFO << "Adding job: " << ms.conda_build_form();
                 Id inst_id = pool_conda_matchspec(m_pool, ms.conda_build_form().c_str());
-                queue_push2(&m_jobs, job_flag | SOLVER_SOLVABLE_PROVIDES, inst_id);
+                m_jobs->push_back(job_flag | SOLVER_SOLVABLE_PROVIDES, inst_id);
             }
         }
     }
@@ -418,7 +425,7 @@ namespace mamba
     {
         MatchSpec ms(job);
         Id inst_id = pool_conda_matchspec(m_pool, ms.conda_build_form().c_str());
-        queue_push2(&m_jobs, SOLVER_INSTALL | SOLVER_SOLVABLE_PROVIDES, inst_id);
+        m_jobs->push_back(SOLVER_INSTALL | SOLVER_SOLVABLE_PROVIDES, inst_id);
     }
 
     void MSolver::add_pin(const std::string& pin)
@@ -481,8 +488,7 @@ namespace mamba
         }
         m_pinned_specs.push_back(ms);
 
-        Queue selected_pkgs;
-        queue_init(&selected_pkgs);
+        solv::ObjQueue selected_pkgs;
 
         for (auto& id : all_solvables)
         {
@@ -490,13 +496,12 @@ namespace mamba
             {
                 // the solvable is _NOT_ matched by our pinning expression! So we have to
                 // lock it to make it un-installable
-                queue_push(&selected_pkgs, id);
+                selected_pkgs.push_back(id);
             }
         }
 
-        Id d = pool_queuetowhatprovides(pool, &selected_pkgs);
-        queue_push2(&m_jobs, SOLVER_LOCK | SOLVER_SOLVABLE_ONE_OF, d);
-        queue_free(&selected_pkgs);
+        Id d = pool_queuetowhatprovides(pool, selected_pkgs.get());
+        m_jobs->push_back(SOLVER_LOCK | SOLVER_SOLVABLE_ONE_OF, d);
     }
 
     void MSolver::add_pins(const std::vector<std::string>& pins)
@@ -579,7 +584,7 @@ namespace mamba
         m_solver.reset(solver_create(m_pool));
         set_flags(m_flags);
 
-        solver_solve(m_solver.get(), &m_jobs);
+        solver_solve(m_solver.get(), m_jobs->get());
         m_is_solved = true;
         LOG_INFO << "Problem count: " << solver_problem_count(m_solver.get());
         const bool success = solver_problem_count(m_solver.get()) == 0;
@@ -603,21 +608,20 @@ namespace mamba
     std::vector<MSolverProblem> MSolver::all_problems_structured() const
     {
         std::vector<MSolverProblem> res;
-        Queue problem_rules;
-        queue_init(&problem_rules);
-        Id count = solver_problem_count(m_solver.get());
+        solv::ObjQueue problem_rules;
+        const Id count = solver_problem_count(m_solver.get());
         for (Id i = 1; i <= count; ++i)
         {
-            solver_findallproblemrules(m_solver.get(), i, &problem_rules);
-            for (Id j = 0; j < problem_rules.count; ++j)
+            solver_findallproblemrules(m_solver.get(), i, problem_rules.get());
+            for (const Id r : problem_rules)
             {
-                if (const Id r = problem_rules.elements[j]; r)
+                if (r != 0)
                 {
                     Id source, target, dep;
-                    const Id type = solver_ruleinfo(m_solver.get(), r, &source, &target, &dep);
+                    const SolverRuleinfo type = solver_ruleinfo(m_solver.get(), r, &source, &target, &dep);
                     res.push_back(make_solver_problem(
                         /* solver= */ m_solver.get(),
-                        /* type= */ static_cast<SolverRuleinfo>(type),
+                        /* type= */ type,
                         /* source_id= */ source,
                         /* target_id= */ target,
                         /* dep_id= */ dep
@@ -625,7 +629,6 @@ namespace mamba
                 }
             }
         }
-        queue_free(&problem_rules);
         return res;
     }
 
@@ -634,36 +637,27 @@ namespace mamba
     {
         std::stringstream problems;
 
-        Queue problem_rules;
-        queue_init(&problem_rules);
+        solv::ObjQueue problem_rules;
         Id count = solver_problem_count(m_solver.get());
         for (Id i = 1; i <= count; ++i)
         {
-            solver_findallproblemrules(m_solver.get(), i, &problem_rules);
-            for (Id j = 0; j < problem_rules.count; ++j)
+            solver_findallproblemrules(m_solver.get(), i, problem_rules.get());
+            for (const Id r : problem_rules)
             {
-                Id type, source, target, dep;
-                Id r = problem_rules.elements[j];
+                Id source, target, dep;
                 if (!r)
                 {
                     problems << "- [SKIP] no problem rule?\n";
                 }
                 else
                 {
-                    type = solver_ruleinfo(m_solver.get(), r, &source, &target, &dep);
+                    const SolverRuleinfo type = solver_ruleinfo(m_solver.get(), r, &source, &target, &dep);
                     problems << "  - "
-                             << solver_problemruleinfo2str(
-                                    m_solver.get(),
-                                    (SolverRuleinfo) type,
-                                    source,
-                                    target,
-                                    dep
-                                )
+                             << solver_problemruleinfo2str(m_solver.get(), type, source, target, dep)
                              << "\n";
                 }
             }
         }
-        queue_free(&problem_rules);
         return problems.str();
     }
 
@@ -712,31 +706,27 @@ namespace mamba
 
     std::string MSolver::problems_to_str() const
     {
-        Queue problem_queue;
-        queue_init(&problem_queue);
+        solv::ObjQueue problem_queue;
         int count = solver_problem_count(m_solver.get());
         std::stringstream problems;
         for (int i = 1; i <= count; i++)
         {
-            queue_push(&problem_queue, i);
+            problem_queue.push_back(i);
             problems << "  - " << solver_problem2str(m_solver.get(), i) << "\n";
         }
-        queue_free(&problem_queue);
         return "Encountered problems while solving:\n" + problems.str();
     }
 
     std::vector<std::string> MSolver::all_problems() const
     {
         std::vector<std::string> problems;
-        Queue problem_queue;
-        queue_init(&problem_queue);
+        solv::ObjQueue problem_queue;
         int count = static_cast<int>(solver_problem_count(m_solver.get()));
         for (int i = 1; i <= count; i++)
         {
-            queue_push(&problem_queue, i);
+            problem_queue.push_back(i);
             problems.emplace_back(solver_problem2str(m_solver.get(), i));
         }
-        queue_free(&problem_queue);
 
         return problems;
     }

--- a/libmamba/src/core/transaction.cpp
+++ b/libmamba/src/core/transaction.cpp
@@ -25,7 +25,8 @@ extern "C"  // Incomplete header
 #include "mamba/core/pool.hpp"
 #include "mamba/core/thread_utils.hpp"
 #include "mamba/core/transaction.hpp"
-#include "mamba/solv-cpp/queue.hpp"
+
+#include "solv-cpp/queue.hpp"
 
 #include "progress_bar_impl.hpp"
 

--- a/libmamba/src/core/transaction.cpp
+++ b/libmamba/src/core/transaction.cpp
@@ -515,7 +515,7 @@ namespace mamba
             {
                 job.push_back(SOLVER_SOLVABLE_PROVIDES, id);
             }
-            selection_solvables(pool, job.get(), q.get());
+            selection_solvables(pool, job.raw(), q.raw());
 
             if (q.size() == 0)
             {
@@ -534,7 +534,7 @@ namespace mamba
             throw std::runtime_error("Could not find packages to remove:" + join("", not_found));
         }
 
-        selection_solvables(pool, job.get(), q.get());
+        selection_solvables(pool, job.raw(), q.raw());
         const bool remove_success = size_t(q.size()) >= specs_to_remove.size();
         Console::instance().json_write({ { "success", remove_success } });
         Id pkg_id;
@@ -546,7 +546,7 @@ namespace mamba
             decision.push_back(pkg_id);
         }
 
-        m_transaction = transaction_create_decisionq(pool, decision.get(), nullptr);
+        m_transaction = transaction_create_decisionq(pool, decision.raw(), nullptr);
         init();
 
         m_history_entry = History::UserRequest::prefilled();
@@ -607,7 +607,7 @@ namespace mamba
             if (solver.only_deps)
             {
                 solv::ObjQueue q = {};
-                transaction_installedresult(m_transaction, q.get());
+                transaction_installedresult(m_transaction, q.raw());
                 for (const Id r : q)
                 {
                     Solvable* s = pool_id2solvable(pool, r);
@@ -674,7 +674,7 @@ namespace mamba
             Solvable* s = nullptr;
             solv::ObjQueue job, q, decision;
 
-            solver_get_decisionqueue(solver, decision.get());
+            solver_get_decisionqueue(solver, decision.raw());
 
             const Id noarch_repo_key = pool_str2id(pool, "solvable:noarch_type", 1);
 
@@ -724,7 +724,7 @@ namespace mamba
                         job.push_back(SOLVER_SOLVABLE_PROVIDES, id);
                     }
 
-                    selection_solvables(pool, job.get(), q.get());
+                    selection_solvables(pool, job.raw(), q.raw());
 
                     Id reinstall_id = -1;
                     for (const Id r : q)
@@ -761,7 +761,7 @@ namespace mamba
             }
 
             transaction_free(m_transaction);
-            m_transaction = transaction_create_decisionq(pool, decision.get(), nullptr);
+            m_transaction = transaction_create_decisionq(pool, decision.raw(), nullptr);
             transaction_order(m_transaction, 0);
 
             // init everything again...
@@ -790,7 +790,7 @@ namespace mamba
             decision.push_back(pkg_id);
         }
 
-        m_transaction = transaction_create_decisionq(pool, decision.get(), nullptr);
+        m_transaction = transaction_create_decisionq(pool, decision.raw(), nullptr);
         transaction_order(m_transaction, 0);
 
         init();
@@ -1531,7 +1531,7 @@ namespace mamba
         };
 
         int mode = SOLVER_TRANSACTION_SHOW_OBSOLETES | SOLVER_TRANSACTION_OBSOLETE_IS_UPGRADE;
-        transaction_classify(m_transaction, mode, classes.get());
+        transaction_classify(m_transaction, mode, classes.raw());
         for (std::size_t n_classes = classes.size(), i = 0; i < n_classes; i += 4)
         {
             const Id cls = classes.at(i);
@@ -1541,7 +1541,7 @@ namespace mamba
                 cls,
                 classes.at(i + 2),
                 classes.at(i + 3),
-                pkgs.get()
+                pkgs.raw()
             );
 
             for (const Id p : pkgs)

--- a/libmamba/src/core/transaction.cpp
+++ b/libmamba/src/core/transaction.cpp
@@ -1532,11 +1532,17 @@ namespace mamba
 
         int mode = SOLVER_TRANSACTION_SHOW_OBSOLETES | SOLVER_TRANSACTION_OBSOLETE_IS_UPGRADE;
         transaction_classify(m_transaction, mode, classes.get());
-        const auto cls_end = classes.end();
-        for (auto cls_iter = classes.begin(); cls_iter < cls_end; cls_iter += 4)
+        for (std::size_t n_classes = classes.size(), i = 0; i < n_classes; i += 4)
         {
-            const Id cls = *cls_iter;
-            transaction_classify_pkgs(m_transaction, mode, cls, cls_iter[2], cls_iter[3], pkgs.get());
+            const Id cls = classes.at(i);
+            transaction_classify_pkgs(
+                m_transaction,
+                mode,
+                cls,
+                classes.at(i + 2),
+                classes.at(i + 3),
+                pkgs.get()
+            );
 
             for (const Id p : pkgs)
             {

--- a/libmamba/src/core/transaction.cpp
+++ b/libmamba/src/core/transaction.cpp
@@ -4,8 +4,6 @@
 //
 // The full license is in the file LICENSE, distributed with this software.
 
-#include "mamba/core/transaction.hpp"
-
 #include <iostream>
 #include <stack>
 
@@ -13,6 +11,10 @@
 #include <fmt/format.h>
 #include <fmt/ostream.h>
 #include <solv/selection.h>
+extern "C"  // Incomplete header
+{
+#include <solv/conda.h>
+}
 
 #include "mamba/core/channel.hpp"
 #include "mamba/core/context.hpp"
@@ -21,9 +23,9 @@
 #include "mamba/core/match_spec.hpp"
 #include "mamba/core/output.hpp"
 #include "mamba/core/pool.hpp"
-#include "mamba/core/queue.hpp"
 #include "mamba/core/thread_utils.hpp"
-#include "mamba/core/util_scope.hpp"
+#include "mamba/core/transaction.hpp"
+#include "mamba/solv-cpp/queue.hpp"
 
 #include "progress_bar_impl.hpp"
 
@@ -499,7 +501,7 @@ namespace mamba
         pool.create_whatprovides();
 
         // Just add the packages we want to remove directly to the transaction
-        MQueue q, job, decision;
+        solv::ObjQueue q, job, decision;
 
         std::vector<std::string> not_found;
         for (auto& s : specs_to_remove)
@@ -507,21 +509,21 @@ namespace mamba
             job.clear();
             q.clear();
 
-            Id id = pool_conda_matchspec((Pool*) pool, s.conda_build_form().c_str());
+            const Id id = pool_conda_matchspec((Pool*) pool, s.conda_build_form().c_str());
             if (id)
             {
-                job.push(SOLVER_SOLVABLE_PROVIDES, id);
+                job.push_back(SOLVER_SOLVABLE_PROVIDES, id);
             }
-            selection_solvables(pool, job, q);
+            selection_solvables(pool, job.get(), q.get());
 
-            if (q.count() == 0)
+            if (q.size() == 0)
             {
                 not_found.push_back("\n - " + s.str());
             }
             for (auto& el : q)
             {
                 // To remove, these have to be negative
-                decision.push(-el);
+                decision.push_back(-el);
             }
         }
 
@@ -531,8 +533,8 @@ namespace mamba
             throw std::runtime_error("Could not find packages to remove:" + join("", not_found));
         }
 
-        selection_solvables(pool, job, q);
-        bool remove_success = size_t(q.count()) >= specs_to_remove.size();
+        selection_solvables(pool, job.get(), q.get());
+        const bool remove_success = size_t(q.size()) >= specs_to_remove.size();
         Console::instance().json_write({ { "success", remove_success } });
         Id pkg_id;
         Solvable* solvable;
@@ -540,10 +542,10 @@ namespace mamba
         // find repo __explicit_specs__ and install all packages from it
         FOR_REPO_SOLVABLES(mrepo.repo(), pkg_id, solvable)
         {
-            decision.push(pkg_id);
+            decision.push_back(pkg_id);
         }
 
-        m_transaction = transaction_create_decisionq(pool, decision, nullptr);
+        m_transaction = transaction_create_decisionq(pool, decision.get(), nullptr);
         init();
 
         m_history_entry = History::UserRequest::prefilled();
@@ -603,12 +605,11 @@ namespace mamba
 
             if (solver.only_deps)
             {
-                Queue q;
-                queue_init(&q);
-                transaction_installedresult(m_transaction, &q);
-                for (int i = 0; i < q.count; ++i)
+                solv::ObjQueue q = {};
+                transaction_installedresult(m_transaction, q.get());
+                for (const Id r : q)
                 {
-                    Solvable* s = pool_id2solvable(pool, q.elements[i]);
+                    Solvable* s = pool_id2solvable(pool, r);
                     if (m_filter_name_ids.count(s->name))
                     {
                         // add the dependencies of this selected package to the added specs
@@ -631,7 +632,6 @@ namespace mamba
                         }
                     }
                 }
-                queue_free(&q);
             }
         }
 
@@ -669,14 +669,11 @@ namespace mamba
 
         if (m_transaction_context.relink_noarch && pool->installed != nullptr)
         {
-            Id p;
-            Solvable* s;
-            Queue job, q, decision;
-            queue_init(&job);
-            queue_init(&q);
-            queue_init(&decision);
+            Id p = 0;
+            Solvable* s = nullptr;
+            solv::ObjQueue job, q, decision;
 
-            solver_get_decisionqueue(solver, &decision);
+            solver_get_decisionqueue(solver, decision.get());
 
             const Id noarch_repo_key = pool_str2id(pool, "solvable:noarch_type", 1);
 
@@ -692,15 +689,15 @@ namespace mamba
                 if (strcmp(noarch_type, "python") == 0)
                 {
                     bool skip_relink = false;
-                    for (int x = 0; x < decision.count; ++x)
+                    for (auto iter = decision.begin(); iter != decision.end(); ++iter)
                     {
                         // if the installed package is kept, delete decision
-                        if (decision.elements[x] == p)
+                        if (*iter == p)
                         {
-                            queue_delete(&decision, x);
+                            iter = decision.erase(iter);
                             break;
                         }
-                        else if (decision.elements[x] == -p)
+                        else if (*iter == -p)
                         {
                             // package is _already_ getting delete
                             // in this case, we do not need to manually relink
@@ -716,25 +713,25 @@ namespace mamba
 
                     PackageInfo pi(s);
 
-                    Id id = pool_conda_matchspec(
-                        (Pool*) pool,
+                    const Id id = pool_conda_matchspec(
+                        pool,
                         fmt::format("{} {} {}", pi.name, pi.version, pi.build_string).c_str()
                     );
 
                     if (id)
                     {
-                        queue_push2(&job, SOLVER_SOLVABLE_PROVIDES, id);
+                        job.push_back(SOLVER_SOLVABLE_PROVIDES, id);
                     }
 
-                    selection_solvables(pool, &job, &q);
+                    selection_solvables(pool, job.get(), q.get());
 
                     Id reinstall_id = -1;
-                    for (int xi = 0; xi < q.count; ++xi)
+                    for (const Id r : q)
                     {
-                        auto* xid = pool_id2solvable(pool, q.elements[xi]);
+                        auto* xid = pool_id2solvable(pool, r);
                         if (xid->repo != pool->installed)
                         {
-                            reinstall_id = q.elements[xi];
+                            reinstall_id = r;
                             break;
                         }
                     }
@@ -754,21 +751,17 @@ namespace mamba
                         continue;
                     }
 
-                    queue_push(&decision, reinstall_id);
-                    queue_push(&decision, -p);
+                    decision.push_back(reinstall_id);
+                    decision.push_back(-p);
 
-                    queue_empty(&q);
-                    queue_empty(&job);
+                    q.clear();
+                    job.clear();
                 }
             }
 
             transaction_free(m_transaction);
-            m_transaction = transaction_create_decisionq((Pool*) pool, &decision, nullptr);
+            m_transaction = transaction_create_decisionq(pool, decision.get(), nullptr);
             transaction_order(m_transaction, 0);
-
-            queue_free(&decision);
-            queue_free(&job);
-            queue_free(&q);
 
             // init everything again...
             init();
@@ -786,23 +779,17 @@ namespace mamba
         MRepo& mrepo = MRepo::create(pool, "__explicit_specs__", packages);
         pool.create_whatprovides();
 
-        Queue job;
-        queue_init(&job);
-        const on_scope_exit _job_release{ [&] { queue_free(&job); } };
-
-        Queue decision;
-        queue_init(&decision);
-        const on_scope_exit _decision_release{ [&] { queue_free(&decision); } };
+        solv::ObjQueue decision = {};
 
         Id pkg_id = {};
         Solvable* solvable = nullptr;
 
         FOR_REPO_SOLVABLES(mrepo.repo(), pkg_id, solvable)
         {
-            queue_push(&decision, pkg_id);
+            decision.push_back(pkg_id);
         }
 
-        m_transaction = transaction_create_decisionq((Pool*) pool, &decision, nullptr);
+        m_transaction = transaction_create_decisionq(pool, decision.get(), nullptr);
         transaction_order(m_transaction, 0);
 
         init();
@@ -1450,10 +1437,8 @@ namespace mamba
                           printers::alignment::left,
                           printers::alignment::right });
         t.set_padding({ 2, 2, 2, 2, 5 });
-        Queue classes, pkgs;
-
-        queue_init(&classes);
-        queue_init(&pkgs);
+        solv::ObjQueue classes = {};
+        solv::ObjQueue pkgs = {};
 
         using rows = std::vector<std::vector<printers::FormattedString>>;
 
@@ -1545,23 +1530,15 @@ namespace mamba
         };
 
         int mode = SOLVER_TRANSACTION_SHOW_OBSOLETES | SOLVER_TRANSACTION_OBSOLETE_IS_UPGRADE;
-        transaction_classify(m_transaction, mode, &classes);
-        Id cls;
-        for (int i = 0; i < classes.count; i += 4)
+        transaction_classify(m_transaction, mode, classes.get());
+        const auto cls_end = classes.end();
+        for (auto cls_iter = classes.begin(); cls_iter < cls_end; cls_iter += 4)
         {
-            cls = classes.elements[i];
-            transaction_classify_pkgs(
-                m_transaction,
-                mode,
-                cls,
-                classes.elements[i + 2],
-                classes.elements[i + 3],
-                &pkgs
-            );
+            const Id cls = *cls_iter;
+            transaction_classify_pkgs(m_transaction, mode, cls, cls_iter[2], cls_iter[3], pkgs.get());
 
-            for (int j = 0; j < pkgs.count; j++)
+            for (const Id p : pkgs)
             {
-                Id p = pkgs.elements[j];
                 Solvable* s = m_transaction->pool->solvables + p;
 
                 if (filter(s))
@@ -1617,9 +1594,6 @@ namespace mamba
                 }
             }
         }
-
-        queue_free(&classes);
-        queue_free(&pkgs);
 
         std::stringstream summary;
         summary << "Summary:\n\n";

--- a/libmamba/src/solv-cpp/queue.cpp
+++ b/libmamba/src/solv-cpp/queue.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, QuantStack and Mamba Contributors
+// Copyright (c) 2023, QuantStack and Mamba Contributors
 //
 // Distributed under the terms of the BSD 3-Clause License.
 //

--- a/libmamba/src/solv-cpp/queue.cpp
+++ b/libmamba/src/solv-cpp/queue.cpp
@@ -9,6 +9,8 @@
 
 #include <cassert>
 #include <limits>
+#include <exception>
+#include <sstream>
 
 #include <solv/queue.h>
 
@@ -142,14 +144,39 @@ namespace mamba::solv
         return *rbegin();
     }
 
-    auto ObjQueue::operator[](int idx) -> reference
+    auto ObjQueue::operator[](size_type pos) -> reference
     {
-        return data()[idx];
+        return data()[pos];
     }
 
-    auto ObjQueue::operator[](int idx) const -> const_reference
+    auto ObjQueue::operator[](size_type pos) const -> const_reference
     {
-        return data()[idx];
+        return data()[pos];
+    }
+
+    namespace
+    {
+        void ensure_valid_pos(ObjQueue::size_type size, ObjQueue::size_type pos)
+        {
+            if (pos >= size)
+            {
+                std::stringstream ss = {};
+                ss << "Index " << pos << " is greater that the number of elements (" << size << ')';
+                throw std::out_of_range(std::move(ss).str());
+            }
+        }
+    }
+
+    auto ObjQueue::at(size_type pos) -> reference
+    {
+        ensure_valid_pos(size(), pos);
+        return operator[](pos);
+    }
+
+    auto ObjQueue::at(size_type pos) const -> const_reference
+    {
+        ensure_valid_pos(size(), pos);
+        return operator[](pos);
     }
 
     auto ObjQueue::begin() -> iterator

--- a/libmamba/src/solv-cpp/queue.cpp
+++ b/libmamba/src/solv-cpp/queue.cpp
@@ -8,8 +8,8 @@
 #include "solv-cpp/queue.hpp"
 
 #include <cassert>
-#include <limits>
 #include <exception>
+#include <limits>
 #include <sstream>
 
 #include <solv/queue.h>

--- a/libmamba/src/solv-cpp/queue.cpp
+++ b/libmamba/src/solv-cpp/queue.cpp
@@ -1,0 +1,186 @@
+// Copyright (c) 2019, QuantStack and Mamba Contributors
+//
+// Distributed under the terms of the BSD 3-Clause License.
+//
+// The full license is in the file LICENSE, distributed with this software.
+
+
+#include "solv-cpp/queue.hpp"
+
+#include <cassert>
+#include <limits>
+
+#include <solv/queue.h>
+
+namespace mamba::solv
+{
+    ObjQueue::ObjQueue()
+    {
+        queue_init(get());
+    }
+
+    ObjQueue::ObjQueue(std::initializer_list<value_type> elems)
+        : ObjQueue(elems.begin(), elems.end())
+    {
+    }
+
+    ObjQueue::~ObjQueue()
+    {
+        queue_free(get());
+    }
+
+    void ObjQueue::push_back(value_type id)
+    {
+        queue_push(get(), id);
+    }
+
+    void ObjQueue::push_back(value_type id1, value_type id2)
+    {
+        queue_push2(get(), id1, id2);
+    }
+
+    auto ObjQueue::insert(const_iterator pos, value_type id) -> iterator
+    {
+        const difference_type offset = pos - begin();
+        assert(offset >= 0);
+        assert(offset <= std::numeric_limits<int>::max());
+        queue_insert(get(), static_cast<int>(offset), id);
+        return begin() + offset;
+    }
+
+    auto ObjQueue::capacity() const -> size_type
+    {
+        return static_cast<size_type>(m_queue.count + m_queue.left);
+    }
+
+    auto ObjQueue::size() const -> size_type
+    {
+        assert(m_queue.count >= 0);
+        return static_cast<std::size_t>(m_queue.count);
+    }
+
+    auto ObjQueue::empty() const -> bool
+    {
+        return size() == 0;
+    }
+
+    auto ObjQueue::erase(const_iterator pos) -> iterator
+    {
+        const difference_type offset = pos - begin();
+        assert(offset >= 0);
+        assert(offset <= std::numeric_limits<int>::max());
+        queue_delete(get(), static_cast<int>(offset));
+        return begin() + offset;
+    }
+
+    void ObjQueue::reserve(size_type new_cap)
+    {
+        if (new_cap < capacity())
+        {
+            return;
+        }
+        size_type cap_diff = new_cap - capacity();
+        assert(cap_diff <= std::numeric_limits<int>::max());
+        queue_prealloc(get(), static_cast<int>(cap_diff));
+    }
+
+    void ObjQueue::clear()
+    {
+        queue_empty(get());
+    }
+
+    auto ObjQueue::front() -> reference
+    {
+        return *begin();
+    }
+
+    auto ObjQueue::front() const -> const_reference
+    {
+        return *begin();
+    }
+
+    auto ObjQueue::back() -> reference
+    {
+        return *rbegin();
+    }
+
+    auto ObjQueue::back() const -> const_reference
+    {
+        return *rbegin();
+    }
+
+    auto ObjQueue::operator[](int idx) -> reference
+    {
+        return m_queue.elements[idx];
+    }
+
+    auto ObjQueue::operator[](int idx) const -> const_reference
+    {
+        return m_queue.elements[idx];
+    }
+
+    auto ObjQueue::begin() -> iterator
+    {
+        return m_queue.elements;
+    }
+
+    auto ObjQueue::begin() const -> const_iterator
+    {
+        return m_queue.elements;
+    }
+
+    auto ObjQueue::end() -> iterator
+    {
+        return m_queue.elements + size();
+    }
+
+    auto ObjQueue::end() const -> const_iterator
+    {
+        return m_queue.elements + size();
+    }
+
+    auto ObjQueue::rbegin() -> reverse_iterator
+    {
+        return std::reverse_iterator{ end() };
+    }
+
+    auto ObjQueue::rbegin() const -> const_reverse_iterator
+    {
+        return std::reverse_iterator{ end() };
+    }
+
+    auto ObjQueue::rend() -> reverse_iterator
+    {
+        return std::reverse_iterator{ begin() };
+    }
+
+    auto ObjQueue::rend() const -> const_reverse_iterator
+    {
+        return std::reverse_iterator{ begin() };
+    }
+
+    auto ObjQueue::get() const -> const ::Queue*
+    {
+        return &m_queue;
+    }
+
+    auto ObjQueue::get() -> ::Queue*
+    {
+        return &m_queue;
+    }
+
+    auto ObjQueue::offset_of(const_iterator pos) const -> size_type
+    {
+        const auto offset = std::distance(begin(), pos);
+        assert(offset >= 0);
+        return static_cast<std::size_t>(offset);
+    }
+
+    void ObjQueue::insert_n(size_type pos, const_iterator first, size_type n)
+    {
+        assert(pos <= std::numeric_limits<int>::max());
+        assert(n <= std::numeric_limits<int>::max());
+        queue_insertn(get(), static_cast<int>(pos), static_cast<int>(n), first);
+    }
+
+}  // namespace mamba

--- a/libmamba/src/solv-cpp/queue.cpp
+++ b/libmamba/src/solv-cpp/queue.cpp
@@ -17,14 +17,13 @@
 namespace mamba::solv
 {
     ObjQueue::ObjQueue(std::nullptr_t)
-        : m_queue{}
     {
     }
 
     ObjQueue::ObjQueue()
         : ObjQueue(nullptr)
     {
-        queue_init(get());
+        queue_init(raw());
     }
 
     ObjQueue::ObjQueue(std::initializer_list<value_type> elems)
@@ -47,7 +46,7 @@ namespace mamba::solv
     {
         if (data() != nullptr)
         {
-            queue_free(get());
+            queue_free(raw());
         }
     }
 
@@ -69,12 +68,12 @@ namespace mamba::solv
 
     void ObjQueue::push_back(value_type id)
     {
-        queue_push(get(), id);
+        queue_push(raw(), id);
     }
 
     void ObjQueue::push_back(value_type id1, value_type id2)
     {
-        queue_push2(get(), id1, id2);
+        queue_push2(raw(), id1, id2);
     }
 
     auto ObjQueue::insert(const_iterator pos, value_type id) -> iterator
@@ -104,7 +103,7 @@ namespace mamba::solv
     {
         const auto offset = offset_of(pos);
         assert(offset <= std::numeric_limits<int>::max());
-        queue_delete(get(), static_cast<int>(offset));
+        queue_delete(raw(), static_cast<int>(offset));
         return begin() + offset;
     }
 
@@ -116,12 +115,12 @@ namespace mamba::solv
         }
         size_type cap_diff = new_cap - capacity();
         assert(cap_diff <= std::numeric_limits<int>::max());
-        queue_prealloc(get(), static_cast<int>(cap_diff));
+        queue_prealloc(raw(), static_cast<int>(cap_diff));
     }
 
     void ObjQueue::clear()
     {
-        queue_empty(get());
+        queue_empty(raw());
     }
 
     auto ObjQueue::front() -> reference
@@ -160,6 +159,7 @@ namespace mamba::solv
         {
             if (pos >= size)
             {
+                // TODO(C++20) std::format
                 std::stringstream ss = {};
                 ss << "Index " << pos << " is greater that the number of elements (" << size << ')';
                 throw std::out_of_range(std::move(ss).str());
@@ -249,12 +249,12 @@ namespace mamba::solv
         return m_queue.elements;
     }
 
-    auto ObjQueue::get() const -> const ::Queue*
+    auto ObjQueue::raw() const -> const ::Queue*
     {
         return &m_queue;
     }
 
-    auto ObjQueue::get() -> ::Queue*
+    auto ObjQueue::raw() -> ::Queue*
     {
         return &m_queue;
     }
@@ -269,14 +269,14 @@ namespace mamba::solv
     void ObjQueue::insert(size_type offset, value_type id)
     {
         assert(offset <= std::numeric_limits<int>::max());
-        queue_insert(get(), static_cast<int>(offset), id);
+        queue_insert(raw(), static_cast<int>(offset), id);
     }
 
     void ObjQueue::insert_n(size_type offset, const_iterator first, size_type n)
     {
         assert(offset <= std::numeric_limits<int>::max());
         assert(n <= std::numeric_limits<int>::max());
-        queue_insertn(get(), static_cast<int>(offset), static_cast<int>(n), first);
+        queue_insertn(raw(), static_cast<int>(offset), static_cast<int>(n), first);
     }
 
     void swap(ObjQueue& a, ObjQueue& b) noexcept

--- a/libmamba/src/solv-cpp/queue.cpp
+++ b/libmamba/src/solv-cpp/queue.cpp
@@ -77,10 +77,8 @@ namespace mamba::solv
 
     auto ObjQueue::insert(const_iterator pos, value_type id) -> iterator
     {
-        const difference_type offset = pos - begin();
-        assert(offset >= 0);
-        assert(offset <= std::numeric_limits<int>::max());
-        queue_insert(get(), static_cast<int>(offset), id);
+        const auto offset = offset_of(pos);
+        insert(offset, id);
         return begin() + offset;
     }
 
@@ -102,8 +100,7 @@ namespace mamba::solv
 
     auto ObjQueue::erase(const_iterator pos) -> iterator
     {
-        const difference_type offset = pos - begin();
-        assert(offset >= 0);
+        const auto offset = offset_of(pos);
         assert(offset <= std::numeric_limits<int>::max());
         queue_delete(get(), static_cast<int>(offset));
         return begin() + offset;
@@ -162,6 +159,11 @@ namespace mamba::solv
 
     auto ObjQueue::begin() const -> const_iterator
     {
+        return cbegin();
+    }
+
+    auto ObjQueue::cbegin() const -> const_iterator
+    {
         return data();
     }
 
@@ -171,6 +173,11 @@ namespace mamba::solv
     }
 
     auto ObjQueue::end() const -> const_iterator
+    {
+        return cend();
+    }
+
+    auto ObjQueue::cend() const -> const_iterator
     {
         return data() + size();
     }
@@ -182,6 +189,11 @@ namespace mamba::solv
 
     auto ObjQueue::rbegin() const -> const_reverse_iterator
     {
+        return crbegin();
+    }
+
+    auto ObjQueue::crbegin() const -> const_reverse_iterator
+    {
         return std::reverse_iterator{ end() };
     }
 
@@ -191,6 +203,11 @@ namespace mamba::solv
     }
 
     auto ObjQueue::rend() const -> const_reverse_iterator
+    {
+        return crend();
+    }
+
+    auto ObjQueue::crend() const -> const_reverse_iterator
     {
         return std::reverse_iterator{ begin() };
     }
@@ -222,11 +239,17 @@ namespace mamba::solv
         return static_cast<std::size_t>(offset);
     }
 
-    void ObjQueue::insert_n(size_type pos, const_iterator first, size_type n)
+    void ObjQueue::insert(size_type offset, value_type id)
     {
-        assert(pos <= std::numeric_limits<int>::max());
+        assert(offset <= std::numeric_limits<int>::max());
+        queue_insert(get(), static_cast<int>(offset), id);
+    }
+
+    void ObjQueue::insert_n(size_type offset, const_iterator first, size_type n)
+    {
+        assert(offset <= std::numeric_limits<int>::max());
         assert(n <= std::numeric_limits<int>::max());
-        queue_insertn(get(), static_cast<int>(pos), static_cast<int>(n), first);
+        queue_insertn(get(), static_cast<int>(offset), static_cast<int>(n), first);
     }
 
     void swap(ObjQueue& a, ObjQueue& b) noexcept

--- a/libmamba/src/solv-cpp/queue.hpp
+++ b/libmamba/src/solv-cpp/queue.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, QuantStack and Mamba Contributors
+// Copyright (c) 2023, QuantStack and Mamba Contributors
 //
 // Distributed under the terms of the BSD 3-Clause License.
 //

--- a/libmamba/src/solv-cpp/queue.hpp
+++ b/libmamba/src/solv-cpp/queue.hpp
@@ -1,0 +1,136 @@
+// Copyright (c) 2019, QuantStack and Mamba Contributors
+//
+// Distributed under the terms of the BSD 3-Clause License.
+//
+// The full license is in the file LICENSE, distributed with this software.
+
+#ifndef MAMBA_SOLV_QUEUE_HPP
+#define MAMBA_SOLV_QUEUE_HPP
+
+#include <iterator>
+#include <utility>
+
+#include <solv/queue.h>
+
+namespace mamba::solv
+{
+    /**
+     * A ``std::vector`` like structure used in libsolv.
+     *
+     * This is used privately within libsolv, hence the direct use of ``Queue`` as an attribute
+     * (for performances).
+     */
+    class ObjQueue
+    {
+    public:
+
+        using value_type = ::Id;
+        using reference = value_type&;
+        using const_reference = const value_type&;
+        using pointer = ::Id*;
+        using const_pointer = const ::Id*;
+        using size_type = std::size_t;
+        using difference_type = std::ptrdiff_t;
+        using iterator = pointer;
+        using const_iterator = const_pointer;
+        using reverse_iterator = std::reverse_iterator<iterator>;
+        using const_reverse_iterator = std::reverse_iterator<const_iterator>;
+
+        ObjQueue();
+        template <typename InputIt>
+        ObjQueue(InputIt first, InputIt last);
+        ObjQueue(std::initializer_list<value_type> elems);
+        ~ObjQueue();
+
+        /**
+         * Move and copy operations are disabled for simplicity but could be added if needed.
+         */
+        ObjQueue(const ObjQueue&) = delete;
+        ObjQueue(ObjQueue&&) = delete;
+        ObjQueue& operator=(const ObjQueue&) = delete;
+        ObjQueue& operator=(ObjQueue&&) = delete;
+
+        auto size() const -> size_type;
+        auto capacity() const -> size_type;
+        auto empty() const -> bool;
+
+        auto insert(const_iterator pos, value_type id) -> iterator;
+        template <typename InputIt>
+        auto insert(const_iterator pos, InputIt first, InputIt last) -> iterator;
+        void push_back(value_type id);
+        void push_back(value_type id1, value_type id2);
+        auto erase(const_iterator pos) -> iterator;
+        void reserve(size_type new_cap);
+        void clear();
+
+        auto front() -> reference;
+        auto front() const -> const_reference;
+        auto back() -> reference;
+        auto back() const -> const_reference;
+        auto operator[](int idx) -> reference;
+        auto operator[](int idx) const -> const_reference;
+        auto begin() -> iterator;
+        auto begin() const -> const_iterator;
+        auto end() -> iterator;
+        auto end() const -> const_iterator;
+        auto rbegin() -> reverse_iterator;
+        auto rbegin() const -> const_reverse_iterator;
+        auto rend() -> reverse_iterator;
+        auto rend() const -> const_reverse_iterator;
+
+        template <template <typename, typename...> class C>
+        auto as() -> C<value_type>;
+
+        auto get() -> ::Queue*;
+        auto get() const -> const ::Queue*;
+
+    private:
+
+        ::Queue m_queue = {};
+
+        auto offset_of(const_iterator pos) const -> size_type;
+        void insert_n(size_type pos, const_iterator first, size_type n);
+    };
+
+    /********************************
+     *  Implementation of ObjQueue  *
+     ********************************/
+
+    template <typename InputIt>
+    ObjQueue::ObjQueue(InputIt first, InputIt last)
+        : ObjQueue()
+    {
+        insert(begin(), first, last);
+    }
+
+    template <typename InputIt>
+    auto ObjQueue::insert(const_iterator pos, InputIt first, InputIt last) -> iterator
+    {
+        const auto pos_idx = offset_of(pos);
+        const auto n = std::distance(first, last);
+
+        if constexpr (std::is_same_v<InputIt, iterator> || std::is_same_v<InputIt, const_iterator>)
+        {
+            insert_n(pos_idx, first, n);
+        }
+        else
+        {
+            reserve(size() + n);
+            for (; first != last; ++first)
+            {
+                pos = insert(pos, *first);
+                ++pos;
+            }
+        }
+        return begin() + pos_idx;
+    }
+
+    template <template <typename, typename...> class C>
+    auto ObjQueue::as() -> C<value_type>
+    {
+        return C<value_type>(begin(), end());
+    }
+
+}  // namespace mamba
+
+#endif

--- a/libmamba/src/solv-cpp/queue.hpp
+++ b/libmamba/src/solv-cpp/queue.hpp
@@ -40,15 +40,13 @@ namespace mamba::solv
         template <typename InputIt>
         ObjQueue(InputIt first, InputIt last);
         ObjQueue(std::initializer_list<value_type> elems);
+        ObjQueue(ObjQueue&& other);
+        ObjQueue(const ObjQueue& other);
+
         ~ObjQueue();
 
-        /**
-         * Move and copy operations are disabled for simplicity but could be added if needed.
-         */
-        ObjQueue(const ObjQueue&) = delete;
-        ObjQueue(ObjQueue&&) = delete;
-        ObjQueue& operator=(const ObjQueue&) = delete;
-        ObjQueue& operator=(ObjQueue&&) = delete;
+        auto operator=(ObjQueue&& other) -> ObjQueue&;
+        auto operator=(const ObjQueue& other) -> ObjQueue&;
 
         auto size() const -> size_type;
         auto capacity() const -> size_type;
@@ -77,6 +75,8 @@ namespace mamba::solv
         auto rbegin() const -> const_reverse_iterator;
         auto rend() -> reverse_iterator;
         auto rend() const -> const_reverse_iterator;
+        auto data() -> pointer;
+        auto data() const -> const_pointer;
 
         template <template <typename, typename...> class C>
         auto as() -> C<value_type>;
@@ -86,11 +86,17 @@ namespace mamba::solv
 
     private:
 
+        friend void swap(ObjQueue& a, ObjQueue& b) noexcept;
+
         ::Queue m_queue = {};
+
+        ObjQueue(std::nullptr_t);
 
         auto offset_of(const_iterator pos) const -> size_type;
         void insert_n(size_type pos, const_iterator first, size_type n);
     };
+
+    void swap(ObjQueue& a, ObjQueue& b) noexcept;
 
     /********************************
      *  Implementation of ObjQueue  *

--- a/libmamba/src/solv-cpp/queue.hpp
+++ b/libmamba/src/solv-cpp/queue.hpp
@@ -87,8 +87,8 @@ namespace mamba::solv
         template <template <typename, typename...> class C>
         auto as() -> C<value_type>;
 
-        auto get() -> ::Queue*;
-        auto get() const -> const ::Queue*;
+        auto raw() -> ::Queue*;
+        auto raw() const -> const ::Queue*;
 
     private:
 
@@ -96,7 +96,7 @@ namespace mamba::solv
 
         ::Queue m_queue = {};
 
-        ObjQueue(std::nullptr_t);
+        explicit ObjQueue(std::nullptr_t);
 
         auto offset_of(const_iterator pos) const -> size_type;
         void insert(size_type offset, value_type id);

--- a/libmamba/src/solv-cpp/queue.hpp
+++ b/libmamba/src/solv-cpp/queue.hpp
@@ -65,8 +65,10 @@ namespace mamba::solv
         auto front() const -> const_reference;
         auto back() -> reference;
         auto back() const -> const_reference;
-        auto operator[](int idx) -> reference;
-        auto operator[](int idx) const -> const_reference;
+        auto operator[](size_type pos) -> reference;
+        auto operator[](size_type pos) const -> const_reference;
+        auto at(size_type pos) -> reference;
+        auto at(size_type pos) const -> const_reference;
         auto begin() -> iterator;
         auto begin() const -> const_iterator;
         auto cbegin() const -> const_iterator;

--- a/libmamba/tests/CMakeLists.txt
+++ b/libmamba/tests/CMakeLists.txt
@@ -12,6 +12,9 @@ find_package(GTest)
 find_package(Threads REQUIRED)
 
 set(LIBMAMBA_TEST_SRCS
+    # C++ wrapping of libsolv
+    solv-cpp/test_queue.cpp
+
     ../longpath.manifest
     test_activation.cpp
     test_channel.cpp
@@ -48,7 +51,7 @@ mamba_target_add_compile_warnings(test_libmamba WARNING_AS_ERROR ${MAMBA_WARNING
 
 target_include_directories(
     test_libmamba
-    PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}"
+    PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}" "${CMAKE_SOURCE_DIR}/libmamba/src"
 )
 
 target_link_libraries(

--- a/libmamba/tests/repodata_json_cache/test_7.state.json
+++ b/libmamba/tests/repodata_json_cache/test_7.state.json
@@ -11,7 +11,5 @@
         "value": true
     },
     "mod": "Fri, 11 Feb 2022 13:52:44 GMT",
-    "mtime_ns": -4762331256009361200,
-    "size": 44,
     "url": "https://conda.anaconda.org/conda-forge/noarch/repodata.json.zst"
 }

--- a/libmamba/tests/repodata_json_cache/test_7.state.json
+++ b/libmamba/tests/repodata_json_cache/test_7.state.json
@@ -11,5 +11,7 @@
         "value": true
     },
     "mod": "Fri, 11 Feb 2022 13:52:44 GMT",
+    "mtime_ns": -4762331256009361200,
+    "size": 44,
     "url": "https://conda.anaconda.org/conda-forge/noarch/repodata.json.zst"
 }

--- a/libmamba/tests/solv-cpp/test_queue.cpp
+++ b/libmamba/tests/solv-cpp/test_queue.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, QuantStack and Mamba Contributors
+// Copyright (c) 2023, QuantStack and Mamba Contributors
 //
 // Distributed under the terms of the BSD 3-Clause License.
 //

--- a/libmamba/tests/solv-cpp/test_queue.cpp
+++ b/libmamba/tests/solv-cpp/test_queue.cpp
@@ -27,14 +27,14 @@ TEST(ObjQueue, constructor)
     EXPECT_EQ(q3.size(), q2.size());
     EXPECT_NE(q2.data(), q3.data());
 
-    auto const q3_data = q3.data();
-    auto const q3_size = q3.size();
+    const auto q3_data = q3.data();
+    const auto q3_size = q3.size();
     auto q4 = std::move(q3);
     EXPECT_EQ(q4.size(), q3_size);
     EXPECT_EQ(q4.data(), q3_data);
 
-    auto const q4_data = q4.data();
-    auto const q4_size = q4.size();
+    const auto q4_data = q4.data();
+    const auto q4_size = q4.size();
     q1 = std::move(q4);
     EXPECT_EQ(q1.size(), q4_size);
     EXPECT_EQ(q1.data(), q4_data);
@@ -43,12 +43,12 @@ TEST(ObjQueue, constructor)
 TEST(ObjQueue, swap)
 {
     auto q1 = ObjQueue();
-    auto const q1_data = q1.data();
-    auto const q1_size = q1.size();
+    const auto q1_data = q1.data();
+    const auto q1_size = q1.size();
 
     auto q2 = ObjQueue{ 1, 2, 3 };
-    auto const q2_size = q2.size();
-    auto const q2_data = q2.data();
+    const auto q2_size = q2.size();
+    const auto q2_data = q2.data();
 
     swap(q1, q2);
     EXPECT_EQ(q1.size(), q2_size);
@@ -85,7 +85,7 @@ TEST(ObjQueue, clear)
 
 TEST(ObjQueue, iterator)
 {
-    auto const q = ObjQueue{ 3, 2, 1 };
+    const auto q = ObjQueue{ 3, 2, 1 };
     std::size_t n = 0;
     for ([[maybe_unused]] auto _ : q)
     {
@@ -93,16 +93,16 @@ TEST(ObjQueue, iterator)
     }
     EXPECT_EQ(n, q.size());
 
-    auto const l = std::list<::Id>(q.begin(), q.end());
-    auto const l_expected = std::list{ 3, 2, 1 };
+    const auto l = std::list<::Id>(q.begin(), q.end());
+    const auto l_expected = std::list{ 3, 2, 1 };
     EXPECT_EQ(l, l_expected);
 }
 
 TEST(ObjQueue, reverse_iterator)
 {
-    auto const q = ObjQueue{ 3, 2, 1 };
+    const auto q = ObjQueue{ 3, 2, 1 };
 
-    auto const v = std::vector(q.crbegin(), q.crend());
+    const auto v = std::vector(q.crbegin(), q.crend());
     EXPECT_EQ(v.front(), q.back());
     EXPECT_EQ(v.back(), q.front());
 }
@@ -119,7 +119,7 @@ TEST(ObjQueue, insert_span)
 {
     auto q = ObjQueue();
 
-    auto const r1 = std::vector{ 1, 2, 3 };
+    const auto r1 = std::vector{ 1, 2, 3 };
     // std::vector::iterator is not always a pointer
     auto iter = q.insert(q.cend(), r1.data(), r1.data() + r1.size());
     EXPECT_EQ(*iter, q[0]);
@@ -127,13 +127,13 @@ TEST(ObjQueue, insert_span)
     EXPECT_EQ(q[1], 2);
     EXPECT_EQ(q[2], 3);
 
-    auto const r2 = std::vector{ 4, 4 };
+    const auto r2 = std::vector{ 4, 4 };
     iter = q.insert(q.cbegin(), r2.data(), r2.data() + r2.size());
     EXPECT_EQ(*iter, q[0]);
     EXPECT_EQ(q[0], 4);
     EXPECT_EQ(q[1], 4);
 
-    auto const r3 = std::vector<int>{};
+    const auto r3 = std::vector<int>{};
     iter = q.insert(q.cbegin(), r3.data(), r3.data() + r3.size());
     EXPECT_EQ(*iter, q[0]);
     EXPECT_EQ(q[0], 4);
@@ -143,20 +143,20 @@ TEST(ObjQueue, insert_range)
 {
     auto q = ObjQueue();
 
-    auto const r1 = std::list{ 1, 2, 3 };
+    const auto r1 = std::list{ 1, 2, 3 };
     auto iter = q.insert(q.cend(), r1.begin(), r1.end());
     EXPECT_EQ(*iter, q[0]);
     EXPECT_EQ(q[0], 1);
     EXPECT_EQ(q[1], 2);
     EXPECT_EQ(q[2], 3);
 
-    auto const r2 = std::list{ 4, 4 };
+    const auto r2 = std::list{ 4, 4 };
     iter = q.insert(q.cbegin(), r2.begin(), r2.end());
     EXPECT_EQ(*iter, q[0]);
     EXPECT_EQ(q[0], 4);
     EXPECT_EQ(q[1], 4);
 
-    auto const r3 = std::list<int>{};
+    const auto r3 = std::list<int>{};
     iter = q.insert(q.cbegin(), r3.begin(), r3.end());
     EXPECT_EQ(*iter, q[0]);
     EXPECT_EQ(q[0], 4);
@@ -165,7 +165,7 @@ TEST(ObjQueue, insert_range)
 TEST(ObjQueue, erase)
 {
     auto q = ObjQueue{ 3, 2, 1 };
-    auto const iter = q.erase(q.cbegin() + 1);
+    const auto iter = q.erase(q.cbegin() + 1);
     EXPECT_EQ(*iter, 1);
     EXPECT_EQ(q.size(), 2);
 }

--- a/libmamba/tests/solv-cpp/test_queue.cpp
+++ b/libmamba/tests/solv-cpp/test_queue.cpp
@@ -1,0 +1,179 @@
+// Copyright (c) 2022, QuantStack and Mamba Contributors
+//
+// Distributed under the terms of the BSD 3-Clause License.
+//
+// The full license is in the file LICENSE, distributed with this software.
+
+#include <list>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "solv-cpp/queue.hpp"
+
+using namespace mamba::solv;
+
+TEST(ObjQueue, constructor)
+{
+    auto q1 = ObjQueue();
+    EXPECT_EQ(q1.size(), 0);
+    EXPECT_TRUE(q1.empty());
+
+    auto q2 = ObjQueue{ 1, 2, 3 };
+    EXPECT_EQ(q2.size(), 3);
+    EXPECT_FALSE(q2.empty());
+
+    auto q3 = q2;
+    EXPECT_EQ(q3.size(), q2.size());
+    EXPECT_NE(q2.data(), q3.data());
+
+    auto const q3_data = q3.data();
+    auto const q3_size = q3.size();
+    auto q4 = std::move(q3);
+    EXPECT_EQ(q4.size(), q3_size);
+    EXPECT_EQ(q4.data(), q3_data);
+
+    auto const q4_data = q4.data();
+    auto const q4_size = q4.size();
+    q1 = std::move(q4);
+    EXPECT_EQ(q1.size(), q4_size);
+    EXPECT_EQ(q1.data(), q4_data);
+}
+
+TEST(ObjQueue, swap)
+{
+    auto q1 = ObjQueue();
+    auto const q1_data = q1.data();
+    auto const q1_size = q1.size();
+
+    auto q2 = ObjQueue{ 1, 2, 3 };
+    auto const q2_size = q2.size();
+    auto const q2_data = q2.data();
+
+    swap(q1, q2);
+    EXPECT_EQ(q1.size(), q2_size);
+    EXPECT_EQ(q1.data(), q2_data);
+    EXPECT_EQ(q2.size(), q1_size);
+    EXPECT_EQ(q2.data(), q1_data);
+}
+
+TEST(ObjQueue, push_back)
+{
+    auto q = ObjQueue();
+    q.push_back(1);
+    EXPECT_EQ(q.front(), 1);
+    EXPECT_EQ(q.back(), 1);
+    q.push_back(3);
+    EXPECT_EQ(q.front(), 1);
+    EXPECT_EQ(q.back(), 3);
+}
+
+TEST(ObjQueue, element)
+{
+    auto q = ObjQueue{ 3, 2, 1 };
+    EXPECT_EQ(q[0], 3);
+    EXPECT_EQ(q[1], 2);
+    EXPECT_EQ(q[2], 1);
+}
+
+TEST(ObjQueue, clear)
+{
+    auto q = ObjQueue{ 3, 2, 1 };
+    q.clear();
+    EXPECT_TRUE(q.empty());
+}
+
+TEST(ObjQueue, iterator)
+{
+    auto const q = ObjQueue{ 3, 2, 1 };
+    std::size_t n = 0;
+    for ([[maybe_unused]] auto _ : q)
+    {
+        ++n;
+    }
+    EXPECT_EQ(n, q.size());
+
+    auto const l = std::list<::Id>(q.begin(), q.end());
+    auto const l_expected = std::list{ 3, 2, 1 };
+    EXPECT_EQ(l, l_expected);
+}
+
+TEST(ObjQueue, reverse_iterator)
+{
+    auto const q = ObjQueue{ 3, 2, 1 };
+
+    auto const v = std::vector(q.crbegin(), q.crend());
+    EXPECT_EQ(v.front(), q.back());
+    EXPECT_EQ(v.back(), q.front());
+}
+
+TEST(ObjQueue, insert_one)
+{
+    auto q = ObjQueue();
+    auto iter = q.insert(q.cbegin(), 4);
+    EXPECT_EQ(*iter, 4);
+    EXPECT_EQ(q.front(), 4);
+}
+
+TEST(ObjQueue, insert_span)
+{
+    auto q = ObjQueue();
+
+    auto const r1 = std::vector{ 1, 2, 3 };
+    // std::vector::iterator is not always a pointer
+    auto iter = q.insert(q.cend(), r1.data(), r1.data() + r1.size());
+    EXPECT_EQ(*iter, q[0]);
+    EXPECT_EQ(q[0], 1);
+    EXPECT_EQ(q[1], 2);
+    EXPECT_EQ(q[2], 3);
+
+    auto const r2 = std::vector{ 4, 4 };
+    iter = q.insert(q.cbegin(), r2.data(), r2.data() + r2.size());
+    EXPECT_EQ(*iter, q[0]);
+    EXPECT_EQ(q[0], 4);
+    EXPECT_EQ(q[1], 4);
+
+    auto const r3 = std::vector<int>{};
+    iter = q.insert(q.cbegin(), r3.data(), r3.data() + r3.size());
+    EXPECT_EQ(*iter, q[0]);
+    EXPECT_EQ(q[0], 4);
+}
+
+TEST(ObjQueue, insert_range)
+{
+    auto q = ObjQueue();
+
+    auto const r1 = std::list{ 1, 2, 3 };
+    auto iter = q.insert(q.cend(), r1.begin(), r1.end());
+    EXPECT_EQ(*iter, q[0]);
+    EXPECT_EQ(q[0], 1);
+    EXPECT_EQ(q[1], 2);
+    EXPECT_EQ(q[2], 3);
+
+    auto const r2 = std::list{ 4, 4 };
+    iter = q.insert(q.cbegin(), r2.begin(), r2.end());
+    EXPECT_EQ(*iter, q[0]);
+    EXPECT_EQ(q[0], 4);
+    EXPECT_EQ(q[1], 4);
+
+    auto const r3 = std::list<int>{};
+    iter = q.insert(q.cbegin(), r3.begin(), r3.end());
+    EXPECT_EQ(*iter, q[0]);
+    EXPECT_EQ(q[0], 4);
+}
+
+TEST(ObjQueue, erase)
+{
+    auto q = ObjQueue{ 3, 2, 1 };
+    auto const iter = q.erase(q.cbegin() + 1);
+    EXPECT_EQ(*iter, 1);
+    EXPECT_EQ(q.size(), 2);
+}
+
+TEST(ObjQueue, capacity)
+{
+    auto q = ObjQueue();
+    q.reserve(10);
+    EXPECT_EQ(q.size(), 0);
+    EXPECT_GE(q.capacity(), 10);
+}

--- a/libmamba/tests/solv-cpp/test_queue.cpp
+++ b/libmamba/tests/solv-cpp/test_queue.cpp
@@ -6,6 +6,7 @@
 
 #include <list>
 #include <vector>
+#include <exception>
 
 #include <gtest/gtest.h>
 
@@ -74,6 +75,15 @@ TEST(ObjQueue, element)
     EXPECT_EQ(q[0], 3);
     EXPECT_EQ(q[1], 2);
     EXPECT_EQ(q[2], 1);
+}
+
+TEST(ObjQueue, at)
+{
+    auto q = ObjQueue{ 3, 2, 1 };
+    EXPECT_EQ(q.at(0), q[0]);
+    EXPECT_EQ(q.at(1), q[1]);
+    EXPECT_EQ(q.at(2), q[2]);
+    EXPECT_THROW(q.at(q.size()), std::out_of_range);
 }
 
 TEST(ObjQueue, clear)

--- a/libmamba/tests/solv-cpp/test_queue.cpp
+++ b/libmamba/tests/solv-cpp/test_queue.cpp
@@ -4,9 +4,9 @@
 //
 // The full license is in the file LICENSE, distributed with this software.
 
+#include <exception>
 #include <list>
 #include <vector>
-#include <exception>
 
 #include <gtest/gtest.h>
 

--- a/micromamba/src/run.cpp
+++ b/micromamba/src/run.cpp
@@ -1,3 +1,9 @@
+// Copyright (c) 2019, QuantStack and Mamba Contributors
+//
+// Distributed under the terms of the BSD 3-Clause License.
+//
+// The full license is in the file LICENSE, distributed with this software.
+
 #include <csignal>
 #include <exception>
 #include <thread>


### PR DESCRIPTION
Part of #2302.

Here the Queue is isolated in a safe RAII object.
It was made to use std conventions rather than libsolv ones.

This is private API so does not have any consequence.

On the immediate side, it caught some memory leaks in `MSolver`!