### PR TITLE
Set `log_level` to critical with `--json` option

### DIFF
--- a/libmamba/src/api/configuration.cpp
+++ b/libmamba/src/api/configuration.cpp
@@ -11,6 +11,7 @@
 
 #include <nlohmann/json.hpp>
 #include <reproc++/run.hpp>
+#include <spdlog/spdlog.h>
 
 #include "mamba/api/configuration.hpp"
 #include "mamba/api/info.hpp"
@@ -20,8 +21,6 @@
 #include "mamba/core/output.hpp"
 #include "mamba/core/transaction.hpp"
 #include "mamba/core/url.hpp"
-
-#include "spdlog/spdlog.h"
 
 namespace mamba
 {
@@ -632,7 +631,7 @@ namespace mamba
 
             if (ctx.output_params.json)
             {
-                return mamba::log_level::off;
+                return mamba::log_level::critical;
             }
             else if (Configuration::instance().at("verbose").configured())
             {


### PR DESCRIPTION
Fix #2446 
I don't know the reason behind setting `log_level` to `off` when dealing with `--json` but I guess it shouldn't be the case.
Let's see if the CI tests fail...