### PR TITLE
Allow the direct installation of both .tar.bz2 and .conda packages

### DIFF
--- a/mamba/mamba/mamba.py
+++ b/mamba/mamba/mamba.py
@@ -330,7 +330,7 @@ def install(args, parser, command="install"):
             if default_pkg_name not in args_packages_names:
                 args_packages.append(default_pkg)
 
-    num_cp = sum(s.endswith(".tar.bz2") for s in args_packages)
+    num_cp = sum((s.endswith(".tar.bz2") or s.endswith(".conda")) for s in args_packages)
     if num_cp:
         if num_cp == len(args_packages):
             explicit(args_packages, prefix, verbose=not (context.quiet or context.json))

--- a/mamba/mamba/mamba.py
+++ b/mamba/mamba/mamba.py
@@ -330,7 +330,9 @@ def install(args, parser, command="install"):
             if default_pkg_name not in args_packages_names:
                 args_packages.append(default_pkg)
 
-    num_cp = sum((s.endswith(".tar.bz2") or s.endswith(".conda")) for s in args_packages)
+    num_cp = sum(
+        (s.endswith(".tar.bz2") or s.endswith(".conda")) for s in args_packages
+    )
     if num_cp:
         if num_cp == len(args_packages):
             explicit(args_packages, prefix, verbose=not (context.quiet or context.json))


### PR DESCRIPTION
Prior to this change, specifying explicit .conda and .tar.bz2 packages would fail saying that specifications and packages can't be mixed.