### PR TITLE
Parse repodata.json

### DIFF
--- a/libmamba/CMakeLists.txt
+++ b/libmamba/CMakeLists.txt
@@ -126,6 +126,7 @@ set(LIBMAMBA_SOURCES
     ${LIBMAMBA_SOURCE_DIR}/core/compression.cpp
     # Implementation of version and matching specs
     ${LIBMAMBA_SOURCE_DIR}/specs/version.cpp
+    ${LIBMAMBA_SOURCE_DIR}/specs/repo_data.cpp
     # Core API (low-level)
     ${LIBMAMBA_SOURCE_DIR}/core/singletons.cpp
     ${LIBMAMBA_SOURCE_DIR}/core/activation.cpp
@@ -198,6 +199,7 @@ set(LIBMAMBA_PUBLIC_HEADERS
     ${LIBMAMBA_INCLUDE_DIR}/mamba/util/cast.hpp
     # Implementation of version and matching specs
     ${LIBMAMBA_INCLUDE_DIR}/mamba/specs/version.hpp
+    ${LIBMAMBA_INCLUDE_DIR}/mamba/specs/repo_data.hpp
     # Core API (low-level)
     ${LIBMAMBA_INCLUDE_DIR}/mamba/core/activation.hpp
     ${LIBMAMBA_INCLUDE_DIR}/mamba/core/channel.hpp

--- a/libmamba/include/mamba/specs/repo_data.hpp
+++ b/libmamba/include/mamba/specs/repo_data.hpp
@@ -71,7 +71,7 @@ namespace mamba::specs
         Version version = Version(0, { { { 0 } } });
 
         /** The build string of the package. */
-        std::string build = {};
+        std::string build_string = {};
 
         /** The build number of the package. */
         std::size_t build_number = {};

--- a/libmamba/include/mamba/specs/repo_data.hpp
+++ b/libmamba/include/mamba/specs/repo_data.hpp
@@ -1,0 +1,167 @@
+// Copyright (c) 2023, QuantStack and Mamba Contributors
+//
+// Distributed under the terms of the BSD 3-Clause License.
+//
+// The full license is in the file LICENSE, distributed with this software.
+
+#include <optional>
+#include <string>
+#include <vector>
+
+#include <nlohmann/json_fwd.hpp>
+
+#include "mamba/specs/version.hpp"
+
+namespace mamba::specs
+{
+    /**
+     * Noarch packages are packages that are not architecture specific.
+     *
+     * Noarch packages only have to be built once.
+     */
+    enum struct NoArchType
+    {
+        /** Noarch generic packages allow users to distribute docs, datasets, and source code. */
+        Generic,
+
+        /**
+         * A noarch python package is a python package without any precompiled python files.
+         *
+         * Normally, precompiled files (`.pyc` or `__pycache__`) are bundled with the package.
+         * However, these files are tied to a specific version of Python and must therefore be
+         * generated for every target platform and architecture.
+         * This complicates the build process.
+         * For noarch Python packages these files are generated when installing the package by
+         * invoking the compilation process through the python binary that is installed in the
+         * same environment.
+         *
+         * @see https://www.anaconda.com/blog/condas-new-noarch-packages
+         * @see
+         * https://docs.conda.io/projects/conda/en/latest/user-guide/concepts/packages.html#noarch-python
+         */
+        Python,
+    };
+
+    /**
+     * A single record in the Conda repodata.
+     *
+     * A single record refers to a single binary distribution of a package on a Conda channel.
+     *
+     * Looking at the `PackageRecord` class in the Conda source code a record can also include
+     * the following fields but it is unclear what they do.
+     *  - std::optional<std::string> preferred_env;
+     *  - std::optional<std::string> date;
+     *  - ? package_type
+     * Repodata also contains some of the following keys, although they are not parsed by Conda.
+     * - std::optional<std::string> app_type;
+     * - std::optional<std::string> app_entry;
+     *
+     * @see conda.models.records
+     *      https://github.com/conda/conda/blob/main/conda/models/records.py
+     * @see rattler_conda_types::repo_data::pacakgeRecord
+     *      https://github.com/mamba-org/rattler/blob/main/crates/rattler_conda_types/src/repo_data/mod.rs
+     */
+    struct PackageRecord
+    {
+        /** The name of the package. */
+        std::string name = {};
+
+        /** The version of the package. */
+        Version version = Version(0, { { { 0 } } });
+
+        /** The build string of the package. */
+        std::string build = {};
+
+        /** The build number of the package. */
+        std::size_t build_number = {};
+
+        /** The subdirectory where the package can be found. */
+        std::string subdir = {};
+
+        /** Optionally a MD5 hash of the package archive. */
+        std::optional<std::string> md5 = {};
+
+        /** Optionally a SHA256 hash of the package archive. */
+        std::optional<std::string> sha256 = {};
+
+        /** A deprecated md5 hash. */
+        std::optional<std::string> legacy_bz2_md5 = {};
+
+        /** A deprecated package archive size. */
+        std::optional<std::size_t> legacy_bz2_size = {};
+
+        /** Optionally the size of the package archive in bytes. */
+        std::optional<std::size_t> size = {};
+
+        /** Optionally the architecture the package supports. */
+        std::optional<std::string> arch = {};
+
+        /** Optionally the platform the package supports. */
+        std::optional<std::string> platform = {};
+
+        /** Specification of packages this package depends on. */
+        std::vector<std::string> depends = {};
+
+        /**
+         * Additional constraints on packages.
+         *
+         * `constrains` are different from `depends` in that packages specified in `depends` must
+         * be installed next to this package, whereas packages specified in `constrains` are not
+         * required to be installed, but if they are installed they must follow these constraints.
+         */
+        std::vector<std::string> constrains = {};
+
+        /**
+         * Track features are nowadays only used to deprioritize packages.
+         *
+         * To that effect, the number of track features is counted (number of commas) and the
+         * package is downweighted by the number of track_features.
+         */
+        std::vector<std::string> track_features = {};
+
+        /**
+         * Features are a deprecated way to specify different feature sets for the conda solver.
+         *
+         * This is not supported anymore and should not be used.
+         * Instead, `mutex` packages should be used to specify mutually exclusive features.
+         */
+        std::optional<std::string> features = {};
+
+        /** If this package is independent of architecture this field specifies in what way. */
+        std::optional<NoArchType> noarch = {};
+
+        /** The specific license of the package. */
+        std::optional<std::string> license = {};
+
+        /** The license family. */
+        std::optional<std::string> license_family = {};
+
+        /**
+         * The UNIX Epoch timestamp when this package was created.
+         *
+         * Note that sometimes this is specified in seconds and sometimes in milliseconds.
+         */
+        std::optional<std::size_t> timestamp = {};
+    };
+
+    /**
+     * Serialize to JSON.
+     *
+     * Optional members are omitted from json.
+     */
+    void to_json(nlohmann::json& j, const PackageRecord& p);
+    void to_json(nlohmann::json& j, PackageRecord&& p);
+
+    /**
+     * Deserialize from JSON
+     *
+     * Missing json entries fill optionals with a null values and collections as empty.
+     * Special handling of the following fields is performed:
+     * - ``"noarch"`` can be a string or a boolean (old behaviour), in which case ``false``
+     *   parse to ``std::nullopt`` and ``true`` to ``NoArchType::Generic``.
+     * - ``"track_features"`` can be a string or list of string. In the former case, it is
+     *   considered as a single element list.
+     */
+    void from_json(const nlohmann::json& j, PackageRecord& p);
+    void from_json(nlohmann::json&& j, PackageRecord& p);
+}

--- a/libmamba/include/mamba/specs/repo_data.hpp
+++ b/libmamba/include/mamba/specs/repo_data.hpp
@@ -59,7 +59,7 @@ namespace mamba::specs
      *
      * @see conda.models.records
      *      https://github.com/conda/conda/blob/main/conda/models/records.py
-     * @see rattler_conda_types::repo_data::pacakgeRecord
+     * @see rattler_conda_types::repo_data::PackageRecord
      *      https://github.com/mamba-org/rattler/blob/main/crates/rattler_conda_types/src/repo_data/mod.rs
      */
     struct RepoDataPackage
@@ -206,7 +206,7 @@ namespace mamba::specs
         /**
          * The conda packages contained in the repodata.json file.
          *
-         * Maps a filename sucha as ``libmamba-1.3.0-hcea66bb_1.conda`` to its RepoDataPackage.
+         * Maps a filename such as ``libmamba-1.3.0-hcea66bb_1.conda`` to its RepoDataPackage.
          * This is put under a different key for backwards compatibility with previous conda
          * versions.
          */

--- a/libmamba/include/mamba/specs/repo_data.hpp
+++ b/libmamba/include/mamba/specs/repo_data.hpp
@@ -4,6 +4,7 @@
 //
 // The full license is in the file LICENSE, distributed with this software.
 
+#include <map>
 #include <optional>
 #include <string>
 #include <vector>
@@ -164,4 +165,74 @@ namespace mamba::specs
      */
     void from_json(const nlohmann::json& j, PackageRecord& p);
     void from_json(nlohmann::json&& j, PackageRecord& p);
+
+
+    /** Information about subdirectory of channel in the Conda RepoData. */
+    struct ChannelInfo
+    {
+        /** The channel's subdirectory. */
+        std::string subdir = {};
+    };
+
+    /** Serialize to JSON. */
+    void to_json(nlohmann::json& j, const ChannelInfo& info);
+    void to_json(nlohmann::json& j, ChannelInfo&& info);
+
+    /** Deserialize from JSON. */
+    void from_json(const nlohmann::json& j, ChannelInfo& info);
+    void from_json(nlohmann::json&& j, ChannelInfo& info);
+
+    /**
+     * The repository data structure.
+     *
+     * This schema maps to the repository ``repodata.json``.
+     **/
+    struct RepoData
+    {
+        /** The version of the repodata format. */
+        std::optional<std::size_t> version = {};
+
+        /** The channel information contained in the repodata.json file.
+         */
+        std::optional<ChannelInfo> info = {};
+
+        /**
+         * The tar.bz2 packages contained in the repodata.json file.
+         *
+         * Maps a filename sucha as ``libmamba-0.13.0-h3a044de_0.tar.bz2`` to its PackageRecord.
+         **/
+        std::map<std::string, PackageRecord> packages = {};
+
+        /**
+         * The conda packages contained in the repodata.json file.
+         *
+         * Maps a filename sucha as ``libmamba-1.3.0-hcea66bb_1.conda`` to its PackageRecord.
+         * This is put under a different key for backwards compatibility with previous conda
+         * versions.
+         */
+        std::map<std::string, PackageRecord> conda_packages = {};
+
+        /**
+         * Removed packages
+         *
+         * These files are still accessible, but they are not installable like regular packages.
+         */
+        std::vector<std::string> removed = {};
+    };
+
+    /**
+     * Serialize to JSON.
+     *
+     * Optional members are omitted from json.
+     */
+    void to_json(nlohmann::json& j, const RepoData& data);
+    void to_json(nlohmann::json& j, RepoData&& data);
+
+    /**
+     * Deserialize from JSON
+     *
+     * Missing json entries fill optionals with a null values and collections as empty.
+     */
+    void from_json(const nlohmann::json& j, RepoData& data);
+    void from_json(nlohmann::json&& j, RepoData& data);
 }

--- a/libmamba/include/mamba/specs/repo_data.hpp
+++ b/libmamba/include/mamba/specs/repo_data.hpp
@@ -44,11 +44,11 @@ namespace mamba::specs
     };
 
     /**
-     * A single record in the Conda repodata.
+     * A single record in the Conda ``repodata.json``.
      *
      * A single record refers to a single binary distribution of a package on a Conda channel.
      *
-     * Looking at the `PackageRecord` class in the Conda source code a record can also include
+     * Looking at the `RepoDataPackage` class in the Conda source code a record can also include
      * the following fields but it is unclear what they do.
      *  - std::optional<std::string> preferred_env;
      *  - std::optional<std::string> date;
@@ -62,7 +62,7 @@ namespace mamba::specs
      * @see rattler_conda_types::repo_data::pacakgeRecord
      *      https://github.com/mamba-org/rattler/blob/main/crates/rattler_conda_types/src/repo_data/mod.rs
      */
