### PR TITLE
Add Version::starts_with and Version::compatible_with

### DIFF
--- a/libmamba/include/mamba/specs/version.hpp
+++ b/libmamba/include/mamba/specs/version.hpp
@@ -130,6 +130,16 @@ namespace mamba::specs
          */
         [[nodiscard]] auto starts_with(const Version& prefix) const -> bool;
 
+        /**
+         * Return true if this version is a compatible upgrade to the given one.
+         *
+         * For instance 1.3.1 is compatible with 1.2.1 at level 0 (first component `1 == 1``),
+         * at level 1 (second component `` 3 >= 2``), but not at level two (because the second
+         * component is stricly larger ``3 > 2``).
+         * Compatible versions are always smaller than the current version.
+         */
+        [[nodiscard]] auto compatible_with(const Version& older, std::size_t level) const -> bool;
+
     private:
 
         // Stored in decreasing size order for performance

--- a/libmamba/include/mamba/specs/version.hpp
+++ b/libmamba/include/mamba/specs/version.hpp
@@ -103,20 +103,32 @@ namespace mamba::specs
 
         static auto parse(std::string_view str) -> Version;
 
+        /** Construct version ``0.0``. */
+        Version() noexcept = default;
         Version(std::size_t epoch, CommonVersion&& version, CommonVersion&& local = {}) noexcept;
 
-        auto epoch() const noexcept -> std::size_t;
-        auto version() const noexcept -> const CommonVersion&;
-        auto local() const noexcept -> const CommonVersion&;
+        [[nodiscard]] auto epoch() const noexcept -> std::size_t;
+        [[nodiscard]] auto version() const noexcept -> const CommonVersion&;
+        [[nodiscard]] auto local() const noexcept -> const CommonVersion&;
 
-        auto str() const -> std::string;
+        [[nodiscard]] auto str() const -> std::string;
 
-        auto operator==(const Version& other) const -> bool;
-        auto operator!=(const Version& other) const -> bool;
-        auto operator<(const Version& other) const -> bool;
-        auto operator<=(const Version& other) const -> bool;
-        auto operator>(const Version& other) const -> bool;
-        auto operator>=(const Version& other) const -> bool;
+        [[nodiscard]] auto operator==(const Version& other) const -> bool;
+        [[nodiscard]] auto operator!=(const Version& other) const -> bool;
+        [[nodiscard]] auto operator<(const Version& other) const -> bool;
+        [[nodiscard]] auto operator<=(const Version& other) const -> bool;
+        [[nodiscard]] auto operator>(const Version& other) const -> bool;
+        [[nodiscard]] auto operator>=(const Version& other) const -> bool;
+
+        /**
+         * Return true if this version starts with the other prefix.
+         *
+         * For instance 1.2.3 starts with 1.2 but not the opposite.
+         * Because Conda versions can contain an arbitrary number of segments, some of which
+         * with alpha releases, this function cannot be written as a comparison.
+         * One would need to comoare with a version with infinitely pre-release segments.
+         */
+        [[nodiscard]] auto starts_with(const Version& prefix) const -> bool;
 
     private:
 

--- a/libmamba/src/specs/version.cpp
+++ b/libmamba/src/specs/version.cpp
@@ -222,17 +222,17 @@ namespace mamba::specs
          */
         template <typename Iter1, typename Iter2, typename Empty1, typename Empty2, typename Cmp>
         constexpr auto lexicographical_compare_three_way_trailing(
-            const Iter1 first1,
-            const Iter1 last1,
-            const Iter2 first2,
-            const Iter2 last2,
-            const Empty1 empty1,
-            const Empty2 empty2,
+            Iter1 first1,
+            Iter1 last1,
+            Iter2 first2,
+            Iter2 last2,
+            const Empty1& empty1,
+            const Empty2& empty2,
             Cmp comp
         ) -> std::pair<strong_ordering, std::size_t>
         {
-            assert(first1 <= last1);
-            assert(first2 <= last2);
+            assert(std::distance(first1, last1) >= 0);
+            assert(std::distance(first2, last2) >= 0);
 
             auto iter1 = first1;
             auto iter2 = first2;
@@ -279,7 +279,7 @@ namespace mamba::specs
             Iter1 last1,
             Iter2 first2,
             Iter2 last2,
-            Empty empty,
+            const Empty& empty,
             Cmp comp
         ) -> std::pair<strong_ordering, std::size_t>
         {
@@ -371,6 +371,14 @@ namespace mamba::specs
         struct AlwaysEqual
         {
         };
+
+        [[maybe_unused]] auto starts_with_three_way(const AlwaysEqual&, const AlwaysEqual&)
+            -> strong_ordering
+        {
+            // This comparison should not happen with the current usage.
+            assert(false);
+            return strong_ordering::equal;
+        }
 
         template <typename T>
         auto starts_with_three_way(const AlwaysEqual&, const T&) -> strong_ordering

--- a/libmamba/src/specs/version.cpp
+++ b/libmamba/src/specs/version.cpp
@@ -216,53 +216,61 @@ namespace mamba::specs
          * ``[1, 2, 0, 0]`` are considered equal, however ``[1, 2]`` and ``[1, 0, 2]`` are not.
          * Similarily ``[1, 1] is less than ``[1, 2, 0]`` but more than ``[1, 1, -1]``
          * because ``-1 < 0``.
+         *
+         * @return The comparison between the two sequence
+         * @return The first index where the two sequence diverge.
          */
         template <typename Iter1, typename Iter2, typename Empty1, typename Empty2, typename Cmp>
         constexpr auto lexicographical_compare_three_way_trailing(
-            Iter1 first1,
-            Iter1 last1,
-            Iter2 first2,
-            Iter2 last2,
-            Empty1 empty1,
-            Empty2 empty2,
+            const Iter1 first1,
+            const Iter1 last1,
+            const Iter2 first2,
+            const Iter2 last2,
+            const Empty1 empty1,
+            const Empty2 empty2,
             Cmp comp
-        ) -> strong_ordering
+        ) -> std::pair<strong_ordering, std::size_t>
         {
-            for (; (first1 != last1) && (first2 != last2); ++first1, ++first2)
+            assert(first1 <= last1);
+            assert(first2 <= last2);
+
+            auto iter1 = first1;
+            auto iter2 = first2;
+            for (; (iter1 != last1) && (iter2 != last2); ++iter1, ++iter2)
             {
-                if (auto c = comp(*first1, *first2); c != strong_ordering::equal)
+                if (auto c = comp(*iter1, *iter2); c != strong_ordering::equal)
                 {
-                    return c;
+                    return { c, static_cast<std::size_t>(std::distance(first1, iter1)) };
                 }
             }
 
             // They have the same leading elements but 1 has more elements
             // We do a lexicographic compare with an infite sequence of empties
-            if ((first1 != last1))
+            if ((iter1 != last1))
             {
-                for (; first1 != last1; ++first1)
+                for (; iter1 != last1; ++iter1)
                 {
-                    if (auto c = comp(*first1, empty2); c != strong_ordering::equal)
+                    if (auto c = comp(*iter1, empty2); c != strong_ordering::equal)
                     {
-                        return c;
+                        return { c, static_cast<std::size_t>(std::distance(first1, iter1)) };
                     }
                 }
             }
             // first2 != last2
             // They have the same leading elements but 2 has more elements
             // We do a lexicographic compare with an infite sequence of empties
-            if ((first2 != last2))
+            if ((iter2 != last2))
             {
-                for (; first2 != last2; ++first2)
+                for (; iter2 != last2; ++iter2)
                 {
-                    if (auto c = comp(empty1, *first2); c != strong_ordering::equal)
+                    if (auto c = comp(empty1, *iter2); c != strong_ordering::equal)
                     {
-                        return c;
+                        return { c, static_cast<std::size_t>(std::distance(first2, iter2)) };
                     }
                 }
             }
             // They have the same elements
-            return strong_ordering::equal;
+            return { strong_ordering::equal, static_cast<std::size_t>(std::distance(first1, iter1)) };
         }
 
         template <typename Iter1, typename Iter2, typename Empty, typename Cmp>
