### PR TITLE
Respect subdir in match spec

### DIFF
--- a/libmamba/src/core/pool.cpp
+++ b/libmamba/src/core/pool.cpp
@@ -221,8 +221,8 @@ namespace mamba
                         }
                     }
                 }
-
             );
+            
             solv::StringId const repr_id = pool.add_string(repr);
             ::Id const offset = pool_queuetowhatprovides(pool.raw(), selected_pkgs.raw());
             // FRAGILE This get deleted when calling ``pool_createwhatprovides`` so care

--- a/libmamba/src/core/pool.cpp
+++ b/libmamba/src/core/pool.cpp
@@ -173,9 +173,9 @@ namespace mamba
             }
             std::string needle_subdir = rsplit(needle_channel, "/", 1)[1];
 
-            std::string candidate_subdir = rsplit(candidate_url, "/", 1)[1];
+            std::string candidate_repo_subdir = rsplit(candidate_repo_url, "/", 1)[1];
 
-            if (candidate_subdir == needle_subdir)
+            if (candidate_repo_subdir == needle_subdir)
             {
                 return true;
             }

--- a/libmamba/src/core/pool.cpp
+++ b/libmamba/src/core/pool.cpp
@@ -160,22 +160,28 @@ namespace mamba
             return false;
         }
 
