### PR TITLE
Fix build with older Clang

### DIFF
--- a/libmamba/src/solv-cpp/queue.cpp
+++ b/libmamba/src/solv-cpp/queue.cpp
@@ -160,7 +160,7 @@ namespace mamba::solv
             if (pos >= size)
             {
                 // TODO(C++20) std::format
-                std::stringstream ss = {};
+                auto ss = std::stringstream{};
                 ss << "Index " << pos << " is greater that the number of elements (" << size << ')';
                 throw std::out_of_range(std::move(ss).str());
             }


### PR DESCRIPTION
This fixes the following build error:

```
  /tmp/micromamba-20230322-77117-1jorcxo/mamba-micromamba-1.4.0/libmamba/src/solv-cpp/queue.cpp:163:35: error: chosen constructor is explicit in copy-initialization
                  std::stringstream ss = {};
                                    ^    ~~
  /Library/Developer/CommandLineTools/SDKs/MacOSX11.sdk/usr/include/c++/v1/sstream:884:14: note: explicit constructor declared here
      explicit basic_stringstream(ios_base::openmode __wch = ios_base::in | ios_base::out);
               ^
```

The error was seen on macOS 11 (on both x86_64 and arm64) while packaging mamba for Homebrew at https://github.com/Homebrew/homebrew-core/pull/126371. Build logs available [here](https://github.com/Homebrew/homebrew-core/actions/runs/4492974988/jobs/7904324210#step:7:126).

I am not sure about the root cause of this error, but it may be due to the lack of an implicit default constructor for `std::stringstream` in macOS 11 SDK's libc++. If I understand it correctly, this is related to the discussion on copy-list-initialization in https://stackoverflow.com/a/38419922.
