### PR TITLE
Honor envs_dirs

### DIFF
--- a/libmamba/data/_mamba_activate.bat
+++ b/libmamba/data/_mamba_activate.bat
@@ -27,7 +27,7 @@
 @ECHO Failed to create temp directory "%TMP%\conda-<RANDOM>\" & exit /b 1
 :tmp_file_created
 
-@"%MAMBA_EXE%" shell --shell cmd.exe %* 1>%UNIQUE%
+@"%MAMBA_EXE%" shell %* --shell cmd.exe 1>%UNIQUE%
 @IF %ErrorLevel% NEQ 0 @EXIT /B %ErrorLevel%
 @FOR /F %%i IN (%UNIQUE%) DO @SET _TEMP_SCRIPT_PATH=%%i
 @RMDIR /S /Q %UNIQUE_DIR%

--- a/libmamba/include/mamba/api/shell.hpp
+++ b/libmamba/include/mamba/api/shell.hpp
@@ -10,13 +10,15 @@
 #include <string>
 #include <string_view>
 
+#include "mamba/core/mamba_fs.hpp"
+
 namespace mamba
 {
-    void shell_init(const std::string& shell_type, std::string_view prefix);
-    void shell_deinit(const std::string& shell_type, std::string_view prefix);
-    void shell_reinit(std::string_view prefix);
+    void shell_init(const std::string& shell_type, const fs::u8path& prefix);
+    void shell_deinit(const std::string& shell_type, const fs::u8path& prefix);
+    void shell_reinit(const fs::u8path& prefix);
     void shell_hook(const std::string& shell_type);
-    void shell_activate(std::string_view prefix, const std::string& shell_type, bool stack);
+    void shell_activate(const fs::u8path& prefix, const std::string& shell_type, bool stack);
     void shell_reactivate(const std::string& shell_type);
     void shell_deactivate(const std::string& shell_type);
     void shell_enable_long_path_support();

--- a/libmamba/src/api/configuration.cpp
+++ b/libmamba/src/api/configuration.cpp
@@ -436,6 +436,60 @@ namespace mamba
             }
         }
 
+        namespace
+        {
+            /** Find the first directory containing the given subdirectory. */
+            auto find_env_in_dirs(std::string_view name, const std::vector<fs::u8path>& dirs)
+                -> std::optional<fs::u8path>
+            {
+                for (const auto& dir : dirs)
+                {
+                    const auto candidate = dir / name;
+                    if (fs::exists(candidate) && fs::is_directory(candidate))
+                    {
+                        return candidate;
+                    }
+                }
+                return std::nullopt;
+            }
+
+            /** Find the first directory that can create the given subdirectory. */
+            auto find_writable_env_in_dirs(std::string_view name, const std::vector<fs::u8path>& dirs)
+                -> std::optional<fs::u8path>
+            {
+                for (const auto& dir : dirs)
+                {
+                    const auto candidate = dir / name;
+                    if (mamba::path::is_writable(candidate))
+                    {
+                        return candidate;
+                    }
+                }
+                return std::nullopt;
+            }
+
+            auto compute_prefix_from_name(
+                const fs::u8path& root_prefix,
+                const std::vector<fs::u8path>& envs_dirs,
+                std::string_view name
+            ) -> fs::u8path
+            {
+                if (name == "base")
+                {
+                    return root_prefix;
+                }
+                if (auto dir = find_env_in_dirs(name, envs_dirs); dir.has_value())
+                {
+                    return std::move(dir).value();
+                }
+                if (auto dir = find_writable_env_in_dirs(name, envs_dirs); dir.has_value())
+                {
+                    return std::move(dir).value();
+                }
+                return root_prefix / "envs" / name;
+            }
+        }
+
         void env_name_hook(std::string& name)
         {
             file_spec_env_name_hook(name);
@@ -464,15 +518,8 @@ namespace mamba
 
             if (!name.empty())
             {
-                fs::u8path prefix;
-                if (name == "base")
-                {
-                    prefix = root_prefix;
-                }
-                else
-                {
-                    prefix = root_prefix / "envs" / name;
-                }
+                const auto& envs_dirs = config.at("envs_dirs").value<std::vector<fs::u8path>>();
+                fs::u8path prefix = compute_prefix_from_name(root_prefix, envs_dirs, name);
 
                 if (!config.at("target_prefix").cli_configured()
                     && config.at("env_name").cli_configured())
@@ -1056,7 +1103,7 @@ namespace mamba
 
         insert(Configurable("env_name", std::string(""))
                    .group("Basic")
-                   .needs({ "root_prefix", "spec_file_env_name" })
+                   .needs({ "root_prefix", "spec_file_env_name", "envs_dirs" })
                    .set_single_op_lifetime()
                    .set_post_merge_hook(detail::env_name_hook)
                    .description("Name of the target prefix"));

--- a/libmamba/src/api/shell.cpp
+++ b/libmamba/src/api/shell.cpp
@@ -53,7 +53,7 @@ namespace mamba
         }
     }
 
