### PR TITLE
Avoid using /tmp

### DIFF
--- a/libmamba/src/core/subdirdata.cpp
+++ b/libmamba/src/core/subdirdata.cpp
@@ -905,7 +905,9 @@ namespace mamba
     void MSubdirData::create_target()
     {
         auto& ctx = Context::instance();
-        m_temp_file = std::make_unique<TemporaryFile>();
+        fs::u8path writable_cache_dir = create_cache_dir(m_writable_pkgs_dir);
+        auto lock = LockFile(writable_cache_dir);
+        m_temp_file = std::make_unique<TemporaryFile>("mambaf", "", writable_cache_dir);
 
         bool use_zst = m_metadata.has_zst.has_value() && m_metadata.has_zst.value().value;
         m_target = std::make_unique<DownloadTarget>(


### PR DESCRIPTION
Attempts to fix https://github.com/mamba-org/mamba/issues/2418

I realised that we already attempt to rename, and if that failed, we attempt to copy then delete the file. However, this seems to still cause `Invalid cross-device link error`.

My proposal is to just avoid storing the temporary file in `/tmp`, and instead use the same cache dir we already use for writing the .json files.