### PR TITLE
Fix ``PKG_BUILDNUM`` env variable for post-link scripts

### DIFF
--- a/libmamba/src/core/link.cpp
+++ b/libmamba/src/core/link.cpp
@@ -408,9 +408,7 @@ namespace mamba
         envmap["PREFIX"] = env_prefix.size() ? env_prefix : prefix.string();
         envmap["PKG_NAME"] = pkg_info.name;
         envmap["PKG_VERSION"] = pkg_info.version;
-        envmap["PKG_BUILDNUM"] = pkg_info.build_string.empty()
-                                     ? std::to_string(pkg_info.build_number)
-                                     : pkg_info.build_string;
+        envmap["PKG_BUILDNUM"] = std::to_string(pkg_info.build_number);
 
         std::string PATH = env::get("PATH").value_or("");
         envmap["PATH"] = concat(path.parent_path().string(), env::pathsep(), PATH);


### PR DESCRIPTION
As documented in https://docs.conda.io/projects/conda-build/en/latest/user-guide/environment-variables.html , during the build process the `PKG_BUILDNUM` environment variable should contain the build number of the package being built, without the hash (which is instead part of the `PKG_BUILD_STRING` environment variable).

When calling the pre-link, post-link and pre-unlink scripts, `PKG_BUILDNUM` is one of the 4 environment variable that need to be set, see https://docs.conda.io/projects/conda-build/en/latest/resources/link-scripts.html (as is the case already), but here it was including also the hash. This breaks the installation of some bioconda packages (e.g. lotus2) when using micromamba (but not mamba, not sure why).

Fix the following error:

```
$ micromamba create --log-level trace -c conda-forge -c bioconda --channel-priority strict -n __lotus2@2.24 lotus2=2.24
...
debug    libmamba For lotus2 at /home/soranzon/micromamba/envs/__lotus2@2.24, executing script: $ /bin/bash /tmp/mambafWdlBXMccxn
trace    libmamba Calling /bin/bash /tmp/mambafWdlBXMccxn
trace    libmamba ENV MAP:
     ROOT_PREFIX: /home/soranzon/micromamba
     PREFIX: /home/soranzon/micromamba/envs/__lotus2@2.24
     PKG_NAME: lotus2
     PKG_VERSION: 2.24
     PKG_BUILDNUM: hdfd78af_0
     PATH: /home/soranzon/micromamba/envs/__lotus2@2.24/bin:/home/soranzon/bin:/home/soranzon/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
     CWD: /home/soranzon/micromamba/envs/__lotus2@2.24/bin
/home/soranzon/micromamba/envs/__lotus2@2.24/bin/.lotus2-post-link.sh: line 4: cd: /home/soranzon/micromamba/envs/__lotus2@2.24/share/lotus2-2.24-hdfd78af_0/: No such file or directory
Can't open perl script "autoInstall.pl": No such file or directory
...
```

where `PKG_BUILDNUM` should have been simply 0.
The relevant part of the `post-link.sh` file of the lotus2 recipe is:

```shell
TARGET=$PREFIX/share/$PKG_NAME-$PKG_VERSION-$PKG_BUILDNUM

cd "$TARGET/"
perl autoInstall.pl -condaDBinstall
```

The same package is installed fine by both conda and mamba, that correctly find and run the `__lotus2@2.24/share/lotus2-2.24-0/autoInstall.pl` script.

Found by @hildebra .