-    void shell_init(const std::string& shell_type, std::string_view prefix)
+    void shell_init(const std::string& shell_type, const fs::u8path& prefix)
     {
         auto& ctx = Context::instance();
         if (prefix.empty() || prefix == "base")
@@ -66,7 +66,7 @@ namespace mamba
         }
     }
 
-    void shell_deinit(const std::string& shell_type, std::string_view prefix)
+    void shell_deinit(const std::string& shell_type, const fs::u8path& prefix)
     {
         auto& ctx = Context::instance();
         if (prefix.empty() || prefix == "base")
@@ -79,7 +79,7 @@ namespace mamba
         }
     }
 
-    void shell_reinit(std::string_view prefix)
+    void shell_reinit(const fs::u8path& prefix)
     {
         // re-initialize all the shell scripts after update
         for (const auto& shell_type : find_initialized_shells())
@@ -107,32 +107,17 @@ namespace mamba
         }
     }
 
-    void shell_activate(std::string_view prefix, const std::string& shell_type, bool stack)
+    void shell_activate(const fs::u8path& prefix, const std::string& shell_type, bool stack)
     {
-        auto activator = make_activator(shell_type);
-        auto& ctx = Context::instance();
-        fs::u8path shell_prefix;
-        if (prefix.empty() || prefix == "base")
-        {
-            shell_prefix = ctx.prefix_params.root_prefix;
-        }
-        else if (prefix.find_first_of("/\\") == std::string::npos)
-        {
-            shell_prefix = ctx.prefix_params.root_prefix / "envs" / prefix;
-        }
-        else
-        {
-            shell_prefix = fs::weakly_canonical(env::expand_user(prefix));
-        }
-
-        if (!fs::exists(shell_prefix))
+        if (!fs::exists(prefix))
         {
             throw std::runtime_error(
-                fmt::format("Cannot activate, prefix does not exist at: {}", shell_prefix)
+                fmt::format("Cannot activate, prefix does not exist at: {}", prefix)
             );
         }
 
-        std::cout << activator->activate(shell_prefix, stack);
+        auto activator = make_activator(shell_type);
+        std::cout << activator->activate(prefix, stack);
     }
 
     void shell_reactivate(const std::string& shell_type)

--- a/libmamba/src/core/run.cpp
+++ b/libmamba/src/core/run.cpp
@@ -19,10 +19,11 @@
 #include <reproc++/run.hpp>
 #include <spdlog/spdlog.h>
 
-#include "mamba/api/configuration.hpp"
-#include "mamba/api/install.hpp"
+#include "mamba/core/context.hpp"
+#include "mamba/core/environment.hpp"
 #include "mamba/core/error_handling.hpp"
 #include "mamba/core/execution.hpp"
+#include "mamba/core/output.hpp"
 #include "mamba/core/run.hpp"
 #include "mamba/core/util_os.hpp"
 #include "mamba/core/util_random.hpp"

--- a/libmamba/src/core/shell_init.cpp
+++ b/libmamba/src/core/shell_init.cpp
@@ -5,7 +5,10 @@
 // The full license is in the file LICENSE, distributed with this software.
 
 #include <regex>
