### PR TITLE
Improve warning when package record not found

### DIFF
--- a/mamba/mamba/utils.py
+++ b/mamba/mamba/utils.py
@@ -5,6 +5,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import json
 import os
+import sys
 import tempfile
 import urllib.parse
 from collections import OrderedDict
@@ -395,7 +396,7 @@ def compute_final_precs(
                     raise
                 break
         else:
-            print("No package record found!")
+            print(f"No package record found for {pkg}!", file=sys.stderr)
 
     for c, pkg, jsn_s in to_link:
         if c.startswith("file://"):


### PR DESCRIPTION
We just triggered this warning in https://github.com/conda/conda-lock/pull/448. We don't know what it means, but it seems it's some sort of package to be unlinked, but there's no mention of the package name, and the output is to `stdout` which is problematic when capturing JSON.