### PR TITLE
fix: parsing of empty track_features

### DIFF
--- a/libmamba/src/core/package_info.cpp
+++ b/libmamba/src/core/package_info.cpp
@@ -114,7 +114,11 @@ namespace mamba
         assign_or(j, "sha256", sha256, ""s);
         if (j.contains("track_features"))
         {
-            track_features = split(j["track_features"].get<std::string_view>(), ",");
+            auto j_track_features = j["track_features"].get<std::string_view>();
+            if (!j_track_features.empty())  // Split empty string would have an empty element
+            {
+                track_features = split(j_track_features, ",");
+            }
         }
 
         // add the noarch type if we know it (only known for installed packages)


### PR DESCRIPTION
Fix on #2478
