### PR TITLE
Reset fish shell status even if variable not exists

### DIFF
--- a/libmamba/src/core/activation.cpp
+++ b/libmamba/src/core/activation.cpp
@@ -1235,7 +1235,7 @@ namespace mamba
 
         for (const std::string& uvar : env_transform.unset_vars)
         {
-            out << "set -e " << uvar << "\n";
+            out << "set -e " << uvar << " || true\n";
         }
 
         for (const auto& [skey, svar] : env_transform.set_vars)


### PR DESCRIPTION
This is pretty straightforward, where it avoids polluting shell status with status code `> 0`.

Currently all the following functions `activate`, `deactivate`, `reactivate`, `install`, ... return non-zero status for me due to the variable setting in functions like
```sh
...
set -e CONDA_PREFIX
set -e CONDA_DEFAULT_ENV
set -e CONDA_PROMPT_MODIFIER
set -gx CONDA_SHLVL "0"
```
will return non-zero status if those variables do not exists.

Note1: `set -e XXX` can't erase non-existing variable, and will return non-zero status if that happens.

Note2: setting variable (e.g. `set -gx CONDA_SHLVL "0"`) does not modify the current return status, so it doesn't reset the fail status from attempting to erase non-existing variables.

----------------
This just modify the erasing command into something like:
```sh
set -e CONDA_PREFIX || true
set -e CONDA_DEFAULT_ENV || true
set -e CONDA_PROMPT_MODIFIER || true
set -gx CONDA_SHLVL "0"
```