@@ -273,7 +281,7 @@ namespace mamba::specs
             Iter2 last2,
             Empty empty,
             Cmp comp
-        ) -> strong_ordering
+        ) -> std::pair<strong_ordering, std::size_t>
         {
             return lexicographical_compare_three_way_trailing(
                 first1,
@@ -290,26 +298,26 @@ namespace mamba::specs
         auto compare_three_way(const VersionPart& a, const VersionPart& b) -> strong_ordering
         {
             return lexicographical_compare_three_way_trailing(
-                a.cbegin(),
-                a.cend(),
-                b.cbegin(),
-                b.cend(),
-                VersionPartAtom{},
-                [](const auto& x, const auto& y) { return compare_three_way(x, y); }
-            );
+                       a.cbegin(),
+                       a.cend(),
+                       b.cbegin(),
+                       b.cend(),
+                       VersionPartAtom{},
+                       [](const auto& x, const auto& y) { return compare_three_way(x, y); }
+            ).first;
         }
 
         template <>
         auto compare_three_way(const CommonVersion& a, const CommonVersion& b) -> strong_ordering
         {
             return lexicographical_compare_three_way_trailing(
-                a.cbegin(),
-                a.cend(),
-                b.cbegin(),
-                b.cend(),
-                VersionPart{},
-                [](const auto& x, const auto& y) { return compare_three_way(x, y); }
-            );
+                       a.cbegin(),
+                       a.cend(),
+                       b.cbegin(),
+                       b.cend(),
+                       VersionPart{},
+                       [](const auto& x, const auto& y) { return compare_three_way(x, y); }
+            ).first;
         }
 
         template <>
@@ -389,27 +397,27 @@ namespace mamba::specs
         auto starts_with_three_way(const VersionPart& a, const VersionPart& b) -> strong_ordering
         {
             return lexicographical_compare_three_way_trailing(
-                a.cbegin(),
-                a.cend(),
-                b.cbegin(),
-                b.cend(),
-                VersionPartAtom{},
-                AlwaysEqual{},
-                [](const auto& x, const auto& y) { return starts_with_three_way(x, y); }
-            );
+                       a.cbegin(),
+                       a.cend(),
+                       b.cbegin(),
+                       b.cend(),
+                       VersionPartAtom{},
+                       AlwaysEqual{},
+                       [](const auto& x, const auto& y) { return starts_with_three_way(x, y); }
+            ).first;
         }
 
         auto starts_with_three_way(const CommonVersion& a, const CommonVersion& b) -> strong_ordering
         {
             return lexicographical_compare_three_way_trailing(
-                a.cbegin(),
-                a.cend(),
-                b.cbegin(),
-                b.cend(),
-                VersionPart{},
-                AlwaysEqual{},
-                [](const auto& x, const auto& y) { return starts_with_three_way(x, y); }
-            );
+                       a.cbegin(),
+                       a.cend(),
+                       b.cbegin(),
+                       b.cend(),
+                       VersionPart{},
+                       AlwaysEqual{},
+                       [](const auto& x, const auto& y) { return starts_with_three_way(x, y); }
+            ).first;
         }
 
         auto starts_with_three_way(const Version& a, const Version& b) -> strong_ordering
@@ -429,6 +437,32 @@ namespace mamba::specs
     auto Version::starts_with(const Version& prefix) const -> bool
     {
         return starts_with_three_way(*this, prefix) == strong_ordering::equal;
+    }
+
+    namespace
+    {
+        auto
+        compatible_with_impl(const CommonVersion& newer, const CommonVersion& older, std::size_t level)
+            -> bool
+        {
+            auto [cmp, idx] = lexicographical_compare_three_way_trailing(
+                newer.cbegin(),
+                newer.cend(),
+                older.cbegin(),
+                older.cend(),
+                VersionPart{},
+                [](const auto& x, const auto& y) { return compare_three_way(x, y); }
+            );
+
+            return (cmp == strong_ordering::equal)
+                   || ((cmp == strong_ordering::greater) && (idx >= level));
+        }
+    }
+
+    auto Version::compatible_with(const Version& older, std::size_t level) const -> bool
+    {
+        return (epoch() == older.epoch()) && compatible_with_impl(version(), older.version(), level)
+               && compatible_with_impl(local(), older.local(), level);
     }
 
     namespace

--- a/libmamba/tests/src/specs/test_version.cpp
+++ b/libmamba/tests/src/specs/test_version.cpp
@@ -174,6 +174,111 @@ TEST_SUITE("version")
         }
     }
 
