### PR TITLE
Use boltons directly instead of using deprecated vendored version from conda

### DIFF
--- a/mamba/mamba/utils.py
+++ b/mamba/mamba/utils.py
@@ -9,7 +9,7 @@ import tempfile
 import urllib.parse
 from collections import OrderedDict
 
-from conda._vendor.boltons.setutils import IndexedSet
+from boltons.setutils import IndexedSet
 from conda.base.constants import ChannelPriority
 from conda.base.context import context
 from conda.common.serialize import json_dump

--- a/mamba/setup.py
+++ b/mamba/setup.py
@@ -42,6 +42,7 @@ setup(
     entry_points={"console_scripts": ["mamba = mamba.mamba:main"]},
     long_description="A (hopefully faster) reimplementation of the slow bits of conda.",
     install_requires=[
+        "boltons",
         "conda>=4.14.0",
         "libmambapy",
     ],


### PR DESCRIPTION
This PR resolves the deprecation warning currently emitted by mamba:

```console
$ mamba --version
/home/duncan/opt/mambaforge/lib/python3.10/site-packages/mamba/utils.py:12: PendingDeprecationWarning: conda._vendor.boltons is pending deprecation and will be removed in 24.3. Use `boltons` instead.
  from conda._vendor.boltons.setutils import IndexedSet
mamba 1.4.6
conda 23.5.0
```

by patching to use `boltons` directly.

As far as I can tell (which isn't bulletproof by any means) any version of `boltons` is fine, but recent versions of `conda` itself have a fairly aggressive version requirement on `boltons` which `mamba` will pick up anyway.