### PR TITLE
Add command to docs for completeness

### DIFF
--- a/docs/source/user_guide/configuration.rst
+++ b/docs/source/user_guide/configuration.rst
@@ -64,6 +64,7 @@ The resulting configuration written using `YAML` syntax is:
 
 .. code::
 
+  $ micromamba config list --sources
   channels:
     - my-channel  # 'CLI'
     - conda-forge  # '~/.mambarc'


### PR DESCRIPTION
Very simple doc change, re: https://github.com/mamba-org/mamba/issues/2697
makes sense, given previous commands in this doc show their commandline to produce the shown stdout
