### PR TITLE
Store PackageInfo::track_features as a vector

### DIFF
--- a/libmamba/include/mamba/core/package_info.hpp
+++ b/libmamba/include/mamba/core/package_info.hpp
@@ -52,7 +52,7 @@ namespace mamba
         std::size_t timestamp = 0;
         std::string md5 = {};
         std::string sha256 = {};
-        std::string track_features = {};
+        std::vector<std::string> track_features = {};
         std::vector<std::string> depends = {};
         std::vector<std::string> constrains = {};
         std::string signatures = {};

--- a/libmamba/src/core/package_info.cpp
+++ b/libmamba/src/core/package_info.cpp
@@ -112,7 +112,10 @@ namespace mamba
         assign_or(j, "license", license, ""s);
         assign_or(j, "md5", md5, ""s);
         assign_or(j, "sha256", sha256, ""s);
-        assign_or(j, "track_features", track_features, ""s);
+        if (j.contains("track_features"))
+        {
+            track_features = split(j["track_features"].get<std::string_view>(), ",");
+        }
 
         // add the noarch type if we know it (only known for installed packages)
         if (j.contains("noarch"))
@@ -194,7 +197,7 @@ namespace mamba
         j["build_string"] = build_string;
         j["build_number"] = build_number;
         j["license"] = license;
-        j["track_features"] = track_features;
+        j["track_features"] = fmt::format("{}", fmt::join(track_features, ","));
         if (!md5.empty())
         {
             j["md5"] = md5;

--- a/libmamba/src/core/pool.cpp
+++ b/libmamba/src/core/pool.cpp
@@ -309,16 +309,9 @@ namespace mamba
             std::transform(q.begin(), q.end(), std::back_inserter(out.constrains), dep2str);
 
             q.clear();
+            auto id2str = [&pool](Id id) { return pool_id2str(pool, id); };
             solvable_lookup_idarray(&s, SOLVABLE_TRACK_FEATURES, q.raw());
-            for (::Id const id : q)
-            {
-                out.track_features += pool_id2str(pool, id);
-                out.track_features += ',';
-            }
-            if (!out.track_features.empty())
-            {
-                out.track_features.pop_back();
-            }
+            std::transform(q.begin(), q.end(), std::back_inserter(out.track_features), id2str);
 
             return out;
         }

--- a/libmamba/src/core/query.cpp
+++ b/libmamba/src/core/query.cpp
@@ -179,9 +179,9 @@ namespace mamba
 
             fmt::print(out, fmtstring, "MD5", pkg.md5.empty() ? "Not available" : pkg.md5);
             fmt::print(out, fmtstring, "SHA256", pkg.sha256.empty() ? "Not available" : pkg.sha256);
-            if (pkg.track_features.size())
+            if (!pkg.track_features.empty())
             {
-                fmt::print(out, fmtstring, "Track Features", pkg.track_features);
+                fmt::print(out, fmtstring, "Track Features", fmt::join(pkg.track_features, ","));
             }
 
             // std::cout << fmt::format<char>(

--- a/libmambapy/libmambapy/__init__.pyi
+++ b/libmambapy/libmambapy/__init__.pyi
@@ -999,7 +999,7 @@ class PackageInfo:
         :type: str
         """
     @track_features.setter
-    def track_features(self, arg0: str) -> None:
+    def track_features(self, arg1: str) -> None:
         pass
     @property
     def url(self) -> str:

--- a/libmambapy/src/main.cpp
+++ b/libmambapy/src/main.cpp
@@ -608,7 +608,15 @@ PYBIND11_MODULE(bindings, m)
         .def_readwrite("timestamp", &PackageInfo::timestamp)
         .def_readwrite("md5", &PackageInfo::md5)
         .def_readwrite("sha256", &PackageInfo::sha256)
-        .def_readwrite("track_features", &PackageInfo::track_features)
+        .def_property(
+            "track_features",
+            [](const PackageInfo& self)
+            {
+                static_assert(LIBMAMBA_VERSION_MAJOR == 1, "Version 1 compatibility.");
+                return fmt::format("{}", fmt::join(self.track_features, ","));
+            },
+            [](PackageInfo& self, std::string_view val) { self.track_features = split(val, ","); }
+        )
         .def_readwrite("depends", &PackageInfo::depends)
         .def_readwrite("constrains", &PackageInfo::constrains)
         .def_readwrite("signatures", &PackageInfo::signatures)


### PR DESCRIPTION
This is meant to be a list but is stored as comma-separated string in conda json.