### PR TITLE
Remove dead code / attribute

### DIFF
--- a/libmamba/include/mamba/core/package_info.hpp
+++ b/libmamba/include/mamba/core/package_info.hpp
@@ -56,7 +56,6 @@ namespace mamba
         std::vector<std::string> depends = {};
         std::vector<std::string> constrains = {};
         std::string signatures = {};
-        std::string extra_metadata = {};
         std::set<std::string> defaulted_keys = {};
     };
 }  // namespace mamba

--- a/libmamba/src/core/package_info.cpp
+++ b/libmamba/src/core/package_info.cpp
@@ -173,7 +173,6 @@ namespace mamba
                 p.depends,
                 p.constrains,
                 p.signatures,
-                p.extra_metadata,
                 p.defaulted_keys
             );
         };
@@ -263,9 +262,6 @@ namespace mamba
         {
             j["constrains"] = constrains;
         }
-
-        // Optional keys that may be part of signed metadata
-        j.merge_patch(nlohmann::json::parse(extra_metadata));
 
         return j;
     }

--- a/libmamba/src/core/pool.cpp
+++ b/libmamba/src/core/pool.cpp
@@ -320,7 +320,6 @@ namespace mamba
                 out.track_features.pop_back();
             }
 
-            out.extra_metadata = "{}";
             return out;
         }
     }

--- a/libmamba/src/core/pool.cpp
+++ b/libmamba/src/core/pool.cpp
@@ -320,40 +320,7 @@ namespace mamba
                 out.track_features.pop_back();
             }
 
-            const ::Id extra_keys_id = pool_str2id(pool, "solvable:extra_keys", 0);
-            const ::Id extra_values_id = pool_str2id(pool, "solvable:extra_values", 0);
-            if (extra_keys_id && extra_values_id)
-            {
-                // Get extra signed keys
-                q.clear();
-                solvable_lookup_idarray(&s, extra_keys_id, q.raw());
-                std::vector<std::string> extra_keys = {};
-                extra_keys.reserve(q.size());
-                std::transform(q.begin(), q.end(), std::back_inserter(extra_keys), dep2str);
-
-                // Get extra signed values
-                q.clear();
-                solvable_lookup_idarray(&s, extra_values_id, q.raw());
-                std::vector<std::string> extra_values = {};
-                extra_values.reserve(q.size());
-                std::transform(q.begin(), q.end(), std::back_inserter(extra_values), dep2str);
-
-                // Build a JSON string for extra signed metadata
-                if (!extra_keys.empty() && (extra_keys.size() == extra_values.size()))
-                {
-                    std::vector<std::string> extra = {};
-                    extra.reserve(extra_keys.size());
-                    for (std::size_t i = 0; i < extra_keys.size(); ++i)
-                    {
-                        extra.push_back(fmt::format(R"("{}":{})", extra_keys[i], extra_values[i]));
-                    }
-                    out.extra_metadata = fmt::format("{{{}}}", fmt::join(extra, ","));
-                }
-            }
-            else
-            {
-                out.extra_metadata = "{}";
-            }
+            out.extra_metadata = "{}";
             return out;
         }
     }

--- a/libmambapy/libmambapy/__init__.pyi
+++ b/libmambapy/libmambapy/__init__.pyi
@@ -899,14 +899,6 @@ class PackageInfo:
     def depends(self, arg0: typing.List[str]) -> None:
         pass
     @property
-    def extra_metadata(self) -> str:
-        """
-        :type: str
-        """
-    @extra_metadata.setter
-    def extra_metadata(self, arg0: str) -> None:
-        pass
-    @property
     def fn(self) -> str:
         """
         :type: str

--- a/libmambapy/src/main.cpp
+++ b/libmambapy/src/main.cpp
@@ -603,7 +603,6 @@ PYBIND11_MODULE(bindings, m)
         .def_readwrite("depends", &PackageInfo::depends)
         .def_readwrite("constrains", &PackageInfo::constrains)
         .def_readwrite("signatures", &PackageInfo::signatures)
-        .def_readwrite("extra_metadata", &PackageInfo::extra_metadata)
         .def_readwrite("defaulted_keys", &PackageInfo::defaulted_keys);
 
     // Content trust - Package signature and verification


### PR DESCRIPTION
The keys `"solvable:extra_xxx"` are not set in any place, and are never used in libsolv.
Therefore that code is dead and `PackageInfo::extra_metadata` is unused.

