### PR TITLE
#2651 fail quietly when removing a non-existing variable

### DIFF
--- a/libmamba/src/core/activation.cpp
+++ b/libmamba/src/core/activation.cpp
@@ -1058,7 +1058,7 @@ namespace mamba
 
     std::string PowerShellActivator::hook_postamble()
     {
-        return "Remove-Variable MambaModuleArgs";
+        return "Remove-Variable -Name MambaModuleArgs -ErrorAction SilentlyContinue";
     }
 
     fs::u8path PowerShellActivator::hook_source_path()

--- a/micromamba/tests/test_activation.py
+++ b/micromamba/tests/test_activation.py
@@ -951,7 +951,7 @@ class TestActivation:
                 f'$Env:MAMBA_EXE="{mamba_exe}"',
                 "$MambaModuleArgs = @{ChangePs1 = $True}",
                 f'Import-Module "{tmp_root_prefix}\\condabin\\Mamba.psm1" -ArgumentList $MambaModuleArgs',
-                "Remove-Variable MambaModuleArgs",
+                "Remove-Variable -Name MambaModuleArgs -ErrorAction SilentlyContinue",
             ]
         elif interpreter == "bash":
             if plat == "linux":


### PR DESCRIPTION
This was discussed in issue #2651 

When Powershell starts it runs the $PROFILE script.
`micromamba init` updates these profiles (e.g. $profile.CurrentUserAllHosts) with something like the following:
```powershell
#region mamba initialize
# !! Contents within this block are managed by 'mamba shell init' !!
$Env:MAMBA_ROOT_PREFIX = "C:\Users\me\micromamba"
$Env:MAMBA_EXE = "C:\Users\me\.bin\micromamba.exe"
(& $Env:MAMBA_EXE 'shell' 'hook' -s 'powershell' -p $Env:MAMBA_ROOT_PREFIX) | Out-String | Invoke-Expression
#endregion
```
When run the following error is produced.

```
Remove-Variable:
Line |
   3 |  Remove-Variable MambaModuleArgs
     |  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     | Cannot find a variable with the name 'MambaModuleArgs'.
```

The cause of the error is revealed by running the following command.

```powershell
(& $Env:MAMBA_EXE 'shell' 'hook' -s 'powershell' -p $Env:MAMBA_ROOT_PREFIX) | Out-String
```
 
Which produces:
```powershell
Import-Module "$Env:MAMBA_ROOT_PREFIX\condabin\Mamba.psm1" -ArgumentList $MambaModuleArgs
Remove-Variable MambaModuleArgs
```

While `Mamba.psm1`  accepts a missing/empty `ArgumentList`, the subsequent `Remove-Variable` on the undefined variable `MambaModuleArgs` produces the error.

I suspect the idea is that `MambaModuleArgs` is presumed to be set outside of the `region mamba initialize`.  Therefore, I think the fix should accommodate that inten by changing the powershell shell hook...

```powershell
Remove-Variable -Name MambaModuleArgs -ErrorAction SilentlyContinue
```

A related issue is that the documentation is weak on the purpose for `MambaModuleArgs`.

It is used in `Mamba.psm1` and where seems to only have one defined entry.
```powershell
$MambaModuleArgs = @{"ChangePs1"=$True};
```