### PR TITLE
Add missing cstdint include for GCC 13

### DIFF
--- a/libmamba/include/mamba/core/util_string.hpp
+++ b/libmamba/include/mamba/core/util_string.hpp
@@ -9,6 +9,7 @@
 
 #include <algorithm>
 #include <array>
+#include <cstdint>
 #include <cstring>
 #include <iomanip>
 #include <iterator>


### PR DESCRIPTION
GCC 13 started complaining about this with errors like
```
mamba-micromamba-1.4.2/libmamba/include/mamba/core/util_string.hpp:164:81: error: ‘SIZE_MAX’ was not declared in this scope
164 |     split(std::string_view input, std::string_view sep, std::size_t max_split = SIZE_MAX);
|                                                                                 ^~~~~~~~
mamba-micromamba-1.4.2/libmamba/include/mamba/core/util_string.hpp:23:1: note: ‘SIZE_MAX’ is defined in header ‘<cstdint>’; did you forget to ‘#include <cstdint>’?
22 | #include "mamba/util/compare.hpp"
+++ |+#include <cstdint>
```
