### PR TITLE
Renamed `validate` namespace to `mamba::validation

### DIFF
--- a/libmamba/include/mamba/core/channel.hpp
+++ b/libmamba/include/mamba/core/channel.hpp
@@ -30,7 +30,7 @@ namespace mamba
         const std::optional<std::string>& token() const;
         const std::optional<std::string>& package_filename() const;
         const std::string& canonical_name() const;
-        const validate::RepoChecker& repo_checker(MultiPackageCache& caches) const;
+        const validation::RepoChecker& repo_checker(MultiPackageCache& caches) const;
 
         std::string base_url() const;
         std::string platform_url(std::string platform, bool with_credential = true) const;
@@ -59,7 +59,7 @@ namespace mamba
         std::optional<std::string> m_token;
         std::optional<std::string> m_package_filename;
         mutable std::optional<std::string> m_canonical_name;
-        mutable std::unique_ptr<validate::RepoChecker> p_repo_checker;
+        mutable std::unique_ptr<validation::RepoChecker> p_repo_checker;
 
         friend class ChannelBuilder;
     };

--- a/libmamba/include/mamba/core/timeref.hpp
+++ b/libmamba/include/mamba/core/timeref.hpp
@@ -4,7 +4,7 @@
 #include <chrono>
 #include <string>
 
-namespace validate
+namespace mamba::validation
 {
 
     /** Define a time reference.

--- a/libmamba/include/mamba/core/validate.hpp
+++ b/libmamba/include/mamba/core/validate.hpp
@@ -18,7 +18,7 @@
 #include "mamba/core/timeref.hpp"
 #include "mamba/core/util.hpp"
 
-namespace validate
+namespace mamba::validation
 {
     using nlohmann::json;
 

--- a/libmamba/src/core/channel.cpp
+++ b/libmamba/src/core/channel.cpp
@@ -145,11 +145,11 @@ namespace mamba
         return m_package_filename;
     }
 
-    const validate::RepoChecker& Channel::repo_checker(MultiPackageCache& caches) const
+    const validation::RepoChecker& Channel::repo_checker(MultiPackageCache& caches) const
     {
         if (p_repo_checker == nullptr)
         {
-            p_repo_checker = std::make_unique<validate::RepoChecker>(
+            p_repo_checker = std::make_unique<validation::RepoChecker>(
                 rsplit(base_url(), "/", 1).front(),
                 Context::instance().root_prefix / "etc" / "trusted-repos"
                     / cache_name_from_url(base_url()),

--- a/libmamba/src/core/link.cpp
+++ b/libmamba/src/core/link.cpp
@@ -597,7 +597,7 @@ namespace mamba
             // Sometimes we might want to raise here ...
             m_clobber_warnings.push_back(rel_dst.string());
 #ifdef _WIN32
-            return std::make_tuple(validate::sha256sum(dst), rel_dst.string());
+            return std::make_tuple(validation::sha256sum(dst), rel_dst.string());
 #endif
             fs::remove(dst);
         }
@@ -689,7 +689,7 @@ namespace mamba
                         fo << launcher << shebang << (buffer.c_str() + arc_pos);
                         fo.close();
                     }
-                    return std::make_tuple(validate::sha256sum(dst), rel_dst.string());
+                    return std::make_tuple(validation::sha256sum(dst), rel_dst.string());
                 }
 #else
                 std::size_t padding_size = (path_data.prefix_placeholder.size() > new_prefix.size())
@@ -738,7 +738,7 @@ namespace mamba
                 codesign(dst, Context::instance().verbosity > 1);
             }
 #endif
-            return std::make_tuple(validate::sha256sum(dst), rel_dst.string());
+            return std::make_tuple(validation::sha256sum(dst), rel_dst.string());
         }
 
         if ((path_data.path_type == PathType::HARDLINK) || path_data.no_link)
@@ -800,7 +800,7 @@ namespace mamba
             );
         }
         return std::make_tuple(
-            path_data.sha256.empty() ? validate::sha256sum(dst) : path_data.sha256,
+            path_data.sha256.empty() ? validation::sha256sum(dst) : path_data.sha256,
             rel_dst.string()
         );
     }
@@ -956,7 +956,7 @@ namespace mamba
 
                     if (exists)
                     {
-                        paths_json["paths"][i]["sha256_in_prefix"] = validate::sha256sum(
+                        paths_json["paths"][i]["sha256_in_prefix"] = validation::sha256sum(
                             m_context->target_prefix / files_record[i]
                         );
                     }

--- a/libmamba/src/core/package_cache.cpp
+++ b/libmamba/src/core/package_cache.cpp
@@ -128,14 +128,14 @@ namespace mamba
             fs::u8path tarball_path = m_path / s.fn;
             // validate that this tarball has the right size and MD5 sum
             // we handle the case where s.size == 0 (explicit packages) or md5 is unknown
-            valid = s.size == 0 || validate::file_size(tarball_path, s.size);
+            valid = s.size == 0 || validation::file_size(tarball_path, s.size);
             if (!s.md5.empty())
             {
-                valid = valid && validate::md5(tarball_path, s.md5);
+                valid = valid && validation::md5(tarball_path, s.md5);
             }
             else if (!s.sha256.empty())
             {
-                valid = valid && validate::sha256(tarball_path, s.md5);
+                valid = valid && validation::sha256(tarball_path, s.md5);
             }
             else
             {

--- a/libmamba/src/core/package_handling.cpp
+++ b/libmamba/src/core/package_handling.cpp
@@ -831,7 +831,7 @@ namespace mamba
                 {
                     bool is_invalid = false;
                     if (p.path_type != PathType::SOFTLINK
-                        && !validate::file_size(full_path, p.size_in_bytes))
+                        && !validation::file_size(full_path, p.size_in_bytes))
                     {
                         LOG_WARNING << "Invalid package cache, file '" << full_path.string()
                                     << "' has incorrect size";
@@ -842,7 +842,7 @@ namespace mamba
                         }
                     }
                     if (full_validation && !is_invalid && p.path_type != PathType::SOFTLINK
-                        && !validate::sha256(full_path, p.sha256))
+                        && !validation::sha256(full_path, p.sha256))
                     {
                         LOG_WARNING << "Invalid package cache, file '" << full_path.string()
                                     << "' has incorrect SHA-256 checksum";

--- a/libmamba/src/core/timeref.cpp
+++ b/libmamba/src/core/timeref.cpp
@@ -1,7 +1,7 @@
 #include <mamba/core/timeref.hpp>
 #include <mamba/core/util.hpp>
 
-namespace validate
+namespace mamba::validation
 {
 
     TimeRef::TimeRef(const std::time_t& time)

--- a/libmamba/src/core/transaction.cpp
+++ b/libmamba/src/core/transaction.cpp
@@ -149,7 +149,7 @@ namespace mamba
 
         if (!m_sha256.empty())
         {
-            auto sha256sum = validate::sha256sum(m_tarball_path);
+            auto sha256sum = validation::sha256sum(m_tarball_path);
             if (m_sha256 != sha256sum)
             {
                 m_validation_result = SHA256_ERROR;
@@ -166,7 +166,7 @@ namespace mamba
         }
         if (!m_md5.empty())
         {
-            auto md5sum = validate::md5sum(m_tarball_path);
+            auto md5sum = validation::md5sum(m_tarball_path);
             if (m_md5 != md5sum)
             {
                 m_validation_result = MD5SUM_ERROR;

--- a/libmamba/src/core/validate.cpp
+++ b/libmamba/src/core/validate.cpp
@@ -77,7 +77,7 @@ namespace mamba
     }
 }
 
-namespace validate
+namespace mamba::validation
 {
     trust_error::trust_error(const std::string& message) noexcept
         : m_message("Content trust error. " + message + ". Aborting.")

--- a/libmamba/tests/src/core/test_validate.cpp
+++ b/libmamba/tests/src/core/test_validate.cpp
@@ -19,7 +19,7 @@
 
 #include "test_data.hpp"
 
-namespace validate
+namespace mamba::validation
 {
     namespace testing
     {

--- a/libmambapy/src/main.cpp
+++ b/libmambapy/src/main.cpp
@@ -122,7 +122,7 @@ PYBIND11_MODULE(bindings, m)
     auto pyPrefixData = py::class_<PrefixData>(m, "PrefixData");
     auto pySolver = py::class_<MSolver>(m, "Solver");
     // only used in a return type; does it belong in the module?
-    auto pyRootRole = py::class_<validate::RootRole>(m, "RootRole");
+    auto pyRootRole = py::class_<validation::RootRole>(m, "RootRole");
 
     py::class_<fs::u8path>(m, "Path")
         .def(py::init<std::string>())
@@ -602,13 +602,13 @@ PYBIND11_MODULE(bindings, m)
         .def_readwrite("defaulted_keys", &PackageInfo::defaulted_keys);
 
     // Content trust - Package signature and verification
-    m.def("generate_ed25519_keypair", &validate::generate_ed25519_keypair_hex);
+    m.def("generate_ed25519_keypair", &validation::generate_ed25519_keypair_hex);
     m.def(
         "sign",
         [](const std::string& data, const std::string& sk)
         {
             std::string signature;
-            if (!validate::sign(data, sk, signature))
+            if (!validation::sign(data, sk, signature))
             {
                 throw std::runtime_error("Signing failed");
             }
@@ -618,85 +618,89 @@ PYBIND11_MODULE(bindings, m)
         py::arg("secret_key")
     );
 
-    py::class_<validate::Key>(m, "Key")
-        .def_readwrite("keytype", &validate::Key::keytype)
-        .def_readwrite("scheme", &validate::Key::scheme)
-        .def_readwrite("keyval", &validate::Key::keyval)
+    py::class_<validation::Key>(m, "Key")
+        .def_readwrite("keytype", &validation::Key::keytype)
+        .def_readwrite("scheme", &validation::Key::scheme)
+        .def_readwrite("keyval", &validation::Key::keyval)
         .def_property_readonly(
             "json_str",
-            [](const validate::Key& key)
+            [](const validation::Key& key)
             {
                 nlohmann::json j;
-                validate::to_json(j, key);
+                validation::to_json(j, key);
                 return j.dump();
             }
         )
-        .def_static("from_ed25519", &validate::Key::from_ed25519);
+        .def_static("from_ed25519", &validation::Key::from_ed25519);
 
-    py::class_<validate::RoleFullKeys>(m, "RoleFullKeys")
+    py::class_<validation::RoleFullKeys>(m, "RoleFullKeys")
         .def(py::init<>())
         .def(
-            py::init<const std::map<std::string, validate::Key>&, const std::size_t&>(),
+            py::init<const std::map<std::string, validation::Key>&, const std::size_t&>(),
             py::arg("keys"),
             py::arg("threshold")
         )
-        .def_readwrite("keys", &validate::RoleFullKeys::keys)
-        .def_readwrite("threshold", &validate::RoleFullKeys::threshold);
+        .def_readwrite("keys", &validation::RoleFullKeys::keys)
+        .def_readwrite("threshold", &validation::RoleFullKeys::threshold);
 
-    py::class_<validate::SpecBase, std::shared_ptr<validate::SpecBase>>(m, "SpecBase");
+    py::class_<validation::SpecBase, std::shared_ptr<validation::SpecBase>>(m, "SpecBase");
 
-    py::class_<validate::RoleBase, std::shared_ptr<validate::RoleBase>>(m, "RoleBase")
-        .def_property_readonly("type", &validate::RoleBase::type)
-        .def_property_readonly("version", &validate::RoleBase::version)
-        .def_property_readonly("spec_version", &validate::RoleBase::spec_version)
-        .def_property_readonly("file_ext", &validate::RoleBase::file_ext)
-        .def_property_readonly("expires", &validate::RoleBase::expires)
-        .def_property_readonly("expired", &validate::RoleBase::expired)
-        .def("all_keys", &validate::RoleBase::all_keys);
+    py::class_<validation::RoleBase, std::shared_ptr<validation::RoleBase>>(m, "RoleBase")
+        .def_property_readonly("type", &validation::RoleBase::type)
+        .def_property_readonly("version", &validation::RoleBase::version)
+        .def_property_readonly("spec_version", &validation::RoleBase::spec_version)
+        .def_property_readonly("file_ext", &validation::RoleBase::file_ext)
+        .def_property_readonly("expires", &validation::RoleBase::expires)
+        .def_property_readonly("expired", &validation::RoleBase::expired)
+        .def("all_keys", &validation::RoleBase::all_keys);
 
-    py::class_<validate::v06::V06RoleBaseExtension, std::shared_ptr<validate::v06::V06RoleBaseExtension>>(
+    py::class_<validation::v06::V06RoleBaseExtension, std::shared_ptr<validation::v06::V06RoleBaseExtension>>(
         m,
         "RoleBaseExtension"
     )
-        .def_property_readonly("timestamp", &validate::v06::V06RoleBaseExtension::timestamp);
+        .def_property_readonly("timestamp", &validation::v06::V06RoleBaseExtension::timestamp);
 
-    py::class_<validate::v06::SpecImpl, validate::SpecBase, std::shared_ptr<validate::v06::SpecImpl>>(
+    py::class_<validation::v06::SpecImpl, validation::SpecBase, std::shared_ptr<validation::v06::SpecImpl>>(
         m,
         "SpecImpl"
     )
         .def(py::init<>());
 
     py::class_<
-        validate::v06::KeyMgrRole,
-        validate::RoleBase,
-        validate::v06::V06RoleBaseExtension,
-        std::shared_ptr<validate::v06::KeyMgrRole>>(m, "KeyMgr")
-        .def(py::init<const std::string&, const validate::RoleFullKeys&, const std::shared_ptr<validate::SpecBase>>(
-        ));
+        validation::v06::KeyMgrRole,
+        validation::RoleBase,
+        validation::v06::V06RoleBaseExtension,
+        std::shared_ptr<validation::v06::KeyMgrRole>>(m, "KeyMgr")
+        .def(py::init<
+             const std::string&,
+             const validation::RoleFullKeys&,
+             const std::shared_ptr<validation::SpecBase>>());
 
     py::class_<
-        validate::v06::PkgMgrRole,
-        validate::RoleBase,
-        validate::v06::V06RoleBaseExtension,
-        std::shared_ptr<validate::v06::PkgMgrRole>>(m, "PkgMgr")
-        .def(py::init<const std::string&, const validate::RoleFullKeys&, const std::shared_ptr<validate::SpecBase>>(
-        ));
+        validation::v06::PkgMgrRole,
+        validation::RoleBase,
+        validation::v06::V06RoleBaseExtension,
+        std::shared_ptr<validation::v06::PkgMgrRole>>(m, "PkgMgr")
+        .def(py::init<
+             const std::string&,
+             const validation::RoleFullKeys&,
+             const std::shared_ptr<validation::SpecBase>>());
 
     py::class_<
-        validate::v06::RootImpl,
-        validate::RoleBase,
-        validate::v06::V06RoleBaseExtension,
-        std::shared_ptr<validate::v06::RootImpl>>(m, "RootImpl")
+        validation::v06::RootImpl,
+        validation::RoleBase,
+        validation::v06::V06RoleBaseExtension,
+        std::shared_ptr<validation::v06::RootImpl>>(m, "RootImpl")
         .def(py::init<const std::string&>(), py::arg("json_str"))
         .def(
             "update",
-            [](validate::v06::RootImpl& role, const std::string& json_str)
+            [](validation::v06::RootImpl& role, const std::string& json_str)
             { return role.update(nlohmann::json::parse(json_str)); },
             py::arg("json_str")
         )
         .def(
             "create_key_mgr",
-            [](validate::v06::RootImpl& role, const std::string& json_str)
+            [](validation::v06::RootImpl& role, const std::string& json_str)
             { return role.create_key_mgr(nlohmann::json::parse(json_str)); },
             py::arg("json_str")
         );


### PR DESCRIPTION
This first put the `validate` namespace under `mamba::`, but doing so leads to a conflicts with `mamba::validate` which is an existing function.
To work around this issue we just rename the namespace to `mamba::validation`.