### PR TITLE
Fix build with older Clang

### DIFF
--- a/libmamba/src/solv-cpp/pool.cpp
+++ b/libmamba/src/solv-cpp/pool.cpp
@@ -132,7 +132,7 @@ namespace mamba::solv
         {
             return id;
         }
-        std::stringstream msg = {};
+        auto msg = std::stringstream {};
         msg << R"(Invalid conda dependency: ")" << dep << '"';
         throw std::invalid_argument(msg.str());
     }

--- a/libmamba/src/solv-cpp/pool.cpp
+++ b/libmamba/src/solv-cpp/pool.cpp
@@ -132,7 +132,7 @@ namespace mamba::solv
         {
             return id;
         }
-        auto msg = std::stringstream {};
+        auto msg = std::stringstream{};
         msg << R"(Invalid conda dependency: ")" << dep << '"';
         throw std::invalid_argument(msg.str());
     }


### PR DESCRIPTION
See #2397

```
  /tmp/micromamba-20230627-77271-10613rh/mamba-micromamba-1.4.5/libmamba/src/solv-cpp/pool.cpp:135:27: error: chosen constructor is explicit in copy-initialization
          std::stringstream msg = {};
                            ^     ~~
  /Library/Developer/CommandLineTools/SDKs/MacOSX11.sdk/usr/include/c++/v1/sstream:884:14: note: explicit constructor declared here
      explicit basic_stringstream(ios_base::openmode __wch = ios_base::in | ios_base::out);
               ^
  1 error generated.
  make[2]: *** [libmamba/CMakeFiles/libmamba.dir/src/solv-cpp/pool.cpp.o] Error 1

```

Occurred in https://github.com/Homebrew/homebrew-core/pull/135110