### PR TITLE
Fix lockfiles topological sort

### DIFF
--- a/libmamba/src/core/prefix_data.cpp
+++ b/libmamba/src/core/prefix_data.cpp
@@ -105,7 +105,7 @@ namespace mamba
                     const auto from_iter = name_to_node_id.find(ms.name);
                     if (from_iter != name_to_node_id.cend())
                     {
-                        dep_graph.add_edge(to_id, from_iter->second);
+                        dep_graph.add_edge(from_iter->second, to_id);
                     }
                 }
             }

--- a/libmamba/src/core/transaction.cpp
+++ b/libmamba/src/core/transaction.cpp
@@ -149,6 +149,10 @@ namespace mamba
         m_transaction = std::make_unique<solv::ObjTransaction>(
             solv::ObjTransaction::from_solvables(m_pool.pool(), decision)
         );
+        // We cannot order the transcation here because we do no have dependency information
+        // from the lockfile
+        // TODO reload dependency information from ``ctx.target_prefix / "conda-meta"`` after
+        // ``fetch_extract_packages`` is called.
         init();
 
         for (auto& s : specs_to_remove)


### PR DESCRIPTION
Lockfiles were in reverse topological sort, leading to bugs.

Close  #2552

