### PR TITLE
Improvement: Remove repodata_use_zst flag

### DIFF
--- a/libmamba/include/mamba/core/context.hpp
+++ b/libmamba/include/mamba/core/context.hpp
@@ -279,7 +279,6 @@ namespace mamba
 
         bool use_only_tar_bz2 = false;
 
-        bool repodata_use_zst = false;
         std::vector<std::string> repodata_has_zst = { "https://conda.anaconda.org/conda-forge" };
 
         // usernames on anaconda.org can have a underscore, which influences the

--- a/libmamba/src/api/configuration.cpp
+++ b/libmamba/src/api/configuration.cpp
@@ -1176,11 +1176,6 @@ namespace mamba
                    .set_env_var_names()
                    .description("Permit use of the --overide-channels command-line flag"));
 
-        insert(Configurable("repodata_use_zst", &ctx.repodata_use_zst)
-                   .group("Repodata")
-                   .set_rc_configurable()
-                   .description("Use zstd encoded repodata when fetching"));
-
         insert(Configurable("repodata_has_zst", &ctx.repodata_has_zst)
                    .group("Repodata")
                    .set_rc_configurable()

--- a/libmamba/src/core/subdirdata.cpp
+++ b/libmamba/src/core/subdirdata.cpp
@@ -600,7 +600,7 @@ namespace mamba
             {
                 bool has_value = m_metadata.has_zst.has_value();
                 bool is_expired = m_metadata.has_zst.has_value()
-                                    && m_metadata.has_zst.value().has_expired();
+                                  && m_metadata.has_zst.value().has_expired();
                 bool has_zst = m_metadata.check_zst(p_channel);
                 if (!has_zst && (is_expired || !has_value))
                 {
@@ -613,7 +613,7 @@ namespace mamba
                     m_check_targets.back()->set_finalize_callback(&MSubdirData::finalize_check, this);
                     m_check_targets.back()->set_ignore_failure(true);
                     if (!(ctx.graphics_params.no_progress_bars || ctx.output_params.quiet
-                            || ctx.output_params.json))
+                          || ctx.output_params.json))
                     {
                         m_progress_bar_check = Console::instance().add_progress_bar(
                             m_name + " (check zst)"

--- a/libmamba/src/core/subdirdata.cpp
+++ b/libmamba/src/core/subdirdata.cpp
@@ -598,33 +598,30 @@ namespace mamba
             auto& ctx = Context::instance();
             if (!ctx.offline || forbid_cache())
             {
-                if (ctx.repodata_use_zst)
+                bool has_value = m_metadata.has_zst.has_value();
+                bool is_expired = m_metadata.has_zst.has_value()
+                                    && m_metadata.has_zst.value().has_expired();
+                bool has_zst = m_metadata.check_zst(p_channel);
+                if (!has_zst && (is_expired || !has_value))
                 {
-                    bool has_value = m_metadata.has_zst.has_value();
-                    bool is_expired = m_metadata.has_zst.has_value()
-                                      && m_metadata.has_zst.value().has_expired();
-                    bool has_zst = m_metadata.check_zst(p_channel);
-                    if (!has_zst && (is_expired || !has_value))
+                    m_check_targets.push_back(std::make_unique<DownloadTarget>(
+                        m_name + " (check zst)",
+                        m_repodata_url + ".zst",
+                        ""
+                    ));
+                    m_check_targets.back()->set_head_only(true);
+                    m_check_targets.back()->set_finalize_callback(&MSubdirData::finalize_check, this);
+                    m_check_targets.back()->set_ignore_failure(true);
+                    if (!(ctx.graphics_params.no_progress_bars || ctx.output_params.quiet
+                            || ctx.output_params.json))
                     {
-                        m_check_targets.push_back(std::make_unique<DownloadTarget>(
-                            m_name + " (check zst)",
-                            m_repodata_url + ".zst",
-                            ""
-                        ));
-                        m_check_targets.back()->set_head_only(true);
-                        m_check_targets.back()->set_finalize_callback(&MSubdirData::finalize_check, this);
-                        m_check_targets.back()->set_ignore_failure(true);
-                        if (!(ctx.graphics_params.no_progress_bars || ctx.output_params.quiet
-                              || ctx.output_params.json))
-                        {
-                            m_progress_bar_check = Console::instance().add_progress_bar(
-                                m_name + " (check zst)"
-                            );
-                            m_check_targets.back()->set_progress_bar(m_progress_bar_check);
-                            m_progress_bar_check.repr().postfix.set_value("Checking");
-                        }
-                        return true;
+                        m_progress_bar_check = Console::instance().add_progress_bar(
+                            m_name + " (check zst)"
+                        );
+                        m_check_targets.back()->set_progress_bar(m_progress_bar_check);
+                        m_progress_bar_check.repr().postfix.set_value("Checking");
                     }
+                    return true;
                 }
                 create_target();
             }
@@ -676,15 +673,12 @@ namespace mamba
             m_solv_cache_valid = true;
         }
 
-        if (Context::instance().repodata_use_zst)
-        {
-            auto state_file = json_file;
-            state_file.replace_extension(".state.json");
-            auto lock = LockFile(state_file);
-            m_metadata.store_file_metadata(json_file);
-            auto outf = open_ofstream(state_file);
-            m_metadata.serialize_to_stream(outf);
-        }
+        auto state_file = json_file;
+        state_file.replace_extension(".state.json");
+        auto lock = LockFile(state_file);
+        m_metadata.store_file_metadata(json_file);
+        auto outf = open_ofstream(state_file);
+        m_metadata.serialize_to_stream(outf);
     }
 
     bool MSubdirData::finalize_transfer(const DownloadTarget&)
@@ -817,79 +811,54 @@ namespace mamba
         m_metadata.cache_control = m_target->get_cache_control();
         m_metadata.stored_file_size = file_size;
 
-        if (!Context::instance().repodata_use_zst)
+
+        LOG_DEBUG << "Opening '" << json_file.string() << "'";
+        path::touch(json_file, true);
+        std::ofstream final_file = open_ofstream(json_file);
+
+        if (!final_file.is_open())
         {
-            LOG_DEBUG << "Opening '" << json_file.string() << "'";
-            path::touch(json_file, true);
-            std::ofstream final_file = open_ofstream(json_file);
-
-            if (!final_file.is_open())
-            {
-                throw mamba_error(
-                    fmt::format("Could not open file '{}'", json_file.string()),
-                    mamba_error_code::subdirdata_not_loaded
-                );
-            }
-
-            if (m_progress_bar)
-            {
-                m_progress_bar.set_postfix("Finalizing");
-            }
-
-            std::ifstream temp_file = open_ifstream(m_temp_file->path());
-            std::stringstream temp_json;
-            m_metadata.serialize_to_stream_tiny(temp_json);
-
-            // replace `}` with `,`
-            temp_json.seekp(-1, temp_json.cur);
-            temp_json << ',';
-            final_file << temp_json.str();
-            temp_file.seekg(1);
-            std::copy(
-                std::istreambuf_iterator<char>(temp_file),
-                std::istreambuf_iterator<char>(),
-                std::ostreambuf_iterator<char>(final_file)
+            throw mamba_error(
+                fmt::format("Could not open file '{}'", json_file.string()),
+                mamba_error_code::subdirdata_not_loaded
             );
-
-            if (!temp_file)
-            {
-                std::error_code ec;
-                fs::remove(json_file, ec);
-                if (ec)
-                {
-                    LOG_ERROR << "Could not remove file " << json_file << ": " << ec.message();
-                }
-                throw mamba_error(
-                    fmt::format("Could not write out repodata file {}: {}", json_file, strerror(errno)),
-                    mamba_error_code::subdirdata_not_loaded
-                );
-            }
-            fs::last_write_time(json_file, fs::now());
         }
-        else
+
+        if (m_progress_bar)
         {
-            fs::u8path state_file = json_file;
-            state_file.replace_extension(".state.json");
+            m_progress_bar.set_postfix("Finalizing");
+        }
+
+        std::ifstream temp_file = open_ifstream(m_temp_file->path());
+        std::stringstream temp_json;
+        m_metadata.serialize_to_stream_tiny(temp_json);
+
+        // replace `}` with `,`
+        temp_json.seekp(-1, temp_json.cur);
+        temp_json << ',';
+        final_file << temp_json.str();
+        temp_file.seekg(1);
+        std::copy(
+            std::istreambuf_iterator<char>(temp_file),
+            std::istreambuf_iterator<char>(),
+            std::ostreambuf_iterator<char>(final_file)
+        );
+
+        if (!temp_file)
+        {
             std::error_code ec;
-            mamba_fs::rename_or_move(m_temp_file->path(), json_file, ec);
+            fs::remove(json_file, ec);
             if (ec)
             {
-                throw mamba_error(
-                    fmt::format(
-                        "Could not move repodata file from {} to {}: {}",
-                        m_temp_file->path(),
-                        json_file,
-                        strerror(errno)
-                    ),
-                    mamba_error_code::subdirdata_not_loaded
-                );
+                LOG_ERROR << "Could not remove file " << json_file << ": " << ec.message();
             }
-            fs::last_write_time(json_file, fs::now());
-
-            m_metadata.store_file_metadata(json_file);
-            std::ofstream state_file_stream = open_ofstream(state_file);
-            m_metadata.serialize_to_stream(state_file_stream);
+            throw mamba_error(
+                fmt::format("Could not write out repodata file {}: {}", json_file, strerror(errno)),
+                mamba_error_code::subdirdata_not_loaded
+            );
         }
+        fs::last_write_time(json_file, fs::now());
+
         if (m_progress_bar)
         {
             m_progress_bar.repr().postfix.set_value("Downloaded").deactivate();

--- a/libmamba/tests/src/core/test_cpp.cpp
+++ b/libmamba/tests/src/core/test_cpp.cpp
@@ -575,8 +575,6 @@ namespace mamba
     {
         TEST_CASE("parse_mod_etag")
         {
-            bool old_value = Context::instance().repodata_use_zst;
-            Context::instance().repodata_use_zst = true;
             fs::u8path cache_folder = fs::u8path{ test_data_dir / "repodata_json_cache" };
             auto mq = detail::read_metadata(cache_folder / "test_1.json");
             CHECK(mq.has_value());
@@ -653,8 +651,6 @@ namespace mamba
             CHECK_EQ(j.url, "https://conda.anaconda.org/conda-forge/noarch/repodata.json.zst");
             CHECK_EQ(j.has_zst.value().value, true);
             CHECK_EQ(j.has_zst.value().last_checked, parse_utc_timestamp("2023-01-06T16:33:06Z"));
-
-            Context::instance().repodata_use_zst = old_value;
         }
     }
 }  // namespace mamba


### PR DESCRIPTION
## Before this PR

Users would have to add `repodata_use_zst: true` in their .condarc file to leverage the much lighter .zst variant of repodatas, should they exist.

## After this PR

We remove the flag and make it default to always use zst where possible for downloading repodatas