-    struct PackageRecord
+    struct RepoDataPackage
     {
         /** The name of the package. */
         std::string name = {};
@@ -150,8 +150,8 @@ namespace mamba::specs
      *
      * Optional members are omitted from json.
      */
-    void to_json(nlohmann::json& j, const PackageRecord& p);
-    void to_json(nlohmann::json& j, PackageRecord&& p);
+    void to_json(nlohmann::json& j, const RepoDataPackage& p);
+    void to_json(nlohmann::json& j, RepoDataPackage&& p);
 
     /**
      * Deserialize from JSON
@@ -163,8 +163,8 @@ namespace mamba::specs
      * - ``"track_features"`` can be a string or list of string. In the former case, it is
      *   considered as a single element list.
      */
-    void from_json(const nlohmann::json& j, PackageRecord& p);
-    void from_json(nlohmann::json&& j, PackageRecord& p);
+    void from_json(const nlohmann::json& j, RepoDataPackage& p);
+    void from_json(nlohmann::json&& j, RepoDataPackage& p);
 
 
     /** Information about subdirectory of channel in the Conda RepoData. */
@@ -199,18 +199,18 @@ namespace mamba::specs
         /**
          * The tar.bz2 packages contained in the repodata.json file.
          *
-         * Maps a filename sucha as ``libmamba-0.13.0-h3a044de_0.tar.bz2`` to its PackageRecord.
+         * Maps a filename sucha as ``libmamba-0.13.0-h3a044de_0.tar.bz2`` to its RepoDataPackage.
          **/
-        std::map<std::string, PackageRecord> packages = {};
+        std::map<std::string, RepoDataPackage> packages = {};
 
         /**
          * The conda packages contained in the repodata.json file.
          *
-         * Maps a filename sucha as ``libmamba-1.3.0-hcea66bb_1.conda`` to its PackageRecord.
+         * Maps a filename sucha as ``libmamba-1.3.0-hcea66bb_1.conda`` to its RepoDataPackage.
          * This is put under a different key for backwards compatibility with previous conda
          * versions.
          */
-        std::map<std::string, PackageRecord> conda_packages = {};
+        std::map<std::string, RepoDataPackage> conda_packages = {};
 
         /**
          * Removed packages

--- a/libmamba/include/mamba/specs/repo_data.hpp
+++ b/libmamba/include/mamba/specs/repo_data.hpp
@@ -151,7 +151,6 @@ namespace mamba::specs
      * Optional members are omitted from json.
      */
     void to_json(nlohmann::json& j, const RepoDataPackage& p);
-    void to_json(nlohmann::json& j, RepoDataPackage&& p);
 
     /**
      * Deserialize from JSON
@@ -164,7 +163,6 @@ namespace mamba::specs
      *   considered as a single element list.
      */
     void from_json(const nlohmann::json& j, RepoDataPackage& p);
-    void from_json(nlohmann::json&& j, RepoDataPackage& p);
 
 
     /** Information about subdirectory of channel in the Conda RepoData. */
@@ -176,11 +174,9 @@ namespace mamba::specs
 
     /** Serialize to JSON. */
     void to_json(nlohmann::json& j, const ChannelInfo& info);
-    void to_json(nlohmann::json& j, ChannelInfo&& info);
 
     /** Deserialize from JSON. */
     void from_json(const nlohmann::json& j, ChannelInfo& info);
-    void from_json(nlohmann::json&& j, ChannelInfo& info);
 
     /**
      * The repository data structure.
@@ -226,7 +222,6 @@ namespace mamba::specs
      * Optional members are omitted from json.
      */
     void to_json(nlohmann::json& j, const RepoData& data);
-    void to_json(nlohmann::json& j, RepoData&& data);
 
     /**
      * Deserialize from JSON
@@ -234,5 +229,4 @@ namespace mamba::specs
      * Missing json entries fill optionals with a null values and collections as empty.
      */
     void from_json(const nlohmann::json& j, RepoData& data);
-    void from_json(nlohmann::json&& j, RepoData& data);
 }

