### PR TITLE
Windows: Fixed environment variables not read as unicode.

### DIFF
--- a/libmamba/include/mamba/core/environment.hpp
+++ b/libmamba/include/mamba/core/environment.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, QuantStack and Mamba Contributors
+// Copyright (c) 2019-2023, QuantStack and Mamba Contributors
 //
 // Distributed under the terms of the BSD 3-Clause License.
 //

--- a/libmamba/include/mamba/core/util_os.hpp
+++ b/libmamba/include/mamba/core/util_os.hpp
@@ -13,8 +13,8 @@
 #include "mamba/core/fsutil.hpp"
 
 #ifdef _WIN32
-#   define WIN32_LEAN_AND_MEAN
-#   include <Windows.h>
+#define WIN32_LEAN_AND_MEAN
+#include <Windows.h>
 #endif
 
 namespace mamba

--- a/libmamba/include/mamba/core/util_os.hpp
+++ b/libmamba/include/mamba/core/util_os.hpp
@@ -12,13 +12,13 @@
 
 #include "mamba/core/fsutil.hpp"
 
-#ifdef _WIN32
-#define WIN32_LEAN_AND_MEAN
-#include <Windows.h>
-#endif
-
 namespace mamba
 {
+#ifdef _WIN32
+    // Intention is to avoid including `Windows.h`, while still using the basic Windows API types.
+    using DWORD = unsigned long;
+#endif
+
     bool is_admin();
     fs::u8path get_self_exe_path();
 

--- a/libmamba/include/mamba/core/util_os.hpp
+++ b/libmamba/include/mamba/core/util_os.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, QuantStack and Mamba Contributors
+// Copyright (c) 2019-2023, QuantStack and Mamba Contributors
 //
 // Distributed under the terms of the BSD 3-Clause License.
 //

--- a/libmamba/include/mamba/core/util_os.hpp
+++ b/libmamba/include/mamba/core/util_os.hpp
@@ -12,6 +12,11 @@
 
 #include "mamba/core/fsutil.hpp"
 
+#ifdef _WIN32
+#   define WIN32_LEAN_AND_MEAN
+#   include <Windows.h>
+#endif
+
 namespace mamba
 {
     bool is_admin();

--- a/libmamba/include/mamba/core/util_os.hpp
+++ b/libmamba/include/mamba/core/util_os.hpp
@@ -40,9 +40,10 @@ namespace mamba
     void reset_console();
 
 #ifdef _WIN32
-    std::string to_utf8(const wchar_t* w, size_t s);
-    std::string to_utf8(const wchar_t* w);
-    std::string to_utf8(const std::wstring& s);
+    std::string to_utf8(const wchar_t* windows_unicode_text, size_t size);
+    std::string to_utf8(const wchar_t* windows_unicode_text);
+    std::string to_utf8(const std::wstring& windows_unicode_text);
+    std::wstring to_windows_unicode(const std::string_view utf8_text);
 #endif
 
     /* Test whether a given `std::ostream` object refers to a terminal. */

--- a/libmamba/include/mamba/core/util_random.hpp
+++ b/libmamba/include/mamba/core/util_random.hpp
@@ -12,6 +12,7 @@
 #include <limits>
 #include <random>
 #include <string>
+#include <array>
 
 namespace mamba
 {

--- a/libmamba/include/mamba/core/util_random.hpp
+++ b/libmamba/include/mamba/core/util_random.hpp
@@ -8,11 +8,11 @@
 #define MAMBA_CORE_UTIL_RANDOM_HPP
 
 #include <algorithm>
+#include <array>
 #include <cstring>
 #include <limits>
 #include <random>
 #include <string>
-#include <array>
 
 namespace mamba
 {

--- a/libmamba/src/core/environment.cpp
+++ b/libmamba/src/core/environment.cpp
@@ -93,7 +93,7 @@ namespace mamba
             const std::wstring unicode_key = to_windows_unicode(key);
             const std::wstring unicode_value = to_windows_unicode(value);
             auto res = _wputenv_s(unicode_key.c_str(), unicode_value.c_str());
-            if (!res)
+            if (res != 0)
             {
                 LOG_ERROR << fmt::format(
                     "Could not set environment variable '{}' to '{}' : {}",
@@ -102,7 +102,7 @@ namespace mamba
                     GetLastError()
                 );
             }
-            return res;
+            return res == 0;
 #else
             return setenv(key.c_str(), value.c_str(), 1) == 0;
 #endif

--- a/libmamba/src/core/util_os.cpp
+++ b/libmamba/src/core/util_os.cpp
@@ -543,6 +543,44 @@ namespace mamba
     {
         return to_utf8(s.data(), s.size());
     }
+
+    std::wstring to_windows_unicode(const std::string_view utf8_text)
+    {
+        std::wstring output;
+        if (!utf8_text.empty())
+        {
+            assert(utf8_text.size() <= INT_MAX);
+            const int size = MultiByteToWideChar(
+                CP_UTF8,
+                0,
+                utf8_text.data(),
+                utf8_text.size(),
+                nullptr,
+                0
+            );
+            if (size <= 0)
+            {
+                unsigned long last_error = ::GetLastError();
+                LOG_ERROR << "Failed to convert UTF-8 string to Windows Unicode (UTF-16)"
+                          << std::system_category().message(static_cast<int>(last_error));
+                throw std::runtime_error("Failed to convert UTF-8 string to UTF-16");
+            }
+
+            output.resize(size);
+            int res_size = MultiByteToWideChar(
+                CP_UTF8,
+                0,
+                utf8_text.data(),
+                utf8_text.size(),
+                output.data(),
+                output.size()
+            );
+            assert(res_size == size);
+        }
+
+        return output;
+    }
+
 #endif
 
     /* From https://github.com/ikalnytskyi/termcolor

--- a/libmamba/src/core/util_os.cpp
+++ b/libmamba/src/core/util_os.cpp
@@ -36,6 +36,10 @@
 #include "mamba/core/util_os.hpp"
 #include "mamba/core/util_string.hpp"
 
+#ifdef _WIN32
+static_assert(std::is_same_v<mamba::DWORD, ::DWORD>);
+#endif
+
 namespace mamba
 {
     // Heavily inspired by https://github.com/gpakosz/whereami/

--- a/libmamba/tests/CMakeLists.txt
+++ b/libmamba/tests/CMakeLists.txt
@@ -43,6 +43,7 @@ set(LIBMAMBA_TEST_SRCS
     src/core/test_util.cpp
     src/core/test_util_string.cpp
     src/core/test_util_os.cpp
+    src/core/test_system_env.cpp
     src/core/test_env_lockfile.cpp
     src/core/test_execution.cpp
     src/core/test_invoke.cpp

--- a/libmamba/tests/CMakeLists.txt
+++ b/libmamba/tests/CMakeLists.txt
@@ -42,6 +42,7 @@ set(LIBMAMBA_TEST_SRCS
     src/core/test_virtual_packages.cpp
     src/core/test_util.cpp
     src/core/test_util_string.cpp
+    src/core/test_util_os.cpp
     src/core/test_env_lockfile.cpp
     src/core/test_execution.cpp
     src/core/test_invoke.cpp

--- a/libmamba/tests/src/core/test_system_env.cpp
+++ b/libmamba/tests/src/core/test_system_env.cpp
@@ -4,9 +4,9 @@
 //
 // The full license is in the file LICENSE, distributed with this software.
 
-#include <gtest/gtest.h>
-
 #include <string>
+
+#include <gtest/gtest.h>
 
 #include "mamba/core/environment.hpp"
 #include "mamba/core/util_random.hpp"
@@ -26,7 +26,6 @@ namespace
         mamba::env::unset(key);
         const auto result_empty = mamba::env::get(key);
         ASSERT_FALSE(result_empty.has_value());
-
     }
 }
 

--- a/libmamba/tests/src/core/test_system_env.cpp
+++ b/libmamba/tests/src/core/test_system_env.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2019, QuantStack and Mamba Contributors
+﻿// Copyright (c) 2023, QuantStack and Mamba Contributors
 //
 // Distributed under the terms of the BSD 3-Clause License.
 //

--- a/libmamba/tests/src/core/test_system_env.cpp
+++ b/libmamba/tests/src/core/test_system_env.cpp
@@ -1,0 +1,47 @@
+﻿// Copyright (c) 2019, QuantStack and Mamba Contributors
+//
+// Distributed under the terms of the BSD 3-Clause License.
+//
+// The full license is in the file LICENSE, distributed with this software.
+
+#include <gtest/gtest.h>
+
+#include <string>
+
+#include "mamba/core/environment.hpp"
+#include "mamba/core/util_random.hpp"
+
+
+namespace
+{
+    void test_set_get_unset_env_variables(const std::string& key, const std::string& value)
+    {
+        const bool did_set = mamba::env::set(key, value);
+        ASSERT_TRUE(did_set);
+
+        const auto result = mamba::env::get(key);
+        ASSERT_TRUE(result.has_value());
+        EXPECT_EQ(*result, value);
+
+        mamba::env::unset(key);
+        const auto result_empty = mamba::env::get(key);
+        ASSERT_FALSE(result_empty.has_value());
+
+    }
+}
+
+TEST(system_env, set_get_unset_env_variables)
+{
+    const auto key = mamba::generate_random_alphanumeric_string(128);
+    const auto value = mamba::generate_random_alphanumeric_string(128);
+
+    test_set_get_unset_env_variables(key, value);
+}
+
+TEST(system_env, set_get_unset_variables_unicode)
+{
+    const std::string key = u8"Joël私のにほん";
+    const std::string value = u8"Hello, I am Joël. 私のにほんごわへたです";
+
+    test_set_get_unset_env_variables(key, value);
+}

--- a/libmamba/tests/src/core/test_system_env.cpp
+++ b/libmamba/tests/src/core/test_system_env.cpp
@@ -44,3 +44,25 @@ TEST(system_env, set_get_unset_variables_unicode)
 
     test_set_get_unset_env_variables(key, value);
 }
+
+#ifdef _WIN32
+
+TEST(system_env, get_predefined_env_variable)
+{
+    // We check that normal pre-defined variables are accessible and do not fail access even if some
+    // of these values have unicode.
+    const std::vector<std::string> predefined_keys{ "PATH",        "OS",           "PATHEXT",
+                                                    "ProgramData", "SystemRoot",   "windir",
+                                                    "APPDATA",     "COMPUTERNAME", "TEMP",
+                                                    "UserName",    "USERPROFILE" };
+
+    for (const auto& key : predefined_keys)
+    {
+        const auto maybe_value = mamba::env::get(key);
+        ASSERT_TRUE(maybe_value.has_value()) << "key = " + key;
+        const auto value = *maybe_value;
+        EXPECT_FALSE(value.empty()) << "key = " + key;
+    }
+}
+
+#endif

--- a/libmamba/tests/src/core/test_util_os.cpp
+++ b/libmamba/tests/src/core/test_util_os.cpp
@@ -1,0 +1,35 @@
+﻿// Copyright (c) 2019, QuantStack and Mamba Contributors
+//
+// Distributed under the terms of the BSD 3-Clause License.
+//
+// The full license is in the file LICENSE, distributed with this software.
+
+#include <gtest/gtest.h>
+
+#include <string>
+
+#include "mamba/core/util_os.hpp"
+
+
+#ifdef _WIN32
+
+namespace
+{
+    const std::wstring text_utf16 = L"Hello, I am Joël. 私のにほんごわへたです";
+    const std::string text_utf8 = u8"Hello, I am Joël. 私のにほんごわへたです";
+}
+
+TEST(to_utf8, basic_unicode_conversion)
+{
+    auto result = mamba::to_utf8(text_utf16);
+    EXPECT_EQ(text_utf8, result);
+}
+
+TEST(to_windows_unicode, basic_unicode_conversion)
+{
+    auto result = mamba::to_windows_unicode(text_utf8);
+    EXPECT_EQ(text_utf16, result);
+}
+
+#endif
+

--- a/libmamba/tests/src/core/test_util_os.cpp
+++ b/libmamba/tests/src/core/test_util_os.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2019, QuantStack and Mamba Contributors
+﻿// Copyright (c) 2023, QuantStack and Mamba Contributors
 //
 // Distributed under the terms of the BSD 3-Clause License.
 //

--- a/libmamba/tests/src/core/test_util_os.cpp
+++ b/libmamba/tests/src/core/test_util_os.cpp
@@ -4,9 +4,9 @@
 //
 // The full license is in the file LICENSE, distributed with this software.
 
-#include <gtest/gtest.h>
-
 #include <string>
+
+#include <gtest/gtest.h>
 
 #include "mamba/core/util_os.hpp"
 
@@ -32,4 +32,3 @@ TEST(to_windows_unicode, basic_unicode_conversion)
 }
 
 #endif
-


### PR DESCRIPTION
The code acquiring environment variables on Windows was doing so using the non-unicode API which lead to some environment variables containing unicode path (or other unicode values) leading to random crashes.
This version uses a simpler API call which is unicode-enabled and should fix https://github.com/mamba-org/mamba/issues/2153