### PR TITLE
CI test should not need static build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,7 +52,6 @@ jobs:
           rm -rf ~/micromamba*/envs/*/envs
 
   libmamba_cpp_tests:
-    needs: [libmamba_static]
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -95,7 +94,6 @@ jobs:
           rm -rf ~/micromamba*/envs/*/envs
 
   umamba_tests:
-    needs: [libmamba_static]
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -154,7 +152,6 @@ jobs:
           rm -rf ~/micromamba*/envs/*/envs
 
   mamba_python_tests:
-    needs: [libmamba_static]
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -360,7 +357,6 @@ jobs:
           rm -rf ~/micromamba*/envs/*/envs
 
   mamba_python_tests_win:
-    needs: [libmamba_static_win]
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -459,7 +455,6 @@ jobs:
           rm -rf ~/micromamba*/envs/*/envs
 
   libmamba_cpp_tests_win:
-    needs: [libmamba_static_win]
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -510,7 +505,6 @@ jobs:
           rm -rf ~/micromamba*/envs/*/envs
 
   umamba_tests_win:
-    needs: [libmamba_static_win]
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:


### PR DESCRIPTION
Static builds often fail for packaging reasons (or even downloading reasons).
This should not prevent tests from running
They provide feedback for dev working on unrelated features.