+    TEST_CASE("compatible_with")
+    {
+        SUBCASE("positive")
+        {
+            // clang-format off
+            auto const versions = std::vector<std::tuple<std::size_t, Version, Version>>{
+                {0, Version(), Version()},
+                {1, Version(), Version()},
+                // 0!1a2post, 0!1a2post
+                {1, Version(0, {{{1, "a"}, {2, "post"}}}), Version(0, {{{1, "a"}, {2, "post"}}})},
+                // 0!1, 0!1
+                {0, Version(0, {{{1}}}), Version(0, {{{1}}})},
+                // 0!1, 0!1
+                {0, Version(0, {{{1}}}), Version(0, {{{1}}})},
+                // 0!1, 0!2
+                {0, Version(0, {{{1}}}), Version(0, {{{2}}})},
+                // 0!1, 0!1
+                {1, Version(0, {{{1}}}), Version(0, {{{1}}})},
+                // 0!1, 0!1.1
+                {0, Version(0, {{{1}}}), Version(0, {{{1}}, {{1}}})},
+                // 0!1, 0!1.1
+                {1, Version(0, {{{1}}}), Version(0, {{{1}}, {{1}}})},
+                // 0!1, 0!1.3
+                {1, Version(0, {{{1}}}), Version(0, {{{1}}, {{3}}})},
+                // 0!1, 0!1.1a
+                {0, Version(0, {{{1}}}), Version(0, {{{1}}, {{1, "a"}}})},
+                // 0!1a, 0!1
+                {0, Version(0, {{{1, "a"}}}), Version(0, {{{1}}})},
+                // 0!1a, 0!1b
+                {0, Version(0, {{{1, "a"}}}), Version(0, {{{1, "b"}}})},
+                // 0!1a, 0!1b
+                {1, Version(0, {{{1}}, {{1, "a"}}}), Version(0, {{{1}}, {{1, "b"}}})},
+                // 0!1, 0!1post
+                {0, Version(0, {{{1}}}), Version(0, {{{1, "post"}}})},
+                // 0!1a, 0!1a.1
+                {0, Version(0, {{{1, "a"}}}), Version(0, {{{1, "a"}}, {{1}}})},
+                // 0!1a, 0!1a.1post3
+                {0, Version(0, {{{1, "a"}}}), Version(0, {{{1, "a"}}, {{1, "post"}, {3}}})},
+                // 0!1.1a, 0!1.1
+                {1, Version(0, {{{1}}, {{1, "a"}}}), Version(0, {{{1}}, {{1}}})},
+                // 0!1.0.0, 0!1
+                {2, Version(0, {{{1}}, {{0}}, {{0}}}), Version(0, {{{1}}})},
+                // 0!1.2.3, 0!1.2.3
+                {2, Version(0, {{{1}}, {{2}}, {{3}}}), Version(0, {{{1}}, {{2}}, {{3}}})},
+                // 0!1.2.3, 0!1.2.4
+                {2, Version(0, {{{1}}, {{2}}, {{3}}}), Version(0, {{{1}}, {{2}}, {{4}}})},
+                // 0!1.2, 0!1.3
+                {1, Version(0, {{{1}}, {{2}}}), Version(0, {{{1}}, {{3}}})},
+            };
+            // clang-format on
+
+            for (const auto& [level, older, newer] : versions)
+            {
+                CAPTURE(level);
+                CAPTURE(older.str());
+                CAPTURE(newer.str());
+                CHECK(newer.compatible_with(older, level));
+            }
+        }
+
+        SUBCASE("negative")
+        {
+            // clang-format off
+            auto const versions = std::vector<std::tuple<std::size_t, Version, Version>>{
+                // 0!1a, 1!1a
+                {0, Version(0, {{{1, "a"}}}), Version(1, {{{1, "a"}}})},
+                // 0!1, 0!1a
+                {0, Version(0, {{{1}}}), Version(0, {{{1, "a"}}})},
+                // 0!1, 0!1a.0a
+                {0, Version(0, {{{1}}}), Version(0, {{{1}}, {{0, "a"}}})},
+                // 0!2, 0!1
+                {0, Version(0, {{{2}}}), Version(0, {{{1}}})},
+                // 0!1, 0!2
+                {1, Version(0, {{{1}}}), Version(0, {{{2}}})},
+                // 0!1.2, 0!1.1
+                {1, Version(0, {{{1}}, {{2}}}), Version(0, {{{1}}, {{1}}})},
+                // 0!1.2, 0!1
+                {1, Version(0, {{{1}}, {{2}}}), Version(0, {{{1}}})},
+                // 0!1.2.3, 0!1.3.1
+                {2, Version(0, {{{1}}, {{2}}, {{3}}}), Version(0, {{{1}}, {{3}}, {{1}}})},
+                // 0!1.2.3, 0!1.3a.0
+                {2, Version(0, {{{1}}, {{2}}, {{3}}}), Version(0, {{{1}}, {{3, "a"}}, {{0}}})},
+                // 0!1.2.3, 0!1.3
+                {2, Version(0, {{{1}}, {{2}}, {{3}}}), Version(0, {{{1}}, {{3}}})},
+                // 0!1.2.3, 0!2a
+                {2, Version(0, {{{1}}, {{2}}, {{3}}}), Version(0, {{{2, "a"}}})},
+                // 0!1.2, 0!1.1
+                {1, Version(0, {{{1}}, {{2}}}), Version(0, {{{1}}, {{1}}})},
+                // 0!1, 0!1.1
+                {2, Version(0, {{{1}}}), Version(0, {{{1}}, {{1}}})},
+                // 0!1.2, 0!1.1
+                {0, Version(0, {{{1}}, {{2}}}), Version(0, {{{1}}, {{1}}})},
+            };
+            // clang-format on
+
+            for (const auto& [level, older, newer] : versions)
+            {
+                CAPTURE(level);
+                CAPTURE(older.str());
+                CAPTURE(newer.str());
+                CHECK_FALSE(newer.compatible_with(older, level));
+            }
+        }
+    }
+
     TEST_CASE("version_format")
     {
         // clang-format off

--- a/libmamba/tests/src/specs/test_version.cpp
+++ b/libmamba/tests/src/specs/test_version.cpp
@@ -97,6 +97,83 @@ TEST_SUITE("version")
         CHECK_GE(Version(0, { { { 11 }, { 0 }, { 0, "post" } } }), Version(0, { { { 2 }, { 0 } } }));
     }
 
