### PR TITLE
Fix broken `ref` directives in docs

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -3,5 +3,6 @@ channels:
   - conda-forge
 dependencies:
   - myst-parser
+  - six
   - sphinx
   - sphinx-book-theme

--- a/docs/source/advanced_usage/artifacts_verification.rst
+++ b/docs/source/advanced_usage/artifacts_verification.rst
@@ -37,7 +37,7 @@ Further documentation will come soon.
 Package tarball
 ---------------
 
-Assuming a valid :ref:`repodata<repodata>` (see the previous :ref:`repodata verification<repodata_verification>`), :ref:`package tarball<tarball>` metadata are used to check if a tarball is valid or not after :ref:`fetching it<fetching_tarball>` from a repository.
+Assuming a valid :ref:`repodata<repodata>` (see the previous :ref:`repodata verification<repodata_verification>`), :ref:`package tarball<tarball>` metadata are used to check if a tarball is valid or not after fetching it from a repository.
 
 
 .. _files_verification:
@@ -45,7 +45,7 @@ Assuming a valid :ref:`repodata<repodata>` (see the previous :ref:`repodata veri
 Package files
 -------------
 
-| All the package files are listed in a ``paths.json`` file index :ref:`extracted<extraction>` from the :ref:`package tarball<tarball>` with files themselves.
+| All the package files are listed in a ``paths.json`` file index extracted from the :ref:`package tarball<tarball>` with files themselves.
 
 This index also contains metadata such as the size and checksum (SHA-256) of each file of the package.
 


### PR DESCRIPTION
I was getting started on making a docs contribution (for #2578 ) and encountered some errors and warnings. There's some explanatory text in the commit messagewhich added `six` to `docs/environment.yml`.