### PR TITLE
Wrap ::Pool and ::Repo

### DIFF
--- a/libmamba/CMakeLists.txt
+++ b/libmamba/CMakeLists.txt
@@ -121,6 +121,7 @@ set(LIBMAMBA_SOURCES
     # C++ wrapping of libsolv
     ${LIBMAMBA_SOURCE_DIR}/solv-cpp/queue.cpp
     ${LIBMAMBA_SOURCE_DIR}/solv-cpp/pool.cpp
+    ${LIBMAMBA_SOURCE_DIR}/solv-cpp/repo.cpp
     # C++ wrapping of libcurl
     ${LIBMAMBA_SOURCE_DIR}/core/curl.cpp
     # C++ wrapping of compression libs (zstd and bzlib)
@@ -273,6 +274,7 @@ set(LIBMAMBA_PRIVATE_HEADERS
     ${LIBMAMBA_SOURCE_DIR}/solv-cpp/queue.hpp
     ${LIBMAMBA_SOURCE_DIR}/solv-cpp/ids.hpp
     ${LIBMAMBA_SOURCE_DIR}/solv-cpp/pool.hpp
+    ${LIBMAMBA_SOURCE_DIR}/solv-cpp/repo.hpp
     # C++ wrapping of compression libs (zstd and bzlib)
     ${LIBMAMBA_SOURCE_DIR}/core/compression.hpp
     # C++ wrapping of libcurl

--- a/libmamba/CMakeLists.txt
+++ b/libmamba/CMakeLists.txt
@@ -269,6 +269,8 @@ set(LIBMAMBA_PUBLIC_HEADERS
 
 set(LIBMAMBA_PRIVATE_HEADERS
     ${LIBMAMBA_SOURCE_DIR}/solv-cpp/queue.hpp
+    ${LIBMAMBA_SOURCE_DIR}/solv-cpp/ids.hpp
+    # C++ wrapping of libcurl
     ${LIBMAMBA_SOURCE_DIR}/core/compression.hpp
     ${LIBMAMBA_SOURCE_DIR}/core/curl.hpp
 )

--- a/libmamba/CMakeLists.txt
+++ b/libmamba/CMakeLists.txt
@@ -122,6 +122,7 @@ set(LIBMAMBA_SOURCES
     ${LIBMAMBA_SOURCE_DIR}/solv-cpp/queue.cpp
     ${LIBMAMBA_SOURCE_DIR}/solv-cpp/pool.cpp
     ${LIBMAMBA_SOURCE_DIR}/solv-cpp/repo.cpp
+    ${LIBMAMBA_SOURCE_DIR}/solv-cpp/solvable.cpp
     # C++ wrapping of libcurl
     ${LIBMAMBA_SOURCE_DIR}/core/curl.cpp
     # C++ wrapping of compression libs (zstd and bzlib)
@@ -274,6 +275,7 @@ set(LIBMAMBA_PRIVATE_HEADERS
     ${LIBMAMBA_SOURCE_DIR}/solv-cpp/queue.hpp
     ${LIBMAMBA_SOURCE_DIR}/solv-cpp/ids.hpp
     ${LIBMAMBA_SOURCE_DIR}/solv-cpp/pool.hpp
+    ${LIBMAMBA_SOURCE_DIR}/solv-cpp/solvable.hpp
     ${LIBMAMBA_SOURCE_DIR}/solv-cpp/repo.hpp
     # C++ wrapping of compression libs (zstd and bzlib)
     ${LIBMAMBA_SOURCE_DIR}/core/compression.hpp

--- a/libmamba/CMakeLists.txt
+++ b/libmamba/CMakeLists.txt
@@ -120,6 +120,7 @@ set(LIBMAMBA_SOURCES
     ${LIBMAMBA_SOURCE_DIR}/version.cpp
     # C++ wrapping of libsolv
     ${LIBMAMBA_SOURCE_DIR}/solv-cpp/queue.cpp
+    ${LIBMAMBA_SOURCE_DIR}/solv-cpp/pool.cpp
     # C++ wrapping of libcurl
     ${LIBMAMBA_SOURCE_DIR}/core/curl.cpp
     # C++ wrapping of compression libs (zstd and bzlib)
@@ -268,10 +269,13 @@ set(LIBMAMBA_PUBLIC_HEADERS
 )
 
 set(LIBMAMBA_PRIVATE_HEADERS
+    # C++ wrapping of libsolv
     ${LIBMAMBA_SOURCE_DIR}/solv-cpp/queue.hpp
     ${LIBMAMBA_SOURCE_DIR}/solv-cpp/ids.hpp
-    # C++ wrapping of libcurl
+    ${LIBMAMBA_SOURCE_DIR}/solv-cpp/pool.hpp
+    # C++ wrapping of compression libs (zstd and bzlib)
     ${LIBMAMBA_SOURCE_DIR}/core/compression.hpp
+    # C++ wrapping of libcurl
     ${LIBMAMBA_SOURCE_DIR}/core/curl.hpp
 )
 

--- a/libmamba/src/core/repo.cpp
+++ b/libmamba/src/core/repo.cpp
@@ -165,6 +165,7 @@ namespace mamba
 
     void MRepo::add_package_info(Repodata* data, const PackageInfo& info)
     {
+        // TODO missing track_feature
         LOG_INFO << "Adding package record to repo " << info.name;
         Pool* pool = m_repo->pool;
 
@@ -217,7 +218,7 @@ namespace mamba
         s->provides = repo_addid_dep(
             m_repo,
             s->provides,
-            pool_rel2id(pool, s->name, s->evr, REL_EQ, 1),
+            pool_rel2id(pool, s->name, s->evr, REL_EQ, /* create= */ 1),
             0
         );
 

--- a/libmamba/src/solv-cpp/ids.hpp
+++ b/libmamba/src/solv-cpp/ids.hpp
@@ -17,6 +17,7 @@ namespace mamba::solv
     using SolvableId = ::Id;
 
     using RelationFlag = int;
+    using DistType = int;
 }
 
 #endif

--- a/libmamba/src/solv-cpp/ids.hpp
+++ b/libmamba/src/solv-cpp/ids.hpp
@@ -1,0 +1,22 @@
+// Copyright (c) 2023, QuantStack and Mamba Contributors
+//
+// Distributed under the terms of the BSD 3-Clause License.
+//
+// The full license is in the file LICENSE, distributed with this software.
+
+#ifndef MAMBA_SOLV_IDS_HPP
+#define MAMBA_SOLV_IDS_HPP
+
+#include <solv/pooltypes.h>
+
+namespace mamba::solv
+{
+    using StringId = ::Id;
+    using DependencyId = ::Id;
+    using RepoId = ::Id;
+    using SolvableId = ::Id;
+
+    using RelationFlag = int;
+}
+
+#endif

--- a/libmamba/src/solv-cpp/pool.cpp
+++ b/libmamba/src/solv-cpp/pool.cpp
@@ -242,18 +242,18 @@ namespace mamba::solv
 
     auto ObjPool::get_solvable(SolvableId id) const -> std::optional<ObjSolvableViewConst>
     {
-        if (const ::Solvable* s = ::pool_id2solvable(raw(), id); s != nullptr)
+        if (const ::Solvable* s = ::pool_id2solvable(raw(), id))
         {
-            return ObjSolvableViewConst{ s };
+            return ObjSolvableViewConst{ *s };
         }
         return std::nullopt;
     }
 
     auto ObjPool::get_solvable(SolvableId id) -> std::optional<ObjSolvableView>
     {
-        if (::Solvable* s = ::pool_id2solvable(raw(), id); s != nullptr)
+        if (::Solvable* s = ::pool_id2solvable(raw(), id))
         {
-            return ObjSolvableView{ s };
+            return ObjSolvableView{ *s };
         }
         return std::nullopt;
     }

--- a/libmamba/src/solv-cpp/pool.cpp
+++ b/libmamba/src/solv-cpp/pool.cpp
@@ -198,13 +198,21 @@ namespace mamba::solv
         return false;
     }
 
-    auto ObjPool::get_solvable(SolvableId id) const -> ObjSolvableViewConst
+    auto ObjPool::get_solvable(SolvableId id) const -> std::optional<ObjSolvableViewConst>
     {
-        return ObjSolvableViewConst{ ::pool_id2solvable(raw(), id) };
+        if (const ::Solvable* s = ::pool_id2solvable(raw(), id); s != nullptr)
+        {
+            return ObjSolvableViewConst{ s };
+        }
+        return std::nullopt;
     }
 
-    auto ObjPool::get_solvable(SolvableId id) -> ObjSolvableView
+    auto ObjPool::get_solvable(SolvableId id) -> std::optional<ObjSolvableView>
     {
-        return ObjSolvableView{ ::pool_id2solvable(raw(), id) };
+        if (::Solvable* s = ::pool_id2solvable(raw(), id); s != nullptr)
+        {
+            return ObjSolvableView{ s };
+        }
+        return std::nullopt;
     }
 }

--- a/libmamba/src/solv-cpp/pool.cpp
+++ b/libmamba/src/solv-cpp/pool.cpp
@@ -1,0 +1,147 @@
+// Copyright (c) 2023, QuantStack and Mamba Contributors
+//
+// Distributed under the terms of the BSD 3-Clause License.
+//
+// The full license is in the file LICENSE, distributed with this software.
+
+#include "solv-cpp/pool.hpp"
+
+#include <cassert>
+#include <limits>
+
+#include <solv/pool.h>
+#include <solv/poolid.h>
+#include <solv/pooltypes.h>
+#include <solv/selection.h>
+
+namespace mamba::solv
+{
+    void ObjPool::PoolDeleter::operator()(::Pool* ptr)
+    {
+        ::pool_free(ptr);
+    }
+
+    ObjPool::ObjPool()
+        : m_pool(::pool_create())
+    {
+    }
+
+    ObjPool::~ObjPool() = default;
+
+    auto ObjPool::raw() -> ::Pool*
+    {
+        return m_pool.get();
+    }
+
+    auto ObjPool::raw() const -> const ::Pool*
+    {
+        return m_pool.get();
+    }
+
+    auto ObjPool::find_string(std::string_view str) const -> std::optional<StringId>
+    {
+        assert(str.size() <= std::numeric_limits<unsigned int>::max());
+        ::Id const id = pool_strn2id(
+            const_cast<::Pool*>(raw()),  // Safe because we do not create
+            str.data(),
+            static_cast<unsigned int>(str.size()),
+            /* .create= */ 0
+        );
+        return (id == 0) ? std::nullopt : std::optional(id);
+    }
+
+    auto ObjPool::add_string(std::string_view str) -> StringId
+    {
+        assert(str.size() <= std::numeric_limits<unsigned int>::max());
+        // Note: libsolv cannot report failure to allocate
+        ::Id const id = pool_strn2id(
+            raw(),
+            str.data(),
+            static_cast<unsigned int>(str.size()),
+            /* .create= */ 1
+        );
+        assert(id != 0);
+        return id;
+    }
+
+    auto ObjPool::get_string(StringId id) const -> std::string_view
+    {
+        assert(!ISRELDEP(id));
+        return pool_id2str(raw(), id);
+    }
+
+    auto ObjPool::find_dependency(StringId name_id, RelationFlag flag, StringId version_id) const
+        -> std::optional<DependencyId>
+    {
+        ::Id const id = pool_rel2id(
+            const_cast<::Pool*>(raw()),  // Safe because we do not create
+            name_id,
+            version_id,
+            flag,
+            /* .create= */ 0
+        );
+        return (id == 0) ? std::nullopt : std::optional(DependencyId{ id });
+    }
+
+    auto ObjPool::add_dependency(StringId name_id, RelationFlag flag, StringId version_id)
+        -> DependencyId
+    {
+        // Note: libsolv cannot report failure to allocate
+        ::Id const id = pool_rel2id(
+            raw(),
+            name_id,
+            version_id,
+            flag,
+            /* .create= */ 1
+        );
+        assert(id != 0);
+        assert(ISRELDEP(id));
+        return id;
+    }
+
+    auto ObjPool::get_dependency_name(DependencyId id) const -> std::string_view
+    {
+        assert(ISRELDEP(id));
+        return pool_id2str(raw(), id);
+    }
+
+    auto ObjPool::get_dependency_version(DependencyId id) const -> std::string_view
+    {
+        assert(ISRELDEP(id));
+        return pool_id2evr(raw(), id);
+    }
+
+    auto ObjPool::get_dependency_relation(DependencyId id) const -> std::string_view
+    {
+        assert(ISRELDEP(id));
+        return pool_id2rel(raw(), id);
+    }
+
+    auto ObjPool::dependency_to_string(DependencyId id) const -> std::string
+    {
+        assert(ISRELDEP(id));
+        return pool_dep2str(
+            // Not const in because function may allocate in pool tmp alloc space
+            const_cast<::Pool*>(raw()),
+            id
+        );
+    }
+
+    auto ObjPool::select_solvables(const ObjQueue& job) const -> ObjQueue
+    {
+        ObjQueue solvables = {};
+        ::selection_solvables(
+            // Not const in because function may allocate in pool tmp alloc space
+            const_cast<::Pool*>(raw()),
+            // Queue selection param is not modified
+            const_cast<::Queue*>(job.raw()),
+            solvables.raw()
+        );
+        return solvables;
+    }
+
+    void ObjPool::create_whatprovides()
+    {
+        pool_createwhatprovides(raw());
+    }
+}

--- a/libmamba/src/solv-cpp/pool.cpp
+++ b/libmamba/src/solv-cpp/pool.cpp
@@ -209,6 +209,31 @@ namespace mamba::solv
         return false;
     }
 
+    auto ObjPool::installed_repo() const -> std::optional<ObjRepoViewConst>
+    {
+        if (const auto* const installed_ptr = raw()->installed; installed_ptr != nullptr)
+        {
+            return ObjRepoViewConst(installed_ptr);
+        }
+        return std::nullopt;
+    }
+
+    auto ObjPool::installed_repo() -> std::optional<ObjRepoView>
+    {
+        if (auto* const installed_ptr = raw()->installed; installed_ptr != nullptr)
+        {
+            return ObjRepoView(installed_ptr);
+        }
+        return std::nullopt;
+    }
+
+    void ObjPool::set_installed_repo(RepoId id)
+    {
+        const auto must_repo = get_repo(id);
+        assert(must_repo.has_value());
+        pool_set_installed(raw(), must_repo->raw());
+    }
+
     auto ObjPool::get_solvable(SolvableId id) const -> std::optional<ObjSolvableViewConst>
     {
         if (const ::Solvable* s = ::pool_id2solvable(raw(), id); s != nullptr)

--- a/libmamba/src/solv-cpp/pool.cpp
+++ b/libmamba/src/solv-cpp/pool.cpp
@@ -54,7 +54,7 @@ namespace mamba::solv
     auto ObjPool::find_string(std::string_view str) const -> std::optional<StringId>
     {
         assert(str.size() <= std::numeric_limits<unsigned int>::max());
-        ::Id const id = ::pool_strn2id(
+        const ::Id id = ::pool_strn2id(
             const_cast<::Pool*>(raw()),  // Safe because we do not create
             str.data(),
             static_cast<unsigned int>(str.size()),
@@ -67,7 +67,7 @@ namespace mamba::solv
     {
         assert(str.size() <= std::numeric_limits<unsigned int>::max());
         // Note: libsolv cannot report failure to allocate
-        ::Id const id = ::pool_strn2id(
+        const ::Id id = ::pool_strn2id(
             raw(),
             str.data(),
             static_cast<unsigned int>(str.size()),
@@ -86,7 +86,7 @@ namespace mamba::solv
     auto ObjPool::find_dependency(StringId name_id, RelationFlag flag, StringId version_id) const
         -> std::optional<DependencyId>
     {
-        ::Id const id = ::pool_rel2id(
+        const ::Id id = ::pool_rel2id(
             const_cast<::Pool*>(raw()),  // Safe because we do not create
             name_id,
             version_id,
@@ -100,7 +100,7 @@ namespace mamba::solv
         -> DependencyId
     {
         // Note: libsolv cannot report failure to allocate
-        ::Id const id = ::pool_rel2id(
+        const ::Id id = ::pool_rel2id(
             raw(),
             name_id,
             version_id,
@@ -193,7 +193,7 @@ namespace mamba::solv
         return { ObjRepoViewConst{ ::pool_id2repo(const_cast<::Pool*>(raw()), id) } };
     }
 
-    auto ObjPool::n_repos() const -> std::size_t
+    auto ObjPool::repo_count() const -> std::size_t
     {
         // Id 0 is special
         assert(raw()->urepos >= 0);

--- a/libmamba/src/solv-cpp/pool.cpp
+++ b/libmamba/src/solv-cpp/pool.cpp
@@ -39,6 +39,17 @@ namespace mamba::solv
         return m_pool.get();
     }
 
+
+    auto ObjPool::disttype() const -> DistType
+    {
+        return raw()->disttype;
+    }
+
+    void ObjPool::set_disttype(DistType dt)
+    {
+        pool_setdisttype(raw(), dt);
+    }
+
     auto ObjPool::find_string(std::string_view str) const -> std::optional<StringId>
     {
         assert(str.size() <= std::numeric_limits<unsigned int>::max());

--- a/libmamba/src/solv-cpp/pool.cpp
+++ b/libmamba/src/solv-cpp/pool.cpp
@@ -166,7 +166,8 @@ namespace mamba::solv
         );
         // No function exists to create a repo id
         assert(raw()->repos[raw()->nrepos - 1] == repo_ptr);
-        return { raw()->nrepos - 1, ObjRepoView{ repo_ptr } };
+        assert(repo_ptr != nullptr);
+        return { raw()->nrepos - 1, ObjRepoView{ *repo_ptr } };
     }
 
     auto ObjPool::has_repo(RepoId id) const -> bool
@@ -180,7 +181,9 @@ namespace mamba::solv
         {
             return std::nullopt;
         }
-        return { ObjRepoView{ ::pool_id2repo(raw(), id) } };
+        auto* repo_ptr = ::pool_id2repo(raw(), id);
+        assert(repo_ptr != nullptr);
+        return { ObjRepoView{ *repo_ptr } };
     }
 
     auto ObjPool::get_repo(RepoId id) const -> std::optional<ObjRepoViewConst>
@@ -189,8 +192,10 @@ namespace mamba::solv
         {
             return std::nullopt;
         }
-        // Safe because we make the Repo deep const
-        return { ObjRepoViewConst{ ::pool_id2repo(const_cast<::Pool*>(raw()), id) } };
+        // Safe const_cast because we make the Repo deep const
+        const auto* repo_ptr = ::pool_id2repo(const_cast<::Pool*>(raw()), id);
+        assert(repo_ptr != nullptr);
+        return { ObjRepoViewConst{ *repo_ptr } };
     }
 
     auto ObjPool::repo_count() const -> std::size_t
@@ -212,18 +217,18 @@ namespace mamba::solv
 
     auto ObjPool::installed_repo() const -> std::optional<ObjRepoViewConst>
     {
-        if (const auto* const installed_ptr = raw()->installed; installed_ptr != nullptr)
+        if (const auto* const installed_ptr = raw()->installed)
         {
-            return ObjRepoViewConst(installed_ptr);
+            return ObjRepoViewConst{ *installed_ptr };
         }
         return std::nullopt;
     }
 
     auto ObjPool::installed_repo() -> std::optional<ObjRepoView>
     {
-        if (auto* const installed_ptr = raw()->installed; installed_ptr != nullptr)
+        if (auto* const installed_ptr = raw()->installed)
         {
-            return ObjRepoView(installed_ptr);
+            return ObjRepoView{ *installed_ptr };
         }
         return std::nullopt;
     }

--- a/libmamba/src/solv-cpp/pool.cpp
+++ b/libmamba/src/solv-cpp/pool.cpp
@@ -23,7 +23,8 @@ namespace mamba::solv
     }
 
     ObjPool::ObjPool()
-        : m_pool(::pool_create())
+        : m_user_debug_callback(nullptr, [](void* /*ptr*/) {})
+        , m_pool(::pool_create())
     {
     }
 

--- a/libmamba/src/solv-cpp/pool.hpp
+++ b/libmamba/src/solv-cpp/pool.hpp
@@ -11,6 +11,7 @@
 #include <optional>
 #include <string>
 #include <string_view>
+#include <utility>
 
 #include "solv-cpp/ids.hpp"
 #include "solv-cpp/queue.hpp"
@@ -58,11 +59,12 @@ namespace mamba::solv
 
         auto select_solvables(const ObjQueue& job) const -> ObjQueue;
 
-        auto add_repo(std::string_view name) -> RepoId;
-        auto get_repo(RepoId id) -> ObjRepoView;
-        auto get_repo(RepoId id) const -> ObjRepoViewConst;
+        auto add_repo(std::string_view name) -> std::pair<RepoId, ObjRepoView>;
+        auto has_repo(RepoId id) const -> bool;
+        auto get_repo(RepoId id) -> std::optional<ObjRepoView>;
+        auto get_repo(RepoId id) const -> std::optional<ObjRepoViewConst>;
         auto n_repos() const -> std::size_t;
-        void remove_repo(RepoId id, bool reuse_ids);
+        auto remove_repo(RepoId id, bool reuse_ids) -> bool;
         template <typename UnaryFunc>
         void for_each_repo_id(UnaryFunc func) const;
         template <typename UnaryFunc>

--- a/libmamba/src/solv-cpp/pool.hpp
+++ b/libmamba/src/solv-cpp/pool.hpp
@@ -74,6 +74,9 @@ namespace mamba::solv
         void for_each_repo(UnaryFunc func);
         template <typename UnaryFunc>
         void for_each_repo(UnaryFunc func) const;
+        auto installed_repo() const -> std::optional<ObjRepoViewConst>;
+        auto installed_repo() -> std::optional<ObjRepoView>;
+        void set_installed_repo(RepoId id);
 
         auto get_solvable(SolvableId id) const -> std::optional<ObjSolvableViewConst>;
         auto get_solvable(SolvableId id) -> std::optional<ObjSolvableView>;

--- a/libmamba/src/solv-cpp/pool.hpp
+++ b/libmamba/src/solv-cpp/pool.hpp
@@ -1,0 +1,63 @@
+// Copyright (c) 2023, QuantStack and Mamba Contributors
+//
+// Distributed under the terms of the BSD 3-Clause License.
+//
+// The full license is in the file LICENSE, distributed with this software.
+
+#ifndef MAMBA_SOLV_POOL_HPP
+#define MAMBA_SOLV_POOL_HPP
+
+#include <memory>
+#include <optional>
+#include <string>
+#include <string_view>
+
+#include "solv-cpp/ids.hpp"
+#include "solv-cpp/queue.hpp"
+
+namespace mamba::solv
+{
+    /**
+     * Pool of solvable involved in resolving en environment.
+     *
+     * The pool contains the solvable (packages) information required from the ``::Solver``.
+     * The pool can be reused by multiple solvers to solve differents requirements with the same
+     * ecosystem.
+     */
+    class ObjPool
+    {
+    public:
+
+        ObjPool();
+        ~ObjPool();
+
+        auto raw() -> ::Pool*;
+        auto raw() const -> const ::Pool*;
+
+        auto find_string(std::string_view str) const -> std::optional<StringId>;
+        auto add_string(std::string_view str) -> StringId;
+        auto get_string(StringId id) const -> std::string_view;
+
+        auto find_dependency(StringId name_id, RelationFlag flag, StringId version_id) const
+            -> std::optional<DependencyId>;
+        auto add_dependency(StringId name_id, RelationFlag flag, StringId version_id) -> DependencyId;
+        auto get_dependency_name(DependencyId id) const -> std::string_view;
+        auto get_dependency_version(DependencyId id) const -> std::string_view;
+        auto get_dependency_relation(DependencyId id) const -> std::string_view;
+        auto dependency_to_string(DependencyId id) const -> std::string;
+
+        void create_whatprovides();
+
+        auto select_solvables(const ObjQueue& job) const -> ObjQueue;
+
+    private:
+
+        struct PoolDeleter
+        {
+            void operator()(::Pool* ptr);
+        };
+
+        std::unique_ptr<::Pool, ObjPool::PoolDeleter> m_pool;
+    };
+}
+#endif

--- a/libmamba/src/solv-cpp/pool.hpp
+++ b/libmamba/src/solv-cpp/pool.hpp
@@ -39,56 +39,196 @@ namespace mamba::solv
         auto raw() -> ::Pool*;
         auto raw() const -> const ::Pool*;
 
+        /**
+         * Get the current distribution type of the pool.
+         *
+         * @see ObjPool::set_disttype
+         */
         auto disttype() const -> DistType;
+
+        /**
+         * Set the distribution type of the pool.
+         *
+         * The distribution type has subtle implications.
+         * For instance the distribution must be of type conda for ``track_feature``,
+         * ``constrains`` and ``build_number`` to be taken into account.
+         */
         void set_disttype(DistType dt);
 
+        /**
+         * Find a string id in the pool if it exists.
+         *
+         * @see ObjPool::add_string
+         */
         auto find_string(std::string_view str) const -> std::optional<StringId>;
+
+        /**
+         * Add a string to the pool.
+         *
+         * The pool hold a set of strings, indexed with an id, to avoid duplicating entries.
+         * It is safe to call this function regardless of whether the string was already added.
+         */
         auto add_string(std::string_view str) -> StringId;
+
+        /**
+         * Get the string associated with an id.
+         *
+         * @see ObjPool::add_string
+         */
         auto get_string(StringId id) const -> std::string_view;
 
+        /**
+         * Find a dependency in the pool, if it exists.
+         *
+         * @see ObjPool::add_dependency
+         */
         auto find_dependency(StringId name_id, RelationFlag flag, StringId version_id) const
             -> std::optional<DependencyId>;
+
+        /**
+         * Add a dependency in the pool.
+         *
+         * A dependency represents a set of packages.
+         * The flag can be used to create complex dependencies. In that case, for instance with
+         * the "or" operator, the name and version ids are (ab)used with other dependency ids.
+         * Handling of complex dependencies in libsolv is quite complex and not used in mamba.
+         */
         auto add_dependency(StringId name_id, RelationFlag flag, StringId version_id) -> DependencyId;
+
+        /** Get the registered name of a dependency. */
         auto get_dependency_name(DependencyId id) const -> std::string_view;
+
+        /** Get the registered version of a dependency. */
         auto get_dependency_version(DependencyId id) const -> std::string_view;
+
+        /** Get the registered realtion between a dependency name and version. */
         auto get_dependency_relation(DependencyId id) const -> std::string_view;
+
+        /** Compute the string representation of a dependency. */
         auto dependency_to_string(DependencyId id) const -> std::string;
 
+        /**
+         * Create an indexed lookup of dependencies.
+         *
+         * Create an index to retrieve the list of solvables satisfying a given dependency.
+         * This is an expensive operation.
+         * The index is also computed over regular ``StringId``, in which case they reprensent
+         * all packages that provide that name (without restriction on version).
+         */
         void create_whatprovides();
         template <typename UnaryFunc>
+
+        /**
+         * Execute function for each solvable id that provides the given dependency.
+         *
+         * @pre ObjPool::create_whatprovides must have been called before.
+         */
         void for_each_whatprovides_id(DependencyId dep, UnaryFunc&& func) const;
         template <typename UnaryFunc>
+
+        /**
+         * Execute function for each solvable that provides the given dependency.
+         *
+         * @pre ObjPool::create_whatprovides must have been called before.
+         */
         void for_each_whatprovides(DependencyId dep, UnaryFunc&& func) const;
         template <typename UnaryFunc>
         void for_each_whatprovides(DependencyId dep, UnaryFunc&& func);
 
+        /**
+         * General purpose query of solvables with given attributes.
+         *
+         * @return A Queue of SolvableId
+         */
         auto select_solvables(const ObjQueue& job) const -> ObjQueue;
 
+        /**
+         * Add a repository with a given name.
+         *
+         * Solvable belong to a repository, although they are stored in the pool.
+         */
         auto add_repo(std::string_view name) -> std::pair<RepoId, ObjRepoView>;
+
+        /** Check if a given repoitory id exists. */
         auto has_repo(RepoId id) const -> bool;
+
+        /** Get the repository associated with the given id, if it exists. */
         auto get_repo(RepoId id) -> std::optional<ObjRepoView>;
+
+        /** Get the repository associated with the given id, if it exists. */
         auto get_repo(RepoId id) const -> std::optional<ObjRepoViewConst>;
+
+        /** Return the number of repository in the pool. */
         auto repo_count() const -> std::size_t;
+
+        /**
+         * Remove a repository.
+         *
+         * Repo ids are not invalidated.
+         * If @p reuse_ids is true, the solvable ids used in the pool can be reused for future
+         * solvables.
+         */
         auto remove_repo(RepoId id, bool reuse_ids) -> bool;
+
+        /** Execute function for each repository id in the pool. */
         template <typename UnaryFunc>
         void for_each_repo_id(UnaryFunc&& func) const;
+
+        /** Execute function for each repository in the pool. */
         template <typename UnaryFunc>
         void for_each_repo(UnaryFunc&& func);
+
+        /** Execute function for each repository in the pool. */
         template <typename UnaryFunc>
         void for_each_repo(UnaryFunc&& func) const;
+
+        /**
+         * Get the repository of installed packages, if it exists.
+         *
+         * @see ObjPool::set_installed_repository
+         */
         auto installed_repo() const -> std::optional<ObjRepoViewConst>;
+
+        /**
+         * Get the repository of installed packages, if it exists.
+         *
+         * @see ObjPool::set_installed_repository
+         */
         auto installed_repo() -> std::optional<ObjRepoView>;
+
+        /**
+         * Set the installed repository.
+         *
+         * The installed repository represents package already installed.
+         * For instance, it is used to filter out the solvable that are alrady available after
+         * a solve.
+         */
         void set_installed_repo(RepoId id);
 
+        /** Get a solvable from its id, if it exisists and regardless of its repository. */
         auto get_solvable(SolvableId id) const -> std::optional<ObjSolvableViewConst>;
+
+        /** Get a solvable from its id, if it exisists and regardless of its repository. */
         auto get_solvable(SolvableId id) -> std::optional<ObjSolvableView>;
+
+        /** Execute function for each solvable id in the pool (in all repositories). */
         template <typename UnaryFunc>
         void for_each_solvable_id(UnaryFunc&& func) const;
+
+        /** Execute function for each solvable in the pool (in all repositories). */
         template <typename UnaryFunc>
         void for_each_solvable(UnaryFunc&& func) const;
+
+        /** Execute function for each solvable in the pool (in all repositories). */
         template <typename UnaryFunc>
         void for_each_solvable(UnaryFunc&& func);
 
+        /** Set the callback to handle libsolv messages.
+         *
+         * The callback takes a ``Pool*``, the type of message as ``int``, and the message
+         * as a ``std::string_view``.
+         * The callback must be marked ``noexcept``.
+         */
         template <typename Func>
         void set_debug_callback(Func&& callback);
 

--- a/libmamba/src/solv-cpp/pool.hpp
+++ b/libmamba/src/solv-cpp/pool.hpp
@@ -37,6 +37,9 @@ namespace mamba::solv
         auto raw() -> ::Pool*;
         auto raw() const -> const ::Pool*;
 
+        auto disttype() const -> DistType;
+        void set_disttype(DistType dt);
+
         auto find_string(std::string_view str) const -> std::optional<StringId>;
         auto add_string(std::string_view str) -> StringId;
         auto get_string(StringId id) const -> std::string_view;

--- a/libmamba/src/solv-cpp/pool.hpp
+++ b/libmamba/src/solv-cpp/pool.hpp
@@ -116,13 +116,15 @@ namespace mamba::solv
     template <typename UnaryFunc>
     void ObjPool::for_each_repo(UnaryFunc func) const
     {
-        return for_each_repo_id([this, func](RepoId id) { func(get_repo(id)); });
+        // Safe optional unchecked because we iterate over available values
+        return for_each_repo_id([this, func](RepoId id) { func(get_repo(id).value()); });
     }
 
     template <typename UnaryFunc>
     void ObjPool::for_each_repo(UnaryFunc func)
     {
-        return for_each_repo_id([this, func](RepoId id) { func(get_repo(id)); });
+        // Safe optional unchecked because we iterate over available values
+        return for_each_repo_id([this, func](RepoId id) { func(get_repo(id).value()); });
     }
 
     template <typename UnaryFunc>

--- a/libmamba/src/solv-cpp/pool.hpp
+++ b/libmamba/src/solv-cpp/pool.hpp
@@ -107,6 +107,8 @@ namespace mamba::solv
  *  Implementation of ObjPool  *
  *******************************/
 
+#include <stdexcept>
+
 #include <solv/pool.h>
 
 namespace mamba::solv
@@ -141,6 +143,10 @@ namespace mamba::solv
     template <typename UnaryFunc>
     void ObjPool::for_each_whatprovides_id(DependencyId dep, UnaryFunc func) const
     {
+        if (raw()->whatprovides == nullptr)
+        {
+            throw std::runtime_error("Whatprovides index is not created");
+        }
         auto* const pool = const_cast<::Pool*>(raw());
         SolvableId id = 0;
         ::Id offset = 0;  // Not really an Id

--- a/libmamba/src/solv-cpp/pool.hpp
+++ b/libmamba/src/solv-cpp/pool.hpp
@@ -72,8 +72,8 @@ namespace mamba::solv
         template <typename UnaryFunc>
         void for_each_repo(UnaryFunc func) const;
 
-        auto get_solvable(SolvableId id) const -> ObjSolvableViewConst;
-        auto get_solvable(SolvableId id) -> ObjSolvableView;
+        auto get_solvable(SolvableId id) const -> std::optional<ObjSolvableViewConst>;
+        auto get_solvable(SolvableId id) -> std::optional<ObjSolvableView>;
         template <typename UnaryFunc>
         void for_each_solvable_id(UnaryFunc func) const;
         template <typename UnaryFunc>
@@ -142,13 +142,21 @@ namespace mamba::solv
     template <typename UnaryFunc>
     void ObjPool::for_each_whatprovides(DependencyId dep, UnaryFunc func) const
     {
-        return for_each_whatprovides_id(dep, [this, func](SolvableId id) { func(get_solvable(id)); });
+        // Safe optional unchecked because we iterate over available values
+        return for_each_whatprovides_id(
+            dep,
+            [this, func](SolvableId id) { func(get_solvable(id)).value(); }
+        );
     }
 
     template <typename UnaryFunc>
     void ObjPool::for_each_whatprovides(DependencyId dep, UnaryFunc func)
     {
-        return for_each_whatprovides_id(dep, [this, func](SolvableId id) { func(get_solvable(id)); });
+        // Safe optional unchecked because we iterate over available values
+        return for_each_whatprovides_id(
+            dep,
+            [this, func](SolvableId id) { func(get_solvable(id).value()); }
+        );
     }
 
     template <typename UnaryFunc>
@@ -165,13 +173,15 @@ namespace mamba::solv
     template <typename UnaryFunc>
     void ObjPool::for_each_solvable(UnaryFunc func) const
     {
-        return for_each_solvable_id([this, func](SolvableId id) { func(get_solvable(id)); });
+        // Safe optional unchecked because we iterate over available values
+        return for_each_solvable_id([this, func](SolvableId id) { func(get_solvable(id).value()); });
     }
 
     template <typename UnaryFunc>
     void ObjPool::for_each_solvable(UnaryFunc func)
     {
-        return for_each_solvable_id([this, func](SolvableId id) { func(get_solvable(id)); });
+        // Safe optional unchecked because we iterate over available values
+        return for_each_solvable_id([this, func](SolvableId id) { func(get_solvable(id).value()); });
     }
 }
 #endif

--- a/libmamba/src/solv-cpp/pool.hpp
+++ b/libmamba/src/solv-cpp/pool.hpp
@@ -14,6 +14,7 @@
 
 #include "solv-cpp/ids.hpp"
 #include "solv-cpp/queue.hpp"
+#include "solv-cpp/repo.hpp"
 
 namespace mamba::solv
 {
@@ -49,6 +50,11 @@ namespace mamba::solv
         void create_whatprovides();
 
         auto select_solvables(const ObjQueue& job) const -> ObjQueue;
+
+        auto add_repo(std::string_view name) -> RepoId;
+        auto get_repo(RepoId id) -> ObjRepoView;
+        auto get_repo(RepoId id) const -> ObjRepoViewConst;
+        void remove_repo(RepoId id, bool reuse_ids);
 
     private:
 

--- a/libmamba/src/solv-cpp/pool.hpp
+++ b/libmamba/src/solv-cpp/pool.hpp
@@ -205,6 +205,9 @@ namespace mamba::solv
          */
         void set_installed_repo(RepoId id);
 
+        /** Get the number of solvable in the pool, all repo combined. */
+        auto solvable_count() const -> std::size_t;
+
         /** Get a solvable from its id, if it exisists and regardless of its repository. */
         auto get_solvable(SolvableId id) const -> std::optional<ObjSolvableViewConst>;
 

--- a/libmamba/src/solv-cpp/queue.cpp
+++ b/libmamba/src/solv-cpp/queue.cpp
@@ -5,6 +5,7 @@
 // The full license is in the file LICENSE, distributed with this software.
 
 
+#include <algorithm>
 #include <cassert>
 #include <exception>
 #include <limits>
@@ -64,16 +65,6 @@ namespace mamba::solv
         auto other_copy = ObjQueue(other);
         swap(*this, other_copy);
         return *this;
-    }
-
-    auto ObjQueue::operator==(const ObjQueue& other) const -> bool
-    {
-        return std::equal(cbegin(), cend(), other.cbegin(), other.cend());
-    }
-
-    auto ObjQueue::operator!=(const ObjQueue& other) const -> bool
-    {
-        return !(*this == other);
     }
 
     void ObjQueue::push_back(value_type id)
@@ -294,5 +285,16 @@ namespace mamba::solv
         using std::swap;
         swap(a.m_queue, b.m_queue);
     }
+
+    auto operator==(const ObjQueue& a, const ObjQueue& b) -> bool
+    {
+        return std::equal(a.cbegin(), a.cend(), b.cbegin(), b.cend());
+    }
+
+    auto operator!=(const ObjQueue& a, const ObjQueue& b) -> bool
+    {
+        return !(a == b);
+    }
+
 
 }  // namespace mamba

--- a/libmamba/src/solv-cpp/queue.cpp
+++ b/libmamba/src/solv-cpp/queue.cpp
@@ -66,6 +66,16 @@ namespace mamba::solv
         return *this;
     }
 
+    auto ObjQueue::operator==(const ObjQueue& other) const -> bool
+    {
+        return std::equal(cbegin(), cend(), other.cbegin(), other.cend());
+    }
+
+    auto ObjQueue::operator!=(const ObjQueue& other) const -> bool
+    {
+        return !(*this == other);
+    }
+
     void ObjQueue::push_back(value_type id)
     {
         queue_push(raw(), id);

--- a/libmamba/src/solv-cpp/queue.hpp
+++ b/libmamba/src/solv-cpp/queue.hpp
@@ -48,6 +48,9 @@ namespace mamba::solv
         auto operator=(ObjQueue&& other) -> ObjQueue&;
         auto operator=(const ObjQueue& other) -> ObjQueue&;
 
+        auto operator==(const ObjQueue& other) const -> bool;
+        auto operator!=(const ObjQueue& other) const -> bool;
+
         auto size() const -> size_type;
         auto capacity() const -> size_type;
         auto empty() const -> bool;

--- a/libmamba/src/solv-cpp/queue.hpp
+++ b/libmamba/src/solv-cpp/queue.hpp
@@ -48,9 +48,6 @@ namespace mamba::solv
         auto operator=(ObjQueue&& other) -> ObjQueue&;
         auto operator=(const ObjQueue& other) -> ObjQueue&;
 
-        auto operator==(const ObjQueue& other) const -> bool;
-        auto operator!=(const ObjQueue& other) const -> bool;
-
         auto size() const -> size_type;
         auto capacity() const -> size_type;
         auto empty() const -> bool;
@@ -107,6 +104,9 @@ namespace mamba::solv
     };
 
     void swap(ObjQueue& a, ObjQueue& b) noexcept;
+
+    auto operator==(const ObjQueue& a, const ObjQueue& b) -> bool;
+    auto operator!=(const ObjQueue& a, const ObjQueue& b) -> bool;
 
     /********************************
      *  Implementation of ObjQueue  *

--- a/libmamba/src/solv-cpp/repo.cpp
+++ b/libmamba/src/solv-cpp/repo.cpp
@@ -10,6 +10,7 @@
 #include <exception>
 #include <sstream>
 
+#include <solv/pool.h>
 #include <solv/repo.h>
 #include <solv/repo_solv.h>
 #include <solv/repo_write.h>
@@ -30,6 +31,23 @@ namespace mamba::solv
     auto ObjRepoViewConst::raw() const -> const ::Repo*
     {
         return m_repo;
+    }
+
+    auto ObjRepoViewConst::id() const -> RepoId
+    {
+        // No function exists to get a repo id
+        const ::Pool* pool = raw()->pool;
+        const ::Repo* repo = nullptr;
+        int repoid = 0;
+        FOR_REPOS(repoid, repo)
+        {
+            if (repo == raw())
+            {
+                return repoid;
+            }
+        }
+        assert(false);
+        return 0;
     }
 
     auto ObjRepoViewConst::n_solvables() const -> std::size_t
@@ -55,7 +73,7 @@ namespace mamba::solv
 
     auto ObjRepoViewConst::get_solvable(SolvableId id) const -> ObjSolvableViewConst
     {
-        return ObjSolvableViewConst{ pool_id2solvable(raw()->pool, id) };
+        return ObjSolvableViewConst{ ::pool_id2solvable(raw()->pool, id) };
     }
 
     void ObjRepoViewConst::write(std::filesystem::path solv_file) const
@@ -65,7 +83,7 @@ namespace mamba::solv
         {
             throw std::system_error(errno, std::generic_category());
         }
-        const auto write_res = repo_write(const_cast<::Repo*>(raw()), fp);
+        const auto write_res = ::repo_write(const_cast<::Repo*>(raw()), fp);
         const auto close_res = std::fclose(fp);
         if (write_res != 0)
         {
@@ -100,7 +118,7 @@ namespace mamba::solv
 
     void ObjRepoView::clear(bool reuse_ids) const
     {
-        repo_empty(raw(), static_cast<int>(reuse_ids));
+        ::repo_empty(raw(), static_cast<int>(reuse_ids));
     }
 
     void ObjRepoView::read(std::filesystem::path solv_file) const
@@ -110,7 +128,7 @@ namespace mamba::solv
         {
             throw std::system_error(errno, std::generic_category());
         }
-        const auto read_res = repo_add_solv(raw(), fp, 0);
+        const auto read_res = ::repo_add_solv(raw(), fp, 0);
         const auto close_res = std::fclose(fp);
         if (read_res != 0)
         {
@@ -130,22 +148,22 @@ namespace mamba::solv
 
     auto ObjRepoView::add_solvable() const -> SolvableId
     {
-        return repo_add_solvable(raw());
+        return ::repo_add_solvable(raw());
     }
 
     auto ObjRepoView::get_solvable(SolvableId id) const -> ObjSolvableView
     {
-        return ObjSolvableView{ pool_id2solvable(raw()->pool, id) };
+        return ObjSolvableView{ ::pool_id2solvable(raw()->pool, id) };
     }
 
     void ObjRepoView::remove_solvable(SolvableId id, bool reuse_id) const
     {
-        repo_free_solvable(raw(), id, reuse_id);
+        ::repo_free_solvable(raw(), id, reuse_id);
     }
 
     void ObjRepoView::internalize()
     {
-        repo_internalize(raw());
+        ::repo_internalize(raw());
     }
 
     /****************************************
@@ -154,7 +172,7 @@ namespace mamba::solv
 
     auto ObjRepoViewConst::name() const -> std::string_view
     {
-        return repo_name(raw());
+        return ::repo_name(raw());
     }
 
     namespace
@@ -175,7 +193,7 @@ namespace mamba::solv
             // solvable representing the repo.
             // The key used does not really matter so we can (ab)use any key that does not have
             // special meaning
-            return ptr_to_strview(repo_lookup_str(const_cast<::Repo*>(repo), SOLVID_META, key));
+            return ptr_to_strview(::repo_lookup_str(const_cast<::Repo*>(repo), SOLVID_META, key));
         }
 
         void repo_set_str(::Repo* repo, ::Id key, const char* str)
@@ -184,7 +202,7 @@ namespace mamba::solv
             // solvable representing the repo.
             // The key used does not really matter so we can (ab)use any key that does not have
             // special meaning
-            repo_set_str(repo, SOLVID_META, key, str);
+            ::repo_set_str(repo, SOLVID_META, key, str);
         }
     }
 

--- a/libmamba/src/solv-cpp/repo.cpp
+++ b/libmamba/src/solv-cpp/repo.cpp
@@ -32,11 +32,6 @@ namespace mamba::solv
         return m_repo;
     }
 
-    auto ObjRepoViewConst::name() const -> std::string_view
-    {
-        return repo_name(raw());
-    }
-
     auto ObjRepoViewConst::n_solvables() const -> std::size_t
     {
         assert(raw()->nsolvables >= 0);
@@ -151,5 +146,90 @@ namespace mamba::solv
     void ObjRepoView::internalize()
     {
         repo_internalize(raw());
+    }
+
+    /****************************************
+     *  Implementation of getter & setters  *
+     ****************************************/
+
+    auto ObjRepoViewConst::name() const -> std::string_view
+    {
+        return repo_name(raw());
+    }
+
+    namespace
+    {
+        auto ptr_to_strview(const char* ptr) -> std::string_view
+        {
+            static constexpr std::string_view null = "<NULL>";
+            if ((ptr == nullptr) || (ptr == null))
+            {
+                return "";
+            }
+            return { ptr };
+        }
+
+        auto repo_lookup_str(const ::Repo* repo, ::Id key) -> std::string_view
+        {
+            // Can only read key/value on solvable, but the special SOLVID_META is used for a fake
+            // solvable representing the repo.
+            // The key used does not really matter so we can (ab)use any key that does not have
+            // special meaning
+            return ptr_to_strview(repo_lookup_str(const_cast<::Repo*>(repo), SOLVID_META, key));
+        }
+
+        void repo_set_str(::Repo* repo, ::Id key, const char* str)
+        {
+            // Can only read key/value on solvable, but the special SOLVID_META is used for a fake
+            // solvable representing the repo.
+            // The key used does not really matter so we can (ab)use any key that does not have
+            // special meaning
+            repo_set_str(repo, SOLVID_META, key, str);
+        }
+    }
+
+    auto ObjRepoViewConst::url() const -> std::string_view
+    {
+        return repo_lookup_str(raw(), SOLVABLE_URL);
+    }
+
+    void ObjRepoView::set_url(raw_str_view str) const
+    {
+        return repo_set_str(raw(), SOLVABLE_URL, str);
+    }
+
+    void ObjRepoView::set_url(const std::string& str) const
+    {
+        return set_url(str.c_str());
+    }
+
+    auto ObjRepoViewConst::channel() const -> std::string_view
+    {
+        return repo_lookup_str(raw(), SOLVABLE_MEDIABASE);
+    }
+
+    void ObjRepoView::set_channel(raw_str_view str) const
+    {
+        return repo_set_str(raw(), SOLVABLE_MEDIABASE, str);
+    }
+
+    void ObjRepoView::set_channel(const std::string& str) const
+    {
+        return set_channel(str.c_str());
+    }
+
+    auto ObjRepoViewConst::subdir() const -> std::string_view
+    {
+        return repo_lookup_str(raw(), SOLVABLE_MEDIADIR);
+    }
+
+    void ObjRepoView::set_subdir(raw_str_view str) const
+    {
+        return repo_set_str(raw(), SOLVABLE_MEDIADIR, str);
+    }
+
+    void ObjRepoView::set_subdir(const std::string& str) const
+    {
+        return set_subdir(str.c_str());
     }
 }

--- a/libmamba/src/solv-cpp/repo.cpp
+++ b/libmamba/src/solv-cpp/repo.cpp
@@ -23,8 +23,8 @@ namespace mamba::solv
      *  Implementation of ConstObjRepoView  *
      ****************************************/
 
-    ObjRepoViewConst::ObjRepoViewConst(const ::Repo* repo) noexcept
-        : m_repo{ repo }
+    ObjRepoViewConst::ObjRepoViewConst(const ::Repo& repo) noexcept
+        : m_repo{ &repo }
     {
     }
 
@@ -124,7 +124,7 @@ namespace mamba::solv
      *  Implementation of ObjRepoView  *
      ***********************************/
 
-    ObjRepoView::ObjRepoView(::Repo* repo) noexcept
+    ObjRepoView::ObjRepoView(::Repo& repo) noexcept
         : ObjRepoViewConst{ repo }
     {
     }

--- a/libmamba/src/solv-cpp/repo.cpp
+++ b/libmamba/src/solv-cpp/repo.cpp
@@ -40,19 +40,7 @@ namespace mamba::solv
 
     auto ObjRepoViewConst::id() const -> RepoId
     {
-        // No function exists to get a repo id
-        const ::Pool* pool = raw()->pool;
-        const ::Repo* repo = nullptr;
-        int repoid = 0;
-        FOR_REPOS(repoid, repo)
-        {
-            if (repo == raw())
-            {
-                return repoid;
-            }
-        }
-        assert(false);
-        return 0;
+        return raw()->repoid;
     }
 
     auto ObjRepoViewConst::solvable_count() const -> std::size_t

--- a/libmamba/src/solv-cpp/repo.cpp
+++ b/libmamba/src/solv-cpp/repo.cpp
@@ -58,6 +58,11 @@ namespace mamba::solv
         return false;
     }
 
+    auto ObjRepoViewConst::get_solvable(SolvableId id) const -> ObjSolvableViewConst
+    {
+        return ObjSolvableViewConst{ pool_id2solvable(raw()->pool, id) };
+    }
+
     void ObjRepoViewConst::write(std::filesystem::path solv_file) const
     {
         auto* fp = std::fopen(solv_file.string().c_str(), "wb");
@@ -131,5 +136,20 @@ namespace mamba::solv
     auto ObjRepoView::add_solvable() const -> SolvableId
     {
         return repo_add_solvable(raw());
+    }
+
+    auto ObjRepoView::get_solvable(SolvableId id) const -> ObjSolvableView
+    {
+        return ObjSolvableView{ pool_id2solvable(raw()->pool, id) };
+    }
+
+    void ObjRepoView::remove_solvable(SolvableId id, bool reuse_id) const
+    {
+        repo_free_solvable(raw(), id, reuse_id);
+    }
+
+    void ObjRepoView::internalize()
+    {
+        repo_internalize(raw());
     }
 }

--- a/libmamba/src/solv-cpp/repo.cpp
+++ b/libmamba/src/solv-cpp/repo.cpp
@@ -74,9 +74,9 @@ namespace mamba::solv
 
     auto ObjRepoViewConst::get_solvable(SolvableId id) const -> std::optional<ObjSolvableViewConst>
     {
-        if (const ::Solvable* s = get_solvable_ptr(raw(), id); s != nullptr)
+        if (const ::Solvable* s = get_solvable_ptr(raw(), id))
         {
-            return { ObjSolvableViewConst{ s } };
+            return { ObjSolvableViewConst{ *s } };
         }
         return std::nullopt;
     }
@@ -169,9 +169,9 @@ namespace mamba::solv
 
     auto ObjRepoView::get_solvable(SolvableId id) const -> std::optional<ObjSolvableView>
     {
-        if (::Solvable* s = get_solvable_ptr(raw(), id); s != nullptr)
+        if (::Solvable* s = get_solvable_ptr(raw(), id))
         {
-            return { ObjSolvableView{ s } };
+            return { ObjSolvableView{ *s } };
         }
         return std::nullopt;
     }

--- a/libmamba/src/solv-cpp/repo.cpp
+++ b/libmamba/src/solv-cpp/repo.cpp
@@ -1,0 +1,135 @@
+// Copyright (c) 2023, QuantStack and Mamba Contributors
+//
+// Distributed under the terms of the BSD 3-Clause License.
+//
+// The full license is in the file LICENSE, distributed with this software.
+
+#include <cassert>
+#include <cerrno>
+#include <cstdio>
+#include <exception>
+#include <sstream>
+
+#include <solv/repo.h>
+#include <solv/repo_solv.h>
+#include <solv/repo_write.h>
+
+#include "solv-cpp/repo.hpp"
+
+namespace mamba::solv
+{
+    /****************************************
+     *  Implementation of ConstObjRepoView  *
+     ****************************************/
+
+    ObjRepoViewConst::ObjRepoViewConst(const ::Repo* repo) noexcept
+        : m_repo{ repo }
+    {
+    }
+
+    auto ObjRepoViewConst::raw() const -> const ::Repo*
+    {
+        return m_repo;
+    }
+
+    auto ObjRepoViewConst::name() const -> std::string_view
+    {
+        return repo_name(raw());
+    }
+
+    auto ObjRepoViewConst::n_solvables() const -> std::size_t
+    {
+        assert(raw()->nsolvables >= 0);
+        return static_cast<std::size_t>(raw()->nsolvables);
+    }
+
+    auto ObjRepoViewConst::contains_solvable(SolvableId id) const -> bool
+    {
+        const ::Repo* const repo = raw();
+        SolvableId other_id = 0;
+        const ::Solvable* s = nullptr;
+        FOR_REPO_SOLVABLES(repo, other_id, s)
+        {
+            if (other_id == id)
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    void ObjRepoViewConst::write(std::filesystem::path solv_file) const
+    {
+        auto* fp = std::fopen(solv_file.string().c_str(), "wb");
+        if (!fp)
+        {
+            throw std::system_error(errno, std::generic_category());
+        }
+        const auto write_res = repo_write(const_cast<::Repo*>(raw()), fp);
+        const auto close_res = std::fclose(fp);
+        if (write_res != 0)
+        {
+            // TODO(C++20) fmt::format
+            auto ss = std::stringstream();
+            ss << "Unable to write repo '" << name() << "' to file";
+            throw std::runtime_error(ss.str());
+        }
+        if (close_res != 0)
+        {
+            // TODO(C++20) fmt::format
+            auto ss = std::stringstream();
+            ss << "Unable to write file '" << solv_file << '\'';
+            throw std::runtime_error(ss.str());
+        }
+    }
+
+    /***********************************
+     *  Implementation of ObjRepoView  *
+     ***********************************/
+
+    ObjRepoView::ObjRepoView(::Repo* repo) noexcept
+        : ObjRepoViewConst{ repo }
+    {
+    }
+
+    auto ObjRepoView::raw() const -> ::Repo*
+    {
+        // Safe because we were passed a ``Repo*`` at construction time.
+        return const_cast<::Repo*>(ObjRepoViewConst::raw());
+    }
+
+    void ObjRepoView::clear(bool reuse_ids) const
+    {
+        repo_empty(raw(), static_cast<int>(reuse_ids));
+    }
+
+    void ObjRepoView::read(std::filesystem::path solv_file) const
+    {
+        auto* fp = std::fopen(solv_file.string().c_str(), "rb");
+        if (!fp)
+        {
+            throw std::system_error(errno, std::generic_category());
+        }
+        const auto read_res = repo_add_solv(raw(), fp, 0);
+        const auto close_res = std::fclose(fp);
+        if (read_res != 0)
+        {
+            // TODO(C++20) fmt::format
+            auto ss = std::stringstream();
+            ss << "Unable to read repo solv file '" << name() << '\'';
+            throw std::runtime_error(ss.str());
+        }
+        if (close_res != 0)
+        {
+            // TODO(C++20) fmt::format
+            auto ss = std::stringstream();
+            ss << "Unable to read from file '" << solv_file << '\'';
+            throw std::runtime_error(ss.str());
+        }
+    }
+
+    auto ObjRepoView::add_solvable() const -> SolvableId
+    {
+        return repo_add_solvable(raw());
+    }
+}

--- a/libmamba/src/solv-cpp/repo.hpp
+++ b/libmamba/src/solv-cpp/repo.hpp
@@ -24,7 +24,7 @@ namespace mamba::solv
     {
     public:
 
-        explicit ObjRepoViewConst(const ::Repo* repo) noexcept;
+        explicit ObjRepoViewConst(const ::Repo& repo) noexcept;
         ~ObjRepoViewConst() noexcept;
 
         auto raw() const -> const ::Repo*;
@@ -92,7 +92,7 @@ namespace mamba::solv
 
         using raw_str_view = const char*;
 
-        explicit ObjRepoView(::Repo* repo) noexcept;
+        explicit ObjRepoView(::Repo& repo) noexcept;
 
         auto raw() const -> ::Repo*;
 

--- a/libmamba/src/solv-cpp/repo.hpp
+++ b/libmamba/src/solv-cpp/repo.hpp
@@ -28,6 +28,10 @@ namespace mamba::solv
         auto raw() const -> const ::Repo*;
 
         auto name() const -> std::string_view;
+        auto url() const -> std::string_view;
+        auto channel() const -> std::string_view;
+        auto subdir() const -> std::string_view;
+
         auto n_solvables() const -> std::size_t;
         auto contains_solvable(SolvableId id) const -> bool;
 
@@ -52,9 +56,19 @@ namespace mamba::solv
     {
     public:
 
+        using raw_str_view = const char*;
+
         explicit ObjRepoView(::Repo* repo) noexcept;
 
         auto raw() const -> ::Repo*;
+
+        /** The following attributes need a call to @ref internalize to be available. */
+        void set_url(raw_str_view str) const;
+        void set_url(const std::string& str) const;
+        void set_channel(raw_str_view str) const;
+        void set_channel(const std::string& str) const;
+        void set_subdir(raw_str_view str) const;
+        void set_subdir(const std::string& str) const;
 
         void clear(bool reuse_ids) const;
 

--- a/libmamba/src/solv-cpp/repo.hpp
+++ b/libmamba/src/solv-cpp/repo.hpp
@@ -206,7 +206,7 @@ namespace mamba::solv
         const ::Solvable* s = nullptr;
         FOR_REPO_SOLVABLES(repo, id, s)
         {
-            func(ObjSolvableViewConst(s));
+            func(ObjSolvableViewConst{ *s });
         }
     }
 
@@ -218,7 +218,7 @@ namespace mamba::solv
         ::Solvable* s = nullptr;
         FOR_REPO_SOLVABLES(repo, id, s)
         {
-            func(ObjSolvableView(s));
+            func(ObjSolvableView{ *s });
         }
     }
 

--- a/libmamba/src/solv-cpp/repo.hpp
+++ b/libmamba/src/solv-cpp/repo.hpp
@@ -46,6 +46,20 @@ namespace mamba::solv
         auto url() const -> std::string_view;
 
         /**
+         * The etag header associated with the url.
+         *
+         * @see ObjRepoView::set_etag
+         */
+        auto etag() const -> std::string_view;
+
+        /**
+         * The mod header associated with the url.
+         *
+         * @see ObjRepoView::set_mod
+         */
+        auto mod() const -> std::string_view;
+
+        /**
          * The channel of the repository.
          *
          * @see ObjRepoView::set_url
@@ -58,6 +72,20 @@ namespace mamba::solv
          * @see ObjRepoView::set_url
          **/
         auto subdir() const -> std::string_view;
+
+        /**
+         * Whether pip was added to Python dependencies and vis versa.
+         *
+         * @see ObjRepoView::set_pip_added
+         */
+        auto pip_added() const -> bool;
+
+        /**
+         * The version used for writing solv files.
+         *
+         * @see ObjRepoView::set_too_version.
+         */
+        auto tool_version() const -> std::string_view;
 
         /** The number of solvables in this repository. */
         auto solvable_count() const -> std::size_t;
@@ -114,6 +142,28 @@ namespace mamba::solv
         void set_url(const std::string& str) const;
 
         /**
+         * Set the etag associated with the url header.
+         *
+         * This has no effect for libsolv and is purely for data storing.
+         *
+         * @note A call to @ref ObjRepoView::internalize is required for this attribute to
+         *       be available for lookup.
+         */
+        void set_etag(raw_str_view str) const;
+        void set_etag(const std::string& str) const;
+
+        /**
+         * Set the mod associated with the url header.
+         *
+         * This has no effect for libsolv and is purely for data storing.
+         *
+         * @note A call to @ref ObjRepoView::internalize is required for this attribute to
+         *       be available for lookup.
+         */
+        void set_mod(raw_str_view str) const;
+        void set_mod(const std::string& str) const;
+
+        /**
          * Set the channel of the repository.
          *
          * This has no effect for libsolv and is purely for data storing.
@@ -135,6 +185,27 @@ namespace mamba::solv
         void set_subdir(raw_str_view str) const;
         void set_subdir(const std::string& str) const;
 
+        /**
+         * Set whether pip was added as a Python dependency and vice versa.
+         *
+         * This has no effect for libsolv and is purely for data storing.
+         *
+         * @note A call to @ref ObjRepoView::internalize is required for this attribute to
+         *       be available for lookup.
+         */
+        void set_pip_added(bool b) const;
+
+        /**
+         * Set the version used for writing solv files.
+         *
+         * This has no effect for libsolv and is purely for data storing.
+         * It is up to the user to make comparsions with this attribute.
+         *
+         * @note A call to @ref ObjRepoView::internalize is required for this attribute to
+         *       be available for lookup.
+         */
+        void set_tool_version(raw_str_view str) const;
+        void set_tool_version(const std::string& str) const;
 
         /**
          * Clear all solvables from the repository.

--- a/libmamba/src/solv-cpp/repo.hpp
+++ b/libmamba/src/solv-cpp/repo.hpp
@@ -15,7 +15,7 @@
 #include "solv-cpp/ids.hpp"
 #include "solv-cpp/solvable.hpp"
 
-typedef struct s_Repo Repo;
+using Repo = struct s_Repo;
 
 namespace mamba::solv
 {
@@ -25,6 +25,7 @@ namespace mamba::solv
     public:
 
         explicit ObjRepoViewConst(const ::Repo* repo) noexcept;
+        ~ObjRepoViewConst() noexcept;
 
         auto raw() const -> const ::Repo*;
 
@@ -35,14 +36,14 @@ namespace mamba::solv
         auto channel() const -> std::string_view;
         auto subdir() const -> std::string_view;
 
-        auto n_solvables() const -> std::size_t;
+        auto solvable_count() const -> std::size_t;
         auto has_solvable(SolvableId id) const -> bool;
         auto get_solvable(SolvableId id) const -> std::optional<ObjSolvableViewConst>;
 
         template <typename UnaryFunc>
-        void for_each_solvable_id(UnaryFunc func) const;
+        void for_each_solvable_id(UnaryFunc&& func) const;
         template <typename UnaryFunc>
-        void for_each_solvable(UnaryFunc func) const;
+        void for_each_solvable(UnaryFunc&& func) const;
 
         /**
          * Write repository information to file.
@@ -88,7 +89,7 @@ namespace mamba::solv
         auto remove_solvable(SolvableId id, bool reuse_id) const -> bool;
 
         template <typename UnaryFunc>
-        void for_each_solvable(UnaryFunc func) const;
+        void for_each_solvable(UnaryFunc&& func) const;
 
         /**
          * Internalize added data.
@@ -110,7 +111,7 @@ namespace mamba::solv
      ****************************************/
 
     template <typename UnaryFunc>
-    void ObjRepoViewConst::for_each_solvable_id(UnaryFunc func) const
+    void ObjRepoViewConst::for_each_solvable_id(UnaryFunc&& func) const
     {
         const ::Repo* const repo = raw();
         SolvableId id = 0;
@@ -122,7 +123,7 @@ namespace mamba::solv
     }
 
     template <typename UnaryFunc>
-    void ObjRepoViewConst::for_each_solvable(UnaryFunc func) const
+    void ObjRepoViewConst::for_each_solvable(UnaryFunc&& func) const
     {
         const ::Repo* const repo = raw();
         SolvableId id = 0;
@@ -134,7 +135,7 @@ namespace mamba::solv
     }
 
     template <typename UnaryFunc>
-    void ObjRepoView::for_each_solvable(UnaryFunc func) const
+    void ObjRepoView::for_each_solvable(UnaryFunc&& func) const
     {
         const ::Repo* const repo = raw();
         SolvableId id = 0;

--- a/libmamba/src/solv-cpp/repo.hpp
+++ b/libmamba/src/solv-cpp/repo.hpp
@@ -1,0 +1,90 @@
+// Copyright (c) 2023, QuantStack and Mamba Contributors
+//
+// Distributed under the terms of the BSD 3-Clause License.
+//
+// The full license is in the file LICENSE, distributed with this software.
+
+#ifndef MAMBA_SOLV_REPO_HPP
+#define MAMBA_SOLV_REPO_HPP
+
+#include <filesystem>
+#include <string_view>
+#include <utility>
+
+#include "solv-cpp/ids.hpp"
+#include "solv-cpp/solvable.hpp"
+
+typedef struct s_Repo Repo;
+
+namespace mamba::solv
+{
+
+    class ObjRepoViewConst
+    {
+    public:
+
+        explicit ObjRepoViewConst(const ::Repo* repo) noexcept;
+
+        auto raw() const -> const ::Repo*;
+
+        auto name() const -> std::string_view;
+        auto n_solvables() const -> std::size_t;
+        auto contains_solvable(SolvableId id) const -> bool;
+
+        template <typename UnaryFunc>
+        void for_each_solvable_id(UnaryFunc func) const;
+
+        /**
+         * Write repository information to file.
+         *
+         * @param solv_file A standard path with system encoding.
+         */
+        void write(std::filesystem::path solv_file) const;
+
+    private:
+
+        const ::Repo* m_repo = nullptr;
+    };
+
+    class ObjRepoView : public ObjRepoViewConst
+    {
+    public:
+
+        explicit ObjRepoView(::Repo* repo) noexcept;
+
+        auto raw() const -> ::Repo*;
+
+        void clear(bool reuse_ids) const;
+
+        /**
+         * Read repository information from file.
+         *
+         * @param solv_file A standard path with system encoding.
+         */
+        void read(std::filesystem::path solv_file) const;
+
+        auto add_solvable() const -> SolvableId;
+    };
+}
+
+#include <solv/repo.h>
+
+namespace mamba::solv
+{
+    /****************************************
+     *  Implementation of ObjRepoViewConst  *
+     ****************************************/
+
+    template <typename UnaryFunc>
+    void ObjRepoViewConst::for_each_solvable_id(UnaryFunc func) const
+    {
+        const ::Repo* const repo = raw();
+        SolvableId id = 0;
+        const ::Solvable* s = nullptr;
+        FOR_REPO_SOLVABLES(repo, id, s)
+        {
+            func(id);
+        }
+    }
+}
+#endif

--- a/libmamba/src/solv-cpp/repo.hpp
+++ b/libmamba/src/solv-cpp/repo.hpp
@@ -27,6 +27,8 @@ namespace mamba::solv
 
         auto raw() const -> const ::Repo*;
 
+        auto id() const -> RepoId;
+
         auto name() const -> std::string_view;
         auto url() const -> std::string_view;
         auto channel() const -> std::string_view;

--- a/libmamba/src/solv-cpp/repo.hpp
+++ b/libmamba/src/solv-cpp/repo.hpp
@@ -39,6 +39,8 @@ namespace mamba::solv
 
         template <typename UnaryFunc>
         void for_each_solvable_id(UnaryFunc func) const;
+        template <typename UnaryFunc>
+        void for_each_solvable(UnaryFunc func) const;
 
         /**
          * Write repository information to file.
@@ -83,6 +85,9 @@ namespace mamba::solv
         auto get_solvable(SolvableId id) const -> ObjSolvableView;
         void remove_solvable(SolvableId id, bool reuse_id) const;
 
+        template <typename UnaryFunc>
+        void for_each_solvable(UnaryFunc func) const;
+
         /**
          * Internalize added data.
          *
@@ -113,5 +118,30 @@ namespace mamba::solv
             func(id);
         }
     }
+
+    template <typename UnaryFunc>
+    void ObjRepoViewConst::for_each_solvable(UnaryFunc func) const
+    {
+        const ::Repo* const repo = raw();
+        SolvableId id = 0;
+        const ::Solvable* s = nullptr;
+        FOR_REPO_SOLVABLES(repo, id, s)
+        {
+            func(ObjSolvableViewConst(s));
+        }
+    }
+
+    template <typename UnaryFunc>
+    void ObjRepoView::for_each_solvable(UnaryFunc func) const
+    {
+        const ::Repo* const repo = raw();
+        SolvableId id = 0;
+        ::Solvable* s = nullptr;
+        FOR_REPO_SOLVABLES(repo, id, s)
+        {
+            func(ObjSolvableView(s));
+        }
+    }
+
 }
 #endif

--- a/libmamba/src/solv-cpp/repo.hpp
+++ b/libmamba/src/solv-cpp/repo.hpp
@@ -31,17 +31,44 @@ namespace mamba::solv
 
         auto id() const -> RepoId;
 
+        /** The name of the repository. */
         auto name() const -> std::string_view;
+
+        /**
+         * The url of the repository.
+         *
+         * @see ObjRepoView::set_url
+         **/
         auto url() const -> std::string_view;
+
+        /**
+         * The channel of the repository.
+         *
+         * @see ObjRepoView::set_url
+         **/
         auto channel() const -> std::string_view;
+
+        /**
+         * The sub-directory of the repository.
+         *
+         * @see ObjRepoView::set_url
+         **/
         auto subdir() const -> std::string_view;
 
+        /** The number of solvables in this repository. */
         auto solvable_count() const -> std::size_t;
+
+        /** Check if a solvable exisists and is in this repository. */
         auto has_solvable(SolvableId id) const -> bool;
+
+        /** Get the current solvable, if it exists and is in this repository. */
         auto get_solvable(SolvableId id) const -> std::optional<ObjSolvableViewConst>;
 
+        /** Execute function of all solvable ids in this repository. */
         template <typename UnaryFunc>
         void for_each_solvable_id(UnaryFunc&& func) const;
+
+        /** Execute function of all solvables in this repository. */
         template <typename UnaryFunc>
         void for_each_solvable(UnaryFunc&& func) const;
 
@@ -49,6 +76,8 @@ namespace mamba::solv
          * Write repository information to file.
          *
          * @param solv_file A standard path with system encoding.
+         * @warning This is a binary file that is not portable and may not even remain valid among
+         *          different libsolv build, let alone versions.
          */
         void write(std::filesystem::path solv_file) const;
 
@@ -68,26 +97,72 @@ namespace mamba::solv
         auto raw() const -> ::Repo*;
 
         /** The following attributes need a call to @ref internalize to be available. */
+
+        /**
+         * Set the url of the repository.
+         *
+         * This has no effect for libsolv and is purely for data storing.
+         *
+         * @note A call to @ref ObjRepoView::internalize is required for this attribute to
+         *       be available for lookup.
+         */
         void set_url(raw_str_view str) const;
         void set_url(const std::string& str) const;
+
+        /**
+         * Set the channel of the repository.
+         *
+         * This has no effect for libsolv and is purely for data storing.
+         *
+         * @note A call to @ref ObjRepoView::internalize is required for this attribute to
+         *       be available for lookup.
+         */
         void set_channel(raw_str_view str) const;
         void set_channel(const std::string& str) const;
+
+        /**
+         * Set the sub-directory of the repository.
+         *
+         * This has no effect for libsolv and is purely for data storing.
+         *
+         * @note A call to @ref ObjRepoView::internalize is required for this attribute to
+         *       be available for lookup.
+         */
         void set_subdir(raw_str_view str) const;
         void set_subdir(const std::string& str) const;
 
+
+        /**
+         * Clear all solvables from the repository.
+         *
+         * If @p reuse_ids is true, the solvable ids used in the pool can be reused for future
+         * solvables (incuding in other repositories).
+         */
         void clear(bool reuse_ids) const;
 
         /**
          * Read repository information from file.
          *
          * @param solv_file A standard path with system encoding.
+         * @see ObjRepoViewConst::write
          */
         void read(std::filesystem::path solv_file) const;
 
+        /** Add an empty solvable to the repository. */
         auto add_solvable() const -> std::pair<SolvableId, ObjSolvableView>;
+
+        /** Get the current solvable, if it exists and is in this repository. */
         auto get_solvable(SolvableId id) const -> std::optional<ObjSolvableView>;
+
+        /**
+         * Remove a solvable from the repository.
+         *
+         * If @p reuse_id is true, the solvable id used in the pool can be reused for future
+         * solvables (incuding in other repositories).
+         */
         auto remove_solvable(SolvableId id, bool reuse_id) const -> bool;
 
+        /** Execute function of all solvables in this repository. */
         template <typename UnaryFunc>
         void for_each_solvable(UnaryFunc&& func) const;
 
@@ -96,7 +171,8 @@ namespace mamba::solv
          *
          * Data must be internalized before it is available for lookup.
          * This concerns data added on solvable too.
-         * This is a costly operation.
+         * @warning This is a costly operation, and should ideally be called once after
+         *          all attributes are set on the repository and its solvables.
          */
         void internalize();
     };

--- a/libmamba/src/solv-cpp/repo.hpp
+++ b/libmamba/src/solv-cpp/repo.hpp
@@ -8,6 +8,7 @@
 #define MAMBA_SOLV_REPO_HPP
 
 #include <filesystem>
+#include <optional>
 #include <string_view>
 #include <utility>
 
@@ -35,9 +36,8 @@ namespace mamba::solv
         auto subdir() const -> std::string_view;
 
         auto n_solvables() const -> std::size_t;
-        auto contains_solvable(SolvableId id) const -> bool;
-
-        auto get_solvable(SolvableId id) const -> ObjSolvableViewConst;
+        auto has_solvable(SolvableId id) const -> bool;
+        auto get_solvable(SolvableId id) const -> std::optional<ObjSolvableViewConst>;
 
         template <typename UnaryFunc>
         void for_each_solvable_id(UnaryFunc func) const;
@@ -83,9 +83,9 @@ namespace mamba::solv
          */
         void read(std::filesystem::path solv_file) const;
 
-        auto add_solvable() const -> SolvableId;
-        auto get_solvable(SolvableId id) const -> ObjSolvableView;
-        void remove_solvable(SolvableId id, bool reuse_id) const;
+        auto add_solvable() const -> std::pair<SolvableId, ObjSolvableView>;
+        auto get_solvable(SolvableId id) const -> std::optional<ObjSolvableView>;
+        auto remove_solvable(SolvableId id, bool reuse_id) const -> bool;
 
         template <typename UnaryFunc>
         void for_each_solvable(UnaryFunc func) const;

--- a/libmamba/src/solv-cpp/repo.hpp
+++ b/libmamba/src/solv-cpp/repo.hpp
@@ -31,6 +31,8 @@ namespace mamba::solv
         auto n_solvables() const -> std::size_t;
         auto contains_solvable(SolvableId id) const -> bool;
 
+        auto get_solvable(SolvableId id) const -> ObjSolvableViewConst;
+
         template <typename UnaryFunc>
         void for_each_solvable_id(UnaryFunc func) const;
 
@@ -64,6 +66,17 @@ namespace mamba::solv
         void read(std::filesystem::path solv_file) const;
 
         auto add_solvable() const -> SolvableId;
+        auto get_solvable(SolvableId id) const -> ObjSolvableView;
+        void remove_solvable(SolvableId id, bool reuse_id) const;
+
+        /**
+         * Internalize added data.
+         *
+         * Data must be internalized before it is available for lookup.
+         * This concerns data added on solvable too.
+         * This is a costly operation.
+         */
+        void internalize();
     };
 }
 

--- a/libmamba/src/solv-cpp/repo.hpp
+++ b/libmamba/src/solv-cpp/repo.hpp
@@ -7,7 +7,6 @@
 #ifndef MAMBA_SOLV_REPO_HPP
 #define MAMBA_SOLV_REPO_HPP
 
-#include <filesystem>
 #include <optional>
 #include <string_view>
 #include <utility>
@@ -16,6 +15,11 @@
 #include "solv-cpp/solvable.hpp"
 
 using Repo = struct s_Repo;
+
+namespace fs
+{
+    class u8path;
+}
 
 namespace mamba::solv
 {
@@ -79,7 +83,7 @@ namespace mamba::solv
          * @warning This is a binary file that is not portable and may not even remain valid among
          *          different libsolv build, let alone versions.
          */
-        void write(std::filesystem::path solv_file) const;
+        void write(const fs::u8path& solv_file) const;
 
     private:
 
@@ -146,7 +150,7 @@ namespace mamba::solv
          * @param solv_file A standard path with system encoding.
          * @see ObjRepoViewConst::write
          */
-        void read(std::filesystem::path solv_file) const;
+        void read(const fs::u8path& solv_file) const;
 
         /** Add an empty solvable to the repository. */
         auto add_solvable() const -> std::pair<SolvableId, ObjSolvableView>;

--- a/libmamba/src/solv-cpp/solvable.cpp
+++ b/libmamba/src/solv-cpp/solvable.cpp
@@ -20,8 +20,8 @@ namespace mamba::solv
      *  Implementation of ConstObjSolvableView  *
      ********************************************/
 
-    ObjSolvableViewConst::ObjSolvableViewConst(const ::Solvable* solvable) noexcept
-        : m_solvable{ solvable }
+    ObjSolvableViewConst::ObjSolvableViewConst(const ::Solvable& solvable) noexcept
+        : m_solvable{ &solvable }
     {
     }
 
@@ -44,7 +44,7 @@ namespace mamba::solv
      *  Implementation of ObjSolvableView  *
      ***************************************/
 
-    ObjSolvableView::ObjSolvableView(::Solvable* solvable) noexcept
+    ObjSolvableView::ObjSolvableView(::Solvable& solvable) noexcept
         : ObjSolvableViewConst{ solvable }
     {
     }

--- a/libmamba/src/solv-cpp/solvable.cpp
+++ b/libmamba/src/solv-cpp/solvable.cpp
@@ -271,6 +271,54 @@ namespace mamba::solv
         ::solvable_set_num(raw(), SOLVABLE_BUILDTIME, n);
     }
 
+    auto ObjSolvableViewConst::url() const -> std::string_view
+    {
+        return ptr_to_strview(::solvable_lookup_str(const_cast<::Solvable*>(raw()), SOLVABLE_URL));
+    }
+
+    void ObjSolvableView::set_url(raw_str_view str) const
+    {
+        ::solvable_set_str(raw(), SOLVABLE_URL, str);
+    }
+
+    void ObjSolvableView::set_url(const std::string& str) const
+    {
+        return set_url(str.c_str());
+    }
+
+    auto ObjSolvableViewConst::channel() const -> std::string_view
+    {
+        // (Ab)using the REPOSITORY_REPOID key since it won't have any side effect
+        return ptr_to_strview(::solvable_lookup_str(const_cast<::Solvable*>(raw()), REPOSITORY_REPOID)
+        );
+    }
+
+    void ObjSolvableView::set_channel(raw_str_view str) const
+    {
+        ::solvable_set_str(raw(), REPOSITORY_REPOID, str);
+    }
+
+    void ObjSolvableView::set_channel(const std::string& str) const
+    {
+        return set_channel(str.c_str());
+    }
+
+    auto ObjSolvableViewConst::subdir() const -> std::string_view
+    {
+        return ptr_to_strview(::solvable_lookup_str(const_cast<::Solvable*>(raw()), SOLVABLE_MEDIADIR)
+        );
+    }
+
+    void ObjSolvableView::set_subdir(raw_str_view str) const
+    {
+        ::solvable_set_str(raw(), SOLVABLE_MEDIADIR, str);
+    }
+
+    void ObjSolvableView::set_subdir(const std::string& str) const
+    {
+        return set_subdir(str.c_str());
+    }
+
     auto ObjSolvableViewConst::dependencies() const -> ObjQueue
     {
         auto q = ObjQueue{};

--- a/libmamba/src/solv-cpp/solvable.cpp
+++ b/libmamba/src/solv-cpp/solvable.cpp
@@ -92,9 +92,14 @@ namespace mamba::solv
         return ptr_to_strview(::solvable_lookup_str(const_cast<::Solvable*>(raw()), SOLVABLE_NAME));
     }
 
+    void ObjSolvableView::set_name(StringId id) const
+    {
+        ::solvable_set_id(raw(), SOLVABLE_NAME, id);
+    }
+
     void ObjSolvableView::set_name(std::string_view str) const
     {
-        ::solvable_set_id(raw(), SOLVABLE_NAME, solvable_add_pool_str(raw()->repo->pool, str));
+        return set_name(solvable_add_pool_str(raw()->repo->pool, str));
     }
 
     auto ObjSolvableViewConst::version() const -> std::string_view
@@ -102,9 +107,14 @@ namespace mamba::solv
         return ptr_to_strview(::solvable_lookup_str(const_cast<::Solvable*>(raw()), SOLVABLE_EVR));
     }
 
+    void ObjSolvableView::set_version(StringId id) const
+    {
+        ::solvable_set_id(raw(), SOLVABLE_EVR, id);
+    }
+
     void ObjSolvableView::set_version(std::string_view str) const
     {
-        ::solvable_set_id(raw(), SOLVABLE_EVR, solvable_add_pool_str(raw()->repo->pool, str));
+        return set_version(solvable_add_pool_str(raw()->repo->pool, str));
     }
 
     auto ObjSolvableViewConst::build_number() const -> std::size_t

--- a/libmamba/src/solv-cpp/solvable.cpp
+++ b/libmamba/src/solv-cpp/solvable.cpp
@@ -1,0 +1,362 @@
+// Copyright (c) 2023, QuantStack and Mamba Contributors
+//
+// Distributed under the terms of the BSD 3-Clause License.
+//
+// The full license is in the file LICENSE, distributed with this software.
+
+#include <cassert>
+#include <limits>
+
+#include <solv/knownid.h>
+#include <solv/repo.h>
+#include <solv/solvable.h>
+
+#include "solv-cpp/solvable.hpp"
+
+namespace mamba::solv
+{
+    /********************************************
+     *  Implementation of ConstObjSolvableView  *
+     ********************************************/
+
+    ObjSolvableViewConst::ObjSolvableViewConst(const ::Solvable* solvable) noexcept
+        : m_solvable{ solvable }
+    {
+    }
+
+    auto ObjSolvableViewConst::raw() const -> const ::Solvable*
+    {
+        return m_solvable;
+    }
+
+    /***************************************
+     *  Implementation of ObjSolvableView  *
+     ***************************************/
+
+    ObjSolvableView::ObjSolvableView(::Solvable* solvable) noexcept
+        : ObjSolvableViewConst{ solvable }
+    {
+    }
+
+    auto ObjSolvableView::raw() const -> ::Solvable*
+    {
+        // Safe because we were passed a ``Solvable*`` at construction time.
+        return const_cast<::Solvable*>(ObjSolvableViewConst::raw());
+    }
+
+
+    /******************************************
+     *  Implementation of getter and setters  *
+     ******************************************/
+
+    namespace
+    {
+        auto ptr_to_strview(const char* ptr) -> std::string_view
+        {
+            static constexpr std::string_view null = "<NULL>";
+            if ((ptr == nullptr) || (ptr == null))
+            {
+                return "";
+            }
+            return { ptr };
+        }
+
+        /**
+         * Add a string to the solvable pool.
+         *
+         * When we know that the solvable attribute needs to be a pool id, we can use this
+         * function to leverage the ``pool_strn2id`` function with a `std::string_view``.
+         */
+        auto solvable_add_pool_str(::Pool* pool, std::string_view value)
+        {
+            assert(value.size() <= std::numeric_limits<unsigned int>::max());
+            ::Id const id = pool_strn2id(
+                pool,
+                value.data(),
+                static_cast<unsigned int>(value.size()),
+                /* .create= */ 1
+            );
+            assert(id != 0);
+            return id;
+        }
+    }
+
+    auto ObjSolvableViewConst::name() const -> std::string_view
+    {
+        return ptr_to_strview(solvable_lookup_str(const_cast<::Solvable*>(raw()), SOLVABLE_NAME));
+    }
+
+    void ObjSolvableView::set_name(std::string_view str) const
+    {
+        solvable_set_id(raw(), SOLVABLE_NAME, solvable_add_pool_str(raw()->repo->pool, str));
+    }
+
+    auto ObjSolvableViewConst::version() const -> std::string_view
+    {
+        return ptr_to_strview(solvable_lookup_str(const_cast<::Solvable*>(raw()), SOLVABLE_EVR));
+    }
+
+    void ObjSolvableView::set_version(std::string_view str) const
+    {
+        solvable_set_id(raw(), SOLVABLE_EVR, solvable_add_pool_str(raw()->repo->pool, str));
+    }
+
+    auto ObjSolvableViewConst::build_number() const -> std::size_t
+    {
+        return solvable_lookup_num(const_cast<::Solvable*>(raw()), SOLVABLE_BUILDVERSION, 0);
+    }
+
+    void ObjSolvableView::set_build_number(std::size_t n) const
+    {
+        solvable_set_num(raw(), SOLVABLE_BUILDVERSION, n);
+    }
+
+    auto ObjSolvableViewConst::build_string() const -> std::string_view
+    {
+        return ptr_to_strview(solvable_lookup_str(const_cast<::Solvable*>(raw()), SOLVABLE_BUILDFLAVOR)
+        );
+    }
+
+    void ObjSolvableView::set_build_string(std::string_view bld) const
+    {
+        solvable_set_id(raw(), SOLVABLE_BUILDFLAVOR, solvable_add_pool_str(raw()->repo->pool, bld));
+    }
+
+    auto ObjSolvableViewConst::file_name() const -> std::string_view
+    {
+        return ptr_to_strview(solvable_lookup_str(const_cast<::Solvable*>(raw()), SOLVABLE_MEDIAFILE));
+    }
+
+    void ObjSolvableView::set_file_name(raw_str_view fn) const
+    {
+        // TODO would like to use ``repodata_set_strn`` or similar but it is not visible
+        solvable_set_str(raw(), SOLVABLE_MEDIAFILE, fn);
+    }
+
+    void ObjSolvableView::set_file_name(const std::string& fn) const
+    {
+        return set_file_name(fn.c_str());
+    }
+
+    auto ObjSolvableViewConst::license() const -> std::string_view
+    {
+        return ptr_to_strview(solvable_lookup_str(const_cast<::Solvable*>(raw()), SOLVABLE_LICENSE));
+    }
+
+    void ObjSolvableView::set_license(raw_str_view str) const
+    {
+        solvable_set_str(raw(), SOLVABLE_LICENSE, str);
+    }
+
+    void ObjSolvableView::set_license(const std::string& str) const
+    {
+        return set_license(str.c_str());
+    }
+
+    auto ObjSolvableViewConst::md5() const -> std::string_view
+    {
+        ::Id type = 0;
+        const char* hash = solvable_lookup_checksum(const_cast<::Solvable*>(raw()), SOLVABLE_PKGID, &type);
+        assert((type == REPOKEY_TYPE_MD5) || (hash == nullptr));
+        return ptr_to_strview(hash);
+    }
+
+    void ObjSolvableView::set_md5(raw_str_view str) const
+    {
+        ::Repo* repo = raw()->repo;
+        repodata_set_checksum(
+            repo_last_repodata(repo),
+            pool_solvable2id(repo->pool, raw()),
+            SOLVABLE_PKGID,
+            REPOKEY_TYPE_MD5,
+            str
+        );
+    }
+
+    void ObjSolvableView::set_md5(const std::string& str) const
+    {
+        return set_md5(str.c_str());
+    }
+
+    auto ObjSolvableViewConst::noarch() const -> std::string_view
+    {
+        return ptr_to_strview(solvable_lookup_str(const_cast<::Solvable*>(raw()), SOLVABLE_SOURCEARCH)
+        );
+    }
+
+    void ObjSolvableView::set_noarch(raw_str_view str) const
+    {
+        solvable_set_str(raw(), SOLVABLE_SOURCEARCH, str);
+    }
+
+    void ObjSolvableView::set_noarch(const std::string& str) const
+    {
+        return set_noarch(str.c_str());
+    }
+
+    auto ObjSolvableViewConst::sha256() const -> std::string_view
+    {
+        ::Id type = 0;
+        const char* hash = solvable_lookup_checksum(
+            const_cast<::Solvable*>(raw()),
+            SOLVABLE_CHECKSUM,
+            &type
+        );
+        assert((type == REPOKEY_TYPE_SHA256) || (hash == nullptr));
+        return ptr_to_strview(hash);
+    }
+
+    void ObjSolvableView::set_sha256(raw_str_view str) const
+    {
+        ::Repo* repo = raw()->repo;
+        repodata_set_checksum(
+            repo_last_repodata(repo),
+            pool_solvable2id(repo->pool, raw()),
+            SOLVABLE_CHECKSUM,
+            REPOKEY_TYPE_SHA256,
+            str
+        );
+    }
+
+    void ObjSolvableView::set_sha256(const std::string& str) const
+    {
+        return set_sha256(str.c_str());
+    }
+
+    auto ObjSolvableViewConst::size() const -> std::size_t
+    {
+        return solvable_lookup_num(const_cast<::Solvable*>(raw()), SOLVABLE_DOWNLOADSIZE, 0);
+    }
+
+    void ObjSolvableView::set_size(std::size_t n) const
+    {
+        solvable_set_num(raw(), SOLVABLE_DOWNLOADSIZE, n);
+    }
+
+    auto ObjSolvableViewConst::timestamp() const -> std::size_t
+    {
+        return solvable_lookup_num(const_cast<::Solvable*>(raw()), SOLVABLE_BUILDTIME, 0);
+    }
+
+    void ObjSolvableView::set_timestamp(std::size_t n) const
+    {
+        solvable_set_num(raw(), SOLVABLE_BUILDTIME, n);
+    }
+
+    auto ObjSolvableViewConst::dependencies() const -> ObjQueue
+    {
+        auto q = ObjQueue{};
+        solvable_lookup_deparray(
+            const_cast<::Solvable*>(raw()),
+            SOLVABLE_REQUIRES,
+            q.raw(),
+            /* marker= */ -1
+        );
+        return q;
+    }
+
+    void ObjSolvableView::set_dependencies(const ObjQueue& q) const
+    {
+        solvable_set_deparray(
+            const_cast<::Solvable*>(raw()),
+            SOLVABLE_REQUIRES,
+            const_cast<::Queue*>(q.raw()),
+            /* marker= */ 0
+        );
+    }
+
+    void ObjSolvableView::add_dependency(DependencyId dep) const
+    {
+        raw()->requires = repo_addid_dep(raw()->repo, raw()->requires, dep, /* marker= */ 0);
+    }
+
+    auto ObjSolvableViewConst::provides() const -> ObjQueue
+    {
+        auto q = ObjQueue{};
+        solvable_lookup_deparray(const_cast<::Solvable*>(raw()), SOLVABLE_PROVIDES, q.raw(), -1);
+        return q;
+    }
+
+    void ObjSolvableView::set_provides(const ObjQueue& q) const
+    {
+        solvable_set_deparray(
+            const_cast<::Solvable*>(raw()),
+            SOLVABLE_PROVIDES,
+            const_cast<::Queue*>(q.raw()),
+            /* marker= */ 0
+        );
+    }
+
+    void ObjSolvableView::add_provide(DependencyId dep) const
+    {
+        raw()->provides = repo_addid_dep(raw()->repo, raw()->provides, dep, /* marker= */ 0);
+    }
+
+    void ObjSolvableView::add_self_provide() const
+    {
+        return add_provide(
+            pool_rel2id(raw()->repo->pool, raw()->name, raw()->evr, REL_EQ, /* create= */ 1)
+        );
+    }
+
+    auto ObjSolvableViewConst::constraints() const -> ObjQueue
+    {
+        auto q = ObjQueue{};
+        solvable_lookup_deparray(const_cast<::Solvable*>(raw()), SOLVABLE_CONSTRAINS, q.raw(), -1);
+        return q;
+    }
+
+    void ObjSolvableView::set_constraints(const ObjQueue& q) const
+    {
+        // Prevent weird behavior when q is empty
+        if (q.empty())
+        {
+            solvable_unset(raw(), SOLVABLE_CONSTRAINS);
+        }
+        else
+        {
+            solvable_set_deparray(
+                const_cast<::Solvable*>(raw()),
+                SOLVABLE_CONSTRAINS,
+                const_cast<::Queue*>(q.raw()),
+                /* marker= */ -1
+            );
+        }
+    }
+
+    void ObjSolvableView::add_constraint(DependencyId dep) const
+    {
+        solvable_add_idarray(raw(), SOLVABLE_CONSTRAINS, dep);
+    }
+
+    auto ObjSolvableViewConst::track_features() const -> ObjQueue
+    {
+        auto q = ObjQueue{};
+        solvable_lookup_idarray(const_cast<::Solvable*>(raw()), SOLVABLE_TRACK_FEATURES, q.raw());
+        return q;
+    }
+
+    void ObjSolvableView::set_track_features(const ObjQueue& q) const
+    {
+        // Prevent weird behavior when q is empty
+        if (q.empty())
+        {
+            solvable_unset(raw(), SOLVABLE_TRACK_FEATURES);
+        }
+        else
+        {
+            solvable_set_idarray(raw(), SOLVABLE_TRACK_FEATURES, const_cast<::Queue*>(q.raw()));
+        }
+    }
+
+    auto ObjSolvableView::add_track_feature(StringId feat) const -> StringId
+    {
+        solvable_add_idarray(raw(), SOLVABLE_TRACK_FEATURES, feat);
+        return feat;
+    }
+
+    auto ObjSolvableView::add_track_feature(std::string_view feat) const -> StringId
+    {
+        return add_track_feature(solvable_add_pool_str(raw()->repo->pool, feat));
+    }
+}

--- a/libmamba/src/solv-cpp/solvable.cpp
+++ b/libmamba/src/solv-cpp/solvable.cpp
@@ -288,14 +288,13 @@ namespace mamba::solv
 
     auto ObjSolvableViewConst::channel() const -> std::string_view
     {
-        // (Ab)using the REPOSITORY_REPOID key since it won't have any side effect
-        return ptr_to_strview(::solvable_lookup_str(const_cast<::Solvable*>(raw()), REPOSITORY_REPOID)
+        return ptr_to_strview(::solvable_lookup_str(const_cast<::Solvable*>(raw()), SOLVABLE_PACKAGER)
         );
     }
 
     void ObjSolvableView::set_channel(raw_str_view str) const
     {
-        ::solvable_set_str(raw(), REPOSITORY_REPOID, str);
+        ::solvable_set_str(raw(), SOLVABLE_PACKAGER, str);
     }
 
     void ObjSolvableView::set_channel(const std::string& str) const

--- a/libmamba/src/solv-cpp/solvable.cpp
+++ b/libmamba/src/solv-cpp/solvable.cpp
@@ -155,6 +155,7 @@ namespace mamba::solv
         static constexpr auto n_digits = 20;
 
         auto str = std::array<char, n_digits + 1>{};  // +1 for null termination
+        str.fill('\0');
         [[maybe_unused]] const auto [ptr, ec] = std::to_chars(str.data(), str.data() + str.size(), n);
         assert(ec == std::errc());
         assert(ptr != nullptr);

--- a/libmamba/src/solv-cpp/solvable.cpp
+++ b/libmamba/src/solv-cpp/solvable.cpp
@@ -25,6 +25,11 @@ namespace mamba::solv
     {
     }
 
+    ObjSolvableViewConst::~ObjSolvableViewConst() noexcept
+    {
+        m_solvable = nullptr;
+    }
+
     auto ObjSolvableViewConst::raw() const -> const ::Solvable*
     {
         return m_solvable;
@@ -62,7 +67,7 @@ namespace mamba::solv
             static constexpr std::string_view null = "<NULL>";
             if ((ptr == nullptr) || (ptr == null))
             {
-                return "";
+                return {};
             }
             return { ptr };
         }
@@ -76,7 +81,7 @@ namespace mamba::solv
         auto solvable_add_pool_str(::Pool* pool, std::string_view value)
         {
             assert(value.size() <= std::numeric_limits<unsigned int>::max());
-            ::Id const id = ::pool_strn2id(
+            const ::Id id = ::pool_strn2id(
                 pool,
                 value.data(),
                 static_cast<unsigned int>(value.size()),

--- a/libmamba/src/solv-cpp/solvable.hpp
+++ b/libmamba/src/solv-cpp/solvable.hpp
@@ -28,6 +28,8 @@ namespace mamba::solv
 
         auto raw() const -> const ::Solvable*;
 
+        auto id() const -> SolvableId;
+
         auto name() const -> std::string_view;
         auto version() const -> std::string_view;
 

--- a/libmamba/src/solv-cpp/solvable.hpp
+++ b/libmamba/src/solv-cpp/solvable.hpp
@@ -67,7 +67,9 @@ namespace mamba::solv
 
         auto raw() const -> ::Solvable*;
 
+        void set_name(StringId id) const;
         void set_name(std::string_view str) const;
+        void set_version(StringId id) const;
         void set_version(std::string_view str) const;
 
         /** The following attributes need a call to @ref ObjRepoView::internalize. */

--- a/libmamba/src/solv-cpp/solvable.hpp
+++ b/libmamba/src/solv-cpp/solvable.hpp
@@ -47,6 +47,27 @@ namespace mamba::solv
         auto size() const -> std::size_t;
         auto timestamp() const -> std::size_t;
 
+        /**
+         * The url of the solvable.
+         *
+         * @see ObjSolvableView::set_url
+         **/
+        auto url() const -> std::string_view;
+
+        /**
+         * The channel of the solvable.
+         *
+         * @see ObjSolvableView::set_channel
+         **/
+        auto channel() const -> std::string_view;
+
+        /**
+         * The sub-directory of the solvable.
+         *
+         * @see ObjSolvableView::set_subdir
+         **/
+        auto subdir() const -> std::string_view;
+
         /** Queue of ``DependencyId``. */
         auto dependencies() const -> ObjQueue;
 
@@ -173,6 +194,45 @@ namespace mamba::solv
          *       be available for lookup.
          */
         void set_timestamp(std::size_t n) const;
+
+        /**
+         * Set the url of the solvable.
+         *
+         * This has no effect for libsolv and is purely for data storing.
+         * This may not be the same as @ref ObjRepoViewConst::url, for instance the install
+         * repository may have no url but its packages do.
+         *
+         * @note A call to @ref ObjRepoView::internalize is required for this attribute to
+         *       be available for lookup.
+         */
+        void set_url(raw_str_view str) const;
+        void set_url(const std::string& str) const;
+
+        /**
+         * Set the channel of the solvable.
+         *
+         * This has no effect for libsolv and is purely for data storing.
+         * This may not be the same as @ref ObjRepoViewConst::channel, for instance the install
+         * repository may have no channel but its packages do.
+         *
+         * @note A call to @ref ObjRepoView::internalize is required for this attribute to
+         *       be available for lookup.
+         */
+        void set_channel(raw_str_view str) const;
+        void set_channel(const std::string& str) const;
+
+        /**
+         * Set the sub-directory of the solvable.
+         *
+         * This has no effect for libsolv and is purely for data storing.
+         * This may not be the same as @ref ObjRepoViewConst::channel, for instance the install
+         * repository may have no subdir but its packages do.
+         *
+         * @note A call to @ref ObjRepoView::internalize is required for this attribute to
+         *       be available for lookup.
+         */
+        void set_subdir(raw_str_view str) const;
+        void set_subdir(const std::string& str) const;
 
         /** Set the dependencies of the solvable. */
         void set_dependencies(const ObjQueue& q) const;

--- a/libmamba/src/solv-cpp/solvable.hpp
+++ b/libmamba/src/solv-cpp/solvable.hpp
@@ -31,7 +31,10 @@ namespace mamba::solv
 
         auto id() const -> SolvableId;
 
+        /** The package name of the solvable. */
         auto name() const -> std::string_view;
+
+        /** The package version of the solvable. */
         auto version() const -> std::string_view;
 
         auto build_number() const -> std::size_t;
@@ -46,10 +49,13 @@ namespace mamba::solv
 
         /** Queue of ``DependencyId``. */
         auto dependencies() const -> ObjQueue;
+
         /** Queue of ``DependencyId``. */
         auto provides() const -> ObjQueue;
+
         /** Queue of ``DependencyId``. */
         auto constraints() const -> ObjQueue;
+
         /** Queue of ``StringId``. */
         auto track_features() const -> ObjQueue;
 
@@ -73,32 +79,142 @@ namespace mamba::solv
         void set_version(StringId id) const;
         void set_version(std::string_view str) const;
 
-        /** The following attributes need a call to @ref ObjRepoView::internalize. */
+        /**
+         * Set the build number of the solvable.
+         *
+         * @warning The pool must be of type conda for this to have an impact in during solving
+         *          @ref ``ObjPool::set_disttype``.
+         * @note A call to @ref ObjRepoView::internalize is required for this attribute to
+         *       be available for lookup.
+         */
         void set_build_number(std::size_t n) const;
+
+        /**
+         * Set the build string of the solvable.
+         *
+         * This is not used by libsolv and is purely for data storing.
+         *
+         * @note A call to @ref ObjRepoView::internalize is required for this attribute to
+         *       be available for lookup.
+         */
         void set_build_string(std::string_view bld) const;
+
+        /**
+         * Set the file name of the solvable.
+         *
+         * This is not used by libsolv and is purely for data storing.
+         *
+         * @note A call to @ref ObjRepoView::internalize is required for this attribute to
+         *       be available for lookup.
+         */
         void set_file_name(raw_str_view fn) const;
         void set_file_name(const std::string& fn) const;
+
+        /**
+         * Set the license of the solvable.
+         *
+         * This is not used by libsolv and is purely for data storing.
+         *
+         * @note A call to @ref ObjRepoView::internalize is required for this attribute to
+         *       be available for lookup.
+         */
         void set_license(raw_str_view str) const;
         void set_license(const std::string& str) const;
+
+        /**
+         * Set the md5 hash of the solvable file.
+         *
+         * This is not used by libsolv and is purely for data storing.
+         *
+         * @note A call to @ref ObjRepoView::internalize is required for this attribute to
+         *       be available for lookup.
+         */
         void set_md5(raw_str_view str) const;
         void set_md5(const std::string& str) const;
+
+        /**
+         * Set the noarch type of the solvable.
+         *
+         * This is not used by libsolv and is purely for data storing.
+         *
+         * @note A call to @ref ObjRepoView::internalize is required for this attribute to
+         *       be available for lookup.
+         */
         void set_noarch(raw_str_view str) const;
         void set_noarch(const std::string& str) const;
+
+        /**
+         * Set the sha256 has of the solvable file..
+         *
+         * This is not used by libsolv and is purely for data storing.
+         *
+         * @note A call to @ref ObjRepoView::internalize is required for this attribute to
+         *       be available for lookup.
+         */
         void set_sha256(raw_str_view str) const;
         void set_sha256(const std::string& str) const;
+
+        /**
+         * Set the size of the solvable size.
+         *
+         * This is not used by libsolv and is purely for data storing.
+         *
+         * @note A call to @ref ObjRepoView::internalize is required for this attribute to
+         *       be available for lookup.
+         */
         void set_size(std::size_t n) const;
+
+        /**
+         * Set the timestamp of the solvable.
+         *
+         * This is not used by libsolv and is purely for data storing.
+         *
+         * @note A call to @ref ObjRepoView::internalize is required for this attribute to
+         *       be available for lookup.
+         */
         void set_timestamp(std::size_t n) const;
 
+        /** Set the dependencies of the solvable. */
         void set_dependencies(const ObjQueue& q) const;
+
+        /** Add a additional dependency to the solvable. */
         void add_dependency(DependencyId dep) const;
+
+        /** Add multiple additional dependencies to the solvable. */
         template <typename Iter>
         void add_dependencies(Iter first, Iter last) const;
         template <typename Range>
         void add_dependencies(const Range& deps) const;
 
+        /**
+         * Set the provides list of a solvable.
+         *
+         * In libsolv, a dependency is not match against a solvable name but against its
+         * ``provides``.
+         * A package can provide multiple names, for instance an ``openblas 1.0.0`` package
+         * could provide ```openblas==1.0.0`` and ``blas<=1.5``.
+         * This is not possible in conda, hence we always use the
+         * @ref ObjSolvableView::add_self_provide function.
+         */
         void set_provides(const ObjQueue& q) const;
+
+        /**
+         * Add an additional provide to the sovable.
+         *
+         * @see ObjSolvableView::set_provides.
+         */
         void add_provide(DependencyId dep) const;
+
+        /**
+         * Add an additional provide to the sovable stating the solvable provides itself.
+         *
+         * Namely the solvable ``s`` provides ``s.name() == s.version()``.
+         *
+         * @see ObjSolvableView::set_provides.
+         */
         void add_self_provide() const;
+
+        /** Add multiple provides to the solvable. */
         template <typename Iter>
         void add_provides(Iter first, Iter last) const;
         template <typename Range>
@@ -107,21 +223,42 @@ namespace mamba::solv
         /**
          * Set all constraints.
          *
-         * Setting this attribute requires a call to @ref ObjRepoView::internalize before it
-         * can be used.
+         * A constraint is like a dependency that is not part of the solving outcome.
+         * In other words, if a solvable has a constraint, it is activated ony if another solvable
+         * in the solving requires that package as a dependencyl
+         *
+         * @warning The pool must be of type conda for this to have an impact in during solving
+         *          @ref ``ObjPool::set_disttype``.
+         * @note A call to @ref ObjRepoView::internalize is required for this attribute to
+         *       be available for lookup.
          **/
         void set_constraints(const ObjQueue& q) const;
+
         /**
          * Add a constraint.
          *
          * This function can be used to add constraints one by one.
-         * After all constraints have been added (or at a later time), a call to
-         * @ref ObjRepoView::internalize is required before the constraints can be used.
-         * If some constraints were already internalized, the effect of this function is to start
-         * a new set of constraints that will replace the old one rather than add to it.
+
+         * @warning The pool must be of type conda for this to have an impact in during solving
+         *          @ref ``ObjPool::set_disttype``.
+         * @note A call to @ref ObjRepoView::internalize is required for this attribute to
+         *       be available for lookup.
+         *       If some constraints were already internalized, the effect of this function is to
+         *       start a new set of constraints that will replace the old ones rather than add
+         *       to it.
          */
         void add_constraint(DependencyId dep) const;
         template <typename Iter>
+
+        /**
+         * Add multiple constraints to the solvable.
+         *
+         * @warning The pool must be of type conda for this to have an impact in during solving
+         *          @ref ``ObjPool::set_disttype``.
+         * @note A call to @ref ObjRepoView::internalize is required for this attribute to
+         *       be available for lookup.
+         * @see ObjSolvableView::add_constraint.
+         */
         void add_constraints(Iter first, Iter last) const;
         template <typename Range>
         void add_constraints(const Range& deps) const;
@@ -129,25 +266,34 @@ namespace mamba::solv
         /**
          * Set all track features.
          *
-         * Setting this attribute requires a call to @ref ObjRepoView::internalize before it
-         * can be used.
+         * The number of track features is used to de-prioritize solvable during solving.
          *
+         * @warning The pool must be of type conda for this to have an impact in during solving
+         *          @ref ``ObjPool::set_disttype``.
+         * @note A call to @ref ObjRepoView::internalize is required for this attribute to
+         *       be available for lookup.
          * @param q A queue of of pool @ref StringId
          **/
         void set_track_features(const ObjQueue& q) const;
+
         /**
          * Add a tracked feature.
          *
          * This function can be used to add tracked feature one by one.
-         * After all tracked features have been added (or at a later time), a call to
-         * @ref ObjRepoView::internalize is required before the tracked features can be used.
-         * If some tracked feature were already internalized, the effect of this function is
-         * to start a new set of constraints that will replace the old one rather than add to it.
          *
+         * @warning The pool must be of type conda for this to have an impact in during solving
+         *          @ref ``ObjPool::set_disttype``.
+         * @note A call to @ref ObjRepoView::internalize is required for this attribute to
+         *       be available for lookup.
+         *       If some constraints were already internalized, the effect of this function is to
+         *       start a new set of constraints that will replace the old ones rather than add
+         *       to it.
+         * @see ObjSolvableView::add_track_feature
          * @param feat A pool @ref StringId of the feature string.
          * @return The same id as @p feat.
          */
         auto add_track_feature(StringId feat) const -> StringId;
+
         /**
          * Add a tracked feature from a string.
          *
@@ -156,6 +302,14 @@ namespace mamba::solv
          * @return The pool @ref StringId associated with @p feat.
          */
         auto add_track_feature(std::string_view feat) const -> StringId;
+
+        /**
+         * Add multiple track features to the solvable.
+         *
+         * The range can contain strings or StringId.
+         *
+         * @see add_track_feature
+         */
         template <typename Iter>
         void add_track_features(Iter first, Iter last) const;
         template <typename Range>

--- a/libmamba/src/solv-cpp/solvable.hpp
+++ b/libmamba/src/solv-cpp/solvable.hpp
@@ -1,0 +1,224 @@
+// Copyright (c) 2023, QuantStack and Mamba Contributors
+//
+// Distributed under the terms of the BSD 3-Clause License.
+//
+// The full license is in the file LICENSE, distributed with this software.
+
+#ifndef MAMBA_SOLV_SOLVABLE_HPP
+#define MAMBA_SOLV_SOLVABLE_HPP
+
+#include <string>
+#include <string_view>
+#include <utility>
+
+#include <solv/pooltypes.h>
+
+#include "solv-cpp/ids.hpp"
+#include "solv-cpp/queue.hpp"
+
+typedef struct s_Solvable Solvable;
+
+namespace mamba::solv
+{
+    class ObjSolvableViewConst
+    {
+    public:
+
+        explicit ObjSolvableViewConst(const ::Solvable* solvable) noexcept;
+
+        auto raw() const -> const ::Solvable*;
+
+        auto name() const -> std::string_view;
+        auto version() const -> std::string_view;
+
+        auto build_number() const -> std::size_t;
+        auto build_string() const -> std::string_view;
+        auto file_name() const -> std::string_view;
+        auto license() const -> std::string_view;
+        auto md5() const -> std::string_view;
+        auto noarch() const -> std::string_view;
+        auto sha256() const -> std::string_view;
+        auto size() const -> std::size_t;
+        auto timestamp() const -> std::size_t;
+
+        /** Queue of ``DependencyId``. */
+        auto dependencies() const -> ObjQueue;
+        /** Queue of ``DependencyId``. */
+        auto provides() const -> ObjQueue;
+        /** Queue of ``DependencyId``. */
+        auto constraints() const -> ObjQueue;
+        /** Queue of ``StringId``. */
+        auto track_features() const -> ObjQueue;
+
+    private:
+
+        const ::Solvable* m_solvable = nullptr;
+    };
+
+    class ObjSolvableView : public ObjSolvableViewConst
+    {
+    public:
+
+        using raw_str_view = const char*;
+
+        explicit ObjSolvableView(::Solvable* repo) noexcept;
+
+        auto raw() const -> ::Solvable*;
+
+        void set_name(std::string_view str) const;
+        void set_version(std::string_view str) const;
+
+        /** The following attributes need a call to @ref ObjRepoView::internalize. */
+        void set_build_number(std::size_t n) const;
+        void set_build_string(std::string_view bld) const;
+        void set_file_name(raw_str_view fn) const;
+        void set_file_name(const std::string& fn) const;
+        void set_license(raw_str_view str) const;
+        void set_license(const std::string& str) const;
+        void set_md5(raw_str_view str) const;
+        void set_md5(const std::string& str) const;
+        void set_noarch(raw_str_view str) const;
+        void set_noarch(const std::string& str) const;
+        void set_sha256(raw_str_view str) const;
+        void set_sha256(const std::string& str) const;
+        void set_size(std::size_t n) const;
+        void set_timestamp(std::size_t n) const;
+
+        void set_dependencies(const ObjQueue& q) const;
+        void add_dependency(DependencyId dep) const;
+        template <typename Iter>
+        void add_dependencies(Iter first, Iter last);
+        template <typename Range>
+        void add_dependencies(const Range& deps);
+
+        void set_provides(const ObjQueue& q) const;
+        void add_provide(DependencyId dep) const;
+        void add_self_provide() const;
+        template <typename Iter>
+        void add_provides(Iter first, Iter last);
+        template <typename Range>
+        void add_provides(const Range& deps);
+
+        /**
+         * Set all constraints.
+         *
+         * Setting this attribute requires a call to @ref ObjRepoView::internalize before it
+         * can be used.
+         **/
+        void set_constraints(const ObjQueue& q) const;
+        /**
+         * Add a constraint.
+         *
+         * This function can be used to add constraints one by one.
+         * After all constraints have been added (or at a later time), a call to
+         * @ref ObjRepoView::internalize is required before the constraints can be used.
+         * If some constraints were already internalized, the effect of this function is to start
+         * a new set of constraints that will replace the old one rather than add to it.
+         */
+        void add_constraint(DependencyId dep) const;
+        template <typename Iter>
+        void add_constraints(Iter first, Iter last);
+        template <typename Range>
+        void add_constraints(const Range& deps);
+
+        /**
+         * Set all track features.
+         *
+         * Setting this attribute requires a call to @ref ObjRepoView::internalize before it
+         * can be used.
+         *
+         * @param q A queue of of pool @ref StringId
+         **/
+        void set_track_features(const ObjQueue& q) const;
+        /**
+         * Add a tracked feature.
+         *
+         * This function can be used to add tracked feature one by one.
+         * After all tracked features have been added (or at a later time), a call to
+         * @ref ObjRepoView::internalize is required before the tracked features can be used.
+         * If some tracked feature were already internalized, the effect of this function is
+         * to start a new set of constraints that will replace the old one rather than add to it.
+         *
+         * @param feat A pool @ref StringId of the feature string.
+         * @return The same id as @p feat.
+         */
+        auto add_track_feature(StringId feat) const -> StringId;
+        /**
+         * Add a tracked feature from a string.
+         *
+         * @see add_track_feature
+         * @param feat The feature to add is also added to the pool.
+         * @return The pool @ref StringId associated with @p feat.
+         */
+        auto add_track_feature(std::string_view feat) const -> StringId;
+        template <typename Iter>
+        void add_track_features(Iter first, Iter last);
+        template <typename Range>
+        void add_track_features(const Range& features);
+    };
+
+    /***************************************
+     *  Implementation of ObjSolvableView  *
+     ***************************************/
+
+    template <typename Iter>
+    void ObjSolvableView::add_dependencies(Iter first, Iter last)
+    {
+        for (; first != last; ++first)
+        {
+            add_dependency(*first);
+        }
+    }
+
+    template <typename Range>
+    void ObjSolvableView::add_dependencies(const Range& deps)
+    {
+        return add_dependencies(deps.cbegin(), deps.cend());
+    }
+
+    template <typename Iter>
+    void ObjSolvableView::add_provides(Iter first, Iter last)
+    {
+        for (; first != last; ++first)
+        {
+            add_provide(*first);
+        }
+    }
+
+    template <typename Range>
+    void ObjSolvableView::add_provides(const Range& deps)
+    {
+        return add_provides(deps.cbegin(), deps.cend());
+    }
+
+    template <typename Iter>
+    void ObjSolvableView::add_constraints(Iter first, Iter last)
+    {
+        for (; first != last; ++first)
+        {
+            add_constraint(*first);
+        }
+    }
+
+    template <typename Range>
+    void ObjSolvableView::add_constraints(const Range& deps)
+    {
+        return add_constraints(deps.cbegin(), deps.cend());
+    }
+
+    template <typename Iter>
+    void ObjSolvableView::add_track_features(Iter first, Iter last)
+    {
+        for (; first != last; ++first)
+        {
+            add_track_feature(*first);
+        }
+    }
+
+    template <typename Range>
+    void ObjSolvableView::add_track_features(const Range& feats)
+    {
+        return add_track_features(feats.cbegin(), feats.cend());
+    }
+}
+#endif

--- a/libmamba/src/solv-cpp/solvable.hpp
+++ b/libmamba/src/solv-cpp/solvable.hpp
@@ -89,17 +89,17 @@ namespace mamba::solv
         void set_dependencies(const ObjQueue& q) const;
         void add_dependency(DependencyId dep) const;
         template <typename Iter>
-        void add_dependencies(Iter first, Iter last);
+        void add_dependencies(Iter first, Iter last) const;
         template <typename Range>
-        void add_dependencies(const Range& deps);
+        void add_dependencies(const Range& deps) const;
 
         void set_provides(const ObjQueue& q) const;
         void add_provide(DependencyId dep) const;
         void add_self_provide() const;
         template <typename Iter>
-        void add_provides(Iter first, Iter last);
+        void add_provides(Iter first, Iter last) const;
         template <typename Range>
-        void add_provides(const Range& deps);
+        void add_provides(const Range& deps) const;
 
         /**
          * Set all constraints.
@@ -119,9 +119,9 @@ namespace mamba::solv
          */
         void add_constraint(DependencyId dep) const;
         template <typename Iter>
-        void add_constraints(Iter first, Iter last);
+        void add_constraints(Iter first, Iter last) const;
         template <typename Range>
-        void add_constraints(const Range& deps);
+        void add_constraints(const Range& deps) const;
 
         /**
          * Set all track features.
@@ -154,9 +154,9 @@ namespace mamba::solv
          */
         auto add_track_feature(std::string_view feat) const -> StringId;
         template <typename Iter>
-        void add_track_features(Iter first, Iter last);
+        void add_track_features(Iter first, Iter last) const;
         template <typename Range>
-        void add_track_features(const Range& features);
+        void add_track_features(const Range& features) const;
     };
 
     /***************************************
@@ -164,7 +164,7 @@ namespace mamba::solv
      ***************************************/
 
     template <typename Iter>
-    void ObjSolvableView::add_dependencies(Iter first, Iter last)
+    void ObjSolvableView::add_dependencies(Iter first, Iter last) const
     {
         for (; first != last; ++first)
         {
@@ -173,13 +173,13 @@ namespace mamba::solv
     }
 
     template <typename Range>
-    void ObjSolvableView::add_dependencies(const Range& deps)
+    void ObjSolvableView::add_dependencies(const Range& deps) const
     {
         return add_dependencies(deps.cbegin(), deps.cend());
     }
 
     template <typename Iter>
-    void ObjSolvableView::add_provides(Iter first, Iter last)
+    void ObjSolvableView::add_provides(Iter first, Iter last) const
     {
         for (; first != last; ++first)
         {
@@ -188,13 +188,13 @@ namespace mamba::solv
     }
 
     template <typename Range>
-    void ObjSolvableView::add_provides(const Range& deps)
+    void ObjSolvableView::add_provides(const Range& deps) const
     {
         return add_provides(deps.cbegin(), deps.cend());
     }
 
     template <typename Iter>
-    void ObjSolvableView::add_constraints(Iter first, Iter last)
+    void ObjSolvableView::add_constraints(Iter first, Iter last) const
     {
         for (; first != last; ++first)
         {
@@ -203,13 +203,13 @@ namespace mamba::solv
     }
 
     template <typename Range>
-    void ObjSolvableView::add_constraints(const Range& deps)
+    void ObjSolvableView::add_constraints(const Range& deps) const
     {
         return add_constraints(deps.cbegin(), deps.cend());
     }
 
     template <typename Iter>
-    void ObjSolvableView::add_track_features(Iter first, Iter last)
+    void ObjSolvableView::add_track_features(Iter first, Iter last) const
     {
         for (; first != last; ++first)
         {
@@ -218,7 +218,7 @@ namespace mamba::solv
     }
 
     template <typename Range>
-    void ObjSolvableView::add_track_features(const Range& feats)
+    void ObjSolvableView::add_track_features(const Range& feats) const
     {
         return add_track_features(feats.cbegin(), feats.cend());
     }

--- a/libmamba/src/solv-cpp/solvable.hpp
+++ b/libmamba/src/solv-cpp/solvable.hpp
@@ -24,7 +24,7 @@ namespace mamba::solv
     {
     public:
 
-        explicit ObjSolvableViewConst(const ::Solvable* solvable) noexcept;
+        explicit ObjSolvableViewConst(const ::Solvable& solvable) noexcept;
         ~ObjSolvableViewConst() noexcept;
 
         auto raw() const -> const ::Solvable*;
@@ -70,7 +70,7 @@ namespace mamba::solv
 
         using raw_str_view = const char*;
 
-        explicit ObjSolvableView(::Solvable* repo) noexcept;
+        explicit ObjSolvableView(::Solvable& repo) noexcept;
 
         auto raw() const -> ::Solvable*;
 

--- a/libmamba/src/solv-cpp/solvable.hpp
+++ b/libmamba/src/solv-cpp/solvable.hpp
@@ -16,7 +16,7 @@
 #include "solv-cpp/ids.hpp"
 #include "solv-cpp/queue.hpp"
 
-typedef struct s_Solvable Solvable;
+using Solvable = struct s_Solvable;
 
 namespace mamba::solv
 {
@@ -25,6 +25,7 @@ namespace mamba::solv
     public:
 
         explicit ObjSolvableViewConst(const ::Solvable* solvable) noexcept;
+        ~ObjSolvableViewConst() noexcept;
 
         auto raw() const -> const ::Solvable*;
 

--- a/libmamba/tests/CMakeLists.txt
+++ b/libmamba/tests/CMakeLists.txt
@@ -15,6 +15,7 @@ set(LIBMAMBA_TEST_SRCS
     # C++ wrapping of libsolv
     src/solv-cpp/test_queue.cpp
     src/solv-cpp/test_pool.cpp
+    src/solv-cpp/test_repo.cpp
     # Utility library
     src/util/test_flat_set.cpp
     src/util/test_graph.cpp

--- a/libmamba/tests/CMakeLists.txt
+++ b/libmamba/tests/CMakeLists.txt
@@ -81,6 +81,7 @@ file(COPY "${CMAKE_CURRENT_SOURCE_DIR}/data" DESTINATION "${CMAKE_CURRENT_BINARY
 target_compile_definitions(
     test_libmamba
     PRIVATE
+        DOCTEST_CONFIG_USE_STD_HEADERS
         MAMBA_TEST_DATA_DIR="${CMAKE_CURRENT_BINARY_DIR}/data"
         MAMBA_TEST_LOCK_EXE="$<TARGET_FILE:testing_libmamba_lock>"
 )

--- a/libmamba/tests/CMakeLists.txt
+++ b/libmamba/tests/CMakeLists.txt
@@ -16,6 +16,7 @@ set(LIBMAMBA_TEST_SRCS
     src/solv-cpp/test_queue.cpp
     src/solv-cpp/test_pool.cpp
     src/solv-cpp/test_repo.cpp
+    src/solv-cpp/test_solvable.cpp
     # Utility library
     src/util/test_flat_set.cpp
     src/util/test_graph.cpp

--- a/libmamba/tests/CMakeLists.txt
+++ b/libmamba/tests/CMakeLists.txt
@@ -14,6 +14,7 @@ set(LIBMAMBA_TEST_SRCS
     src/test_main.cpp
     # C++ wrapping of libsolv
     src/solv-cpp/test_queue.cpp
+    src/solv-cpp/test_pool.cpp
     # Utility library
     src/util/test_flat_set.cpp
     src/util/test_graph.cpp

--- a/libmamba/tests/src/solv-cpp/test_pool.cpp
+++ b/libmamba/tests/src/solv-cpp/test_pool.cpp
@@ -123,5 +123,21 @@ TEST_SUITE("ObjPool")
                 CHECK_FALSE(pool.remove_repo(1234, true));
             }
         }
+
+        SUBCASE("Add a debug callback")
+        {
+            std::string_view message = "";
+            int type = 0;
+            pool.set_debug_callback(
+                [&](auto* /* pool */, auto t, auto msg)
+                {
+                    message = msg;
+                    type = t;
+                }
+            );
+            pool_debug(pool.raw(), SOLV_DEBUG_RESULT, "Ho no!");
+            CHECK_EQ(message, "Ho no!");
+            CHECK_EQ(type, SOLV_DEBUG_RESULT);
+        }
     }
 }

--- a/libmamba/tests/src/solv-cpp/test_pool.cpp
+++ b/libmamba/tests/src/solv-cpp/test_pool.cpp
@@ -133,7 +133,7 @@ TEST_SUITE("ObjPool")
                 CHECK_FALSE(pool.remove_repo(1234, true));
             }
 
-            SUBCASE("Iterate through whatprovides")
+            SUBCASE("Manage solvables")
             {
                 auto [id1, s1] = repo1.add_solvable();
                 const auto pkg_name_id = pool.add_string("mamba");
@@ -147,26 +147,36 @@ TEST_SUITE("ObjPool")
                 s2.set_version("2.0.0");
                 s2.add_self_provide();
 
-                const auto dep_id = pool.add_dependency(pkg_name_id, REL_EQ, pkg_version_id);
-
-                SUBCASE("Without creating the whatprovides index is an error")
+                SUBCASE("Retrieve solvables")
                 {
-                    CHECK_THROWS_AS(
-                        pool.for_each_whatprovides_id(dep_id, [&](auto) {}),
-                        std::runtime_error
-                    );
+                    CHECK_EQ(pool.solvable_count(), 2);
+                    CHECK(pool.get_solvable(id1).has_value());
+                    CHECK(pool.get_solvable(id2).has_value());
                 }
 
-                SUBCASE("With creation of whatprovides index")
+                SUBCASE("Iterate through whatprovides")
                 {
-                    pool.create_whatprovides();
-                    auto whatprovides_ids = std::vector<SolvableId>();
-                    pool.for_each_whatprovides_id(
-                        dep_id,
-                        [&](auto id) { whatprovides_ids.push_back(id); }
-                    );
-                    // Only one solvable matches
-                    CHECK_EQ(whatprovides_ids, std::vector{ id1 });
+                    const auto dep_id = pool.add_dependency(pkg_name_id, REL_EQ, pkg_version_id);
+
+                    SUBCASE("Without creating the whatprovides index is an error")
+                    {
+                        CHECK_THROWS_AS(
+                            pool.for_each_whatprovides_id(dep_id, [&](auto) {}),
+                            std::runtime_error
+                        );
+                    }
+
+                    SUBCASE("With creation of whatprovides index")
+                    {
+                        pool.create_whatprovides();
+                        auto whatprovides_ids = std::vector<SolvableId>();
+                        pool.for_each_whatprovides_id(
+                            dep_id,
+                            [&](auto id) { whatprovides_ids.push_back(id); }
+                        );
+                        // Only one solvable matches
+                        CHECK_EQ(whatprovides_ids, std::vector{ id1 });
+                    }
                 }
             }
         }

--- a/libmamba/tests/src/solv-cpp/test_pool.cpp
+++ b/libmamba/tests/src/solv-cpp/test_pool.cpp
@@ -84,6 +84,14 @@ TEST_SUITE("ObjPool")
             auto [repo3_id, repo3] = pool.add_repo("repo3");
             CHECK_EQ(pool.n_repos(), 3);
 
+            SUBCASE("Set installed repo")
+            {
+                CHECK_FALSE(pool.installed_repo().has_value());
+                pool.set_installed_repo(repo2_id);
+                REQUIRE(pool.installed_repo().has_value());
+                CHECK_EQ(pool.installed_repo()->id(), repo2_id);
+            }
+
             SUBCASE("Iterate over repos")
             {
                 const auto repo_ids = std::array{ repo1_id, repo2_id, repo3_id };

--- a/libmamba/tests/src/solv-cpp/test_pool.cpp
+++ b/libmamba/tests/src/solv-cpp/test_pool.cpp
@@ -67,15 +67,15 @@ TEST_SUITE("ObjPool")
 
         SUBCASE("Add repo")
         {
-            RepoId repo1_id = pool.add_repo("repo1");
-            CHECK_EQ(pool.get_repo(repo1_id).id(), repo1_id);
+            auto [repo1_id, repo1] = pool.add_repo("repo1");
+            CHECK_EQ(repo1.id(), repo1_id);
+            REQUIRE(pool.has_repo(repo1_id));
+            REQUIRE(pool.get_repo(repo1_id).has_value());
+            CHECK_EQ(pool.get_repo(repo1_id).value().id(), repo1_id);
             CHECK_EQ(pool.n_repos(), 1);
 
-            RepoId repo2_id = pool.add_repo("repo2");
-            CHECK_EQ(pool.get_repo(repo2_id).id(), repo2_id);
-            CHECK_EQ(pool.n_repos(), 2);
-            RepoId repo3_id = pool.add_repo("repo2");
-            CHECK_EQ(pool.get_repo(repo3_id).id(), repo3_id);
+            auto [repo2_id, repo2] = pool.add_repo("repo2");
+            auto [repo3_id, repo3] = pool.add_repo("repo3");
             CHECK_EQ(pool.n_repos(), 3);
 
             SUBCASE("Iterate over repos")
@@ -90,6 +90,23 @@ TEST_SUITE("ObjPool")
                     }
                 );
                 CHECK_EQ(n_repos, pool.n_repos());
+            }
+
+            SUBCASE("Get inexisting repo")
+            {
+                CHECK_FALSE(pool.has_repo(1234));
+                CHECK_FALSE(pool.get_repo(1234).has_value());
+            }
+
+            SUBCASE("Remove repo")
+            {
+                CHECK(pool.remove_repo(repo2_id, true));
+                CHECK_FALSE(pool.has_repo(repo2_id));
+                CHECK(pool.get_repo(repo1_id).has_value());
+                CHECK_EQ(pool.n_repos(), 2);
+
+                // Remove invalid repo is a noop
+                CHECK_FALSE(pool.remove_repo(1234, true));
             }
         }
     }

--- a/libmamba/tests/src/solv-cpp/test_pool.cpp
+++ b/libmamba/tests/src/solv-cpp/test_pool.cpp
@@ -4,6 +4,9 @@
 //
 // The full license is in the file LICENSE, distributed with this software.
 
+#include <algorithm>
+#include <array>
+
 #include <doctest/doctest.h>
 #include <solv/pool.h>
 
@@ -60,6 +63,34 @@ TEST_SUITE("ObjPool")
             CHECK_EQ(pool.get_dependency_relation(id_rel), " > ");
             CHECK_EQ(pool.get_dependency_version(id_rel), "1.0.0");
             CHECK_EQ(pool.dependency_to_string(id_rel), "mamba > 1.0.0");
+        }
+
+        SUBCASE("Add repo")
+        {
+            RepoId repo1_id = pool.add_repo("repo1");
+            CHECK_EQ(pool.get_repo(repo1_id).id(), repo1_id);
+            CHECK_EQ(pool.n_repos(), 1);
+
+            RepoId repo2_id = pool.add_repo("repo2");
+            CHECK_EQ(pool.get_repo(repo2_id).id(), repo2_id);
+            CHECK_EQ(pool.n_repos(), 2);
+            RepoId repo3_id = pool.add_repo("repo2");
+            CHECK_EQ(pool.get_repo(repo3_id).id(), repo3_id);
+            CHECK_EQ(pool.n_repos(), 3);
+
+            SUBCASE("Iterate over repos")
+            {
+                const auto repo_ids = std::array{ repo1_id, repo2_id, repo3_id };
+                std::size_t n_repos = 0;
+                pool.for_each_repo_id(
+                    [&](RepoId id)
+                    {
+                        CHECK_NE(std::find(repo_ids.cbegin(), repo_ids.cend(), id), repo_ids.cend());
+                        n_repos++;
+                    }
+                );
+                CHECK_EQ(n_repos, pool.n_repos());
+            }
         }
     }
 }

--- a/libmamba/tests/src/solv-cpp/test_pool.cpp
+++ b/libmamba/tests/src/solv-cpp/test_pool.cpp
@@ -6,10 +6,13 @@
 
 #include <algorithm>
 #include <array>
+#include <string_view>
+#include <vector>
 
 #include <doctest/doctest.h>
 #include <solv/pool.h>
 
+#include "solv-cpp/ids.hpp"
 #include "solv-cpp/pool.hpp"
 
 using namespace mamba::solv;

--- a/libmamba/tests/src/solv-cpp/test_pool.cpp
+++ b/libmamba/tests/src/solv-cpp/test_pool.cpp
@@ -1,0 +1,65 @@
+// Copyright (c) 2023, QuantStack and Mamba Contributors
+//
+// Distributed under the terms of the BSD 3-Clause License.
+//
+// The full license is in the file LICENSE, distributed with this software.
+
+#include <doctest/doctest.h>
+#include <solv/pool.h>
+
+#include "solv-cpp/pool.hpp"
+
+using namespace mamba::solv;
+
+TEST_SUITE("ObjPool")
+{
+    TEST_CASE("Construct a pool")
+    {
+        auto pool = ObjPool();
+
+        SUBCASE("Add strings")
+        {
+            const auto id_hello = pool.add_string("Hello");
+            const auto maybe_id_hello = pool.find_string("Hello");
+            REQUIRE(maybe_id_hello.has_value());
+            CHECK_EQ(maybe_id_hello.value(), id_hello);
+            CHECK_EQ(pool.get_string(id_hello), "Hello");
+
+            SUBCASE("Add another string")
+            {
+                const auto id_world = pool.add_string("World");
+                CHECK_NE(id_world, id_hello);
+                const auto maybe_id_world = pool.find_string("World");
+                REQUIRE(maybe_id_world.has_value());
+                CHECK_EQ(maybe_id_world.value(), id_world);
+                CHECK_EQ(pool.get_string(id_world), "World");
+
+                SUBCASE("Add the same one again")
+                {
+                    const auto id_world_again = pool.add_string("World");
+                    CHECK_EQ(id_world_again, id_world);
+                }
+            }
+
+            SUBCASE("Find non-existant string")
+            {
+                CHECK_FALSE(pool.find_string("Bar").has_value());
+            }
+        }
+
+        SUBCASE("Add dependencies")
+        {
+            const auto id_name = pool.add_string("mamba");
+            const auto id_version_1 = pool.add_string("1.0.0");
+
+            const auto id_rel = pool.add_dependency(id_name, REL_GT, id_version_1);
+            const auto maybe_id_rel = pool.find_dependency(id_name, REL_GT, id_version_1);
+            REQUIRE(maybe_id_rel.has_value());
+            CHECK_EQ(maybe_id_rel.value(), id_rel);
+            CHECK_EQ(pool.get_dependency_name(id_rel), "mamba");
+            CHECK_EQ(pool.get_dependency_relation(id_rel), " > ");
+            CHECK_EQ(pool.get_dependency_version(id_rel), "1.0.0");
+            CHECK_EQ(pool.dependency_to_string(id_rel), "mamba > 1.0.0");
+        }
+    }
+}

--- a/libmamba/tests/src/solv-cpp/test_pool.cpp
+++ b/libmamba/tests/src/solv-cpp/test_pool.cpp
@@ -78,11 +78,11 @@ TEST_SUITE("ObjPool")
             REQUIRE(pool.has_repo(repo1_id));
             REQUIRE(pool.get_repo(repo1_id).has_value());
             CHECK_EQ(pool.get_repo(repo1_id).value().id(), repo1_id);
-            CHECK_EQ(pool.n_repos(), 1);
+            CHECK_EQ(pool.repo_count(), 1);
 
             auto [repo2_id, repo2] = pool.add_repo("repo2");
             auto [repo3_id, repo3] = pool.add_repo("repo3");
-            CHECK_EQ(pool.n_repos(), 3);
+            CHECK_EQ(pool.repo_count(), 3);
 
             SUBCASE("Set installed repo")
             {
@@ -103,7 +103,7 @@ TEST_SUITE("ObjPool")
                         n_repos++;
                     }
                 );
-                CHECK_EQ(n_repos, pool.n_repos());
+                CHECK_EQ(n_repos, pool.repo_count());
             }
 
             SUBCASE("Get inexisting repo")
@@ -117,7 +117,7 @@ TEST_SUITE("ObjPool")
                 CHECK(pool.remove_repo(repo2_id, true));
                 CHECK_FALSE(pool.has_repo(repo2_id));
                 CHECK(pool.get_repo(repo1_id).has_value());
-                CHECK_EQ(pool.n_repos(), 2);
+                CHECK_EQ(pool.repo_count(), 2);
 
                 // Remove invalid repo is a noop
                 CHECK_FALSE(pool.remove_repo(1234, true));
@@ -166,7 +166,7 @@ TEST_SUITE("ObjPool")
             std::string_view message = "";
             int type = 0;
             pool.set_debug_callback(
-                [&](auto* /* pool */, auto t, auto msg)
+                [&](auto* /* pool */, auto t, auto msg) noexcept
                 {
                     message = msg;
                     type = t;

--- a/libmamba/tests/src/solv-cpp/test_pool.cpp
+++ b/libmamba/tests/src/solv-cpp/test_pool.cpp
@@ -122,6 +122,43 @@ TEST_SUITE("ObjPool")
                 // Remove invalid repo is a noop
                 CHECK_FALSE(pool.remove_repo(1234, true));
             }
+
+            SUBCASE("Iterate through whatprovides")
+            {
+                auto [id1, s1] = repo1.add_solvable();
+                const auto pkg_name_id = pool.add_string("mamba");
+                const auto pkg_version_id = pool.add_string("1.0.0");
+                s1.set_name(pkg_name_id);
+                s1.set_version(pkg_version_id);
+                s1.add_self_provide();
+
+                auto [id2, s2] = repo2.add_solvable();
+                s2.set_name(pkg_name_id);
+                s2.set_version("2.0.0");
+                s2.add_self_provide();
+
+                const auto dep_id = pool.add_dependency(pkg_name_id, REL_EQ, pkg_version_id);
+
+                SUBCASE("Without creating the whatprovides index is an error")
+                {
+                    CHECK_THROWS_AS(
+                        pool.for_each_whatprovides_id(dep_id, [&](auto) {}),
+                        std::runtime_error
+                    );
+                }
+
+                SUBCASE("With creation of whatprovides index")
+                {
+                    pool.create_whatprovides();
+                    auto whatprovides_ids = std::vector<SolvableId>();
+                    pool.for_each_whatprovides_id(
+                        dep_id,
+                        [&](auto id) { whatprovides_ids.push_back(id); }
+                    );
+                    // Only one solvable matches
+                    CHECK_EQ(whatprovides_ids, std::vector{ id1 });
+                }
+            }
         }
 
         SUBCASE("Add a debug callback")

--- a/libmamba/tests/src/solv-cpp/test_pool.cpp
+++ b/libmamba/tests/src/solv-cpp/test_pool.cpp
@@ -20,6 +20,12 @@ TEST_SUITE("ObjPool")
     {
         auto pool = ObjPool();
 
+        SUBCASE("Change distribution type")
+        {
+            pool.set_disttype(DISTTYPE_CONDA);
+            CHECK_EQ(pool.disttype(), DISTTYPE_CONDA);
+        }
+
         SUBCASE("Add strings")
         {
             const auto id_hello = pool.add_string("Hello");

--- a/libmamba/tests/src/solv-cpp/test_pool.cpp
+++ b/libmamba/tests/src/solv-cpp/test_pool.cpp
@@ -84,6 +84,13 @@ TEST_SUITE("ObjPool")
             auto [repo3_id, repo3] = pool.add_repo("repo3");
             CHECK_EQ(pool.repo_count(), 3);
 
+            SUBCASE("Add repo with same name")
+            {
+                auto [repo1_bis_id, repo1_bis] = pool.add_repo("repo1");
+                CHECK_EQ(pool.repo_count(), 4);
+                CHECK_NE(repo1_bis_id, repo1_id);
+            }
+
             SUBCASE("Set installed repo")
             {
                 CHECK_FALSE(pool.installed_repo().has_value());

--- a/libmamba/tests/src/solv-cpp/test_queue.cpp
+++ b/libmamba/tests/src/solv-cpp/test_queue.cpp
@@ -190,4 +190,19 @@ TEST_SUITE("ObjQueue")
         CHECK_EQ(q.size(), 0);
         CHECK_GE(q.capacity(), 10);
     }
+
+    TEST_CASE("comparison")
+    {
+        CHECK_EQ(ObjQueue{}, ObjQueue{});
+
+        auto q1 = ObjQueue{ 1, 2, 3 };
+
+        CHECK_EQ(q1, q1);
+        CHECK_NE(q1, ObjQueue{});
+
+        auto q2 = q1;
+        CHECK_EQ(q1, q2);
+        q2.reserve(10);
+        CHECK_EQ(q1, q2);
+    }
 }

--- a/libmamba/tests/src/solv-cpp/test_repo.cpp
+++ b/libmamba/tests/src/solv-cpp/test_repo.cpp
@@ -65,14 +65,14 @@ TEST_SUITE("ObjRepo")
 
         SUBCASE("Add solvables")
         {
-            CHECK_EQ(repo.n_solvables(), 0);
+            CHECK_EQ(repo.solvable_count(), 0);
             const auto [id1, s1] = repo.add_solvable();
             REQUIRE(repo.get_solvable(id1).has_value());
             CHECK_EQ(repo.get_solvable(id1)->raw(), s1.raw());
-            CHECK_EQ(repo.n_solvables(), 1);
+            CHECK_EQ(repo.solvable_count(), 1);
             CHECK(repo.has_solvable(id1));
             const auto [id2, s2] = repo.add_solvable();
-            CHECK_EQ(repo.n_solvables(), 2);
+            CHECK_EQ(repo.solvable_count(), 2);
             CHECK(repo.has_solvable(id2));
 
             SUBCASE("Iterate through solvables")
@@ -86,7 +86,7 @@ TEST_SUITE("ObjRepo")
                         n_solvables++;
                     }
                 );
-                CHECK_EQ(n_solvables, repo.n_solvables());
+                CHECK_EQ(n_solvables, repo.solvable_count());
             }
 
             SUBCASE("Get inexisting solvable")
@@ -100,7 +100,7 @@ TEST_SUITE("ObjRepo")
                 CHECK(repo.remove_solvable(id2, true));
                 CHECK_FALSE(repo.has_solvable(id2));
                 CHECK(repo.has_solvable(id1));
-                CHECK_EQ(repo.n_solvables(), 1);
+                CHECK_EQ(repo.solvable_count(), 1);
             }
 
             SUBCASE("Confuse ids from another repo")
@@ -116,7 +116,7 @@ TEST_SUITE("ObjRepo")
             SUBCASE("Clear solvables")
             {
                 repo.clear(true);
-                CHECK_EQ(repo.n_solvables(), 0);
+                CHECK_EQ(repo.solvable_count(), 0);
                 CHECK_FALSE(repo.has_solvable(id1));
                 CHECK_FALSE(repo.get_solvable(id1).has_value());
             }
@@ -130,14 +130,14 @@ TEST_SUITE("ObjRepo")
                 SUBCASE("Read repo from file")
                 {
                     // Delete repo
-                    const auto n_solvables = repo.n_solvables();
+                    const auto n_solvables = repo.solvable_count();
                     pool.remove_repo(repo_id, true);
 
                     // Create new repo from file
                     auto [repo_id2, repo2] = pool.add_repo("test-forge");
                     repo2.read(solv_file);
 
-                    CHECK_EQ(repo2.n_solvables(), n_solvables);
+                    CHECK_EQ(repo2.solvable_count(), n_solvables);
                     // True because we reused ids
                     CHECK(repo2.has_solvable(id1));
                     CHECK(repo2.has_solvable(id2));

--- a/libmamba/tests/src/solv-cpp/test_repo.cpp
+++ b/libmamba/tests/src/solv-cpp/test_repo.cpp
@@ -22,10 +22,14 @@ TEST_SUITE("ObjRepo")
         auto pool = ObjPool();
         auto repo_id = pool.add_repo("test-forge");
         auto repo = pool.get_repo(repo_id);
+        CHECK_EQ(repo.id(), repo_id);
+        CHECK_EQ(repo.name(), "test-forge");
 
         SUBCASE("Fetch the repo")
         {
-            CHECK_EQ(pool.get_repo(repo_id).name(), "test-forge");
+            auto repo_alt = pool.get_repo(repo_id);
+            CHECK_EQ(repo_alt.name(), repo.name());
+            CHECK_EQ(repo_alt.id(), repo.id());
         }
 
         SUBCASE("Set attributes")

--- a/libmamba/tests/src/solv-cpp/test_repo.cpp
+++ b/libmamba/tests/src/solv-cpp/test_repo.cpp
@@ -28,6 +28,37 @@ TEST_SUITE("ObjRepo")
             CHECK_EQ(pool.get_repo(repo_id).name(), "test-forge");
         }
 
+        SUBCASE("Set attributes")
+        {
+            repo.set_url("https://repo.mamba.pm/conda-forge");
+            repo.set_channel("conda-forge");
+            repo.set_subdir("noarch");
+
+            SUBCASE("Empty without internalize")
+            {
+                CHECK_EQ(repo.url(), "");
+                CHECK_EQ(repo.channel(), "");
+                CHECK_EQ(repo.subdir(), "");
+            }
+
+            SUBCASE("Internalize and get attributes")
+            {
+                repo.internalize();
+
+                CHECK_EQ(repo.url(), "https://repo.mamba.pm/conda-forge");
+                CHECK_EQ(repo.channel(), "conda-forge");
+                CHECK_EQ(repo.subdir(), "noarch");
+
+                SUBCASE("Override attribute")
+                {
+                    repo.set_subdir("linux-64");
+                    CHECK_EQ(repo.subdir(), "noarch");
+                    repo.internalize();
+                    CHECK_EQ(repo.subdir(), "linux-64");
+                }
+            }
+        }
+
         SUBCASE("Add solvables")
         {
             // Adding solvable

--- a/libmamba/tests/src/solv-cpp/test_repo.cpp
+++ b/libmamba/tests/src/solv-cpp/test_repo.cpp
@@ -35,14 +35,22 @@ TEST_SUITE("ObjRepo")
         SUBCASE("Set attributes")
         {
             repo.set_url("https://repo.mamba.pm/conda-forge");
+            repo.set_etag(R"(etag)W/"8eea3023872b68ef71fd930472a15599"(etag)");
+            repo.set_mod("Tue, 25 Apr 2023 11:48:37 GMT");
             repo.set_channel("conda-forge");
             repo.set_subdir("noarch");
+            repo.set_pip_added(true);
+            repo.set_tool_version("1.2.3.4");
 
             SUBCASE("Empty without internalize")
             {
                 CHECK_EQ(repo.url(), "");
+                CHECK_EQ(repo.etag(), "");
+                CHECK_EQ(repo.mod(), "");
                 CHECK_EQ(repo.channel(), "");
                 CHECK_EQ(repo.subdir(), "");
+                CHECK_EQ(repo.pip_added(), false);
+                CHECK_EQ(repo.tool_version(), "");
             }
 
             SUBCASE("Internalize and get attributes")
@@ -52,6 +60,10 @@ TEST_SUITE("ObjRepo")
                 CHECK_EQ(repo.url(), "https://repo.mamba.pm/conda-forge");
                 CHECK_EQ(repo.channel(), "conda-forge");
                 CHECK_EQ(repo.subdir(), "noarch");
+                CHECK_EQ(repo.etag(), R"(etag)W/"8eea3023872b68ef71fd930472a15599"(etag)");
+                CHECK_EQ(repo.mod(), "Tue, 25 Apr 2023 11:48:37 GMT");
+                CHECK_EQ(repo.pip_added(), true);
+                CHECK_EQ(repo.tool_version(), "1.2.3.4");
 
                 SUBCASE("Override attribute")
                 {

--- a/libmamba/tests/src/solv-cpp/test_repo.cpp
+++ b/libmamba/tests/src/solv-cpp/test_repo.cpp
@@ -1,0 +1,88 @@
+// Copyright (c) 2023, QuantStack and Mamba Contributors
+//
+// Distributed under the terms of the BSD 3-Clause License.
+//
+// The full license is in the file LICENSE, distributed with this software.
+
+#include <algorithm>
+#include <array>
+
+#include <doctest/doctest.h>
+
+#include "mamba/core/util.hpp"
+#include "solv-cpp/pool.hpp"
+#include "solv-cpp/repo.hpp"
+
+using namespace mamba::solv;
+
+TEST_SUITE("ObjRepo")
+{
+    TEST_CASE("Construct a repo")
+    {
+        auto pool = ObjPool();
+        auto repo_id = pool.add_repo("test-forge");
+        auto repo = pool.get_repo(repo_id);
+
+        SUBCASE("Fetch the repo")
+        {
+            CHECK_EQ(pool.get_repo(repo_id).name(), "test-forge");
+        }
+
+        SUBCASE("Add solvables")
+        {
+            // Adding solvable
+            CHECK_EQ(repo.n_solvables(), 0);
+            const auto id1 = repo.add_solvable();
+            CHECK_EQ(repo.n_solvables(), 1);
+            CHECK(repo.contains_solvable(id1));
+            const auto id2 = repo.add_solvable();
+            CHECK_EQ(repo.n_solvables(), 2);
+            CHECK(repo.contains_solvable(id2));
+
+            SUBCASE("Iterate through solvables")
+            {
+                // Iterating through solvables
+                const auto ids = std::array{ id1, id2 };
+                std::size_t n_solvables = 0;
+                repo.for_each_solvable_id(
+                    [&](SolvableId id)
+                    {
+                        CHECK_NE(std::find(ids.cbegin(), ids.cend(), id), ids.cend());
+                        n_solvables++;
+                    }
+                );
+                CHECK_EQ(n_solvables, repo.n_solvables());
+            }
+
+            SUBCASE("Clear solvables")
+            {
+                repo.clear(true);
+                CHECK_EQ(repo.n_solvables(), 0);
+            }
+
+            SUBCASE("Write repo to file")
+            {
+                auto dir = mamba::TemporaryDirectory();
+                const auto solv_file = dir.path() / "test-forge.hpp";
+                repo.write(solv_file);
+
+                SUBCASE("Read repo from file")
+                {
+                    // Delete repo
+                    const auto n_solvables = repo.n_solvables();
+                    pool.remove_repo(repo_id, true);
+
+                    // Create new repo from file
+                    auto repo_id2 = pool.add_repo("test-forge");
+                    auto repo2 = pool.get_repo(repo_id2);
+                    repo2.read(solv_file);
+
+                    CHECK_EQ(repo2.n_solvables(), n_solvables);
+                    // True because we reused ids
+                    CHECK(repo2.contains_solvable(id1));
+                    CHECK(repo2.contains_solvable(id2));
+                }
+            }
+        }
+    }
+}

--- a/libmamba/tests/src/solv-cpp/test_repo.cpp
+++ b/libmamba/tests/src/solv-cpp/test_repo.cpp
@@ -20,14 +20,14 @@ TEST_SUITE("ObjRepo")
     TEST_CASE("Construct a repo")
     {
         auto pool = ObjPool();
-        auto repo_id = pool.add_repo("test-forge");
-        auto repo = pool.get_repo(repo_id);
+        auto [repo_id, repo] = pool.add_repo("test-forge");
         CHECK_EQ(repo.id(), repo_id);
         CHECK_EQ(repo.name(), "test-forge");
 
         SUBCASE("Fetch the repo")
         {
-            auto repo_alt = pool.get_repo(repo_id);
+            REQUIRE(pool.has_repo(repo_id));
+            auto repo_alt = pool.get_repo(repo_id).value();
             CHECK_EQ(repo_alt.name(), repo.name());
             CHECK_EQ(repo_alt.id(), repo.id());
         }
@@ -76,7 +76,6 @@ TEST_SUITE("ObjRepo")
 
             SUBCASE("Iterate through solvables")
             {
-                // Iterating through solvables
                 const auto ids = std::array{ id1, id2 };
                 std::size_t n_solvables = 0;
                 repo.for_each_solvable_id(
@@ -108,8 +107,7 @@ TEST_SUITE("ObjRepo")
                     pool.remove_repo(repo_id, true);
 
                     // Create new repo from file
-                    auto repo_id2 = pool.add_repo("test-forge");
-                    auto repo2 = pool.get_repo(repo_id2);
+                    auto [repo_id2, repo2] = pool.add_repo("test-forge");
                     repo2.read(solv_file);
 
                     CHECK_EQ(repo2.n_solvables(), n_solvables);

--- a/libmamba/tests/src/solv-cpp/test_solvable.cpp
+++ b/libmamba/tests/src/solv-cpp/test_solvable.cpp
@@ -1,0 +1,249 @@
+// Copyright (c) 2023, QuantStack and Mamba Contributors
+//
+// Distributed under the terms of the BSD 3-Clause License.
+//
+// The full license is in the file LICENSE, distributed with this software.
+
+#include <doctest/doctest.h>
+
+#include "solv-cpp/pool.hpp"
+#include "solv-cpp/repo.hpp"
+#include "solv-cpp/solvable.hpp"
+
+using namespace mamba::solv;
+
+TEST_SUITE("ObjSolvable")
+{
+    TEST_CASE("Create a solvable")
+    {
+        auto pool = ObjPool();
+        auto repo_id = pool.add_repo("test-forge");
+        auto repo = pool.get_repo(repo_id);
+        const auto solv_id = repo.add_solvable();
+        auto solv = repo.get_solvable(solv_id);
+
+        SUBCASE("Set name and version")
+        {
+            solv.set_name("my-package");
+            solv.set_version("0.1.1");
+            CHECK_EQ(solv.name(), "my-package");
+            CHECK_EQ(solv.version(), "0.1.1");
+
+            SUBCASE("Change name version")
+            {
+                solv.set_name("other-package");
+                solv.set_version("0.2.2");
+                CHECK_EQ(solv.name(), "other-package");
+                CHECK_EQ(solv.version(), "0.2.2");
+            }
+        }
+
+        SUBCASE("Set attributes")
+        {
+            solv.set_build_number(33);
+            solv.set_build_string("build");
+            solv.set_file_name("file.tar.gz");
+            solv.set_license("MIT");
+            solv.set_md5("6f29ba77e8b03b191c9d667f331bf2a0");
+            solv.set_sha256("ecde63af23e0d49c0ece19ec539d873ea408a6f966d3126994c6d33ae1b9d3f7");
+            solv.set_noarch(std::string("python"));
+            solv.set_size(2345);
+            solv.set_timestamp(4110596167);
+
+            SUBCASE("Empty without internalize")
+            {
+                CHECK_EQ(solv.build_number(), 0);
+                CHECK_EQ(solv.build_string(), "");
+                CHECK_EQ(solv.file_name(), "");
+                CHECK_EQ(solv.license(), "");
+                CHECK_EQ(solv.md5(), "");
+                CHECK_EQ(solv.sha256(), "");
+                CHECK_EQ(solv.noarch(), "");
+                CHECK_EQ(solv.size(), 0);
+                CHECK_EQ(solv.timestamp(), 0);
+            }
+
+            SUBCASE("Internalize and get attributes")
+            {
+                repo.internalize();
+
+                CHECK_EQ(solv.build_string(), "build");
+                CHECK_EQ(solv.build_number(), 33);
+                CHECK_EQ(solv.build_string(), "build");
+                CHECK_EQ(solv.file_name(), "file.tar.gz");
+                CHECK_EQ(solv.license(), "MIT");
+                CHECK_EQ(solv.md5(), "6f29ba77e8b03b191c9d667f331bf2a0");
+                CHECK_EQ(
+                    solv.sha256(),
+                    "ecde63af23e0d49c0ece19ec539d873ea408a6f966d3126994c6d33ae1b9d3f7"
+                );
+                CHECK_EQ(solv.noarch(), "python");
+                CHECK_EQ(solv.size(), 2345);
+                CHECK_EQ(solv.timestamp(), 4110596167);
+
+                SUBCASE("Override attribute")
+                {
+                    solv.set_license("GPL");
+                    CHECK_EQ(solv.license(), "MIT");
+                    repo.internalize();
+                    CHECK_EQ(solv.license(), "GPL");
+                }
+            }
+        }
+
+        SUBCASE("Get unset attributes")
+        {
+            CHECK_EQ(solv.name(), "");
+            CHECK_EQ(solv.version(), "");
+            CHECK_EQ(solv.build_number(), 0);
+            CHECK_EQ(solv.build_string(), "");
+            CHECK_EQ(solv.file_name(), "");
+            CHECK_EQ(solv.license(), "");
+            CHECK_EQ(solv.md5(), "");
+            CHECK_EQ(solv.sha256(), "");
+            CHECK_EQ(solv.noarch(), "");
+            CHECK_EQ(solv.size(), 0);
+            CHECK_EQ(solv.timestamp(), 0);
+        }
+
+        SUBCASE("Add dependency")
+        {
+            solv.add_dependency(33);
+            CHECK_EQ(solv.dependencies(), ObjQueue{ 33 });
+
+            SUBCASE("Add more dependencies")
+            {
+                solv.add_dependencies(ObjQueue{ 44, 22 });
+                CHECK_EQ(solv.dependencies(), ObjQueue{ 33, 44, 22 });
+            }
+
+            SUBCASE("Reset dependencies")
+            {
+                solv.set_dependencies({});
+                CHECK(solv.dependencies().empty());
+            }
+        }
+
+        SUBCASE("Add provide")
+        {
+            solv.add_provide(33);
+            CHECK_EQ(solv.provides(), ObjQueue{ 33 });
+
+            SUBCASE("Add self provide")
+            {
+                solv.add_self_provide();
+                CHECK_EQ(solv.provides().size(), 2);
+            }
+
+            SUBCASE("Add more provides")
+            {
+                solv.add_provides(ObjQueue{ 44, 22 });
+                CHECK_EQ(solv.provides(), ObjQueue{ 33, 44, 22 });
+            }
+
+            SUBCASE("Reset provides")
+            {
+                solv.set_provides({});
+                CHECK(solv.provides().empty());
+            }
+        }
+
+        SUBCASE("Add constraint")
+        {
+            solv.add_constraint(33);
+
+            SUBCASE("Internalize and get constraint")
+            {
+                repo.internalize();
+                CHECK_EQ(solv.constraints(), ObjQueue{ 33 });
+
+                SUBCASE("Fail to add more constraint")
+                {
+                    solv.add_constraint(44);
+                    CHECK_EQ(solv.constraints(), ObjQueue{ 33 });
+
+                    SUBCASE("Override when internalizing again")
+                    {
+                        repo.internalize();
+                        CHECK_EQ(solv.constraints(), ObjQueue{ 44 });
+                    }
+                }
+
+                SUBCASE("Fail to set constraints")
+                {
+                    solv.set_constraints({ 22 });
+                    CHECK_EQ(solv.constraints(), ObjQueue{ 33 });
+
+                    SUBCASE("Override when internalizing again")
+                    {
+                        repo.internalize();
+                        CHECK_EQ(solv.constraints(), ObjQueue{ 22 });
+                    }
+                }
+            }
+
+            SUBCASE("Add more constraints")
+            {
+                solv.add_constraints(ObjQueue{ 44, 22 });
+                repo.internalize();
+                CHECK_EQ(solv.constraints(), ObjQueue{ 33, 44, 22 });
+            }
+
+            SUBCASE("Reset constraints")
+            {
+                solv.set_constraints({});
+                repo.internalize();
+                CHECK(solv.constraints().empty());
+            }
+        }
+
+        SUBCASE("Track feature")
+        {
+            const StringId feat1_id = solv.add_track_feature("feature1");
+
+            SUBCASE("Internalize and get tracked features")
+            {
+                repo.internalize();
+                CHECK_EQ(solv.track_features(), ObjQueue{ feat1_id });
+
+                SUBCASE("Fail to track more features")
+                {
+                    const StringId feat2_id = solv.add_track_feature("feature2");
+                    CHECK_EQ(solv.track_features(), ObjQueue{ feat1_id });
+
+                    SUBCASE("Override when internalizing again")
+                    {
+                        repo.internalize();
+                        CHECK_EQ(solv.track_features(), ObjQueue{ feat2_id });
+                    }
+                }
+
+                SUBCASE("Fail to set tracked features")
+                {
+                    solv.set_track_features({ 22 });
+                    CHECK_EQ(solv.track_features(), ObjQueue{ feat1_id });
+
+                    SUBCASE("Override when internalizing again")
+                    {
+                        repo.internalize();
+                        CHECK_EQ(solv.track_features(), ObjQueue{ 22 });
+                    }
+                }
+            }
+
+            SUBCASE("Track more features")
+            {
+                solv.add_track_features(ObjQueue{ 44, 11 });
+                repo.internalize();
+                CHECK_EQ(solv.track_features(), ObjQueue{ feat1_id, 44, 11 });
+            }
+
+            SUBCASE("Reset tracked features")
+            {
+                solv.set_track_features({});
+                repo.internalize();
+                CHECK(solv.track_features().empty());
+            }
+        }
+    }
+}

--- a/libmamba/tests/src/solv-cpp/test_solvable.cpp
+++ b/libmamba/tests/src/solv-cpp/test_solvable.cpp
@@ -18,8 +18,7 @@ TEST_SUITE("ObjSolvable")
     {
         auto pool = ObjPool();
         auto [repo_id, repo] = pool.add_repo("test-forge");
-        const auto solv_id = repo.add_solvable();
-        auto solv = repo.get_solvable(solv_id);
+        const auto [solv_id, solv] = repo.add_solvable();
         CHECK_EQ(solv_id, solv.id());
 
         SUBCASE("Set name and version")

--- a/libmamba/tests/src/solv-cpp/test_solvable.cpp
+++ b/libmamba/tests/src/solv-cpp/test_solvable.cpp
@@ -48,6 +48,9 @@ TEST_SUITE("ObjSolvable")
             solv.set_noarch(std::string("python"));
             solv.set_size(2345);
             solv.set_timestamp(4110596167);
+            solv.set_url("https://conda.anaconda.org/conda-forge/linux-64");
+            solv.set_channel("conda-forge");
+            solv.set_subdir("linux-64");
 
             SUBCASE("Empty without internalize")
             {
@@ -60,6 +63,9 @@ TEST_SUITE("ObjSolvable")
                 CHECK_EQ(solv.noarch(), "");
                 CHECK_EQ(solv.size(), 0);
                 CHECK_EQ(solv.timestamp(), 0);
+                CHECK_EQ(solv.url(), "");
+                CHECK_EQ(solv.channel(), "");
+                CHECK_EQ(solv.subdir(), "");
             }
 
             SUBCASE("Internalize and get attributes")
@@ -79,6 +85,9 @@ TEST_SUITE("ObjSolvable")
                 CHECK_EQ(solv.noarch(), "python");
                 CHECK_EQ(solv.size(), 2345);
                 CHECK_EQ(solv.timestamp(), 4110596167);
+                CHECK_EQ(solv.url(), "https://conda.anaconda.org/conda-forge/linux-64");
+                CHECK_EQ(solv.channel(), "conda-forge");
+                CHECK_EQ(solv.subdir(), "linux-64");
 
                 SUBCASE("Override attribute")
                 {
@@ -103,6 +112,9 @@ TEST_SUITE("ObjSolvable")
             CHECK_EQ(solv.noarch(), "");
             CHECK_EQ(solv.size(), 0);
             CHECK_EQ(solv.timestamp(), 0);
+            CHECK_EQ(solv.url(), "");
+            CHECK_EQ(solv.channel(), "");
+            CHECK_EQ(solv.subdir(), "");
         }
 
         SUBCASE("Add dependency")

--- a/libmamba/tests/src/solv-cpp/test_solvable.cpp
+++ b/libmamba/tests/src/solv-cpp/test_solvable.cpp
@@ -17,8 +17,7 @@ TEST_SUITE("ObjSolvable")
     TEST_CASE("Create a solvable")
     {
         auto pool = ObjPool();
-        auto repo_id = pool.add_repo("test-forge");
-        auto repo = pool.get_repo(repo_id);
+        auto [repo_id, repo] = pool.add_repo("test-forge");
         const auto solv_id = repo.add_solvable();
         auto solv = repo.get_solvable(solv_id);
         CHECK_EQ(solv_id, solv.id());

--- a/libmamba/tests/src/solv-cpp/test_solvable.cpp
+++ b/libmamba/tests/src/solv-cpp/test_solvable.cpp
@@ -21,6 +21,7 @@ TEST_SUITE("ObjSolvable")
         auto repo = pool.get_repo(repo_id);
         const auto solv_id = repo.add_solvable();
         auto solv = repo.get_solvable(solv_id);
+        CHECK_EQ(solv_id, solv.id());
 
         SUBCASE("Set name and version")
         {


### PR DESCRIPTION
For  #2302

- Add ObjPool
- Use ObjPool in MPool
- Add skeleton ObjRepoView
- Add solv Repo io

If https://github.com/openSUSE/libsolv/pull/526 is merged and release, we can use `std::string_view` for setting solvable attributes.