+    TEST_CASE("starts_with")
+    {
+        SUBCASE("positive")
+        {
+            // clang-format off
+            auto const versions = std::vector<std::tuple<Version, Version>>{
+                // 0!1.0.0, 0!1
+                {Version(), Version()},
+                // 0!1a2post, 0!1a2post
+                {Version(0, {{{1, "a"}, {2, "post"}}}), Version(0, {{{1, "a"}, {2, "post"}}})},
+                // 0!1a2post, 0!1a2post
+                {Version(0, {{{1, "a"}, {2, "post"}}}), Version(0, {{{1, "a"}, {2, "post"}}})},
+                // 0!1, 0!1
+                {Version(0, {{{1}}}), Version(0, {{{1}}})},
+                // 0!1, 0!1.1
+                {Version(0, {{{1}}}), Version(0, {{{1}}, {{1}}})},
+                // 0!1, 0!1.3
+                {Version(0, {{{1}}}), Version(0, {{{1}}, {{3}}})},
+                // 0!1, 0!1.1a
+                {Version(0, {{{1}}}), Version(0, {{{1}}, {{1, "a"}}})},
+                // 0!1, 0!1a
+                {Version(0, {{{1}}}), Version(0, {{{1, "a"}}})},
+                // 0!1, 0!1.0a
+                {Version(0, {{{1}}}), Version(0, {{{1}}, {{0, "a"}}})},
+                // 0!1, 0!1post
+                {Version(0, {{{1}}}), Version(0, {{{1, "post"}}})},
+                // 0!1a, 0!1a.1
+                {Version(0, {{{1, "a"}}}), Version(0, {{{1, "a"}}, {{1}}})},
+                // 0!1a, 0!1a.1post3
+                {Version(0, {{{1, "a"}}}), Version(0, {{{1, "a"}}, {{1, "post"}, {3}}})},
+                // 0!1.0.0, 0!1
+                {Version(0, {{{1}}, {{0}}, {{0}}}), Version(0, {{{1}}})},
+            };
+            // clang-format on
+
+            for (const auto& [prefix, ver] : versions)
+            {
+                CAPTURE(prefix.str());
+                CAPTURE(ver.str());
+                CHECK(ver.starts_with(prefix));
+            }
+        }
+
+        SUBCASE("negative")
+        {
+            // clang-format off
+            auto const versions = std::vector<std::tuple<Version, Version>>{
+                // 0!1a, 1!1a
+                {Version(0, {{{1, "a"}}}), Version(1, {{{1, "a"}}})},
+                // 0!2, 0!1
+                {Version(0, {{{2}}}), Version(0, {{{1}}})},
+                // 0!1, 0!2
+                {Version(0, {{{1}}}), Version(0, {{{2}}})},
+                // 0!1.2, 0!1.3
+                {Version(0, {{{1}}, {{2}}}), Version(0, {{{1}}, {{3}}})},
+                // 0!1.2, 0!1.1
+                {Version(0, {{{1}}, {{2}}}), Version(0, {{{1}}, {{1}}})},
+                // 0!1.2, 0!1
+                {Version(0, {{{1}}, {{2}}}), Version(0, {{{1}}})},
+                // 0!1a, 0!1b
+                {Version(0, {{{1, "a"}}}), Version(0, {{{1, "b"}}})},
+                // 0!1.1a, 0!1.1b
+                {Version(0, {{{1}}, {{1, "a"}}}), Version(0, {{{1}}, {{1, "b"}}})},
+                // 0!1.1a, 0!1.1
+                {Version(0, {{{1}}, {{1, "a"}}}), Version(0, {{{1}}, {{1}}})},
+            };
+            // clang-format on
+
+            for (const auto& [prefix, ver] : versions)
+            {
+                CAPTURE(prefix.str());
+                CAPTURE(ver.str());
+                CHECK_FALSE(ver.starts_with(prefix));
+            }
+        }
+    }
+
     TEST_CASE("version_format")
     {
         // clang-format off

--- a/libmamba/tests/src/specs/test_version.cpp
+++ b/libmamba/tests/src/specs/test_version.cpp
@@ -5,6 +5,7 @@
 // The full license is in the file LICENSE, distributed with this software.
 
 #include <algorithm>
+#include <array>
 #include <string>
 #include <vector>
 
@@ -37,19 +38,19 @@ namespace mamba::specs
             CHECK_GE(VersionPartAtom(1, "a"), VersionPartAtom(1, "dev"));
 
             // clang-format off
-            auto sorted_atoms = std::vector<VersionPartAtom>{
-                { 1, "*" },
-                { 1, "dev" },
-                { 1, "_" },
-                { 1, "a" },
-                { 1, "alpha" },
-                { 1, "b" },
-                { 1, "beta" },
-                { 1, "c" },
-                { 1, "r" },
-                { 1, "rc" },
-                { 1, "" },
-                { 1, "post" },
+            auto sorted_atoms = std::array{
+               VersionPartAtom{ 1, "*" },
+               VersionPartAtom{ 1, "dev" },
+               VersionPartAtom{ 1, "_" },
+               VersionPartAtom{ 1, "a" },
+               VersionPartAtom{ 1, "alpha" },
+               VersionPartAtom{ 1, "b" },
+               VersionPartAtom{ 1, "beta" },
+               VersionPartAtom{ 1, "c" },
+               VersionPartAtom{ 1, "r" },
+               VersionPartAtom{ 1, "rc" },
+               VersionPartAtom{ 1, "" },
+               VersionPartAtom{ 1, "post" },
             };
             // clang-format on
 

--- a/libmamba/tests/src/specs/test_version.cpp
+++ b/libmamba/tests/src/specs/test_version.cpp
@@ -13,31 +13,30 @@
 
 #include "mamba/specs/version.hpp"
 
-namespace mamba::specs
+using namespace mamba::specs;
+
+TEST_SUITE("version")
 {
-
-    TEST_SUITE("version")
+    TEST_CASE("atom_comparison")
     {
-        TEST_CASE("atom_comparison")
-        {
-            // No literal
-            CHECK_EQ(VersionPartAtom(1), VersionPartAtom(1, ""));
-            // lowercase
-            CHECK_EQ(VersionPartAtom(1, "dev"), VersionPartAtom(1, "DEV"));
-            // All operator comparison for mumerals
-            CHECK_NE(VersionPartAtom(1), VersionPartAtom(2, "dev"));
-            CHECK_LT(VersionPartAtom(1), VersionPartAtom(2, "dev"));
-            CHECK_LE(VersionPartAtom(1), VersionPartAtom(2, "dev"));
-            CHECK_GT(VersionPartAtom(2, "dev"), VersionPartAtom(1));
-            CHECK_GE(VersionPartAtom(2, "dev"), VersionPartAtom(1));
-            // All operator comparison for literals
-            CHECK_NE(VersionPartAtom(1, "dev"), VersionPartAtom(1, "a"));
-            CHECK_LT(VersionPartAtom(1, "dev"), VersionPartAtom(1, "a"));
-            CHECK_LE(VersionPartAtom(1, "dev"), VersionPartAtom(1, "a"));
-            CHECK_GT(VersionPartAtom(1, "a"), VersionPartAtom(1, "dev"));
-            CHECK_GE(VersionPartAtom(1, "a"), VersionPartAtom(1, "dev"));
+        // No literal
+        CHECK_EQ(VersionPartAtom(1), VersionPartAtom(1, ""));
+        // lowercase
+        CHECK_EQ(VersionPartAtom(1, "dev"), VersionPartAtom(1, "DEV"));
+        // All operator comparison for mumerals
+        CHECK_NE(VersionPartAtom(1), VersionPartAtom(2, "dev"));
+        CHECK_LT(VersionPartAtom(1), VersionPartAtom(2, "dev"));
+        CHECK_LE(VersionPartAtom(1), VersionPartAtom(2, "dev"));
+        CHECK_GT(VersionPartAtom(2, "dev"), VersionPartAtom(1));
+        CHECK_GE(VersionPartAtom(2, "dev"), VersionPartAtom(1));
+        // All operator comparison for literals
+        CHECK_NE(VersionPartAtom(1, "dev"), VersionPartAtom(1, "a"));
+        CHECK_LT(VersionPartAtom(1, "dev"), VersionPartAtom(1, "a"));
+        CHECK_LE(VersionPartAtom(1, "dev"), VersionPartAtom(1, "a"));
+        CHECK_GT(VersionPartAtom(1, "a"), VersionPartAtom(1, "dev"));
+        CHECK_GE(VersionPartAtom(1, "a"), VersionPartAtom(1, "dev"));
 
-            // clang-format off
+        // clang-format off
             auto sorted_atoms = std::array{
                VersionPartAtom{ 1, "*" },
                VersionPartAtom{ 1, "dev" },
@@ -52,58 +51,55 @@ namespace mamba::specs
                VersionPartAtom{ 1, "" },
                VersionPartAtom{ 1, "post" },
             };
-            // clang-format on
+        // clang-format on
 
-            // Strict ordering
-            CHECK(std::is_sorted(sorted_atoms.cbegin(), sorted_atoms.cend()));
-            // None compare equal (given the is_sorted assumption)
-            CHECK_EQ(
-                std::adjacent_find(sorted_atoms.cbegin(), sorted_atoms.cend()),
-                sorted_atoms.cend()
-            );
-        }
+        // Strict ordering
+        CHECK(std::is_sorted(sorted_atoms.cbegin(), sorted_atoms.cend()));
+        // None compare equal (given the is_sorted assumption)
+        CHECK_EQ(std::adjacent_find(sorted_atoms.cbegin(), sorted_atoms.cend()), sorted_atoms.cend());
+    }
 
-        TEST_CASE("atom_format")
-        {
-            CHECK_EQ(VersionPartAtom(1, "dev").str(), "1dev");
-            CHECK_EQ(VersionPartAtom(2).str(), "2");
-        }
+    TEST_CASE("atom_format")
+    {
+        CHECK_EQ(VersionPartAtom(1, "dev").str(), "1dev");
+        CHECK_EQ(VersionPartAtom(2).str(), "2");
+    }
 
-        TEST_CASE("version_comparison")
-        {
-            auto v = Version(0, { { { 1, "post" } } });
-            REQUIRE_EQ(v.version().size(), 1);
-            REQUIRE_EQ(v.version().front().size(), 1);
-            REQUIRE_EQ(v.version().front().front(), VersionPartAtom(1, "post"));
+    TEST_CASE("version_comparison")
+    {
+        auto v = Version(0, { { { 1, "post" } } });
+        REQUIRE_EQ(v.version().size(), 1);
+        REQUIRE_EQ(v.version().front().size(), 1);
+        REQUIRE_EQ(v.version().front().front(), VersionPartAtom(1, "post"));
 
-            // Same empty 0!1post version
-            CHECK_EQ(Version(0, { { { 1, "post" } } }), Version(0, { { { 1, "post" } } }));
-            // Empty trailing atom 0!1a == 0!1a0""
-            CHECK_EQ(Version(0, { { { 1, "a" } } }), Version(0, { { { 1, "a" }, {} } }));
-            // Empty trailing part 0!1a == 0!1a.0""
-            CHECK_EQ(Version(0, { { { 1, "a" } } }), Version(0, { { { 1, "a" } }, { {} } }));
-            // Mixed 0!1a0""0"" == 0!1a.0""
-            CHECK_EQ(Version(0, { { { 1, "a" }, {}, {} } }), Version(0, { { { 1, "a" } }, { {} } }));
+        // Same empty 0!1post version
+        CHECK_EQ(Version(0, { { { 1, "post" } } }), Version(0, { { { 1, "post" } } }));
+        // Empty trailing atom 0!1a == 0!1a0""
+        CHECK_EQ(Version(0, { { { 1, "a" } } }), Version(0, { { { 1, "a" }, {} } }));
+        // Empty trailing part 0!1a == 0!1a.0""
+        CHECK_EQ(Version(0, { { { 1, "a" } } }), Version(0, { { { 1, "a" } }, { {} } }));
+        // Mixed 0!1a0""0"" == 0!1a.0""
+        CHECK_EQ(Version(0, { { { 1, "a" }, {}, {} } }), Version(0, { { { 1, "a" } }, { {} } }));
 
-            // Different epoch 0!2post < 1!1dev
-            CHECK_LT(Version(0, { { { 2, "post" } } }), Version(1, { { { 1, "dev" } } }));
-            CHECK_GE(Version(1, { { { 1, "dev" } } }), Version(0, { { { 2, "post" } } }));
-            // Different lenght with dev
-            CHECK_LT(Version(0, { { { 1 } }, { { 0, "dev" } } }), Version(0, { { { 1 } } }));
-            CHECK_LT(Version(0, { { { 1 } }, { { 0 } }, { { 0, "dev" } } }), Version(0, { { { 1 } } }));
-            // Different major 0!1post < 0!2dev
-            CHECK_LT(Version(0, { { { 1, "post" } } }), Version(0, { { { 2, "dev" } } }));
-            // Different length 0!2"".0"" < 0!11"".0"".0post all operator
-            CHECK_NE(Version(0, { { { 2 }, { 0 } } }), Version(0, { { { 11 }, { 0 }, { 0, "post" } } }));
-            CHECK_LT(Version(0, { { { 2 }, { 0 } } }), Version(0, { { { 11 }, { 0 }, { 0, "post" } } }));
-            CHECK_LE(Version(0, { { { 2 }, { 0 } } }), Version(0, { { { 11 }, { 0 }, { 0, "post" } } }));
-            CHECK_GT(Version(0, { { { 11 }, { 0 }, { 0, "post" } } }), Version(0, { { { 2 }, { 0 } } }));
-            CHECK_GE(Version(0, { { { 11 }, { 0 }, { 0, "post" } } }), Version(0, { { { 2 }, { 0 } } }));
-        }
+        // Different epoch 0!2post < 1!1dev
+        CHECK_LT(Version(0, { { { 2, "post" } } }), Version(1, { { { 1, "dev" } } }));
+        CHECK_GE(Version(1, { { { 1, "dev" } } }), Version(0, { { { 2, "post" } } }));
+        // Different lenght with dev
+        CHECK_LT(Version(0, { { { 1 } }, { { 0, "dev" } } }), Version(0, { { { 1 } } }));
+        CHECK_LT(Version(0, { { { 1 } }, { { 0 } }, { { 0, "dev" } } }), Version(0, { { { 1 } } }));
+        // Different major 0!1post < 0!2dev
+        CHECK_LT(Version(0, { { { 1, "post" } } }), Version(0, { { { 2, "dev" } } }));
+        // Different length 0!2"".0"" < 0!11"".0"".0post all operator
+        CHECK_NE(Version(0, { { { 2 }, { 0 } } }), Version(0, { { { 11 }, { 0 }, { 0, "post" } } }));
+        CHECK_LT(Version(0, { { { 2 }, { 0 } } }), Version(0, { { { 11 }, { 0 }, { 0, "post" } } }));
+        CHECK_LE(Version(0, { { { 2 }, { 0 } } }), Version(0, { { { 11 }, { 0 }, { 0, "post" } } }));
+        CHECK_GT(Version(0, { { { 11 }, { 0 }, { 0, "post" } } }), Version(0, { { { 2 }, { 0 } } }));
+        CHECK_GE(Version(0, { { { 11 }, { 0 }, { 0, "post" } } }), Version(0, { { { 2 }, { 0 } } }));
+    }
 
-        TEST_CASE("version_format")
-        {
-            // clang-format off
+    TEST_CASE("version_format")
+    {
+        // clang-format off
             CHECK_EQ(
                 Version(0, {{{11, "a"}, {0, "post"}}, {{3}}, {{4, "dev"}}}).str(),
                 "11a0post.3.4dev"
@@ -116,17 +112,17 @@ namespace mamba::specs
                 Version(1, {{{11, "a"}, {0}}, {{3}}, {{4, "dev"}}}, {{{1}}, {{2}}}).str(),
                 "1!11a0.3.4dev+1.2"
             );
-            // clang-format on
-        }
+        // clang-format on
+    }
 
-        /**
-         * Test from Conda
-         *
-         * @see https://github.com/conda/conda/blob/main/tests/models/test_version.py
-         */
-        TEST_CASE("parse")
-        {
-            // clang-format off
+    /**
+     * Test from Conda
+     *
+     * @see https://github.com/conda/conda/blob/main/tests/models/test_version.py
+     */
+    TEST_CASE("parse")
+    {
+        // clang-format off
             auto sorted_version = std::vector<std::pair<std::string_view, Version>>{
                 {"0.4",         Version(0, {{{0}}, {{4}}})},
                 {"0.4.0",       Version(0, {{{0}}, {{4}}, {{0}}})},
@@ -183,82 +179,82 @@ namespace mamba::specs
                 {"1!3.1.1.6",   Version(1, {{{3}}, {{1}}, {{1}}, {{6}}})},
                 {"2!0.4.1",     Version(2, {{{0}}, {{4}}, {{1}}})},
             };
-            // clang-format on
-            for (const auto& [raw, expected] : sorted_version)
-            {
-                CHECK_EQ(Version::parse(raw), expected);
-            }
-
-            CHECK(std::is_sorted(
-                sorted_version.cbegin(),
-                sorted_version.cend(),
-                [](const auto& a, const auto& b) { return a.second < b.second; }
-            ));
-
-            // Lowercase and strip
-            CHECK_EQ(Version::parse("0.4.1.rc"), Version::parse("  0.4.1.RC  "));
-            CHECK_EQ(Version::parse("  0.4.1.RC  "), Version::parse("0.4.1.rc"));
-
-            // Functional assertions
-            CHECK_EQ(Version::parse("  0.4.rc  "), Version::parse("0.4.RC"));
-            CHECK_EQ(Version::parse("0.4"), Version::parse("0.4.0"));
-            CHECK_NE(Version::parse("0.4"), Version::parse("0.4.1"));
-            CHECK_EQ(Version::parse("0.4.a1"), Version::parse("0.4.0a1"));
-            CHECK_NE(Version::parse("0.4.a1"), Version::parse("0.4.1a1"));
+        // clang-format on
+        for (const auto& [raw, expected] : sorted_version)
+        {
+            CHECK_EQ(Version::parse(raw), expected);
         }
 
-        TEST_CASE("parse_invalid")
-        {
-            // Wrong epoch
-            CHECK_THROWS_AS(Version::parse("!1.1"), std::invalid_argument);
-            CHECK_THROWS_AS(Version::parse("-1!1.1"), std::invalid_argument);
-            CHECK_THROWS_AS(Version::parse("foo!1.1"), std::invalid_argument);
-            CHECK_THROWS_AS(Version::parse("0post1!1.1"), std::invalid_argument);
+        CHECK(std::is_sorted(
+            sorted_version.cbegin(),
+            sorted_version.cend(),
+            [](const auto& a, const auto& b) { return a.second < b.second; }
+        ));
 
-            // Empty parts
-            CHECK_THROWS_AS(Version::parse(""), std::invalid_argument);
-            CHECK_THROWS_AS(Version::parse("  "), std::invalid_argument);
-            CHECK_THROWS_AS(Version::parse("!2.2"), std::invalid_argument);
-            CHECK_THROWS_AS(Version::parse("0!"), std::invalid_argument);
-            CHECK_THROWS_AS(Version::parse("!"), std::invalid_argument);
-            CHECK_THROWS_AS(Version::parse("1."), std::invalid_argument);
-            CHECK_THROWS_AS(Version::parse("1..1"), std::invalid_argument);
-            CHECK_THROWS_AS(Version::parse("5.5..mw"), std::invalid_argument);
-            CHECK_THROWS_AS(Version::parse("1.2post+"), std::invalid_argument);
-            CHECK_THROWS_AS(Version::parse("1!+1.1"), std::invalid_argument);
+        // Lowercase and strip
+        CHECK_EQ(Version::parse("0.4.1.rc"), Version::parse("  0.4.1.RC  "));
+        CHECK_EQ(Version::parse("  0.4.1.RC  "), Version::parse("0.4.1.rc"));
 
-            // Repeated delimiters
-            CHECK_THROWS_AS(Version::parse("5.5++"), std::invalid_argument);
-            CHECK_THROWS_AS(Version::parse("5.5+1+0.0"), std::invalid_argument);
-            CHECK_THROWS_AS(Version::parse("1!2!3.0"), std::invalid_argument);
+        // Functional assertions
+        CHECK_EQ(Version::parse("  0.4.rc  "), Version::parse("0.4.RC"));
+        CHECK_EQ(Version::parse("0.4"), Version::parse("0.4.0"));
+        CHECK_NE(Version::parse("0.4"), Version::parse("0.4.1"));
+        CHECK_EQ(Version::parse("0.4.a1"), Version::parse("0.4.0a1"));
+        CHECK_NE(Version::parse("0.4.a1"), Version::parse("0.4.1a1"));
+    }
 
-            // '-' and '_' delimiters not allowed together.
-            CHECK_THROWS_AS(Version::parse("1-1_1"), std::invalid_argument);
+    TEST_CASE("parse_invalid")
+    {
+        // Wrong epoch
+        CHECK_THROWS_AS(Version::parse("!1.1"), std::invalid_argument);
+        CHECK_THROWS_AS(Version::parse("-1!1.1"), std::invalid_argument);
+        CHECK_THROWS_AS(Version::parse("foo!1.1"), std::invalid_argument);
+        CHECK_THROWS_AS(Version::parse("0post1!1.1"), std::invalid_argument);
 
-            // Forbidden characters
-            CHECK_THROWS_AS(Version::parse("3.5&1"), std::invalid_argument);
-            CHECK_THROWS_AS(Version::parse("3.5|1"), std::invalid_argument);
-        }
+        // Empty parts
+        CHECK_THROWS_AS(Version::parse(""), std::invalid_argument);
+        CHECK_THROWS_AS(Version::parse("  "), std::invalid_argument);
+        CHECK_THROWS_AS(Version::parse("!2.2"), std::invalid_argument);
+        CHECK_THROWS_AS(Version::parse("0!"), std::invalid_argument);
+        CHECK_THROWS_AS(Version::parse("!"), std::invalid_argument);
+        CHECK_THROWS_AS(Version::parse("1."), std::invalid_argument);
+        CHECK_THROWS_AS(Version::parse("1..1"), std::invalid_argument);
+        CHECK_THROWS_AS(Version::parse("5.5..mw"), std::invalid_argument);
+        CHECK_THROWS_AS(Version::parse("1.2post+"), std::invalid_argument);
+        CHECK_THROWS_AS(Version::parse("1!+1.1"), std::invalid_argument);
 
-        /**
-         * Test from Conda.
-         *
-         * Some packages (most notably openssl) have incompatible version conventions.
-         * In particular, openssl interprets letters as version counters rather than
-         * pre-release identifiers. For openssl, the relation
-         *
-         * 1.0.1 < 1.0.1a  =>  False  # should be true for openssl
-         *
-         * holds, whereas conda packages use the opposite ordering. You can work-around
-         * this problem by appending an underscore to plain version numbers:
-         *
-         * 1.0.1_ < 1.0.1a =>  True   # ensure correct ordering for openssl
-         *
-         * @see https://github.com/conda/conda/blob/main/tests/models/test_version.py
-         */
-        TEST_CASE("parse_openssl")
-        {
-            // clang-format off
+        // Repeated delimiters
+        CHECK_THROWS_AS(Version::parse("5.5++"), std::invalid_argument);
+        CHECK_THROWS_AS(Version::parse("5.5+1+0.0"), std::invalid_argument);
+        CHECK_THROWS_AS(Version::parse("1!2!3.0"), std::invalid_argument);
+
+        // '-' and '_' delimiters not allowed together.
+        CHECK_THROWS_AS(Version::parse("1-1_1"), std::invalid_argument);
+
+        // Forbidden characters
+        CHECK_THROWS_AS(Version::parse("3.5&1"), std::invalid_argument);
+        CHECK_THROWS_AS(Version::parse("3.5|1"), std::invalid_argument);
+    }
+
+    /**
+     * Test from Conda.
+     *
+     * Some packages (most notably openssl) have incompatible version conventions.
+     * In particular, openssl interprets letters as version counters rather than
+     * pre-release identifiers. For openssl, the relation
+     *
+     * 1.0.1 < 1.0.1a  =>  False  # should be true for openssl
+     *
+     * holds, whereas conda packages use the opposite ordering. You can work-around
+     * this problem by appending an underscore to plain version numbers:
+     *
+     * 1.0.1_ < 1.0.1a =>  True   # ensure correct ordering for openssl
+     *
+     * @see https://github.com/conda/conda/blob/main/tests/models/test_version.py
+     */
+    TEST_CASE("parse_openssl")
+    {
+        // clang-format off
             auto versions = std::vector{
                 Version::parse("1.0.1dev"),
                 Version::parse("1.0.1_"),  // <- this
@@ -278,84 +274,83 @@ namespace mamba::specs
                 Version::parse("1.0.1post.za"),
                 Version::parse("1.0.2"),
             };
-            // clang-format on
+        // clang-format on
 
-            // Strict ordering
-            CHECK(std::is_sorted(versions.cbegin(), versions.cend()));
-            // None compare equal (given the is_sorted assumption)
-            CHECK_EQ(std::adjacent_find(versions.cbegin(), versions.cend()), versions.cend());
-        }
+        // Strict ordering
+        CHECK(std::is_sorted(versions.cbegin(), versions.cend()));
+        // None compare equal (given the is_sorted assumption)
+        CHECK_EQ(std::adjacent_find(versions.cbegin(), versions.cend()), versions.cend());
+    }
 
-        /**
-         * Test from Conda slightly modified from the PEP 440 test suite.
-         *
-         * @see https://github.com/conda/conda/blob/main/tests/models/test_version.py
-         * @see https://github.com/pypa/packaging/blob/master/tests/test_version.py
-         */
-        TEST_CASE("parse_pep440")
-        {
-            auto versions = std::vector{
-                // Implicit epoch of 0
-                Version::parse("1.0a1"),
-                Version::parse("1.0a2.dev456"),
-                Version::parse("1.0a12.dev456"),
-                Version::parse("1.0a12"),
-                Version::parse("1.0b1.dev456"),
-                Version::parse("1.0b2"),
-                Version::parse("1.0b2.post345.dev456"),
-                Version::parse("1.0b2.post345"),
-                Version::parse("1.0c1.dev456"),
-                Version::parse("1.0c1"),
-                Version::parse("1.0c3"),
-                Version::parse("1.0rc2"),
-                Version::parse("1.0.dev456"),
-                Version::parse("1.0"),
-                Version::parse("1.0.post456.dev34"),
-                Version::parse("1.0.post456"),
-                Version::parse("1.1.dev1"),
-                Version::parse("1.2.r32+123456"),
-                Version::parse("1.2.rev33+123456"),
-                Version::parse("1.2+abc"),
-                Version::parse("1.2+abc123def"),
-                Version::parse("1.2+abc123"),
-                Version::parse("1.2+123abc"),
-                Version::parse("1.2+123abc456"),
-                Version::parse("1.2+1234.abc"),
-                Version::parse("1.2+123456"),
-                // Explicit epoch of 1
-                Version::parse("1!1.0a1"),
-                Version::parse("1!1.0a2.dev456"),
-                Version::parse("1!1.0a12.dev456"),
-                Version::parse("1!1.0a12"),
-                Version::parse("1!1.0b1.dev456"),
-                Version::parse("1!1.0b2"),
-                Version::parse("1!1.0b2.post345.dev456"),
-                Version::parse("1!1.0b2.post345"),
-                Version::parse("1!1.0c1.dev456"),
-                Version::parse("1!1.0c1"),
-                Version::parse("1!1.0c3"),
-                Version::parse("1!1.0rc2"),
-                Version::parse("1!1.0.dev456"),
-                Version::parse("1!1.0"),
-                Version::parse("1!1.0.post456.dev34"),
-                Version::parse("1!1.0.post456"),
-                Version::parse("1!1.1.dev1"),
-                Version::parse("1!1.2.r32+123456"),
-                Version::parse("1!1.2.rev33+123456"),
-                Version::parse("1!1.2+abc"),
-                Version::parse("1!1.2+abc123def"),
-                Version::parse("1!1.2+abc123"),
-                Version::parse("1!1.2+123abc"),
-                Version::parse("1!1.2+123abc456"),
-                Version::parse("1!1.2+1234.abc"),
-                Version::parse("1!1.2+123456"),
-            };
-            // clang-format on
+    /**
+     * Test from Conda slightly modified from the PEP 440 test suite.
+     *
+     * @see https://github.com/conda/conda/blob/main/tests/models/test_version.py
+     * @see https://github.com/pypa/packaging/blob/master/tests/test_version.py
+     */
+    TEST_CASE("parse_pep440")
+    {
+        auto versions = std::vector{
+            // Implicit epoch of 0
+            Version::parse("1.0a1"),
+            Version::parse("1.0a2.dev456"),
+            Version::parse("1.0a12.dev456"),
+            Version::parse("1.0a12"),
+            Version::parse("1.0b1.dev456"),
+            Version::parse("1.0b2"),
+            Version::parse("1.0b2.post345.dev456"),
+            Version::parse("1.0b2.post345"),
+            Version::parse("1.0c1.dev456"),
+            Version::parse("1.0c1"),
+            Version::parse("1.0c3"),
+            Version::parse("1.0rc2"),
+            Version::parse("1.0.dev456"),
+            Version::parse("1.0"),
+            Version::parse("1.0.post456.dev34"),
+            Version::parse("1.0.post456"),
+            Version::parse("1.1.dev1"),
+            Version::parse("1.2.r32+123456"),
+            Version::parse("1.2.rev33+123456"),
+            Version::parse("1.2+abc"),
+            Version::parse("1.2+abc123def"),
+            Version::parse("1.2+abc123"),
+            Version::parse("1.2+123abc"),
+            Version::parse("1.2+123abc456"),
+            Version::parse("1.2+1234.abc"),
+            Version::parse("1.2+123456"),
+            // Explicit epoch of 1
+            Version::parse("1!1.0a1"),
+            Version::parse("1!1.0a2.dev456"),
+            Version::parse("1!1.0a12.dev456"),
+            Version::parse("1!1.0a12"),
+            Version::parse("1!1.0b1.dev456"),
+            Version::parse("1!1.0b2"),
+            Version::parse("1!1.0b2.post345.dev456"),
+            Version::parse("1!1.0b2.post345"),
+            Version::parse("1!1.0c1.dev456"),
+            Version::parse("1!1.0c1"),
+            Version::parse("1!1.0c3"),
+            Version::parse("1!1.0rc2"),
+            Version::parse("1!1.0.dev456"),
+            Version::parse("1!1.0"),
+            Version::parse("1!1.0.post456.dev34"),
+            Version::parse("1!1.0.post456"),
+            Version::parse("1!1.1.dev1"),
+            Version::parse("1!1.2.r32+123456"),
+            Version::parse("1!1.2.rev33+123456"),
+            Version::parse("1!1.2+abc"),
+            Version::parse("1!1.2+abc123def"),
+            Version::parse("1!1.2+abc123"),
+            Version::parse("1!1.2+123abc"),
+            Version::parse("1!1.2+123abc456"),
+            Version::parse("1!1.2+1234.abc"),
+            Version::parse("1!1.2+123456"),
+        };
+        // clang-format on
 
-            // Strict ordering
-            CHECK(std::is_sorted(versions.cbegin(), versions.cend()));
-            // None compare equal (given the is_sorted assumption)
-            CHECK_EQ(std::adjacent_find(versions.cbegin(), versions.cend()), versions.cend());
-        }
+        // Strict ordering
+        CHECK(std::is_sorted(versions.cbegin(), versions.cend()));
+        // None compare equal (given the is_sorted assumption)
+        CHECK_EQ(std::adjacent_find(versions.cbegin(), versions.cend()), versions.cend());
     }
 }

--- a/libmamba/tests/src/specs/test_version.cpp
+++ b/libmamba/tests/src/specs/test_version.cpp
@@ -10,6 +10,7 @@
 #include <vector>
 
 #include <doctest/doctest.h>
+#include <fmt/format.h>
 
 #include "mamba/specs/version.hpp"
 
@@ -134,8 +135,9 @@ TEST_SUITE("version")
 
             for (const auto& [prefix, ver] : versions)
             {
-                CAPTURE(prefix.str());
-                CAPTURE(ver.str());
+                // Working around clang compilation issue.
+                const auto msg = fmt::format(R"(prefix="{}" version="{}")", prefix.str(), ver.str());
+                CAPTURE(msg);
                 CHECK(ver.starts_with(prefix));
             }
         }
@@ -167,8 +169,9 @@ TEST_SUITE("version")
 
             for (const auto& [prefix, ver] : versions)
             {
-                CAPTURE(prefix.str());
-                CAPTURE(ver.str());
+                // Working around clang compilation issue.
+                const auto msg = fmt::format(R"(prefix="{}" version="{}")", prefix.str(), ver.str());
+                CAPTURE(msg);
                 CHECK_FALSE(ver.starts_with(prefix));
             }
         }
@@ -227,9 +230,14 @@ TEST_SUITE("version")
 
             for (const auto& [level, older, newer] : versions)
             {
-                CAPTURE(level);
-                CAPTURE(older.str());
-                CAPTURE(newer.str());
+                // Working around clang compilation issue.
+                const auto msg = fmt::format(
+                    R"(level={} prefix="{}" version="{}")",
+                    level,
+                    older.str(),
+                    newer.str()
+                );
+                CAPTURE(msg);
                 CHECK(newer.compatible_with(older, level));
             }
         }
@@ -271,9 +279,14 @@ TEST_SUITE("version")
 
             for (const auto& [level, older, newer] : versions)
             {
-                CAPTURE(level);
-                CAPTURE(older.str());
-                CAPTURE(newer.str());
+                // Working around clang compilation issue.
+                const auto msg = fmt::format(
+                    R"(level={} prefix="{}" version="{}")",
+                    level,
+                    older.str(),
+                    newer.str()
+                );
+                CAPTURE(msg);
                 CHECK_FALSE(newer.compatible_with(older, level));
             }
         }


### PR DESCRIPTION
More ``spec::Version`` comparison functions needed to implement ``VersionSpec``.
It also removes one level of indentation in `test_version.cpp`, sorry for the big diff.