### PR TITLE
Update build to enable SPDLOG for shared builds

### DIFF
--- a/libmamba/CMakeLists.txt
+++ b/libmamba/CMakeLists.txt
@@ -55,7 +55,6 @@ if (NOT ${BUILD_LOG_LEVEL} MATCHES "^(TRACE|DEBUG|INFO|WARN|ERROR|CRITICAL|OFF)$
 endif ()
 
 if (BUILD_STATIC)
-    add_definitions("-DSPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_${BUILD_LOG_LEVEL}")
     add_definitions(-DLIBMAMBA_STATIC_DEPS)
 endif ()
 
@@ -401,7 +400,10 @@ macro(libmamba_create_target target_name linkage output_name)
             find_package(spdlog CONFIG REQUIRED)
             find_package(tl-expected REQUIRED)
 
-            add_compile_definitions(SPDLOG_FMT_EXTERNAL)
+            target_compile_definitions(${target_name} PUBLIC
+              SPDLOG_FMT_EXTERNAL
+              SPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_${BUILD_LOG_LEVEL}
+            )
             target_link_libraries(
               ${target_name}
               PUBLIC
@@ -467,8 +469,9 @@ macro(libmamba_create_target target_name linkage output_name)
                 tl::expected
             )
 
-            add_compile_definitions(
+            target_compile_definitions(${target_name} PUBLIC
               SPDLOG_FMT_EXTERNAL
+              SPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_${BUILD_LOG_LEVEL}
               LIBARCHIVE_STATIC
               CURL_STATICLIB
               SOLV_BUILD_STATIC
@@ -512,7 +515,10 @@ macro(libmamba_create_target target_name linkage output_name)
             spdlog::spdlog_header_only
         )
 
-        add_compile_definitions(SPDLOG_FMT_EXTERNAL)
+        target_compile_definitions(${target_name} PUBLIC
+          SPDLOG_FMT_EXTERNAL
+          SPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_${BUILD_LOG_LEVEL}
+        )
         target_link_libraries(${target_name} PUBLIC
                               ${LIBMAMBA_LIBRARIES_DEPS}
                               ${MAMBA_FORCE_DYNAMIC_LIBS})
@@ -547,8 +553,6 @@ macro(libmamba_create_target target_name linkage output_name)
         set_target_properties(
             ${target_name}
             PROPERTIES
-            #PUBLIC_HEADER "${LIBMAMBA_PUBLIC_HEADERS}"
-            COMPILE_DEFINITIONS "LIBMAMBA_EXPORTS"
             PREFIX ""
             VERSION "${LIBMAMBA_BINARY_COMPATIBLE}.${LIBMAMBA_BINARY_REVISION}.${LIBMAMBA_BINARY_AGE}"
             SOVERSION ${LIBMAMBA_BINARY_COMPATIBLE}
@@ -558,8 +562,6 @@ macro(libmamba_create_target target_name linkage output_name)
         set_target_properties(
             ${target_name}
             PROPERTIES
-            #PUBLIC_HEADER "${LIBMAMBA_PUBLIC_HEADERS}"
-            COMPILE_DEFINITIONS "LIBMAMBA_EXPORTS"
             PREFIX ""
             VERSION ${LIBMAMBA_BINARY_VERSION}
             SOVERSION ${LIBMAMBA_BINARY_CURRENT}

--- a/libmamba/include/mamba/core/util_scope.hpp
+++ b/libmamba/include/mamba/core/util_scope.hpp
@@ -6,8 +6,6 @@
 
 #include "mamba/core/output.hpp"
 
-#include "spdlog/spdlog.h"
-
 namespace mamba
 {
 

--- a/libmamba/src/core/progress_bar_impl.hpp
+++ b/libmamba/src/core/progress_bar_impl.hpp
@@ -16,7 +16,6 @@
 #include <vector>
 
 #include <fmt/color.h>
-#include <spdlog/spdlog.h>
 
 #include "mamba/core/progress_bar.hpp"
 

--- a/micromamba/tests/test_log.py
+++ b/micromamba/tests/test_log.py
@@ -1,0 +1,37 @@
+import subprocess
+
+from .helpers import get_umamba
+
+def info(*args):
+    umamba = get_umamba()
+    cmd = [umamba, "info"] + [arg for arg in args if arg]
+
+    try:
+        p = subprocess.run(
+            cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=True,
+        )
+    except subprocess.CalledProcessError as e:
+        print(f"Command {cmd} failed with stderr: {e.stderr.decode()}")
+        print(f"Command {cmd} failed with stdout: {e.stdout.decode()}")
+        raise e
+    return p.stdout.decode(), p.stderr.decode()
+
+
+def test_log_level():
+    stdout, stderr = info()
+    assert not "debug" in stdout
+    assert not "debug" in stderr
+    assert not "trace" in stdout
+    assert not "trace" in stderr
+    for arg in ["--log-level=debug", "-vv"]:
+        stdout, stderr = info(arg)
+        assert "debug" in stderr
+        assert not "debug" in stdout
+        assert not "trace" in stderr
+        assert not "trace" in stdout
+    for arg in ["--log-level=trace", "-vvv"]:
+        stdout, stderr = info(arg)
+        assert "debug" in stderr
+        assert not "debug" in stdout
+        assert "trace" in stderr
+        assert not "trace" in stdout

--- a/micromamba/tests/test_log.py
+++ b/micromamba/tests/test_log.py
@@ -2,13 +2,17 @@ import subprocess
 
 from .helpers import get_umamba
 
+
 def info(*args):
     umamba = get_umamba()
     cmd = [umamba, "info"] + [arg for arg in args if arg]
 
     try:
         p = subprocess.run(
-            cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=True,
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=True,
         )
     except subprocess.CalledProcessError as e:
         print(f"Command {cmd} failed with stderr: {e.stderr.decode()}")


### PR DESCRIPTION
Maybe there is an honest reason that this wasn't allowed for shared builds, but I found it very annoying to not have logging during development.

This merge request is basically doing a few things:

* Small clean up of how we set some compile definitions in the libmamba project's CMake file. Now we're using target_compile_definitions, which is a bit more precise and tidy than the old way.

 * removed some unnecessary spdlog includes

 * Added a new test in micromamba that checks whether the log level settings are working as they should. Making sure that only the right level of detail shows up in our logs, depending on how verbose we ask the logs to be.
 
 aside: out of scope for this but the logging for this project is done in such a way that micromamba emits `libmamba` as the source of the log.  In the future that should probably be addressed to avoid confusion.