### PR TITLE
Call init_console in mamba to prevent UTF8 errors when extracting pac…

### DIFF
--- a/libmambapy/libmambapy/__init__.pyi
+++ b/libmambapy/libmambapy/__init__.pyi
@@ -120,6 +120,7 @@ __all__ = [
     "generate_ed25519_keypair",
     "get_channels",
     "get_virtual_packages",
+    "init_console",
     "ostream_redirect",
     "sign",
     "simplify_conflicts",
@@ -1591,6 +1592,9 @@ def get_channels(arg0: typing.List[str]) -> typing.List[Channel]:
     pass
 
 def get_virtual_packages() -> typing.List[PackageInfo]:
+    pass
+
+def init_console() -> None:
     pass
 
 def sign(data: str, secret_key: str) -> str:

--- a/libmambapy/src/main.cpp
+++ b/libmambapy/src/main.cpp
@@ -30,6 +30,7 @@
 #include "mamba/core/subdirdata.hpp"
 #include "mamba/core/transaction.hpp"
 #include "mamba/core/url.hpp"
+#include "mamba/core/util_os.hpp"
 #include "mamba/core/util_string.hpp"
 #include "mamba/core/validate.hpp"
 #include "mamba/core/virtual_packages.hpp"
@@ -1003,6 +1004,8 @@ PYBIND11_MODULE(bindings, m)
         py::arg("compression_level"),
         py::arg("compression_threads") = 1
     );
+
+    m.def("init_console", &init_console);
 
     // fix extract from error_handling first
     // auto package_handling_sm = m.def_submodule("package_handling");

--- a/mamba/mamba/mamba.py
+++ b/mamba/mamba/mamba.py
@@ -226,6 +226,8 @@ def install(args, parser, command="install"):
     context.validate_configuration()
     check_non_admin()
 
+    api.init_console()
+
     init_api_context(use_mamba_experimental)
 
     newenv = bool(command == "create")


### PR DESCRIPTION
…kages

Completes #2655 