### PR TITLE
Remove unused libarchive header in fetch

### DIFF
--- a/libmamba/include/mamba/core/fetch.hpp
+++ b/libmamba/include/mamba/core/fetch.hpp
@@ -9,7 +9,6 @@
 
 extern "C"
 {
-#include <archive.h>
 #include <curl/curl.h>
 }
 


### PR DESCRIPTION
Fix #2337 
It seems that `libarchive` usage is quite contained in `package_handling.cpp`, so I guess that no further actions are needed.
cc @JohanMabille 