### PR TITLE
fix: Correct a command in installation.rst

### DIFF
--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -164,7 +164,7 @@ An exclusive `conda-forge <https://conda-forge.org/>`_ setup can be configured w
 
    micromamba config append channels conda-forge
    micromamba config append channels nodefaults
-   micromamba set channel_priority strict
+   micromamba config set channel_priority strict
 
 .. _umamba-install-win:
 Windows


### PR DESCRIPTION
The original command `micromamba set channel_priority strict` would fail with the error `The following arguments were not expected: strict channel_priority --set`