### PR TITLE
Activate SAT error messages

### DIFF
--- a/libmamba/include/mamba/core/context.hpp
+++ b/libmamba/include/mamba/core/context.hpp
@@ -151,8 +151,6 @@ namespace mamba
         std::string log_pattern = "%^%-9!l%-8n%$ %v";
         std::size_t log_backtrace = 0;
 
-        bool experimental_sat_error_message = false;
-
         bool dev = false;
         bool on_ci = false;
         bool dry_run = false;

--- a/libmamba/src/api/configuration.cpp
+++ b/libmamba/src/api/configuration.cpp
@@ -1508,11 +1508,6 @@ namespace mamba
                    .long_description(unindent(R"(
                             Set the log pattern.)")));
 
-        insert(Configurable("experimental_sat_error_message", &ctx.experimental_sat_error_message)
-                   .group("Output, Prompt and Flow Control")
-                   .set_rc_configurable()
-                   .description("Enable experimental satisfiability (conflict) error messages"));
-
         insert(Configurable("json", &ctx.json)
                    .group("Output, Prompt and Flow Control")
                    .set_rc_configurable()

--- a/libmamba/src/core/solver.cpp
+++ b/libmamba/src/core/solver.cpp
@@ -670,36 +670,14 @@ namespace mamba
     std::ostream& MSolver::explain_problems(std::ostream& out) const
     {
         const auto& ctx = Context::instance();
-        bool sat_error_message = ctx.experimental_sat_error_message;
-        if (sat_error_message)
-        {
-            out << "Could not solve for environment specs\n";
-            fmt::print(out, "{:=^80}\n", " Experimental satisfiability error messages ");
-            out << "You are seeing this because you set `experimental_sat_error_message: true`\n"
-                   "Use the following issue to share feedback on this experimental feature\n"
-                   "   https://github.com/mamba-org/mamba/issues/2078\n\n";
-            fmt::print(out, "{:=^100}\n", " Legacy messages (old) ");
-            out << problems_to_str() << '\n'
-                << "The environment can't be solved, aborting the operation\n";
-            fmt::print(out, "{:=^100}\n", " Experimental messages (new) ");
-            const auto pbs = ProblemsGraph::from_solver(*this, pool());
-            const auto cp_pbs = CompressedProblemsGraph::from_problems_graph(pbs);
-            print_problem_tree_msg(
-                out,
-                cp_pbs,
-                {
-                    /* .unavailable= */ ctx.palette.failure,
-                    /* .available= */ ctx.palette.success,
-                }
-            );
-            fmt::print(out, "\n{:=^100}\n", "");
-        }
-        else
-        {
-            out << "Could not solve for environment specs\n"
-                << problems_to_str() << '\n'
-                << "The environment can't be solved, aborting the operation\n";
-        }
+        out << "Could not solve for environment specs\n";
+        const auto pbs = ProblemsGraph::from_solver(*this, pool());
+        const auto cp_pbs = CompressedProblemsGraph::from_problems_graph(pbs);
+        print_problem_tree_msg(
+            out,
+            cp_pbs,
+            { /* .unavailable= */ ctx.palette.failure, /* .available= */ ctx.palette.success }
+        );
         return out;
     }
 

--- a/libmambapy/libmambapy/__init__.pyi
+++ b/libmambapy/libmambapy/__init__.pyi
@@ -515,7 +515,7 @@ class Context:
         :type: bool
         """
     @experimental_sat_error_message.setter
-    def experimental_sat_error_message(self, arg0: bool) -> None:
+    def experimental_sat_error_message(self, arg1: bool) -> None:
         pass
     @property
     def extract_threads(self) -> int:

--- a/libmambapy/src/main.cpp
+++ b/libmambapy/src/main.cpp
@@ -523,7 +523,19 @@ PYBIND11_MODULE(bindings, m)
         .def_readwrite("channel_alias", &Context::channel_alias)
         .def_readwrite("use_only_tar_bz2", &Context::use_only_tar_bz2)
         .def_readwrite("channel_priority", &Context::channel_priority)
-        .def_readwrite("experimental_sat_error_message", &Context::experimental_sat_error_message)
+        .def_property(
+            "experimental_sat_error_message",
+            [](const Context&)
+            {
+                deprecated("The new error messages are always enabled.");
+                return true;
+            },
+            [](const Context&, bool)
+            {
+                deprecated("Setting ``Context.experimental_sat_error_message`` has no effect."
+                           " The new error messages are always enabled.");
+            }
+        )
         .def_readwrite("use_lockfiles", &Context::use_lockfiles)
         .def("set_verbosity", &Context::set_verbosity)
         .def("set_log_level", &Context::set_log_level);


### PR DESCRIPTION
With this PR
- The new error messages are the default
- They cannot be deactivated
- The Python API is preserved and marked deprecated

@syslaila 