### PR TITLE
LockFile behavior on file-locking is now almost independent from Context

### DIFF
--- a/libmamba/src/api/configuration.cpp
+++ b/libmamba/src/api/configuration.cpp
@@ -1841,6 +1841,8 @@ namespace mamba
         }
         m_load_lock = false;
 
+        allow_file_locking(Context::instance().use_lockfiles);
+
         LOG_DEBUG << m_config.size() << " configurables computed";
 
         if (this->at("print_config_only").value<bool>())

--- a/libmamba/src/core/run.cpp
+++ b/libmamba/src/core/run.cpp
@@ -194,7 +194,7 @@ namespace mamba
         : location{ proc_dir() / fmt::format("{}.json", getpid()) }
     {
         // Lock must be hold for the duraction of this constructor.
-        if (Context::instance().use_lockfiles)
+        if (is_file_locking_allowed())
         {
             assert(proc_dir_lock);
         }

--- a/libmamba/tests/src/core/test_lockfile.cpp
+++ b/libmamba/tests/src/core/test_lockfile.cpp
@@ -56,7 +56,7 @@ namespace mamba
 
             ~LockDirTest()
             {
-                mamba::Context::instance().use_lockfiles = true;
+                mamba::allow_file_locking(true);
                 spdlog::set_level(spdlog::level::info);
             }
         };
@@ -79,14 +79,14 @@ namespace mamba
             TEST_CASE_FIXTURE(LockDirTest, "disable_locking")
             {
                 {
-                    auto _ = on_scope_exit([] { mamba::Context::instance().use_lockfiles = true; });
-                    mamba::Context::instance().use_lockfiles = false;
+                    auto _ = on_scope_exit([] { mamba::allow_file_locking(true); });
+                    mamba::allow_file_locking(false);
                     auto lock = LockFile(tempdir_path);
                     CHECK_FALSE(lock);
                 }
-                REQUIRE(mamba::Context::instance().use_lockfiles);
+                REQUIRE(mamba::is_file_locking_allowed());
                 {
-                    REQUIRE(mamba::Context::instance().use_lockfiles);
+                    REQUIRE(mamba::is_file_locking_allowed());
                     auto lock = LockFile(tempdir_path);
                     CHECK(lock);
                 }

--- a/libmambapy/libmambapy/__init__.pyi
+++ b/libmambapy/libmambapy/__init__.pyi
@@ -789,7 +789,7 @@ class Context:
         :type: bool
         """
     @use_lockfiles.setter
-    def use_lockfiles(self, arg0: bool) -> None:
+    def use_lockfiles(self, arg1: bool) -> None:
         pass
     @property
     def use_only_tar_bz2(self) -> bool:

--- a/libmambapy/src/main.cpp
+++ b/libmambapy/src/main.cpp
@@ -533,7 +533,19 @@ PYBIND11_MODULE(bindings, m)
                            " The new error messages are always enabled.");
             }
         )
-        .def_readwrite("use_lockfiles", &Context::use_lockfiles)
+        .def_property(
+            "use_lockfiles",
+            [](Context& ctx)
+            {
+                ctx.use_lockfiles = is_file_locking_allowed();
+                return ctx.use_lockfiles;
+            },
+            [](Context& ctx, bool allow)
+            {
+                allow_file_locking(allow);
+                ctx.use_lockfiles = allow;
+            }
+        )
         .def("set_verbosity", &Context::set_verbosity)
         .def("set_log_level", &Context::set_log_level);
 


### PR DESCRIPTION
This is part of the effort to make `mamba::Context` not-a-singleton.