--- a/libmamba/src/specs/repo_data.cpp
+++ b/libmamba/src/specs/repo_data.cpp
@@ -81,7 +81,7 @@ namespace mamba::specs
         {
             j["name"] = std::forward<PackRec>(p).name;
             j["version"] = p.version.str();
-            j["build"] = std::forward<PackRec>(p).build;
+            j["build"] = std::forward<PackRec>(p).build_string;
             j["build_number"] = std::forward<PackRec>(p).build_number;
             j["subdir"] = std::forward<PackRec>(p).subdir;
             j["md5"] = std::forward<PackRec>(p).md5;
@@ -132,7 +132,7 @@ namespace mamba::specs
         {
             p.name = std::forward<Json>(j).at("name");
             p.version = Version::parse(j.at("version").template get<std::string_view>());
-            p.build = std::forward<Json>(j).at("build");
+            p.build_string = std::forward<Json>(j).at("build");
             p.build_number = std::forward<Json>(j).at("build_number");
             p.subdir = std::forward<Json>(j).at("subdir");
             deserialize_maybe_missing(std::forward<Json>(j), "md5", p.md5);

--- a/libmamba/src/specs/repo_data.cpp
+++ b/libmamba/src/specs/repo_data.cpp
@@ -190,4 +190,88 @@ namespace mamba::specs
     {
         return from_json_PackageRecord_impl(std::move(j), p);
     }
+
+    namespace
+    {
+        template <typename ChanInfo>
+        void to_json_ChannelInfo_impl(nlohmann::json& j, ChanInfo&& info)
+        {
+            j["subdir"] = std::forward<ChanInfo>(info).subdir;
+        }
+    }
+
+    void to_json(nlohmann::json& j, const ChannelInfo& info)
+    {
+        return to_json_ChannelInfo_impl(j, info);
+    }
+
+    void to_json(nlohmann::json& j, ChannelInfo&& info)
+    {
+        return to_json_ChannelInfo_impl(j, std::move(info));
+    }
+
+    namespace
+    {
+        template <typename Json>
+        void from_json_ChannelInfo_impl(Json&& j, ChannelInfo& info)
+        {
+            info.subdir = std::forward<Json>(j)["subdir"];
+        }
+    }
+
+    void from_json(const nlohmann::json& j, ChannelInfo& info)
+    {
+        return from_json_ChannelInfo_impl(j, info);
+    }
+
+    void from_json(nlohmann::json&& j, ChannelInfo& info)
+    {
+        return from_json_ChannelInfo_impl(std::move(j), info);
+    }
+
+    namespace
+    {
+        template <typename ReData>
+        void to_json_RepoData_impl(nlohmann::json& j, ReData&& data)
+        {
+            j["version"] = std::forward<ReData>(data).version;
+            j["info"] = std::forward<ReData>(data).info;
+            j["packages"] = std::forward<ReData>(data).packages;
+            j["conda_packages"] = std::forward<ReData>(data).conda_packages;
+            j["removed"] = std::forward<ReData>(data).removed;
+        }
+    }
+
+    void to_json(nlohmann::json& j, const RepoData& data)
+    {
+        return to_json_RepoData_impl(j, data);
+    }
+
+    void to_json(nlohmann::json& j, RepoData&& data)
+    {
+        return to_json_RepoData_impl(j, std::move(data));
+    }
+
+    namespace
+    {
+        template <typename Json>
+        void from_json_RepoData_impl(Json&& j, RepoData& data)
+        {
+            deserialize_maybe_missing(std::forward<Json>(j), "version", data.version);
+            deserialize_maybe_missing(std::forward<Json>(j), "info", data.info);
+            deserialize_maybe_missing(std::forward<Json>(j), "packages", data.packages);
+            deserialize_maybe_missing(std::forward<Json>(j), "conda_packages", data.conda_packages);
+            deserialize_maybe_missing(std::forward<Json>(j), "removed", data.removed);
+        }
+    }
+
+    void from_json(const nlohmann::json& j, RepoData& data)
+    {
+        return from_json_RepoData_impl(j, data);
+    }
+
+    void from_json(nlohmann::json&& j, RepoData& data)
+    {
+        return from_json_RepoData_impl(std::move(j), data);
+    }
 }

--- a/libmamba/src/specs/repo_data.cpp
+++ b/libmamba/src/specs/repo_data.cpp
@@ -1,0 +1,193 @@
+// Copyright (c) 2023, QuantStack and Mamba Contributors
+//
+// Distributed under the terms of the BSD 3-Clause License.
+//
+// The full license is in the file LICENSE, distributed with this software.
+
+
+#include <string_view>
+#include <utility>
+
+#include <nlohmann/json.hpp>
+
+#include "mamba/specs/repo_data.hpp"
+
+NLOHMANN_JSON_NAMESPACE_BEGIN
+template <typename T>
+struct adl_serializer<std::optional<T>>
+{
+    template <typename Opt>
+    static void to_json_impl(json& j, Opt&& opt)
+    {
+        if (opt.has_value())
+        {
+            j = std::forward<Opt>(opt).value();
+        }
+        else
+        {
+            j = nullptr;
+        }
+    }
+
+    static void to_json(json& j, const std::optional<T>& opt)
+    {
+        return to_json_impl(j, opt);
+    }
+
+    static void to_json(json& j, std::optional<T>&& opt)
+    {
+        return to_json_impl(j, std::move(opt));
+    }
+
+    template <typename Json>
+    static void from_json_impl(Json&& j, std::optional<T>& opt)
+    {
+        if (!j.is_null())
+        {
+            opt = std::forward<Json>(j).template get<T>();
+        }
+        else
+        {
+            opt = std::nullopt;
+        }
+    }
+
+    static void from_json(const json& j, std::optional<T>& opt)
+    {
+        return from_json_impl(j, opt);
+    }
+
+    static void from_json(json&& j, std::optional<T>& opt)
+    {
+        return from_json_impl(std::move(j), opt);
+    }
+};
+NLOHMANN_JSON_NAMESPACE_END
+
+namespace mamba::specs
+{
+    NLOHMANN_JSON_SERIALIZE_ENUM(
+        NoArchType,
+        {
+            { NoArchType::Generic, "generic" },
+            { NoArchType::Python, "python" },
+        }
+    )
+
+    namespace
+    {
+        template <typename PackRec>
+        void to_json_PackageRecord_impl(nlohmann::json& j, PackRec&& p)
+        {
+            j["name"] = std::forward<PackRec>(p).name;
+            j["version"] = p.version.str();
+            j["build"] = std::forward<PackRec>(p).build;
+            j["build_number"] = std::forward<PackRec>(p).build_number;
+            j["subdir"] = std::forward<PackRec>(p).subdir;
+            j["md5"] = std::forward<PackRec>(p).md5;
+            j["sha256"] = std::forward<PackRec>(p).sha256;
+            j["legacy_bz2_md5"] = std::forward<PackRec>(p).legacy_bz2_md5;
+            j["legacy_bz2_size"] = std::forward<PackRec>(p).legacy_bz2_size;
+            j["size"] = std::forward<PackRec>(p).size;
+            j["arch"] = std::forward<PackRec>(p).arch;
+            j["platform"] = std::forward<PackRec>(p).platform;
+            j["depends"] = std::forward<PackRec>(p).depends;
+            j["constrains"] = std::forward<PackRec>(p).constrains;
+            j["track_features"] = std::forward<PackRec>(p).track_features;
+            j["features"] = std::forward<PackRec>(p).features;
+            j["noarch"] = std::forward<PackRec>(p).noarch;
+            j["license"] = std::forward<PackRec>(p).license;
+            j["license_family"] = std::forward<PackRec>(p).license_family;
+            j["timestamp"] = std::forward<PackRec>(p).timestamp;
+        }
+    }
+
+    void to_json(nlohmann::json& j, const PackageRecord& p)
+    {
+        return to_json_PackageRecord_impl(j, p);
+    }
+
+    void to_json(nlohmann::json& j, PackageRecord&& p)
+    {
+        return to_json_PackageRecord_impl(j, std::move(p));
+    }
+
+    namespace
+    {
+        template <typename Json, std::size_t N, typename T>
+        void deserialize_maybe_missing(Json&& j, const char (&name)[N], T& t)
+        {
+            if (j.contains(name))
+            {
+                t = std::forward<Json>(j)[name].template get<T>();
+            }
+            else
+            {
+                t = {};
+            }
+        }
+
+        template <typename Json>
+        void from_json_PackageRecord_impl(Json&& j, PackageRecord& p)
+        {
+            p.name = std::forward<Json>(j).at("name");
+            p.version = Version::parse(j.at("version").template get<std::string_view>());
+            p.build = std::forward<Json>(j).at("build");
+            p.build_number = std::forward<Json>(j).at("build_number");
+            p.subdir = std::forward<Json>(j).at("subdir");
+            deserialize_maybe_missing(std::forward<Json>(j), "md5", p.md5);
+            deserialize_maybe_missing(std::forward<Json>(j), "sha256", p.sha256);
+            deserialize_maybe_missing(std::forward<Json>(j), "legacy_bz2_md5", p.legacy_bz2_md5);
+            deserialize_maybe_missing(std::forward<Json>(j), "legacy_bz2_size", p.legacy_bz2_size);
+            deserialize_maybe_missing(std::forward<Json>(j), "size", p.size);
+            deserialize_maybe_missing(std::forward<Json>(j), "arch", p.arch);
+            deserialize_maybe_missing(std::forward<Json>(j), "platform", p.platform);
+            deserialize_maybe_missing(std::forward<Json>(j), "depends", p.depends);
+            deserialize_maybe_missing(std::forward<Json>(j), "constrains", p.constrains);
+            if (j.contains("track_features"))
+            {
+                auto&& track_features = std::forward<Json>(j)["track_features"];
+                if (track_features.is_array())
+                {
+                    p.track_features = std::forward<decltype(track_features)>(track_features);
+                }
+                // Consider a single element
+                else if (track_features.is_string())
+                {
+                    p.track_features.push_back(std::forward<decltype(track_features)>(track_features));
+                }
+            }
+            deserialize_maybe_missing(std::forward<Json>(j), "features", p.features);
+            if (j.contains("noarch") && !j["noarch"].is_null())
+            {
+                auto&& noarch = j["noarch"];
+                // old behaviour
+                if (noarch.is_boolean())
+                {
+                    if (noarch.template get<bool>())
+                    {
+                        p.noarch = NoArchType::Generic;
+                    }
+                }
+                else
+                {
+                    // Regular enum deserialization
+                    p.noarch = std::forward<decltype(noarch)>(noarch);
+                }
+            }
+            deserialize_maybe_missing(std::forward<Json>(j), "license", p.license);
+            deserialize_maybe_missing(std::forward<Json>(j), "license_family", p.license_family);
+            deserialize_maybe_missing(std::forward<Json>(j), "timestamp", p.timestamp);
+        }
+    }
+
+    void from_json(const nlohmann::json& j, PackageRecord& p)
+    {
+        return from_json_PackageRecord_impl(j, p);
+    }
+
+    void from_json(nlohmann::json&& j, PackageRecord& p)
+    {
+        return from_json_PackageRecord_impl(std::move(j), p);
+    }
+}

--- a/libmamba/src/specs/repo_data.cpp
+++ b/libmamba/src/specs/repo_data.cpp
@@ -77,7 +77,7 @@ namespace mamba::specs
     namespace
     {
         template <typename PackRec>
-        void to_json_PackageRecord_impl(nlohmann::json& j, PackRec&& p)
+        void to_json_RepoDataPackage_impl(nlohmann::json& j, PackRec&& p)
         {
             j["name"] = std::forward<PackRec>(p).name;
             j["version"] = p.version.str();
@@ -102,14 +102,14 @@ namespace mamba::specs
         }
     }
 
-    void to_json(nlohmann::json& j, const PackageRecord& p)
+    void to_json(nlohmann::json& j, const RepoDataPackage& p)
     {
-        return to_json_PackageRecord_impl(j, p);
+        return to_json_RepoDataPackage_impl(j, p);
     }
 
-    void to_json(nlohmann::json& j, PackageRecord&& p)
+    void to_json(nlohmann::json& j, RepoDataPackage&& p)
     {
-        return to_json_PackageRecord_impl(j, std::move(p));
+        return to_json_RepoDataPackage_impl(j, std::move(p));
     }
 
     namespace
@@ -128,7 +128,7 @@ namespace mamba::specs
         }
 
         template <typename Json>
