### PR TITLE
Resume `Context` structuring 

### DIFF
--- a/docs/source/python_api.rst
+++ b/docs/source/python_api.rst
@@ -31,9 +31,9 @@ The mamba_api exposes the following objects:
 .. code::
 
    from mamba import mamba_api
-   mamba_api.Context().conda_prefix = "/home/wolfv/conda"
+   mamba_api.Context().prefix_params.conda_prefix = "/home/wolfv/conda"
    ctx = mamba_api.Context()
-   print(ctx.root_prefix)
+   print(ctx.prefix_params.root_prefix)
 
 
 Here is an example usage of the mamba_api:
@@ -84,7 +84,7 @@ Here is an example usage of the mamba_api:
         def __init__(self, prefix, channels, platform):
 
             api_ctx = mamba_api.Context()
-            api_ctx.conda_prefix = prefix
+            api_ctx.prefix_params.conda_prefix = prefix
 
             self.channels = channels
             self.platform = platform

--- a/libmamba/include/mamba/core/context.hpp
+++ b/libmamba/include/mamba/core/context.hpp
@@ -169,14 +169,23 @@ namespace mamba
             bool is_micromamba{ false };
         };
 
+        struct ThreadsParams
+        {
+            std::size_t download_threads{ 5 };
+            int extract_threads{ 0 };
+        };
+
+        struct PrefixParams
+        {
+            fs::u8path target_prefix;
+            fs::u8path root_prefix;
+            fs::u8path conda_prefix;
+            fs::u8path relocate_prefix;
+        };
+
         // Configurable
         bool experimental = false;
         bool debug = false;
-
-        fs::u8path target_prefix;
-        fs::u8path root_prefix;
-        fs::u8path conda_prefix;
-        fs::u8path relocate_prefix;
 
         // TODO check writable and add other potential dirs
         std::vector<fs::u8path> envs_dirs;
@@ -190,8 +199,6 @@ namespace mamba
         ChannelPriority channel_priority = ChannelPriority::kFlexible;
         bool auto_activate_base = false;
 
-        std::size_t download_threads = 5;
-        int extract_threads = 0;
         bool extract_sparse = false;
 
         bool dev = false;  // TODO this is always used as default=false and isn't set anywhere => to
@@ -230,6 +237,8 @@ namespace mamba
         GraphicsParams graphics_params;
         SrcParams src_params;
         CommandParams command_params;
+        ThreadsParams threads_params;
+        PrefixParams prefix_params;
 
         std::map<std::string, std::string> proxy_servers;
 

--- a/libmamba/src/api/clean.cpp
+++ b/libmamba/src/api/clean.cpp
@@ -117,14 +117,14 @@ namespace mamba
             }
         }
 
-        if (fs::exists(ctx.root_prefix / "conda-meta"))
+        if (fs::exists(ctx.prefix_params.root_prefix / "conda-meta"))
         {
-            envs.push_back(ctx.root_prefix);
+            envs.push_back(ctx.prefix_params.root_prefix);
         }
 
