### PR TITLE
fix subcommands handling in recent versions of conda

### DIFF
--- a/mamba/mamba/mamba.py
+++ b/mamba/mamba/mamba.py
@@ -922,9 +922,15 @@ def main(*args, **kwargs):
             return mamba_env.main()
         elif args[1] == "build":
             # calling mamba build == conda mambabuild
-            from boa.cli import mambabuild
+            try:
+                from boa.cli import mambabuild
 
-            return mambabuild.main()
+                return mambabuild.main()
+            except ImportError as exc:
+                raise ImportError(
+                    "Please install boa to use mamba build:\n"
+                    "  $ mamba install -c conda-forge boa"
+                ) from exc
 
     def exception_converter(*args, **kwargs):
         exit_code = 0

--- a/mamba/mamba/mamba.py
+++ b/mamba/mamba/mamba.py
@@ -709,9 +709,9 @@ def do_call(args, parser):
     if hasattr(args, "func"):
         relative_mod, func_name = args.func.rsplit(".", 1)
     elif hasattr(args, "_plugin_subcommand"):
-        relative_mod = f'.{args._plugin_subcommand.action.__module__.split(".")[-1]}'
-        print(relative_mod)
-        func_name = args._plugin_subcommand.action.__name__
+        action = args._plugin_subcommand.action
+        relative_mod = f'.{action.__module__.split(".")[-1]}'
+        func_name = action.__name__
     else:
         raise ValueError("Unrecognized 'args' object: %r" % args)
 


### PR DESCRIPTION
Closes https://github.com/mamba-org/mamba/issues/2715

I guess users were expecting `mamba build` to work, but it was basically by chance I'd say (conda would happen to find `conda_build` in `bin/`). Now that the subcommands use a plugin system, we can't just rely on the existence of binaries, and need to forward the calls manually.

In this PR:

- Forward `mamba env` to `mamba.mamba_env`
- Forward `mamba build` to `boa.cli.mambabuild`
- Add namespace compatibility for plugins