-        void from_json_PackageRecord_impl(Json&& j, PackageRecord& p)
+        void from_json_RepoDataPackage_impl(Json&& j, RepoDataPackage& p)
         {
             p.name = std::forward<Json>(j).at("name");
             p.version = Version::parse(j.at("version").template get<std::string_view>());
@@ -181,14 +181,14 @@ namespace mamba::specs
         }
     }
 
-    void from_json(const nlohmann::json& j, PackageRecord& p)
+    void from_json(const nlohmann::json& j, RepoDataPackage& p)
     {
-        return from_json_PackageRecord_impl(j, p);
+        return from_json_RepoDataPackage_impl(j, p);
     }
 
-    void from_json(nlohmann::json&& j, PackageRecord& p)
+    void from_json(nlohmann::json&& j, RepoDataPackage& p)
     {
-        return from_json_PackageRecord_impl(std::move(j), p);
+        return from_json_RepoDataPackage_impl(std::move(j), p);
     }
 
     namespace

--- a/libmamba/tests/CMakeLists.txt
+++ b/libmamba/tests/CMakeLists.txt
@@ -20,6 +20,7 @@ set(LIBMAMBA_TEST_SRCS
     src/util/test_cast.cpp
     # Implementation of version and matching specs
     src/specs/test_version.cpp
+    src/specs/test_repo_data.cpp
 
     ../longpath.manifest
     src/core/test_activation.cpp

--- a/libmamba/tests/src/specs/test_repo_data.cpp
+++ b/libmamba/tests/src/specs/test_repo_data.cpp
@@ -85,18 +85,24 @@ TEST(repo_data, RepoData_to_json)
 {
     auto data = RepoData();
     data.version = 1;
-    data.info = ChannelInfo{ "subdir" };
+    data.info = ChannelInfo{ /* .subdir= */ "linux-64" };
     data.packages = {
-        { "mamba-1", RepoDataPackage{ "mamba" } },
-        { "conda-1", RepoDataPackage{ "conda" } },
+        { "mamba-1.0-h12345.tar.bz2", RepoDataPackage{ "mamba" } },
+        { "conda-1.0-h54321.tar.bz2", RepoDataPackage{ "conda" } },
     };
     data.removed = { "bad-package-1" };
 
     const nl::json j = data;
     EXPECT_EQ(j.at("version"), data.version);
     EXPECT_EQ(j.at("info").at("subdir"), data.info.value().subdir);
-    EXPECT_EQ(j.at("packages").at("mamba-1"), data.packages.at("mamba-1"));
-    EXPECT_EQ(j.at("packages").at("conda-1"), data.packages.at("conda-1"));
+    EXPECT_EQ(
+        j.at("packages").at("mamba-1.0-h12345.tar.bz2"),
+        data.packages.at("mamba-1.0-h12345.tar.bz2")
+    );
+    EXPECT_EQ(
+        j.at("packages").at("conda-1.0-h54321.tar.bz2"),
+        data.packages.at("conda-1.0-h54321.tar.bz2")
+    );
     EXPECT_EQ(j.at("removed"), std::vector{ "bad-package-1" });
 }
 
@@ -105,14 +111,14 @@ TEST(repo_data, RepoData_from_json)
     auto j = nl::json::object();
     j["version"] = 1;
     j["info"]["subdir"] = "somedir";
-    j["packages"]["mamba-1.0.tar.gz"]["name"] = "mamba";
-    j["packages"]["mamba-1.0.tar.gz"]["version"] = "1.1.0";
-    j["packages"]["mamba-1.0.tar.gz"]["build"] = "foo1";
-    j["packages"]["mamba-1.0.tar.gz"]["build_number"] = 2;
-    j["packages"]["mamba-1.0.tar.gz"]["subdir"] = "folder";
-    j["packages"]["mamba-1.0.tar.gz"]["depends"] = nl::json::array({ "libsolv>=1.0" });
-    j["packages"]["mamba-1.0.tar.gz"]["constrains"] = nl::json::array();
-    j["packages"]["mamba-1.0.tar.gz"]["track_features"] = nl::json::array();
+    j["packages"]["mamba-1.0-h12345.tar.bz2"]["name"] = "mamba";
+    j["packages"]["mamba-1.0-h12345.tar.bz2"]["version"] = "1.1.0";
+    j["packages"]["mamba-1.0-h12345.tar.bz2"]["build"] = "foo1";
+    j["packages"]["mamba-1.0-h12345.tar.bz2"]["build_number"] = 2;
+    j["packages"]["mamba-1.0-h12345.tar.bz2"]["subdir"] = "folder";
+    j["packages"]["mamba-1.0-h12345.tar.bz2"]["depends"] = nl::json::array({ "libsolv>=1.0" });
+    j["packages"]["mamba-1.0-h12345.tar.bz2"]["constrains"] = nl::json::array();
+    j["packages"]["mamba-1.0-h12345.tar.bz2"]["track_features"] = nl::json::array();
     j["conda_packages"] = nl::json::object();
     j["removed"][0] = "bad-package.tar.gz";
 
@@ -121,7 +127,10 @@ TEST(repo_data, RepoData_from_json)
     EXPECT_EQ(data.version, j["version"]);
     ASSERT_TRUE(data.info.has_value());
     EXPECT_EQ(data.info.value().subdir, j["info"]["subdir"]);
-    EXPECT_EQ(data.packages.at("mamba-1.0.tar.gz").name, j["packages"]["mamba-1.0.tar.gz"]["name"]);
+    EXPECT_EQ(
+        data.packages.at("mamba-1.0-h12345.tar.bz2").name,
+        j["packages"]["mamba-1.0-h12345.tar.bz2"]["name"]
+    );
     EXPECT_TRUE(data.conda_packages.empty());
     EXPECT_EQ(data.removed, j["removed"]);
 }