-        if (fs::exists(ctx.root_prefix / "envs"))
+        if (fs::exists(ctx.prefix_params.root_prefix / "envs"))
         {
-            for (auto& p : fs::directory_iterator(ctx.root_prefix / "envs"))
+            for (auto& p : fs::directory_iterator(ctx.prefix_params.root_prefix / "envs"))
             {
                 if (p.is_directory() && fs::exists(p.path() / "conda-meta"))
                 {
@@ -137,7 +137,7 @@ namespace mamba
         if (clean_trash)
         {
             Console::stream() << "Cleaning *.mamba_trash files" << std::endl;
-            clean_trash_files(ctx.root_prefix, true);
+            clean_trash_files(ctx.prefix_params.root_prefix, true);
         }
 
         // globally, collect installed packages

--- a/libmamba/src/api/create.cpp
+++ b/libmamba/src/api/create.cpp
@@ -31,21 +31,22 @@ namespace mamba
 
         if (!ctx.dry_run)
         {
-            if (fs::exists(ctx.target_prefix))
+            if (fs::exists(ctx.prefix_params.target_prefix))
             {
-                if (ctx.target_prefix == ctx.root_prefix)
+                if (ctx.prefix_params.target_prefix == ctx.prefix_params.root_prefix)
                 {
                     LOG_ERROR << "Overwriting root prefix is not permitted";
                     throw std::runtime_error("Aborting.");
                 }
-                else if (fs::exists(ctx.target_prefix / "conda-meta"))
+                else if (fs::exists(ctx.prefix_params.target_prefix / "conda-meta"))
                 {
                     if (Console::prompt(
-                            "Found conda-prefix at '" + ctx.target_prefix.string() + "'. Overwrite?",
+                            "Found conda-prefix at '" + ctx.prefix_params.target_prefix.string()
+                                + "'. Overwrite?",
                             'n'
                         ))
                     {
-                        fs::remove_all(ctx.target_prefix);
+                        fs::remove_all(ctx.prefix_params.target_prefix);
                     }
                     else
                     {
@@ -60,12 +61,12 @@ namespace mamba
             }
             if (create_specs.empty())
             {
-                detail::create_empty_target(ctx.target_prefix);
+                detail::create_empty_target(ctx.prefix_params.target_prefix);
             }
 
             if (config.at("platform").configured() && !config.at("platform").rc_configured())
             {
-                detail::store_platform_config(ctx.target_prefix, ctx.platform);
+                detail::store_platform_config(ctx.prefix_params.target_prefix, ctx.platform);
             }
         }
 

--- a/libmamba/src/api/info.cpp
+++ b/libmamba/src/api/info.cpp
@@ -98,10 +98,10 @@ namespace mamba
             std::vector<std::tuple<std::string, nlohmann::json>> items;
 
             std::string name, location;
-            if (!ctx.target_prefix.empty())
+            if (!ctx.prefix_params.target_prefix.empty())
             {
-                name = env_name(ctx.target_prefix);
-                location = ctx.target_prefix.string();
+                name = env_name(ctx.prefix_params.target_prefix);
+                location = ctx.prefix_params.target_prefix.string();
             }
             else
             {
@@ -109,14 +109,15 @@ namespace mamba
                 location = "-";
             }
 
-            if (std::getenv("CONDA_PREFIX") && (std::getenv("CONDA_PREFIX") == ctx.target_prefix))
+            if (std::getenv("CONDA_PREFIX")
+                && (std::getenv("CONDA_PREFIX") == ctx.prefix_params.target_prefix))
             {
                 name += " (active)";
             }
-            else if (fs::exists(ctx.target_prefix))
+            else if (fs::exists(ctx.prefix_params.target_prefix))
             {
-                if (!(fs::exists(ctx.target_prefix / "conda-meta")
-                      || (ctx.target_prefix == ctx.root_prefix)))
+                if (!(fs::exists(ctx.prefix_params.target_prefix / "conda-meta")
+                      || (ctx.prefix_params.target_prefix == ctx.prefix_params.root_prefix)))
                 {
                     name += " (not env)";
                 }
@@ -172,7 +173,7 @@ namespace mamba
             }
             items.push_back({ "channels", channel_urls });
 
-            items.push_back({ "base environment", ctx.root_prefix.string() });
+            items.push_back({ "base environment", ctx.prefix_params.root_prefix.string() });
 
             items.push_back({ "platform", ctx.platform });
 

--- a/libmamba/src/api/install.cpp
+++ b/libmamba/src/api/install.cpp
@@ -123,7 +123,7 @@ namespace mamba
         {
             const auto maybe_instructions = get_other_pkg_mgr_install_instructions(
                 pkg_mgr,
-                ctx.target_prefix.string(),
+                ctx.prefix_params.target_prefix.string(),
                 specs.path()
             );
             if (maybe_instructions)
@@ -136,7 +136,10 @@ namespace mamba
             }
         }();
 
-        auto [wrapped_command, tmpfile] = prepare_wrapped_call(ctx.target_prefix, install_instructions);
+        auto [wrapped_command, tmpfile] = prepare_wrapped_call(
+            ctx.prefix_params.target_prefix,
+            install_instructions
+        );
 
         reproc::options options;
         options.redirect.parent = true;
@@ -433,14 +436,14 @@ namespace mamba
         auto& only_deps = config.at("only_deps").value<bool>();
         auto& retry_clean_cache = config.at("retry_clean_cache").value<bool>();
 
-        if (ctx.target_prefix.empty())
+        if (ctx.prefix_params.target_prefix.empty())
         {
             throw std::runtime_error("No active target prefix");
         }
-        if (!fs::exists(ctx.target_prefix) && create_env == false)
+        if (!fs::exists(ctx.prefix_params.target_prefix) && create_env == false)
         {
             throw std::runtime_error(
-                fmt::format("Prefix does not exist at: {}", ctx.target_prefix.string())
+                fmt::format("Prefix does not exist at: {}", ctx.prefix_params.target_prefix.string())
             );
         }
 
@@ -465,8 +468,8 @@ namespace mamba
         // which limits this syntax
         /*auto exp_prefix_data = load_channels(pool, package_caches, is_retry)
                                .and_then([&ctx](const auto&) { return
-           PrefixData::create(ctx.target_prefix); } ) .map_error([](const mamba_error& err) { throw
-           std::runtime_error(err.what());
+           PrefixData::create(ctx.prefix_params.target_prefix); } ) .map_error([](const mamba_error&
+           err) { throw std::runtime_error(err.what());
                                 });*/
         auto exp_load = load_channels(pool, package_caches, is_retry);
         if (!exp_load)
@@ -474,7 +477,7 @@ namespace mamba
             throw std::runtime_error(exp_load.error().what());
         }
 
-        auto exp_prefix_data = PrefixData::create(ctx.target_prefix);
+        auto exp_prefix_data = PrefixData::create(ctx.prefix_params.target_prefix);
         if (!exp_prefix_data)
         {
             throw std::runtime_error(exp_prefix_data.error().what());
@@ -577,7 +580,7 @@ namespace mamba
         {
             if (create_env && !Context::instance().dry_run)
             {
-                detail::create_target_directory(ctx.target_prefix);
+                detail::create_target_directory(ctx.prefix_params.target_prefix);
             }
 
             trans.execute(prefix_data);
@@ -598,7 +601,7 @@ namespace mamba
         {
             MPool pool;
             auto& ctx = Context::instance();
-            auto exp_prefix_data = PrefixData::create(ctx.target_prefix);
+            auto exp_prefix_data = PrefixData::create(ctx.prefix_params.target_prefix);
             if (!exp_prefix_data)
             {
                 // TODO: propagate tl::expected mechanism
@@ -625,7 +628,7 @@ namespace mamba
             {
                 if (create_env && !Context::instance().dry_run)
                 {
-                    detail::create_target_directory(ctx.target_prefix);
+                    detail::create_target_directory(ctx.prefix_params.target_prefix);
                 }
 
                 transaction.execute(prefix_data);

--- a/libmamba/src/api/list.cpp
+++ b/libmamba/src/api/list.cpp
@@ -49,7 +49,7 @@ namespace mamba
         {
             auto& ctx = Context::instance();
 
-            auto sprefix_data = PrefixData::create(ctx.target_prefix);
+            auto sprefix_data = PrefixData::create(ctx.prefix_params.target_prefix);
             if (!sprefix_data)
             {
                 // TODO: propagate tl::expected mechanism
@@ -93,7 +93,8 @@ namespace mamba
                 return;
             }
 
-            std::cout << "List of packages in environment: " << ctx.target_prefix << "\n\n";
+            std::cout << "List of packages in environment: " << ctx.prefix_params.target_prefix
+                      << "\n\n";
 
             formatted_pkg formatted_pkgs;
 

--- a/libmamba/src/api/remove.cpp
+++ b/libmamba/src/api/remove.cpp
@@ -37,7 +37,7 @@ namespace mamba
 
         if (remove_all)
         {
-            auto sprefix_data = PrefixData::create(ctx.target_prefix);
+            auto sprefix_data = PrefixData::create(ctx.prefix_params.target_prefix);
             if (!sprefix_data)
             {
                 // TODO: propagate tl::expected mechanism
@@ -68,13 +68,13 @@ namespace mamba
         {
             auto& ctx = Context::instance();
 
-            if (ctx.target_prefix.empty())
+            if (ctx.prefix_params.target_prefix.empty())
             {
                 LOG_ERROR << "No active target prefix.";
                 throw std::runtime_error("Aborted.");
             }
 
-            auto exp_prefix_data = PrefixData::create(ctx.target_prefix);
+            auto exp_prefix_data = PrefixData::create(ctx.prefix_params.target_prefix);
             if (!exp_prefix_data)
             {
                 // TODO: propagate tl::expected mechanism
@@ -85,7 +85,7 @@ namespace mamba
             MPool pool;
             MRepo::create(pool, prefix_data);
 
-            const fs::u8path pkgs_dirs(ctx.root_prefix / "pkgs");
+            const fs::u8path pkgs_dirs(ctx.prefix_params.root_prefix / "pkgs");
             MultiPackageCache package_caches({ pkgs_dirs });
 
             auto execute_transaction = [&](MTransaction& transaction)
@@ -119,7 +119,7 @@ namespace mamba
                     }
                 );
 
-                History history(ctx.target_prefix);
+                History history(ctx.prefix_params.target_prefix);
                 auto hist_map = history.get_requested_specs_map();
                 std::vector<std::string> keep_specs;
                 for (auto& it : hist_map)

--- a/libmamba/src/api/repoquery.cpp
+++ b/libmamba/src/api/repoquery.cpp
@@ -36,7 +36,7 @@ namespace mamba
             {
                 Console::stream() << "Using local repodata..." << std::endl;
             }
-            auto exp_prefix_data = PrefixData::create(ctx.target_prefix);
+            auto exp_prefix_data = PrefixData::create(ctx.prefix_params.target_prefix);
             if (!exp_prefix_data)
             {
                 // TODO: propagate tl::expected mechanism
@@ -46,8 +46,8 @@ namespace mamba
             MRepo::create(pool, prefix_data);
             if (format != QueryResultFormat::kJSON)
             {
-                Console::stream() << "Loaded current active prefix: " << ctx.target_prefix
-                                  << std::endl;
+                Console::stream() << "Loaded current active prefix: "
+                                  << ctx.prefix_params.target_prefix << std::endl;
             }
         }
         else

--- a/libmamba/src/api/shell.cpp
+++ b/libmamba/src/api/shell.cpp
@@ -93,7 +93,7 @@ namespace mamba
         {
             if (prefix.empty() || prefix == "base")
             {
-                shell_prefix = ctx.root_prefix.string();
+                shell_prefix = ctx.prefix_params.root_prefix.string();
             }
             else
             {
@@ -106,7 +106,7 @@ namespace mamba
         {
             if (prefix.empty() || prefix == "base")
             {
-                shell_prefix = ctx.root_prefix.string();
+                shell_prefix = ctx.prefix_params.root_prefix.string();
             }
             else
             {
@@ -144,11 +144,11 @@ namespace mamba
         {
             if (prefix.empty() || prefix == "base")
             {
-                shell_prefix = ctx.root_prefix.string();
+                shell_prefix = ctx.prefix_params.root_prefix.string();
             }
             else if (prefix.find_first_of("/\\") == std::string::npos)
             {
-                shell_prefix = (ctx.root_prefix / "envs" / prefix).string();
+                shell_prefix = (ctx.prefix_params.root_prefix / "envs" / prefix).string();
             }
             else
             {

--- a/libmamba/src/api/update.cpp
+++ b/libmamba/src/api/update.cpp
@@ -50,7 +50,7 @@ namespace mamba
             throw std::runtime_error(exp_loaded.error().what());
         }
 
-        auto exp_prefix_data = PrefixData::create(ctx.target_prefix);
+        auto exp_prefix_data = PrefixData::create(ctx.prefix_params.target_prefix);
         if (!exp_prefix_data)
         {
             // TODO: propagate tl::expected mechanism

--- a/libmamba/src/core/activation.cpp
+++ b/libmamba/src/core/activation.cpp
@@ -49,7 +49,7 @@ namespace mamba
 
     std::string Activator::get_default_env(const fs::u8path& prefix)
     {
-        if (paths_equal(prefix, Context::instance().root_prefix))
+        if (paths_equal(prefix, Context::instance().prefix_params.root_prefix))
         {
             return "base";
         }
@@ -284,7 +284,7 @@ namespace mamba
             );
             if (no_condabin)
             {
-                auto condabin_dir = Context::instance().root_prefix / "condabin";
+                auto condabin_dir = Context::instance().prefix_params.root_prefix / "condabin";
                 path_list.insert(path_list.begin(), condabin_dir);
             }
         }
@@ -557,7 +557,7 @@ namespace mamba
         //         from .exceptions import EnvironmentLocationNotFound
         //         raise EnvironmentLocationNotFound(prefix)
         // elif env_name_or_prefix in (ROOT_ENV_NAME, 'root'):
-        //     prefix = context.root_prefix
+        //     prefix = context.prefix_params.root_prefix
         // else:
         //     prefix = locate_prefix_by_name(env_name_or_prefix)
 
@@ -873,7 +873,7 @@ namespace mamba
 
     fs::u8path PosixActivator::hook_source_path()
     {
-        return Context::instance().root_prefix / "etc" / "profile.d" / "micromamba.sh";
+        return Context::instance().prefix_params.root_prefix / "etc" / "profile.d" / "micromamba.sh";
     }
 
     /*********************************
@@ -972,7 +972,7 @@ namespace mamba
 
     fs::u8path CshActivator::hook_source_path()
     {
-        return Context::instance().root_prefix / "etc" / "profile.d" / "micromamba.csh";
+        return Context::instance().prefix_params.root_prefix / "etc" / "profile.d" / "micromamba.csh";
     }
 
 
@@ -1074,7 +1074,7 @@ namespace mamba
 
     fs::u8path PowerShellActivator::hook_source_path()
     {
-        return Context::instance().root_prefix / "condabin" / "mamba_hook.ps1";
+        return Context::instance().prefix_params.root_prefix / "condabin" / "mamba_hook.ps1";
     }
 
     std::pair<std::string, std::string>
@@ -1142,7 +1142,7 @@ namespace mamba
 
     fs::u8path XonshActivator::hook_source_path()
     {
-        return Context::instance().root_prefix / "etc" / "profile.d" / "mamba.xsh";
+        return Context::instance().prefix_params.root_prefix / "etc" / "profile.d" / "mamba.xsh";
     }
 
     std::pair<std::string, std::string>
@@ -1210,7 +1210,8 @@ namespace mamba
 
     fs::u8path FishActivator::hook_source_path()
     {
-        return Context::instance().root_prefix / "etc" / "fish" / "conf.d" / "mamba.fish";
+        return Context::instance().prefix_params.root_prefix / "etc" / "fish" / "conf.d"
+               / "mamba.fish";
     }
 
     std::pair<std::string, std::string>

--- a/libmamba/src/core/channel.cpp
+++ b/libmamba/src/core/channel.cpp
@@ -151,7 +151,7 @@ namespace mamba
         {
             p_repo_checker = std::make_unique<validation::RepoChecker>(
                 rsplit(base_url(), "/", 1).front(),
-                Context::instance().root_prefix / "etc" / "trusted-repos"
+                Context::instance().prefix_params.root_prefix / "etc" / "trusted-repos"
                     / cache_name_from_url(base_url()),
                 caches.first_writable_path() / "cache" / cache_name_from_url(base_url())
             );
@@ -877,8 +877,8 @@ namespace mamba
 
         // Local channels
         std::vector<std::string> local_channels = {
-            Context::instance().target_prefix.string() + "/conda-bld",
-            Context::instance().root_prefix.string() + "/conda-bld",
+            Context::instance().prefix_params.target_prefix.string() + "/conda-bld",
+            Context::instance().prefix_params.root_prefix.string() + "/conda-bld",
             "~/conda-bld"
         };
 

--- a/libmamba/src/core/context.cpp
+++ b/libmamba/src/core/context.cpp
@@ -71,11 +71,11 @@ namespace mamba
         MainExecutor::instance().on_close(tasksync.synchronized([this] { logger->flush(); }));
 
         on_ci = bool(env::get("CI"));
-        root_prefix = env::get("MAMBA_ROOT_PREFIX").value_or("");
-        conda_prefix = root_prefix;
+        prefix_params.root_prefix = env::get("MAMBA_ROOT_PREFIX").value_or("");
+        prefix_params.conda_prefix = prefix_params.root_prefix;
 
-        envs_dirs = { root_prefix / "envs" };
-        pkgs_dirs = { root_prefix / "pkgs",
+        envs_dirs = { prefix_params.root_prefix / "envs" };
+        pkgs_dirs = { prefix_params.root_prefix / "pkgs",
                       fs::u8path("~") / ".mamba" / "pkgs"
 #ifdef _WIN32
                       ,
@@ -278,7 +278,7 @@ namespace mamba
         {
             throw std::runtime_error("Empty path");
         }
-        if (paths_equal(prefix, Context::instance().root_prefix))
+        if (paths_equal(prefix, Context::instance().prefix_params.root_prefix))
         {
             return ROOT_ENV_NAME;
         }
@@ -300,7 +300,7 @@ namespace mamba
         assert(!name.empty());
         if (name == ROOT_ENV_NAME)
         {
-            return Context::instance().root_prefix;
+            return Context::instance().prefix_params.root_prefix;
         }
         for (auto& d : Context::instance().envs_dirs)
         {
@@ -326,8 +326,8 @@ namespace mamba
 
         auto out = Console::stream();
         out << std::boolalpha << ">>> MAMBA CONTEXT <<< \n";
-        PRINT_CTX(out, target_prefix);
-        PRINT_CTX(out, root_prefix);
+        PRINT_CTX(out, prefix_params.target_prefix);
+        PRINT_CTX(out, prefix_params.root_prefix);
         PRINT_CTX(out, dry_run);
         PRINT_CTX(out, always_yes);
         PRINT_CTX(out, allow_softlinks);
@@ -346,7 +346,7 @@ namespace mamba
         PRINT_CTX(out, use_only_tar_bz2);
         PRINT_CTX(out, auto_activate_base);
         PRINT_CTX(out, extra_safety_checks);
-        PRINT_CTX(out, download_threads);
+        PRINT_CTX(out, threads_params.download_threads);
         PRINT_CTX(out, output_params.verbosity);
         PRINT_CTX(out, channel_alias);
         out << "channel_priority: " << static_cast<int>(channel_priority) << '\n';

--- a/libmamba/src/core/environments_manager.cpp
+++ b/libmamba/src/core/environments_manager.cpp
@@ -150,7 +150,7 @@ namespace mamba
                 }
             }
         }
-        all_env_paths.insert(Context::instance().root_prefix);
+        all_env_paths.insert(Context::instance().prefix_params.root_prefix);
         return all_env_paths;
     }
 

--- a/libmamba/src/core/fetch.cpp
+++ b/libmamba/src/core/fetch.cpp
@@ -726,7 +726,9 @@ namespace mamba
 
     MultiDownloadTarget::MultiDownloadTarget()
     {
-        p_curl_handle = std::make_unique<CURLMultiHandle>(Context::instance().threads_params.download_threads);
+        p_curl_handle = std::make_unique<CURLMultiHandle>(
+            Context::instance().threads_params.download_threads
+        );
     }
 
     MultiDownloadTarget::~MultiDownloadTarget()

--- a/libmamba/src/core/fetch.cpp
+++ b/libmamba/src/core/fetch.cpp
@@ -726,7 +726,7 @@ namespace mamba
 
     MultiDownloadTarget::MultiDownloadTarget()
     {
-        p_curl_handle = std::make_unique<CURLMultiHandle>(Context::instance().download_threads);
+        p_curl_handle = std::make_unique<CURLMultiHandle>(Context::instance().threads_params.download_threads);
     }
 
     MultiDownloadTarget::~MultiDownloadTarget()

--- a/libmamba/src/core/link.cpp
+++ b/libmamba/src/core/link.cpp
@@ -359,7 +359,7 @@ namespace mamba
             if (activate)
             {
                 script_file = wrap_call(
-                    Context::instance().root_prefix,
+                    Context::instance().prefix_params.root_prefix,
                     prefix,
                     Context::instance().dev,
                     false,
@@ -387,7 +387,7 @@ namespace mamba
             {
                 // std::string caller
                 script_file = wrap_call(
-                    Context::instance().root_prefix.string(),
+                    Context::instance().prefix_params.root_prefix.string(),
                     prefix,
                     Context::instance().dev,
                     false,
@@ -404,7 +404,7 @@ namespace mamba
             }
         }
 
-        envmap["ROOT_PREFIX"] = Context::instance().root_prefix.string();
+        envmap["ROOT_PREFIX"] = Context::instance().prefix_params.root_prefix.string();
         envmap["PREFIX"] = env_prefix.size() ? env_prefix : prefix.string();
         envmap["PKG_NAME"] = pkg_info.name;
         envmap["PKG_VERSION"] = pkg_info.version;

--- a/libmamba/src/core/menuinst.cpp
+++ b/libmamba/src/core/menuinst.cpp
@@ -216,7 +216,7 @@ namespace mamba
     void replace_variables(std::string& text, TransactionContext* transaction_context)
     {
         auto& ctx = mamba::Context::instance();
-        fs::u8path root_prefix = ctx.root_prefix;
+        fs::u8path root_prefix = ctx.prefix_params.root_prefix;
 
         fs::u8path target_prefix;
         std::string py_ver;
@@ -310,8 +310,8 @@ namespace mamba
             // }
 
             auto& ctx = mamba::Context::instance();
-            const fs::u8path root_prefix = ctx.root_prefix;
-            const fs::u8path target_prefix = ctx.target_prefix;
+            const fs::u8path root_prefix = ctx.prefix_params.root_prefix;
+            const fs::u8path target_prefix = ctx.prefix_params.target_prefix;
 
             // using legacy stuff here
             const fs::u8path root_py = root_prefix / "python.exe";

--- a/libmamba/src/core/run.cpp
+++ b/libmamba/src/core/run.cpp
@@ -200,7 +200,7 @@ namespace mamba
         nlohmann::json file_json;
         file_json["name"] = name;
         file_json["command"] = command;
-        file_json["prefix"] = Context::instance().target_prefix.string();
+        file_json["prefix"] = Context::instance().prefix_params.target_prefix.string();
         // TODO: add other info here if necessary
         pid_file << file_json;
     }
@@ -282,9 +282,10 @@ namespace mamba
         const std::string& specific_process_name
     )
     {
-        if (!fs::exists(Context::instance().target_prefix))
+        if (!fs::exists(Context::instance().prefix_params.target_prefix))
         {
-            LOG_CRITICAL << "The given prefix does not exist: " << Context::instance().target_prefix;
+            LOG_CRITICAL << "The given prefix does not exist: "
+                         << Context::instance().prefix_params.target_prefix;
             return 1;
         }
         std::vector<std::string> raw_command = command;
@@ -308,7 +309,7 @@ namespace mamba
 #endif
 
         auto [wrapped_command, script_file] = prepare_wrapped_call(
-            Context::instance().target_prefix,
+            Context::instance().prefix_params.target_prefix,
             command
         );
 

--- a/libmamba/src/core/shell_init.cpp
+++ b/libmamba/src/core/shell_init.cpp
@@ -558,12 +558,12 @@ namespace mamba
         }
         else if (shell == "cmd.exe")
         {
-            init_root_prefix_cmdexe(Context::instance().root_prefix);
+            init_root_prefix_cmdexe(Context::instance().prefix_params.root_prefix);
             LOG_WARNING << "Hook installed, now 'manually' execute:";
             LOG_WARNING << "       CALL "
-                        << std::quoted(
-                               (Context::instance().root_prefix / "condabin" / "mamba_hook.bat").string()
-                           );
+                        << std::quoted((Context::instance().prefix_params.root_prefix / "condabin"
+                                        / "mamba_hook.bat")
+                                           .string());
         }
         else if (shell == "fish")
         {
@@ -685,7 +685,7 @@ namespace mamba
 
     void init_root_prefix(const std::string& shell, const fs::u8path& root_prefix)
     {
-        Context::instance().root_prefix = root_prefix;
+        Context::instance().prefix_params.root_prefix = root_prefix;
 
         if (!fs::exists(root_prefix))
         {
@@ -780,7 +780,7 @@ namespace mamba
             return;
         }
 
-        Context::instance().root_prefix = root_prefix;
+        Context::instance().prefix_params.root_prefix = root_prefix;
 
         if (shell == "zsh" || shell == "bash" || shell == "posix")
         {

--- a/libmamba/src/core/transaction.cpp
+++ b/libmamba/src/core/transaction.cpp
@@ -572,13 +572,14 @@ namespace mamba
         if (!empty())
         {
             Console::instance().json_down("actions");
-            Console::instance().json_write({ { "PREFIX",
-                                               Context::instance().target_prefix.string() } });
+            Console::instance().json_write(
+                { { "PREFIX", Context::instance().prefix_params.target_prefix.string() } }
+            );
         }
 
         m_transaction_context = TransactionContext(
-            Context::instance().target_prefix,
-            Context::instance().relocate_prefix,
+            Context::instance().prefix_params.target_prefix,
+            Context::instance().prefix_params.relocate_prefix,
             find_python_version(),
             specs_to_install
         );
@@ -666,13 +667,14 @@ namespace mamba
         if (!empty())
         {
             Console::instance().json_down("actions");
-            Console::instance().json_write({ { "PREFIX",
-                                               Context::instance().target_prefix.string() } });
+            Console::instance().json_write(
+                { { "PREFIX", Context::instance().prefix_params.target_prefix.string() } }
+            );
         }
 
         m_transaction_context = TransactionContext(
-            Context::instance().target_prefix,
-            Context::instance().relocate_prefix,
+            Context::instance().prefix_params.target_prefix,
+            Context::instance().prefix_params.relocate_prefix,
             find_python_version(),
             solver.install_specs()
         );
@@ -818,8 +820,8 @@ namespace mamba
         }
 
         m_transaction_context = TransactionContext(
-            Context::instance().target_prefix,
-            Context::instance().relocate_prefix,
+            Context::instance().prefix_params.target_prefix,
+            Context::instance().prefix_params.relocate_prefix,
             find_python_version(),
             specs_to_install
         );
@@ -968,7 +970,7 @@ namespace mamba
             Console::instance().json_up();
         }
         Console::instance().json_write({ { "dry_run", ctx.dry_run },
-                                         { "prefix", ctx.target_prefix.string() } });
+                                         { "prefix", ctx.prefix_params.target_prefix.string() } });
         if (empty())
         {
             Console::instance().json_write({ { "message",
@@ -981,8 +983,8 @@ namespace mamba
             return true;
         }
 
-        auto lf = LockFile(ctx.target_prefix / "conda-meta");
-        clean_trash_files(ctx.target_prefix, false);
+        auto lf = LockFile(ctx.prefix_params.target_prefix / "conda-meta");
+        clean_trash_files(ctx.prefix_params.target_prefix, false);
 
         Console::stream() << "\nTransaction starting";
         fetch_extract_packages();
@@ -1190,7 +1192,7 @@ namespace mamba
         auto& aggregated_pbar_manager = dynamic_cast<AggregatedBarManager&>(pbar_manager);
 
         auto& ctx = Context::instance();
-        DownloadExtractSemaphore::set_max(ctx.extract_threads);
+        DownloadExtractSemaphore::set_max(ctx.threads_params.extract_threads);
 
         if (ctx.experimental && ctx.verify_artifacts)
         {
@@ -1407,7 +1409,7 @@ namespace mamba
         }
 
         Console::instance().print("Transaction\n");
-        Console::stream() << "  Prefix: " << ctx.target_prefix.string() << "\n";
+        Console::stream() << "  Prefix: " << ctx.prefix_params.target_prefix.string() << "\n";
 
         // check size of transaction
         if (empty())

--- a/libmamba/src/core/transaction_context.cpp
+++ b/libmamba/src/core/transaction_context.cpp
@@ -226,7 +226,7 @@ namespace mamba
 #endif
         std::map<std::string, std::string> envmap;
         auto& ctx = Context::instance();
-        envmap["MAMBA_EXTRACT_THREADS"] = std::to_string(ctx.extract_threads);
+        envmap["MAMBA_EXTRACT_THREADS"] = std::to_string(ctx.threads_params.extract_threads);
         auto qemu_ld_prefix = env::get("QEMU_LD_PREFIX");
         if (qemu_ld_prefix)
         {

--- a/libmamba/src/core/util.cpp
+++ b/libmamba/src/core/util.cpp
@@ -555,13 +555,16 @@ namespace mamba
                 {
                     // The conda-meta directory is locked by transaction execute
                     auto trash_index = open_ofstream(
-                        Context::instance().target_prefix / "conda-meta" / "mamba_trash.txt",
+                        Context::instance().prefix_params.target_prefix / "conda-meta"
+                            / "mamba_trash.txt",
                         std::ios::app | std::ios::binary
                     );
 
                     // TODO add some unicode tests here?
-                    trash_index << fs::relative(trash_file, Context::instance().target_prefix).string()
-                                << "\n";
+                    trash_index
+                        << fs::relative(trash_file, Context::instance().prefix_params.target_prefix)
+                               .string()
+                        << "\n";
                     return 1;
                 }
 
@@ -1301,7 +1304,7 @@ namespace mamba
         if (!fs::exists(conda_bat) && Context::instance().command_params.is_micromamba)
         {
             // this adds in the needed .bat files for activation
-            init_root_prefix_cmdexe(Context::instance().root_prefix);
+            init_root_prefix_cmdexe(Context::instance().prefix_params.root_prefix);
         }
 
         auto tf = std::make_unique<TemporaryFile>("mamba_bat_", ".bat");
@@ -1390,7 +1393,7 @@ namespace mamba
             // Micromamba hook
             out << "export MAMBA_EXE=" << std::quoted(get_self_exe_path().string(), '\'') << "\n";
             hook_quoted << "$MAMBA_EXE 'shell' 'hook' '-s' 'bash' '-p' "
-                        << std::quoted(Context::instance().root_prefix.string(), '\'');
+                        << std::quoted(Context::instance().prefix_params.root_prefix.string(), '\'');
         }
         if (debug_wrapper_scripts)
         {
@@ -1438,7 +1441,7 @@ namespace mamba
             }
 
             script_file = wrap_call(
-                Context::instance().root_prefix,
+                Context::instance().prefix_params.root_prefix,
                 prefix,
                 Context::instance().dev,
                 false,
@@ -1462,7 +1465,7 @@ namespace mamba
             }
 
             script_file = wrap_call(
-                Context::instance().root_prefix,
+                Context::instance().prefix_params.root_prefix,
                 prefix,
                 Context::instance().dev,
                 false,

--- a/libmamba/tests/src/core/test_cpp.cpp
+++ b/libmamba/tests/src/core/test_cpp.cpp
@@ -330,8 +330,8 @@ namespace mamba
             if constexpr (on_mac || on_linux)
             {
                 auto& ctx = Context::instance();
-                ctx.root_prefix = "/home/user/micromamba/";
-                ctx.envs_dirs = { ctx.root_prefix / "envs" };
+                ctx.prefix_params.root_prefix = "/home/user/micromamba/";
+                ctx.envs_dirs = { ctx.prefix_params.root_prefix / "envs" };
                 fs::u8path prefix = "/home/user/micromamba/envs/testprefix";
 
                 CHECK_EQ(env_name(prefix), "testprefix");

--- a/libmambapy/libmambapy/__init__.pyi
+++ b/libmambapy/libmambapy/__init__.pyi
@@ -422,6 +422,34 @@ class Context:
             pass
         pass
 
+    class PrefixParams:
+        def __init__(self) -> None: ...
+        @property
+        def conda_prefix(self) -> Path:
+            """
+            :type: Path
+            """
+        @conda_prefix.setter
+        def conda_prefix(self, arg0: Path) -> None:
+            pass
+        @property
+        def root_prefix(self) -> Path:
+            """
+            :type: Path
+            """
+        @root_prefix.setter
+        def root_prefix(self, arg0: Path) -> None:
+            pass
+        @property
+        def target_prefix(self) -> Path:
+            """
+            :type: Path
+            """
+        @target_prefix.setter
+        def target_prefix(self, arg0: Path) -> None:
+            pass
+        pass
+
     class RemoteFetchParams:
         def __init__(self) -> None: ...
         @property
@@ -473,6 +501,26 @@ class Context:
         def user_agent(self, arg0: str) -> None:
             pass
         pass
+
+    class ThreadsParams:
+        def __init__(self) -> None: ...
+        @property
+        def download_threads(self) -> int:
+            """
+            :type: int
+            """
+        @download_threads.setter
+        def download_threads(self, arg0: int) -> None:
+            pass
+        @property
+        def extract_threads(self) -> int:
+            """
+            :type: int
+            """
+        @extract_threads.setter
+        def extract_threads(self, arg0: int) -> None:
+            pass
+        pass
     def __init__(self) -> None: ...
     def set_log_level(self, arg0: LogLevel) -> None: ...
     def set_verbosity(self, arg0: int) -> None: ...
@@ -517,14 +565,6 @@ class Context:
     def channels(self, arg0: typing.List[str]) -> None:
         pass
     @property
-    def conda_prefix(self) -> Path:
-        """
-        :type: Path
-        """
-    @conda_prefix.setter
-    def conda_prefix(self, arg0: Path) -> None:
-        pass
-    @property
     def custom_channels(self) -> typing.Dict[str, str]:
         """
         :type: typing.Dict[str, str]
@@ -557,14 +597,6 @@ class Context:
     def download_only(self, arg0: bool) -> None:
         pass
     @property
-    def download_threads(self) -> int:
-        """
-        :type: int
-        """
-    @download_threads.setter
-    def download_threads(self, arg0: int) -> None:
-        pass
-    @property
     def dry_run(self) -> bool:
         """
         :type: bool
@@ -587,14 +619,6 @@ class Context:
         """
     @experimental_sat_error_message.setter
     def experimental_sat_error_message(self, arg1: bool) -> None:
-        pass
-    @property
-    def extract_threads(self) -> int:
-        """
-        :type: int
-        """
-    @extract_threads.setter
-    def extract_threads(self, arg0: int) -> None:
         pass
     @property
     def local_repodata_ttl(self) -> int:
@@ -637,6 +661,14 @@ class Context:
     def platform(self, arg0: str) -> None:
         pass
     @property
+    def prefix_params(self) -> Context.PrefixParams:
+        """
+        :type: Context.PrefixParams
+        """
+    @prefix_params.setter
+    def prefix_params(self, arg0: Context.PrefixParams) -> None:
+        pass
+    @property
     def proxy_servers(self) -> typing.Dict[str, str]:
         """
         :type: typing.Dict[str, str]
@@ -653,20 +685,12 @@ class Context:
     def remote_fetch_params(self, arg0: Context.RemoteFetchParams) -> None:
         pass
     @property
-    def root_prefix(self) -> Path:
+    def threads_params(self) -> Context.ThreadsParams:
         """
-        :type: Path
+        :type: Context.ThreadsParams
         """
-    @root_prefix.setter
-    def root_prefix(self, arg0: Path) -> None:
-        pass
-    @property
-    def target_prefix(self) -> Path:
-        """
-        :type: Path
-        """
-    @target_prefix.setter
-    def target_prefix(self, arg0: Path) -> None:
+    @threads_params.setter
+    def threads_params(self, arg0: Context.ThreadsParams) -> None:
         pass
     @property
     def use_index_cache(self) -> bool:

--- a/libmambapy/src/main.cpp
+++ b/libmambapy/src/main.cpp
@@ -512,16 +512,11 @@ PYBIND11_MODULE(bindings, m)
         .def_readwrite("offline", &Context::offline)
         .def_readwrite("local_repodata_ttl", &Context::local_repodata_ttl)
         .def_readwrite("use_index_cache", &Context::use_index_cache)
-        .def_readwrite("download_threads", &Context::download_threads)
-        .def_readwrite("extract_threads", &Context::extract_threads)
         .def_readwrite("always_yes", &Context::always_yes)
         .def_readwrite("dry_run", &Context::dry_run)
         .def_readwrite("download_only", &Context::download_only)
         .def_readwrite("proxy_servers", &Context::proxy_servers)
         .def_readwrite("add_pip_as_python_dependency", &Context::add_pip_as_python_dependency)
-        .def_readwrite("target_prefix", &Context::target_prefix)
-        .def_readwrite("conda_prefix", &Context::conda_prefix)
-        .def_readwrite("root_prefix", &Context::root_prefix)
         .def_readwrite("envs_dirs", &Context::envs_dirs)
         .def_readwrite("pkgs_dirs", &Context::pkgs_dirs)
         .def_readwrite("platform", &Context::platform)
@@ -565,8 +560,21 @@ PYBIND11_MODULE(bindings, m)
         .def_readwrite("json", &Context::OutputParams::json)
         .def_readwrite("quiet", &Context::OutputParams::quiet);
 
+    py::class_<Context::ThreadsParams>(ctx, "ThreadsParams")
+        .def(py::init<>())
+        .def_readwrite("download_threads", &Context::ThreadsParams::download_threads)
+        .def_readwrite("extract_threads", &Context::ThreadsParams::extract_threads);
+
+    py::class_<Context::PrefixParams>(ctx, "PrefixParams")
+        .def(py::init<>())
+        .def_readwrite("target_prefix", &Context::PrefixParams::target_prefix)
+        .def_readwrite("conda_prefix", &Context::PrefixParams::conda_prefix)
+        .def_readwrite("root_prefix", &Context::PrefixParams::root_prefix);
+
     ctx.def_readwrite("remote_fetch_params", &Context::remote_fetch_params)
-        .def_readwrite("output_params", &Context::output_params);
+        .def_readwrite("output_params", &Context::output_params)
+        .def_readwrite("threads_params", &Context::threads_params)
+        .def_readwrite("prefix_params", &Context::prefix_params);
 
     pyPrefixData
         .def(py::init(

--- a/mamba/mamba/api.py
+++ b/mamba/mamba/api.py
@@ -144,7 +144,7 @@ def install(
     (base_prefix / "pkgs").mkdir(parents=True, exist_ok=True)
 
     context = libmambapy.Context()
-    context.target_prefix = str(prefix)
+    context.prefix_params.target_prefix = str(prefix)
     context.pkgs_dirs = [str(base_prefix / "pkgs")]
 
     solver = MambaSolver(channels, target_platform, context)

--- a/mamba/mamba/mamba.py
+++ b/mamba/mamba/mamba.py
@@ -714,8 +714,10 @@ def clean(args, parser):
         init_api_context()
 
         root_prefix = os.environ.get("MAMBA_ROOT_PREFIX")
-        if api.Context().root_prefix != root_prefix:
-            os.environ["MAMBA_ROOT_PREFIX"] = str(api.Context().root_prefix)
+        if api.Context().prefix_params.root_prefix != root_prefix:
+            os.environ["MAMBA_ROOT_PREFIX"] = str(
+                api.Context().prefix_params.root_prefix
+            )
 
         api.Configuration().show_banner = False
         api.clean(api.MAMBA_CLEAN_LOCKS)

--- a/mamba/mamba/mamba_env.py
+++ b/mamba/mamba/mamba_env.py
@@ -32,7 +32,7 @@ from mamba.utils import (
 def mamba_install(prefix, specs, args, env, dry_run=False, *_, **kwargs):
     # TODO: support all various ways this happens
     init_api_context()
-    api.Context().target_prefix = prefix
+    api.Context().prefix_params.target_prefix = prefix
     # conda doesn't ask for confirmation with env
     api.Context().always_yes = True
 

--- a/mamba/mamba/utils.py
+++ b/mamba/mamba/utils.py
@@ -219,7 +219,7 @@ def init_api_context(use_mamba_experimental=False):
     if "MAMBA_EXTRACT_THREADS" in os.environ:
         try:
             max_threads = int(os.environ["MAMBA_EXTRACT_THREADS"])
-            api_ctx.extract_threads = max_threads
+            api_ctx.threads_params.extract_threads = max_threads
         except ValueError:
             v = os.environ["MAMBA_EXTRACT_THREADS"]
             raise ValueError(
@@ -263,9 +263,9 @@ def init_api_context(use_mamba_experimental=False):
         api_ctx.remote_fetch_params.ssl_verify = "<false>"
     elif context.ssl_verify is not True:
         api_ctx.remote_fetch_params.ssl_verify = context.ssl_verify
-    api_ctx.target_prefix = context.target_prefix
-    api_ctx.root_prefix = context.root_prefix
-    api_ctx.conda_prefix = context.conda_prefix
+    api_ctx.prefix_params.target_prefix = context.target_prefix
+    api_ctx.prefix_params.root_prefix = context.root_prefix
+    api_ctx.prefix_params.conda_prefix = context.conda_prefix
     api_ctx.pkgs_dirs = context.pkgs_dirs
     api_ctx.envs_dirs = context.envs_dirs
 

--- a/micromamba/src/config.cpp
+++ b/micromamba/src/config.cpp
@@ -71,7 +71,7 @@ compute_config_path(bool touch_if_not_exists)
     }
     else if (env_path.configured())
     {
-        rc_source = fs::u8path{ ctx.target_prefix / ".condarc" };
+        rc_source = fs::u8path{ ctx.prefix_params.target_prefix / ".condarc" };
     }
     else if (system_path.configured())
     {

--- a/micromamba/src/env.cpp
+++ b/micromamba/src/env.cpp
@@ -25,7 +25,7 @@ get_env_name(const fs::u8path& px)
 {
     const auto& ctx = Context::instance();
     auto& ed = ctx.envs_dirs[0];
-    if (px == ctx.root_prefix)
+    if (px == ctx.prefix_params.root_prefix)
     {
         return "base";
     }
@@ -85,7 +85,7 @@ set_env_command(CLI::App* com)
             if (explicit_format)
             {
                 // TODO: handle error
-                auto pd = PrefixData::create(ctx.target_prefix).value();
+                auto pd = PrefixData::create(ctx.prefix_params.target_prefix).value();
                 auto records = pd.sorted_records();
                 std::cout << "# This file may be used to create an environment using:\n"
                           << "# $ conda create --name <env> --file <this file>\n"
@@ -106,12 +106,12 @@ set_env_command(CLI::App* com)
             }
             else
             {
-                auto pd = PrefixData::create(ctx.target_prefix).value();
+                auto pd = PrefixData::create(ctx.prefix_params.target_prefix).value();
                 History& hist = pd.history();
 
                 const auto& versions_map = pd.records();
 
-                std::cout << "name: " << get_env_name(ctx.target_prefix) << "\n";
+                std::cout << "name: " << get_env_name(ctx.prefix_params.target_prefix) << "\n";
                 std::cout << "channels:\n";
 
                 auto requested_specs_map = hist.get_requested_specs_map();
@@ -185,7 +185,7 @@ set_env_command(CLI::App* com)
 
             for (auto& env : env_manager.list_all_known_prefixes())
             {
-                bool is_active = (env == ctx.target_prefix);
+                bool is_active = (env == ctx.prefix_params.target_prefix);
                 t.add_row({ get_env_name(env), is_active ? "*" : "", env.string() });
             }
             t.print(std::cout);
@@ -207,7 +207,7 @@ set_env_command(CLI::App* com)
             const auto& ctx = Context::instance();
             if (!ctx.dry_run)
             {
-                const auto& prefix = ctx.target_prefix;
+                const auto& prefix = ctx.prefix_params.target_prefix;
                 // Remove env directory or rename it (e.g. if used)
                 remove_or_rename(env::expand_user(prefix));
 

--- a/micromamba/src/shell.cpp
+++ b/micromamba/src/shell.cpp
@@ -93,12 +93,14 @@ set_shell_command(CLI::App* subcom)
             {
                 if (prefix.empty() || prefix == "base")
                 {
-                    Context::instance().target_prefix = Context::instance().root_prefix;
+                    Context::instance().prefix_params.target_prefix = Context::instance()
+                                                                          .prefix_params.root_prefix;
                 }
                 else
                 {
-                    Context::instance().target_prefix = Context::instance().root_prefix / "envs"
-                                                        / prefix;
+                    Context::instance().prefix_params.target_prefix = Context::instance()
+                                                                          .prefix_params.root_prefix
+                                                                      / "envs" / prefix;
                 }
 
                 std::string default_shell = "bash";

--- a/micromamba/src/update.cpp
+++ b/micromamba/src/update.cpp
@@ -29,7 +29,7 @@ update_self(const std::optional<std::string>& version)
 
     // set target_prefix to root_prefix (irrelevant, but transaction tries to lock
     // the conda-meta folder of the target_prefix)
-    ctx.target_prefix = ctx.root_prefix;
+    ctx.prefix_params.target_prefix = ctx.prefix_params.root_prefix;
 
     mamba::MPool pool;
     mamba::MultiPackageCache package_caches(ctx.pkgs_dirs);
@@ -85,7 +85,7 @@ update_self(const std::optional<std::string>& version)
 
     ctx.download_only = true;
     MTransaction t(pool, { latest_micromamba.value() }, package_caches);
-    auto exp_prefix_data = PrefixData::create(ctx.root_prefix);
+    auto exp_prefix_data = PrefixData::create(ctx.prefix_params.root_prefix);
     if (!exp_prefix_data)
     {
         throw exp_prefix_data.error();
@@ -137,7 +137,7 @@ update_self(const std::optional<std::string>& version)
 
     Console::instance().print("\nReinitializing all previously initialized shells\n");
     std::string shell_type = "";
-    mamba::shell("reinit", shell_type, ctx.root_prefix, false);
+    mamba::shell("reinit", shell_type, ctx.prefix_params.root_prefix, false);
 
     return 0;
 }


### PR DESCRIPTION
Follow-up of #2432 

The `Context` structuring is quite touchy and involves many files. Since a lot of the `Context` data can have similar names to other variables in the codebase, a manual check is needed making it both cumbersome and time-consuming.
I believe this work can be done in a rather long period of time (to avoid madness) in this same PR or, in order to avoid a significant divergence with the `main` branch and having to spend a lot of time resolving conflicts, submit several PRs.
I guess the second option is probably better.