### PR TITLE
Add risc-v support for micromamba

### DIFF
--- a/libmamba/CMakeLists.txt
+++ b/libmamba/CMakeLists.txt
@@ -448,9 +448,10 @@ macro(libmamba_create_target target_name linkage deps_linkage output_name)
             ${LIBSOLV_LIBRARIES}
             ${LIBSOLVEXT_LIBRARIES}
             ${LibArchive_LIBRARIES}
-            $<IF:$<TARGET_EXISTS:zstd::libzstd_shared>,zstd::libzstd_shared,zstd::libzstd_static>
+            zstd::libzstd_shared
             ${CURL_LIBRARIES}
             ${OPENSSL_LIBRARIES}
+            zstd::libzstd_shared
             BZip2::BZip2
             yaml-cpp
             reproc++

--- a/libmamba/CMakeLists.txt
+++ b/libmamba/CMakeLists.txt
@@ -448,10 +448,9 @@ macro(libmamba_create_target target_name linkage deps_linkage output_name)
             ${LIBSOLV_LIBRARIES}
             ${LIBSOLVEXT_LIBRARIES}
             ${LibArchive_LIBRARIES}
-            zstd::libzstd_shared
+            $<IF:$<TARGET_EXISTS:zstd::libzstd_shared>,zstd::libzstd_shared,zstd::libzstd_static>
             ${CURL_LIBRARIES}
             ${OPENSSL_LIBRARIES}
-            zstd::libzstd_shared
             BZip2::BZip2
             yaml-cpp
             reproc++

--- a/libmamba/include/mamba/core/context.hpp
+++ b/libmamba/include/mamba/core/context.hpp
@@ -55,6 +55,10 @@ namespace mamba
 #endif
 #elif defined(__s390x__)
         static const char MAMBA_PLATFORM[] = "linux-s390x";
+#elif defined(__riscv) && defined(__riscv_xlen) && (__riscv_xlen == 32)
+        static const char MAMBA_PLATFORM[] = "linux-riscv32";
+#elif defined(__riscv) && defined(__riscv_xlen) && (__riscv_xlen == 64)
+        static const char MAMBA_PLATFORM[] = "linux-riscv64";
 #else
 #error "Unknown Linux platform"
 #endif


### PR DESCRIPTION
+ Add platform definitions for linux-riscv32/64. Please see also https://github.com/conda/conda/pull/12319/.
+ ~~Link with ```zstd_static``` when building dynamically linked ```libmamba``` if  ```zstd_shared``` is not available.~~

Tested with Ubuntu 22.04.1 LTS (GNU/Linux 5.19.0-1012-generic riscv64, GCC 11.3.0). Only statically linked ```micromamba``` was built and tested. 

closes #2308

