### PR TITLE
Fix `mamba init --no-user`

### DIFF
--- a/mamba/mamba/mamba_shell_init.py
+++ b/mamba/mamba/mamba_shell_init.py
@@ -81,12 +81,7 @@ def shell_init(args):
         return initialize_dev(shell)
 
     else:
-        for_user = args.user
-        if not (args.install and args.user and args.system):
-            for_user = True
-        # no_user removed in Conda 23.1.0, see https://github.com/mamba-org/mamba/issues/2248
-        if hasattr(args, "no_user") and args.no_user:
-            for_user = False
+        for_user = args.user and not args.system
 
         anaconda_prompt = on_win and args.anaconda_prompt
         exit_code = initialize(

--- a/mamba/mamba/mamba_shell_init.py
+++ b/mamba/mamba/mamba_shell_init.py
@@ -81,7 +81,13 @@ def shell_init(args):
         return initialize_dev(shell)
 
     else:
-        for_user = args.user and not args.system
+        if hasattr(args, "no_user"):
+            # this seems to be conda < 23.1.0
+            # the `no_user` flag, if set, gets erroneously set to False
+            for_user = (args.no_user != False and args.user != False and
+                        not args.system)
+        else:
+            for_user = args.user and not args.system
 
         anaconda_prompt = on_win and args.anaconda_prompt
         exit_code = initialize(

--- a/mamba/mamba/mamba_shell_init.py
+++ b/mamba/mamba/mamba_shell_init.py
@@ -83,9 +83,14 @@ def shell_init(args):
     else:
         if hasattr(args, "no_user"):
             # this seems to be conda < 23.1.0
-            # the `no_user` flag, if set, gets erroneously set to False
-            for_user = (args.no_user != False and args.user != False and
-                        not args.system)
+            # Here, we use the old behavior even though the --no-user flag
+            # doesn't behave as desired, see:
+            # https://github.com/conda/conda/issues/11948
+            for_user = args.user
+            if not (args.install and args.user and args.system):
+                for_user = True
+            if args.no_user:
+                for_user = False
         else:
             for_user = args.user and not args.system
 


### PR DESCRIPTION
This merge makes changes similar to
https://github.com/conda/conda/pull/11949
to fix `mamba init` so that the `--no-user` flag actually has the intended effect of not changing a user's `.bashrc` or equivalent. Without this change, `--no-user` has no effect as was previously the case in conda, see:
https://github.com/conda/conda/issues/11948