--- a/libmamba/tests/src/specs/test_repo_data.cpp
+++ b/libmamba/tests/src/specs/test_repo_data.cpp
@@ -128,7 +128,7 @@ TEST(repo_data, RepoData_from_json)
 
 TEST(repo_data, repodata_json)
 {
-    // Mybe not the best way to set this test.
+    // Maybe not the best way to set this test.
     // ``repodata.json`` of interest are very large files. Should we check them in in VCS?
     // Download them in CMake? Do a specific integration test?
     // Could be downloaded in the tests, but we would like to keep these tests Context-free.
@@ -139,7 +139,7 @@ TEST(repo_data, repodata_json)
     }
     auto repodata_file = std::ifstream(repodata_file_path);
     // Deserialize
-    const auto data = nl::json::parse(repodata_file).get<RepoData>();
+    auto data = nl::json::parse(repodata_file).get<RepoData>();
     // Serialize
-    const nl::json json = data;
+    const nl::json json = std::move(data);
 }

--- a/libmamba/tests/src/specs/test_repo_data.cpp
+++ b/libmamba/tests/src/specs/test_repo_data.cpp
@@ -19,7 +19,7 @@ TEST(repo_data, RepoDataPackage_to_json)
     auto p = RepoDataPackage();
     p.name = "mamba";
     p.version = Version::parse("1.0.0");
