### PR TITLE
Add missing newline in legacy errors

### DIFF
--- a/libmamba/src/core/solver.cpp
+++ b/libmamba/src/core/solver.cpp
@@ -452,7 +452,7 @@ namespace mamba
         std::stringstream problems;
         solver().for_each_problem_id(
             [&](solv::ProblemId pb)
-            { problems << "  - " << solver().problem_to_string(m_pool.pool(), pb); }
+            { problems << "  - " << solver().problem_to_string(m_pool.pool(), pb) << "\n"; }
         );
         return "Encountered problems while solving:\n" + problems.str();
     }


### PR DESCRIPTION
@costrouc [found out](https://github.com/conda/conda-libmamba-solver/pull/242#issuecomment-1672572585) an issue with the legacy error messages (which we use to parse and anticipate conflicts) in v1.4.5 and later, where each message is [no longer separated by a newline](https://github.com/mamba-org/mamba/pull/2544/files#diff-6a1aa709238cca66bca724329d07cd1a9da34068b774c70416245c929aed963dL609-R469).

This PR simply adds that back.