### PR TITLE
Add doctest printer for pair and vector

### DIFF
--- a/libmamba/tests/src/doctest-printer/pair.hpp
+++ b/libmamba/tests/src/doctest-printer/pair.hpp
@@ -1,0 +1,22 @@
+// Copyright (c) 2023, QuantStack and Mamba Contributors
+//
+// Distributed under the terms of the BSD 3-Clause License.
+//
+// The full license is in the file LICENSE, distributed with this software.
+
+#include <utility>
+
+#include <doctest/doctest.h>
+#include <fmt/format.h>
+
+namespace doctest
+{
+    template <typename T, typename U>
+    struct StringMaker<std::pair<T, U>>
+    {
+        static auto convert(const std::pair<T, U>& value) -> String
+        {
+            return { fmt::format("std::pair{{{}, {}}}", value.first, value.second).c_str() };
+        }
+    };
+}

--- a/libmamba/tests/src/doctest-printer/vector.hpp
+++ b/libmamba/tests/src/doctest-printer/vector.hpp
@@ -1,0 +1,22 @@
+// Copyright (c) 2023, QuantStack and Mamba Contributors
+//
+// Distributed under the terms of the BSD 3-Clause License.
+//
+// The full license is in the file LICENSE, distributed with this software.
+
+#include <vector>
+
+#include <doctest/doctest.h>
+#include <fmt/format.h>
+
+namespace doctest
+{
+    template <typename T>
+    struct StringMaker<std::vector<T>>
+    {
+        static auto convert(const std::vector<T>& value) -> String
+        {
+            return { fmt::format("std::vector{{{}}}", fmt::join(value, ", ")).c_str() };
+        }
+    };
+}


### PR DESCRIPTION
Include these files for doctest to properly print the value.
They can be used and improved gradually.