-    p.build = "bld";
+    p.build_string = "bld";
     p.build_number = 3;
     p.subdir = "folder";
     p.md5 = "ffsd";
@@ -28,7 +28,7 @@ TEST(repo_data, RepoDataPackage_to_json)
     nl::json const j = p;
     EXPECT_EQ(j.at("name"), p.name);
     EXPECT_EQ(j.at("version"), p.version.str());
-    EXPECT_EQ(j.at("build"), p.build);
+    EXPECT_EQ(j.at("build"), p.build_string);
     EXPECT_EQ(j.at("build_number"), p.build_number);
     EXPECT_EQ(j.at("subdir"), p.subdir);
     EXPECT_EQ(j.at("md5"), p.md5);
@@ -53,7 +53,7 @@ TEST(repo_data, RepoDataPackage_from_json)
         EXPECT_EQ(p.name, j.at("name"));
         // Note Version::parse is not injective
         EXPECT_EQ(p.version.str(), j.at("version"));
-        EXPECT_EQ(p.build, j.at("build"));
+        EXPECT_EQ(p.build_string, j.at("build"));
         EXPECT_EQ(p.build_number, j.at("build_number"));
         EXPECT_EQ(p.subdir, j.at("subdir"));
         EXPECT_FALSE(p.md5.has_value());

