### PR TITLE
Improve micromamba transaction message

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ include/mamba/core/version.hpp
 **/build/
 **/build-*/
 CMakeUserPresets.json
+**/cmake-build-debug/
 
 # CMake files that should not exists because they should be generated under a build folder
 CMakeLists.txt.user

--- a/libmamba/src/core/transaction.cpp
+++ b/libmamba/src/core/transaction.cpp
@@ -1101,8 +1101,10 @@ namespace mamba
                               << "To activate this environment, use:\n\n"
                               << "    " << executable << " activate " << environment << "\n\n"
                               << "Or to execute a single command in this environment, use:\n\n"
-                              << "    " << executable << " run "
-                              // Use -n or -p depending on if the env_name is a full prefix or just a name.
+                              << "    " << executable
+                              << " run "
+                              // Use -n or -p depending on if the env_name is a full prefix or just
+                              // a name.
                               << (environment == ctx.target_prefix ? "-p " : "-n ") << environment
                               << " mycommand\n";
 

--- a/libmamba/src/core/transaction.cpp
+++ b/libmamba/src/core/transaction.cpp
@@ -1090,9 +1090,7 @@ namespace mamba
             m_transaction_context.wait_for_pyc_compilation();
 
             // Get the name of the executable used directly from the command.
-            std::istringstream iss(ctx.command_params.current_command);
-            std::string executable;
-            std::getline(iss, executable, ' ');
+            const auto executable = ctx.command_params.is_micromamba ? "micromamba" : "mamba";
 
             // Get the name of the environment
             const auto environment = env_name(ctx.target_prefix);

--- a/libmamba/src/core/transaction.cpp
+++ b/libmamba/src/core/transaction.cpp
@@ -1086,15 +1086,26 @@ namespace mamba
         }
         else
         {
-            // TODO: add executable name
-            // TODO: add environment name/prefix
             LOG_INFO << "Waiting for pyc compilation to finish";
             m_transaction_context.wait_for_pyc_compilation();
+
+            // Get the name of the executable used directly from the command.
+            std::istringstream iss(ctx.command_params.current_command);
+            std::string executable;
+            std::getline(iss, executable, ' ');
+
+            // Get the name of the environment
+            const auto environment = env_name(ctx.target_prefix);
+
             Console::stream() << "\nTransaction finished\n\n"
                               << "To activate this environment, use:\n\n"
-                              << "    $ [micro]mamba activate <environment>\n\n"
+                              << "    " << executable << " activate " << environment << "\n\n"
                               << "Or to execute a single command in this environment, use:\n\n"
-                              << "    $ [micro]mamba run -n <environment> mycommand\n";
+                              << "    " << executable << " run "
+                              // Use -n or -p depending on if the env_name is a full prefix or just a name.
+                              << (environment == ctx.target_prefix ? "-p " : "-n ") << environment
+                              << " mycommand\n";
+
 
             prefix.history().add_entry(m_history_entry);
         }

--- a/libmamba/src/core/transaction.cpp
+++ b/libmamba/src/core/transaction.cpp
@@ -1095,7 +1095,7 @@ namespace mamba
             const auto executable = ctx.command_params.is_micromamba ? "micromamba" : "mamba";
 
             // Get the name of the environment
-            const auto environment = env_name(ctx.target_prefix);
+            const auto environment = env_name(ctx.prefix_params.target_prefix);
 
             Console::stream() << "\nTransaction finished\n\n"
                               << "To activate this environment, use:\n\n"
@@ -1105,8 +1105,8 @@ namespace mamba
                               << " run "
                               // Use -n or -p depending on if the env_name is a full prefix or just
                               // a name.
-                              << (environment == ctx.target_prefix ? "-p " : "-n ") << environment
-                              << " mycommand\n";
+                              << (environment == ctx.prefix_params.target_prefix ? "-p " : "-n ")
+                              << environment << " mycommand\n";
 
 
             prefix.history().add_entry(m_history_entry);


### PR DESCRIPTION
Before:
```bash
Transaction finished

To activate this environment, use:

    $ [micro]mamba activate <environment>

Or to execute a single command in this environment, use:

    $ [micro]mamba run -n <environment> mycommand
```
Examples of the result now:
```bash
$ time ./build/micromamba/micromamba create -c conda-forge --yes -n test python

# results in

Transaction finished

To activate this environment, use:

    micromamba activate test

Or to execute a single command in this environment, use:

    micromamba run -n test mycommand
    

$ time ./micromamba create -c conda-forge --yes -p ~/testing python

# results in, note the -p or -n

Transaction finished

To activate this environment, use:

   micromamba activate /home/rarts/testing

Or to execute a single command in this environment, use:

    micromamba run -p /home/rarts/testing mycommand
```

Notable improvements:
- If is_micromamba is true micromamba will be used as the executable
- Use no `$` to make the line double click + copy + paste.
- Use `-p` when using prefix, use `-n` for a named env.