### PR TITLE
Handle `url` via ChannelBuilder in Repo constructor

### DIFF
--- a/libmamba/src/core/repo.cpp
+++ b/libmamba/src/core/repo.cpp
@@ -13,13 +13,13 @@ extern "C"  // Incomplete header
 #include <solv/repo_conda.h>
 }
 
+#include "mamba/core/channel_builder.hpp"
 #include "mamba/core/context.hpp"
 #include "mamba/core/output.hpp"
 #include "mamba/core/package_info.hpp"
 #include "mamba/core/pool.hpp"
 #include "mamba/core/repo.hpp"
 #include "mamba/core/util_string.hpp"
-#include "mamba/core/channel_builder.hpp"
 
 
 #define MAMBA_TOOL_VERSION "1.1"

--- a/libmamba/src/core/repo.cpp
+++ b/libmamba/src/core/repo.cpp
@@ -19,6 +19,7 @@ extern "C"  // Incomplete header
 #include "mamba/core/pool.hpp"
 #include "mamba/core/repo.hpp"
 #include "mamba/core/util_string.hpp"
+#include "mamba/core/channel_builder.hpp"
 
 
 #define MAMBA_TOOL_VERSION "1.1"
@@ -58,6 +59,7 @@ namespace mamba
         m_repo = repo_create(pool, name.c_str());
         m_repo->appdata = this;
         read_file(index);
+        p_channel = &ChannelBuilder::make_cached_channel(url);
     }
 
     MRepo::MRepo(MPool& pool, const std::string& name, const std::vector<PackageInfo>& package_infos)


### PR DESCRIPTION
Alternative to https://github.com/mamba-org/mamba/pull/2352.

This seems like an easier fix and works for my intended use case. No new APIs, just a fix where we do use that `url` parameter. But maybe this is the wrong way to do it? 