--- a/libmamba/tests/src/specs/test_repo_data.cpp
+++ b/libmamba/tests/src/specs/test_repo_data.cpp
@@ -14,9 +14,9 @@
 using namespace mamba::specs;
 namespace nl = nlohmann;
 
-TEST(repo_data, PackageRecord_to_json)
+TEST(repo_data, RepoDataPackage_to_json)
 {
-    auto p = PackageRecord();
+    auto p = RepoDataPackage();
     p.name = "mamba";
     p.version = Version::parse("1.0.0");
     p.build = "bld";
@@ -36,7 +36,7 @@ TEST(repo_data, PackageRecord_to_json)
     EXPECT_EQ(j.at("noarch"), "python");
 }
 
-TEST(repo_data, PackageRecord_from_json)
+TEST(repo_data, RepoDataPackage_from_json)
 {
     auto j = nl::json::object();
     j["name"] = "mamba";
@@ -49,7 +49,7 @@ TEST(repo_data, PackageRecord_from_json)
     j["constrains"] = nl::json::array();
     j["track_features"] = nl::json::array();
     {
-        const auto p = j.get<PackageRecord>();
+        const auto p = j.get<RepoDataPackage>();
         EXPECT_EQ(p.name, j.at("name"));
         // Note Version::parse is not injective
         EXPECT_EQ(p.version.str(), j.at("version"));
@@ -65,18 +65,18 @@ TEST(repo_data, PackageRecord_from_json)
     }
     j["noarch"] = "python";
     {
-        const auto p = j.get<PackageRecord>();
+        const auto p = j.get<RepoDataPackage>();
         EXPECT_EQ(p.noarch, NoArchType::Python);
     }
     // Old beahiour
     j["noarch"] = true;
     {
-        const auto p = j.get<PackageRecord>();
+        const auto p = j.get<RepoDataPackage>();
         EXPECT_EQ(p.noarch, NoArchType::Generic);
     }
     j["noarch"] = false;
     {
-        const auto p = j.get<PackageRecord>();
+        const auto p = j.get<RepoDataPackage>();
         EXPECT_FALSE(p.noarch.has_value());
     }
 }
@@ -87,8 +87,8 @@ TEST(repo_data, RepoData_to_json)
     data.version = 1;
     data.info = ChannelInfo{ "subdir" };
     data.packages = {
-        { "mamba-1", PackageRecord{ "mamba" } },
-        { "conda-1", PackageRecord{ "conda" } },
+        { "mamba-1", RepoDataPackage{ "mamba" } },
+        { "conda-1", RepoDataPackage{ "conda" } },
     };
     data.removed = { "bad-package-1" };
 


### PR DESCRIPTION
For  #2302

Parse `repodata.json` instead of relying on libsolv.
- [x] Add ``PackageRecord`` to reprensent `repodata.json` entries.
- [x] Add ``RepoData`` to match `repodata.json` schema
- [x] Add (integration) test on whole repodata.json.

To discuss:
- What is the best way to keep `repodata.json` files for testing as they are quite large.
- Do `nlohmann::json` work with rvlaue reference overloads? No