+#include <set>
 #include <stdexcept>
+#include <string>
+#include <vector>
 
 #include <fmt/color.h>
 #include <fmt/format.h>
@@ -23,8 +26,6 @@
 #include "mamba/core/util.hpp"
 #include "mamba/core/util_os.hpp"
 #include "mamba/core/util_string.hpp"
-
-#include "progress_bar_impl.hpp"
 
 namespace mamba
 {
@@ -292,7 +293,7 @@ namespace mamba
         content << "export MAMBA_EXE=" << std::quoted(cyg_mamba_exe, '\'') << ";\n";
         content << "export MAMBA_ROOT_PREFIX=" << std::quoted(cyg_env_prefix, '\'') << ";\n";
         content << "eval \"$(\"$MAMBA_EXE\" shell hook --shell " << shell
-                << " --prefix \"$MAMBA_ROOT_PREFIX\")\"\n";
+                << " --root-prefix \"$MAMBA_ROOT_PREFIX\")\"\n";
         content << "# <<< mamba initialize <<<\n";
         return content.str();
 
@@ -305,7 +306,7 @@ namespace mamba
         content << "export MAMBA_EXE=" << mamba_exe << ";\n";
         content << "export MAMBA_ROOT_PREFIX=" << env_prefix << ";\n";
         content << "__mamba_setup=\"$(\"$MAMBA_EXE\" shell hook --shell " << shell
-                << " --prefix \"$MAMBA_ROOT_PREFIX\" 2> /dev/null)\"\n";
+                << " --root-prefix \"$MAMBA_ROOT_PREFIX\" 2> /dev/null)\"\n";
         content << "if [ $? -eq 0 ]; then\n";
         content << "    eval \"$__mamba_setup\"\n";
         content << "else\n";
@@ -376,7 +377,7 @@ namespace mamba
         content << "# !! Contents within this block are managed by 'mamba init' !!\n";
         content << "set -gx MAMBA_EXE " << mamba_exe << "\n";
         content << "set -gx MAMBA_ROOT_PREFIX " << env_prefix << "\n";
-        content << "$MAMBA_EXE shell hook --shell fish --prefix $MAMBA_ROOT_PREFIX | source\n";
+        content << "$MAMBA_EXE shell hook --shell fish --root-prefix $MAMBA_ROOT_PREFIX | source\n";
         content << "# <<< mamba initialize <<<\n";
         return content.str();
     }

--- a/libmamba/src/core/util.cpp
+++ b/libmamba/src/core/util.cpp
@@ -1392,7 +1392,7 @@ namespace mamba
         {
             // Micromamba hook
             out << "export MAMBA_EXE=" << std::quoted(get_self_exe_path().string(), '\'') << "\n";
-            hook_quoted << "$MAMBA_EXE 'shell' 'hook' '-s' 'bash' '-p' "
+            hook_quoted << "$MAMBA_EXE 'shell' 'hook' '-s' 'bash' '-r' "
                         << std::quoted(Context::instance().prefix_params.root_prefix.string(), '\'');
         }
         if (debug_wrapper_scripts)

--- a/libmamba/tests/src/core/test_util.cpp
+++ b/libmamba/tests/src/core/test_util.cpp
@@ -151,6 +151,9 @@ namespace mamba
                 env::expand_user("~/.libmamba-non-existing-writable-test-delete-me.txt")
             ));
 
+            CHECK(path::is_writable(test_dir_path / "non-existing-subfolder"));
+            CHECK_FALSE(fs::exists(test_dir_path / "non-existing-subfolder"));
+
             {
                 const auto existing_file_path = test_dir_path
                                                 / "existing-writable-test-delete-me.txt";

--- a/libmamba/tests/src/core/test_util_string.cpp
+++ b/libmamba/tests/src/core/test_util_string.cpp
@@ -60,6 +60,8 @@ namespace mamba
             CHECK(contains(":hello&", "ll"));
             CHECK_FALSE(contains(":hello&", "eo"));
             CHECK(contains("áäáœ©gþhëb®hüghœ©®xb", "ëb®"));
+            CHECK_FALSE(contains("", "ab"));
+            CHECK(contains("", ""));  // same as Python ``"" in ""``
         }
 
         TEST_CASE("any_starts_with")

