### PR TITLE
Fix error message explaining why a package cannot be installed

### DIFF
--- a/libmamba/src/core/satisfiability_error.cpp
+++ b/libmamba/src/core/satisfiability_error.cpp
@@ -1642,11 +1642,11 @@ namespace mamba
                     {
                         if (tn.depth() == 1)
                         {
-                            write(" is requested and can be installed");
+                            write(" is requested and can not be installed");
                         }
                         else
                         {
-                            write(", which can be installed");
+                            write(", which can not be installed");
                         }
                     }
                     else


### PR DESCRIPTION
```
mamba install "pythran>=0.12.1"

                  __    __    __    __
                 /  \  /  \  /  \  /  \
                /    \/    \/    \/    \
███████████████/  /██/  /██/  /██/  /████████████████████████
              /  / \   / \   / \   / \  \____
             /  /   \_/   \_/   \_/   \    o \__,
            / _/                       \_____/  `
            |/
        ███╗   ███╗ █████╗ ███╗   ███╗██████╗  █████╗
        ████╗ ████║██╔══██╗████╗ ████║██╔══██╗██╔══██╗
        ██╔████╔██║███████║██╔████╔██║██████╔╝███████║
        ██║╚██╔╝██║██╔══██║██║╚██╔╝██║██╔══██╗██╔══██║
        ██║ ╚═╝ ██║██║  ██║██║ ╚═╝ ██║██████╔╝██║  ██║
        ╚═╝     ╚═╝╚═╝  ╚═╝╚═╝     ╚═╝╚═════╝ ╚═╝  ╚═╝

        mamba (1.4.2) supported by @QuantStack

        GitHub:  https://github.com/mamba-org/mamba
        Twitter: https://twitter.com/QuantStack

█████████████████████████████████████████████████████████████

Looking for: ["pythran[version='>=0.12.1']"]

warning  libmamba Cache file "/home/mark/mambaforge/pkgs/cache/1a6399ac.json" was modified by another program
warning  libmamba Cache file "/home/mark/mambaforge/pkgs/cache/8e383ab4.json" was modified by another program
conda-forge/noarch                                  11.8MB @ 275.4kB/s 43.1s
conda-forge/linux-64                                30.7MB @ 343.3kB/s 1m:29.9s

Pinned packages:
  - python 3.9.*

Could not solve for environment specs
The following packages are incompatible
└─ pythran >=0.12.1  is installable with the potential options
   ├─ pythran 0.12.1 would require
   │  ├─ beniget 0.4.* , which requires
   │  │  └─ gast >=0.5.0,<0.6.0 , which can be installed;
   │  └─ gast 0.5.* , which can be installed;
   ├─ pythran 0.12.1 would require
   │  └─ python >=3.10,<3.11.0a0 , which can be installed;
   ├─ pythran 0.12.1 would require
   │  └─ python >=3.11,<3.12.0a0 , which can be installed;
   └─ pythran 0.12.1 would require
      └─ python >=3.8,<3.9.0a0 , which can be installed.
```

The above example hits the incompatibility explained in https://github.com/conda-forge/pythran-feedstock/issues/71