### PR TITLE
Force conda-forge in Anaconda install

### DIFF
--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -30,7 +30,7 @@ To get ``mamba``, just install it *into the base environment* from the ``conda-f
 
 .. code:: bash
 
-   conda install mamba -n base -c conda-forge
+   conda install -n base --override-channels -c conda-forge mamba 'python_abi=*=*cp*'
 
 
 .. warning::


### PR DESCRIPTION
Taken from here https://github.com/mamba-org/mamba/issues/2547#issuecomment-1602613370

fyi @itamarst

Are we sure we always have `python_abi` on all platforms?