--- a/micromamba/src/shell.cpp
+++ b/micromamba/src/shell.cpp
@@ -38,7 +38,9 @@ namespace
     {
         auto& root = config.at("root_prefix");
         subcmd->add_option(
-            "root_prefix,-r,--root-prefix",
+            "root_prefix,-r,--root-prefix"
+            // TODO deprecated, remove in 2.0.0
+            ",--prefix,-p,--name,-n",
             root.get_cli_config<fs::u8path>(),
             root.description()
         );

--- a/micromamba/tests/test_activation.py
+++ b/micromamba/tests/test_activation.py
@@ -4,7 +4,7 @@ import platform
 import shutil
 import subprocess
 import tempfile
-from pathlib import PurePosixPath, PureWindowsPath
+from pathlib import Path, PurePosixPath, PureWindowsPath
 
 import pytest
 
@@ -911,6 +911,18 @@ class TestActivation:
         res = shell("activate", prefix_short, "-s", interpreter)
         dict_res = self.to_dict(res, interpreter)
         assert any([str(tmp_empty_env) in p for p in dict_res.values()])
+
+    @pytest.mark.parametrize("interpreter", get_interpreters())
+    def test_activate_envs_dirs(
+        self, tmp_root_prefix: Path, interpreter, tmp_path: Path
+    ):
+        """Activate an environemt as the non leading entry in ``envs_dirs``."""
+        env_name = "myenv"
+        create("-p", tmp_path / env_name, "--offline", "--no-rc", no_dry_run=True)
+        os.environ["CONDA_ENVS_DIRS"] = f"{Path('/noperm')},{tmp_path}"
+        res = shell("activate", env_name, "-s", interpreter)
+        dict_res = self.to_dict(res, interpreter)
+        assert any([env_name in p for p in dict_res.values()])
 
     @pytest.mark.parametrize("interpreter", get_self_update_interpreters())
     def test_self_update(

--- a/micromamba/tests/test_activation.py
+++ b/micromamba/tests/test_activation.py
@@ -330,7 +330,7 @@ class TestActivation:
         stdout, stderr = call(s)
         assert stdout == str(tmp_root_prefix)
 
-        s = [f"{umamba} shell init -p {rpv} {xonsh_shell_args(interpreter)}"]
+        s = [f"{umamba} shell init -r {rpv} {xonsh_shell_args(interpreter)}"]
         stdout, stderr = call(s)
 
         if interpreter == "cmd.exe":
@@ -346,7 +346,7 @@ class TestActivation:
                 assert find_path_in_str(tmp_root_prefix, x)
                 prev_text = x
 
-        s = [f"{umamba} shell init -p {rpv} {xonsh_shell_args(interpreter)}"]
+        s = [f"{umamba} shell init -r {rpv} {xonsh_shell_args(interpreter)}"]
         stdout, stderr = call(s)
 
         if interpreter == "cmd.exe":
@@ -363,7 +363,7 @@ class TestActivation:
 
         if interpreter == "cmd.exe":
             write_windows_registry(regkey, "echo 'test'", winreg_value[1])
-            s = [f"{umamba} shell init -p {rpv}"]
+            s = [f"{umamba} shell init -r {rpv}"]
             stdout, stderr = call(s)
 
             value = read_windows_registry(regkey)
@@ -384,7 +384,7 @@ class TestActivation:
                 )
                 fo.write(text)
 
-            s = [f"{umamba} shell init -p {rpv}"]
+            s = [f"{umamba} shell init -r {rpv}"]
             stdout, stderr = call(s)
             with open(path) as fi:
                 x = fi.read()
@@ -394,7 +394,7 @@ class TestActivation:
         other_root_prefix = tmp_path / "prefix"
         other_root_prefix.mkdir()
         s = [
-            f"{umamba} shell init -p {other_root_prefix} {xonsh_shell_args(interpreter)}"
+            f"{umamba} shell init -r {other_root_prefix} {xonsh_shell_args(interpreter)}"
         ]
         stdout, stderr = call(s)
 
@@ -452,7 +452,7 @@ class TestActivation:
             return call_interpreter(command, tmp_path, interpreter)
 
         s = [
-            f"{umamba} shell init -p {tmp_root_prefix} {xonsh_shell_args(interpreter)}"
+            f"{umamba} shell init -r {tmp_root_prefix} {xonsh_shell_args(interpreter)}"
         ]
         call(s)
 
@@ -460,7 +460,7 @@ class TestActivation:
             assert file.exists()
 
         s = [
-            f"{umamba} shell deinit -p {tmp_root_prefix} {xonsh_shell_args(interpreter)}"
+            f"{umamba} shell deinit -r {tmp_root_prefix} {xonsh_shell_args(interpreter)}"
         ]
         call(s)
 
@@ -488,7 +488,7 @@ class TestActivation:
         assert not find_path_in_str(tmp_root_prefix, prev_value[0])
 
         s = [
-            f"{umamba} shell init -p {tmp_root_prefix} {xonsh_shell_args(interpreter)}"
+            f"{umamba} shell init -r {tmp_root_prefix} {xonsh_shell_args(interpreter)}"
         ]
         call(s)
 
@@ -497,7 +497,7 @@ class TestActivation:
         assert find_path_in_str(tmp_root_prefix, value_after_init[0])
 
         s = [
-            f"{umamba} shell deinit -p {tmp_root_prefix} {xonsh_shell_args(interpreter)}"
+            f"{umamba} shell deinit -r {tmp_root_prefix} {xonsh_shell_args(interpreter)}"
         ]
         call(s)
 
@@ -536,7 +536,7 @@ class TestActivation:
         assert not find_path_in_str(tmp_root_prefix, prev_rc_contents)
 
         s = [
-            f"{umamba} shell init -p {tmp_root_prefix} {xonsh_shell_args(interpreter)}"
+            f"{umamba} shell init -r {tmp_root_prefix} {xonsh_shell_args(interpreter)}"
         ]
         call(s)
 
@@ -549,7 +549,7 @@ class TestActivation:
             assert find_path_in_str(tmp_root_prefix, rc_contents_after_init)
 
         s = [
-            f"{umamba} shell deinit -p {tmp_root_prefix} {xonsh_shell_args(interpreter)}"
+            f"{umamba} shell deinit -r {tmp_root_prefix} {xonsh_shell_args(interpreter)}"
         ]
         call(s)
 
@@ -571,7 +571,7 @@ class TestActivation:
 
         umamba = get_umamba()
 
-        s = [f"{umamba} shell init -p {tmp_root_prefix}"]
+        s = [f"{umamba} shell init -r {tmp_root_prefix}"]
         stdout, stderr = call_interpreter(s, tmp_path, interpreter)
 
         call = lambda s: call_interpreter(s, tmp_path, interpreter, interactive=True)
@@ -670,7 +670,7 @@ class TestActivation:
 
         umamba = get_umamba()
 
-        s = [f"{umamba} shell init -p {tmp_root_prefix}"]
+        s = [f"{umamba} shell init -r {tmp_root_prefix}"]
         stdout, stderr = call_interpreter(s, tmp_path, interpreter)
 
         call = lambda s: call_interpreter(s, tmp_path, interpreter, interactive=True)
@@ -793,7 +793,7 @@ class TestActivation:
 
         umamba = get_umamba()
 
-        s = [f"{umamba} shell init -p {tmp_root_prefix}"]
+        s = [f"{umamba} shell init -r {tmp_root_prefix}"]
         stdout, stderr = call_interpreter(s, tmp_path, interpreter)
 
         call = lambda s: call_interpreter(s, tmp_path, interpreter, interactive=True)
@@ -925,7 +925,7 @@ class TestActivation:
         mamba_exe = backup_umamba
 
         shell_init = [
-            f"{format_path(mamba_exe, interpreter)} shell init -s {interpreter} -p {format_path(tmp_root_prefix, interpreter)}"
+            f"{format_path(mamba_exe, interpreter)} shell init -s {interpreter} -r {format_path(tmp_root_prefix, interpreter)}"
         ]
         call_interpreter(shell_init, tmp_path, interpreter)
 

--- a/micromamba/tests/test_create.py
+++ b/micromamba/tests/test_create.py
@@ -467,6 +467,14 @@ def test_create_empty(tmp_home, tmp_root_prefix, tmp_path, prefix_selector, crea
     assert (effective_prefix / "conda-meta" / "history").exists()
 
 
+def test_create_envs_dirs(tmp_root_prefix: Path, tmp_path: Path):
+    """Create an environment when the first env dir is not writable."""
+    os.environ["CONDA_ENVS_DIRS"] = f"{Path('/noperm')},{tmp_path}"
+    env_name = "myenv"
+    helpers.create("-n", env_name, "--offline", "--no-rc", no_dry_run=True)
+    assert (tmp_path / env_name / "conda-meta" / "history").exists()
+
+
 @pytest.mark.skipif(
     helpers.dry_run_tests is helpers.DryRun.ULTRA_DRY,
     reason="Running only ultra-dry tests",

--- a/micromamba/tests/test_shell.py
+++ b/micromamba/tests/test_shell.py
@@ -3,7 +3,6 @@ import os
 import platform
 import shutil
 import subprocess
-import tempfile
 from pathlib import Path
 
 import pytest
@@ -195,7 +194,7 @@ class TestShell:
             p = TestShell.prefix
             n = TestShell.env_name
 
-        cmd = ["activate", "-s", shell_type, "-p"]
+        cmd = ["activate", "-s", shell_type]
         if prefix_type == "expanded_prefix":
             cmd.append(p)
         elif prefix_type == "shrinked_prefix":
@@ -237,12 +236,12 @@ class TestShell:
         if prefix_selector is None:
             res = shell("-y", "init", "-s", shell_type)
         else:
-            res = shell("-y", "init", "-s", shell_type, "-p", TestShell.root_prefix)
+            res = shell("-y", "init", "-s", shell_type, "-r", TestShell.root_prefix)
         assert res
 
         if multiple_time:
             if same_prefix and shell_type == "cmd.exe":
-                res = shell("-y", "init", "-s", shell_type, "-p", TestShell.root_prefix)
+                res = shell("-y", "init", "-s", shell_type, "-r", TestShell.root_prefix)
                 assert res.splitlines() == [
                     "cmd.exe already initialized.",
                     "Windows long-path support already enabled.",
@@ -253,7 +252,7 @@ class TestShell:
                     "init",
                     "-s",
                     shell_type,
-                    "-p",
+                    "-r",
                     os.path.join(TestShell.root_prefix, random_string()),
                 )
 
@@ -264,7 +263,7 @@ class TestShell:
         else:
             assert Path(os.path.join(TestShell.root_prefix, "condabin")).is_dir()
 
-        shell("init", "-y", "-s", shell_type, "-p", TestShell.current_root_prefix)
+        shell("init", "-y", "-s", shell_type, "-r", TestShell.current_root_prefix)
 
     def test_dash(self):
         skip_if_shell_incompat("dash")


### PR DESCRIPTION
- Refactor `micromamba shell` to differentiate `--name`, `--prefix`, and `--root-prefix` options (CLI backward incompatible)
- Make `Configuration::target_prefix` honor `envs_dirs`
- Switch to using `target_prefix` in `activate` and `create`

- Close #2465 
- Close #2475 (supersede)
- Close #2386
- Close #2442
- Close #2271
- Close #1110

@katringoogoo, I had to start anew due to large number of conflicts. This solves the issue of `envs_dirs` with `create` and `activate` (with tests).
Do you want to iterate on this and make sure `envs_dirs` is honored with other commands as well (`install`, `update`, `env`...)? With the refactor of putting the logic inside `Configuration`, this could be as simple as making sure these commands use `target_prefix`.