-        bool
-        subdir_match(std::string candidate_url, std::string needle_spec)
+        bool subdir_match(std::string candidate_repo_url, std::string needle_spec)
         {
+            // Example candidate_repo_url: https://.../conda-forge/linux-64
+            // example needle_spec: conda-forge/osx-64::xtensor
+
             std::string needle_channel = split(needle_spec, ":", 1)[0];
-            if (!contains(needle_channel, "/")){
+            if (!contains(needle_channel, "/"))
+            {
+                // Subdir not specified, so any subdir is fine
                 return true;
             }
             std::string needle_subdir = rsplit(needle_channel, "/", 1)[1];
 
             std::string candidate_subdir = rsplit(candidate_url, "/", 1)[1];
 
-            if (candidate_subdir == needle_subdir){
+            if (candidate_subdir == needle_subdir)
+            {
                 return true;
             }
-            throw std::runtime_error(
-                fmt::format("The package \"{}\" is not available for the specified platform", needle_spec
+            throw std::runtime_error(fmt::format(
+                "The package \"{}\" is not available for the specified platform",
+                needle_spec
             ));
         }
 
@@ -216,13 +222,14 @@ namespace mamba
                     auto const url = std::string(repo.url());
                     if (channel_match(channel_context, channel_context.make_channel(url), c))
                     {
-                        if (subdir_match(url, ms.spec)){
+                        if (subdir_match(url, ms.spec))
+                        {
                             selected_pkgs.push_back(s.id());
                         }
                     }
                 }
             );
-            
+
             solv::StringId const repr_id = pool.add_string(repr);
             ::Id const offset = pool_queuetowhatprovides(pool.raw(), selected_pkgs.raw());
             // FRAGILE This get deleted when calling ``pool_createwhatprovides`` so care

--- a/mamba/tests/test_all.py
+++ b/mamba/tests/test_all.py
@@ -163,8 +163,8 @@ def test_create_subdir(tmpdir):
     except subprocess.CalledProcessError as e:
         result = json.loads(e.output)
         assert result["error"] == (
-        "RuntimeError('The package \"conda-forge/noarch::xtensor\" is"
-        " not available for the specified platform')"
+            'RuntimeError(\'The package "conda-forge/noarch::xtensor" is'
+            " not available for the specified platform')"
         )
 
 
@@ -257,7 +257,7 @@ def test_multi_channels_with_subdir(config_file, tmpdir):
     except subprocess.CalledProcessError as e:
         result = json.loads(e.output)
         assert result["error"] == (
-            "RuntimeError('The package \"conda-forge2/noarch::xtensor\" is"
+            'RuntimeError(\'The package "conda-forge2/noarch::xtensor" is'
             " not available for the specified platform')"
         )
 

--- a/mamba/tests/test_all.py
+++ b/mamba/tests/test_all.py
@@ -150,6 +150,24 @@ def test_create_dry_run(experimental, use_json, tmpdir):
         assert not env_dir.check()
 
 
+def test_create_subdir(tmpdir):
+    env_dir = tmpdir / str(uuid.uuid1())
+
+    try:
+        output = subprocess.check_output(
+            "mamba create --dry-run --json "
+            f"-p {env_dir} "
+            f"conda-forge/noarch::xtensor",
+            shell=True,
+        )
+    except subprocess.CalledProcessError as e:
+        result = json.loads(e.output)
+        assert result["error"] == (
+        "RuntimeError('The package \"conda-forge/noarch::xtensor\" is"
+        " not available for the specified platform')"
+        )
+
+
 def test_create_files(tmpdir):
     """Check that multiple --file arguments are respected."""
     (tmpdir / "1.txt").write(b"a")
@@ -216,6 +234,32 @@ def test_multi_channels(config_file, tmpdir):
         assert pkg["channel"].startswith("https://conda.anaconda.org/conda-forge")
     for pkg in res["actions"]["LINK"]:
         assert pkg["base_url"] == "https://conda.anaconda.org/conda-forge"
+
+
+@pytest.mark.parametrize("config_file", [multichannel_config], indirect=["config_file"])
+def test_multi_channels_with_subdir(config_file, tmpdir):
+    # we need to create a config file first
+    call_env = os.environ.copy()
+    call_env["CONDA_PKGS_DIRS"] = str(tmpdir / random_string())
+    try:
+        output = subprocess.check_output(
+            [
+                "mamba",
+                "create",
+                "-n",
+                "multichannels_with_subdir",
+                "conda-forge2/noarch::xtensor",
+                "--dry-run",
+                "--json",
+            ],
+            env=call_env,
+        )
+    except subprocess.CalledProcessError as e:
+        result = json.loads(e.output)
+        assert result["error"] == (
+            "RuntimeError('The package \"conda-forge2/noarch::xtensor\" is"
+            " not available for the specified platform')"
+        )
 
 
 def test_update_py():

--- a/micromamba/tests/test_create.py
+++ b/micromamba/tests/test_create.py
@@ -613,6 +613,21 @@ def test_spec_with_channel(tmp_home, tmp_root_prefix, tmp_path):
             assert link["version"].startswith("0.22.")
 
 
+def test_spec_with_channel_and_subdir():
+    env_name = "myenv"
+    try:
+        res = helpers.create(
+            "-n", env_name, "conda-forge/noarch::xtensor", "--dry-run"
+        )
+    except subprocess.CalledProcessError as e:
+        assert (
+            e.stderr.decode()
+            == (
+                "critical libmamba The package \"conda-forge/noarch::xtensor\" is "
+                "not available for the specified platform\n"
+            )
+        )
+
 @pytest.mark.parametrize("shared_pkgs_dirs", [True], indirect=True)
 def test_channel_nodefaults(tmp_home, tmp_root_prefix, tmp_path):
     rc_file = tmp_path / "rc.yaml"

--- a/micromamba/tests/test_create.py
+++ b/micromamba/tests/test_create.py
@@ -616,17 +616,13 @@ def test_spec_with_channel(tmp_home, tmp_root_prefix, tmp_path):
 def test_spec_with_channel_and_subdir():
     env_name = "myenv"
     try:
-        res = helpers.create(
-            "-n", env_name, "conda-forge/noarch::xtensor", "--dry-run"
-        )
+        res = helpers.create("-n", env_name, "conda-forge/noarch::xtensor", "--dry-run")
     except subprocess.CalledProcessError as e:
-        assert (
-            e.stderr.decode()
-            == (
-                "critical libmamba The package \"conda-forge/noarch::xtensor\" is "
-                "not available for the specified platform\n"
-            )
+        assert e.stderr.decode() == (
+            'critical libmamba The package "conda-forge/noarch::xtensor" is '
+            "not available for the specified platform\n"
         )
+
 
 @pytest.mark.parametrize("shared_pkgs_dirs", [True], indirect=True)
 def test_channel_nodefaults(tmp_home, tmp_root_prefix, tmp_path):


### PR DESCRIPTION
This PR addresses #2041 and #2226. 

If a package can't be found in the specified subdir, the output now looks like this.
```
micromamba create -n xxx 'conda-forge/noarch::git'
...
critical libmamba Selected channel specific (or force-reinstall) job, but package is not available from channel.
...
```

I'm not too proficient in C++, so any feedback is highly appreciated! 🙂

cc @jonashaag 