### PR TITLE
Isolate URL object

### DIFF
--- a/libmamba/CMakeLists.txt
+++ b/libmamba/CMakeLists.txt
@@ -120,6 +120,8 @@ set(LIBMAMBA_SOURCES
     ${LIBMAMBA_SOURCE_DIR}/version.cpp
     # C++ utility library
     ${LIBMAMBA_SOURCE_DIR}/util/string.cpp
+    ${LIBMAMBA_SOURCE_DIR}/util/url_manip.cpp
+    ${LIBMAMBA_SOURCE_DIR}/util/url.cpp
     # C++ wrapping of libsolv
     ${LIBMAMBA_SOURCE_DIR}/solv-cpp/queue.cpp
     ${LIBMAMBA_SOURCE_DIR}/solv-cpp/pool.cpp
@@ -151,7 +153,6 @@ set(LIBMAMBA_SOURCES
     ${LIBMAMBA_SOURCE_DIR}/core/mamba_fs.cpp
     ${LIBMAMBA_SOURCE_DIR}/core/match_spec.cpp
     ${LIBMAMBA_SOURCE_DIR}/core/menuinst.cpp
-    ${LIBMAMBA_SOURCE_DIR}/core/url.cpp
     ${LIBMAMBA_SOURCE_DIR}/core/output.cpp
     ${LIBMAMBA_SOURCE_DIR}/core/package_handling.cpp
     ${LIBMAMBA_SOURCE_DIR}/core/package_cache.cpp
@@ -215,6 +216,8 @@ set(LIBMAMBA_PUBLIC_HEADERS
     ${LIBMAMBA_INCLUDE_DIR}/mamba/util/graph.hpp
     ${LIBMAMBA_INCLUDE_DIR}/mamba/util/iterator.hpp
     ${LIBMAMBA_INCLUDE_DIR}/mamba/util/string.hpp
+    ${LIBMAMBA_INCLUDE_DIR}/mamba/util/url_manip.hpp
+    ${LIBMAMBA_INCLUDE_DIR}/mamba/util/url.hpp
     # Implementation of version and matching specs
     ${LIBMAMBA_INCLUDE_DIR}/mamba/specs/platform.hpp
     ${LIBMAMBA_INCLUDE_DIR}/mamba/specs/version.hpp
@@ -255,7 +258,6 @@ set(LIBMAMBA_PUBLIC_HEADERS
     ${LIBMAMBA_INCLUDE_DIR}/mamba/core/package_download.hpp
     ${LIBMAMBA_INCLUDE_DIR}/mamba/core/transaction.hpp
     ${LIBMAMBA_INCLUDE_DIR}/mamba/core/transaction_context.hpp
-    ${LIBMAMBA_INCLUDE_DIR}/mamba/core/url.hpp
     ${LIBMAMBA_INCLUDE_DIR}/mamba/core/util.hpp
     ${LIBMAMBA_INCLUDE_DIR}/mamba/core/fsutil.hpp
     ${LIBMAMBA_INCLUDE_DIR}/mamba/core/util_os.hpp

--- a/libmamba/include/mamba/core/context.hpp
+++ b/libmamba/include/mamba/core/context.hpp
@@ -227,7 +227,6 @@ namespace mamba
         // first two characters
         const std::regex token_regex{ "/t/([a-zA-Z0-9-_]{0,2}[a-zA-Z0-9-]*)" };
         const std::regex http_basicauth_regex{ "(://|^)([^\\s]+):([^\\s]+)@" };
-        const std::regex scheme_regex{ "[a-z][a-z0-9]{0,11}://" };
 
         static Context& instance();
 

--- a/libmamba/include/mamba/core/url.hpp
+++ b/libmamba/include/mamba/core/url.hpp
@@ -123,13 +123,13 @@ namespace mamba
         /** Return the user, or empty if none. */
         [[nodiscard]] auto user() const -> const std::string&;
 
-        /** Set the user, or clear the user and password. */
+        /** Set or clear the user. */
         URL& set_user(std::string_view user);
 
         /** Return the password, or empty if none. */
         [[nodiscard]] auto password() const -> const std::string&;
 
-        /** Set the password, user must be set first. */
+        /** Set or clear the password. */
         URL& set_password(std::string_view password);
 
         /** Return the basic authetification string. */

--- a/libmamba/include/mamba/core/url.hpp
+++ b/libmamba/include/mamba/core/url.hpp
@@ -76,12 +76,12 @@ namespace mamba
     // Only returns a cache name without extension
     std::string cache_name_from_url(const std::string& url);
 
-    class URLHandler
+    class URL
     {
     public:
 
-        URLHandler() = default;
-        URLHandler(std::string_view url);
+        URL() = default;
+        URL(std::string_view url);
 
         [[nodiscard]] auto scheme() const -> const std::string&;
         [[nodiscard]] auto host() const -> const std::string&;
@@ -95,14 +95,14 @@ namespace mamba
         [[nodiscard]] auto url(bool strip_scheme = false) -> std::string;
         [[nodiscard]] auto auth() const -> std::string;
 
-        URLHandler& set_scheme(std::string_view scheme);
-        URLHandler& set_host(std::string_view host);
-        URLHandler& set_path(std::string_view path);
-        URLHandler& set_port(std::string_view port);
-        URLHandler& set_query(std::string_view query);
-        URLHandler& set_fragment(std::string_view fragment);
-        URLHandler& set_user(std::string_view user);
-        URLHandler& set_password(std::string_view password);
+        URL& set_scheme(std::string_view scheme);
+        URL& set_host(std::string_view host);
+        URL& set_path(std::string_view path);
+        URL& set_port(std::string_view port);
+        URL& set_query(std::string_view query);
+        URL& set_fragment(std::string_view fragment);
+        URL& set_user(std::string_view user);
+        URL& set_password(std::string_view password);
 
     private:
 

--- a/libmamba/include/mamba/core/url.hpp
+++ b/libmamba/include/mamba/core/url.hpp
@@ -32,14 +32,22 @@ namespace mamba
         std::string& platform
     );
 
-    [[nodiscard]] auto get_scheme(std::string_view url) -> std::string_view;
+    /**
+     * If @p url starts with a scheme, return it, otherwise return empty string.
+     *
+     * Does not include "://"
+     */
+    [[nodiscard]] auto url_get_scheme(std::string_view url) -> std::string_view;
 
-    [[nodiscard]] auto has_scheme(std::string_view url) -> bool;
+    /**
+     * Retrun true if @p url starts with a URL scheme.
+     */
+    [[nodiscard]] auto url_has_scheme(std::string_view url) -> bool;
 
     /**
      * Check if a Windows path (not URL) starts with a drive letter.
      */
-    [[nodiscard]] auto has_drive_letter(std::string_view path) -> bool;
+    [[nodiscard]] auto path_has_drive_letter(std::string_view path) -> bool;
 
     void split_anaconda_token(const std::string& url, std::string& cleaned_url, std::string& token);
 

--- a/libmamba/include/mamba/core/url.hpp
+++ b/libmamba/include/mamba/core/url.hpp
@@ -32,6 +32,8 @@ namespace mamba
         std::string& platform
     );
 
+    [[nodiscard]] auto get_scheme(std::string_view url) -> std::string_view;
+
     [[nodiscard]] auto has_scheme(std::string_view url) -> bool;
 
     void split_anaconda_token(const std::string& url, std::string& cleaned_url, std::string& token);

--- a/libmamba/include/mamba/core/url.hpp
+++ b/libmamba/include/mamba/core/url.hpp
@@ -118,8 +118,9 @@ namespace mamba
         [[nodiscard]] auto user() const -> const std::string&;
         [[nodiscard]] auto password() const -> const std::string&;
 
-        [[nodiscard]] auto str(StripScheme opt = StripScheme::no) const -> std::string;
+        [[nodiscard]] auto authority() const -> std::string;
         [[nodiscard]] auto authentication() const -> std::string;
+        [[nodiscard]] auto str(StripScheme opt = StripScheme::no) const -> std::string;
 
         URL& set_scheme(std::string_view scheme);
         URL& set_host(std::string_view host);

--- a/libmamba/include/mamba/core/url.hpp
+++ b/libmamba/include/mamba/core/url.hpp
@@ -111,6 +111,7 @@ namespace mamba
         [[nodiscard]] auto scheme() const -> const std::string&;
         [[nodiscard]] auto host() const -> const std::string&;
         [[nodiscard]] auto path() const -> const std::string&;
+        [[nodiscard]] auto pretty_path() const -> std::string_view;
         [[nodiscard]] auto port() const -> const std::string&;
         [[nodiscard]] auto query() const -> const std::string&;
         [[nodiscard]] auto fragment() const -> const std::string&;
@@ -118,7 +119,7 @@ namespace mamba
         [[nodiscard]] auto password() const -> const std::string&;
 
         [[nodiscard]] auto str(StripScheme opt = StripScheme::no) const -> std::string;
-        [[nodiscard]] auto auth() const -> std::string;
+        [[nodiscard]] auto authentication() const -> std::string;
 
         URL& set_scheme(std::string_view scheme);
         URL& set_host(std::string_view host);

--- a/libmamba/include/mamba/core/url.hpp
+++ b/libmamba/include/mamba/core/url.hpp
@@ -36,6 +36,11 @@ namespace mamba
 
     [[nodiscard]] auto has_scheme(std::string_view url) -> bool;
 
+    /**
+     * Check if a Windows path (not URL) starts with a drive letter.
+     */
+    [[nodiscard]] auto has_drive_letter(std::string_view path) -> bool;
+
     void split_anaconda_token(const std::string& url, std::string& cleaned_url, std::string& token);
 
     void split_scheme_auth_token(

--- a/libmamba/include/mamba/core/url.hpp
+++ b/libmamba/include/mamba/core/url.hpp
@@ -32,7 +32,7 @@ namespace mamba
         std::string& platform
     );
 
-    bool has_scheme(const std::string& url);
+    [[nodiscard]] auto has_scheme(std::string_view url) -> bool;
 
     void split_anaconda_token(const std::string& url, std::string& cleaned_url, std::string& token);
 

--- a/libmamba/include/mamba/core/url.hpp
+++ b/libmamba/include/mamba/core/url.hpp
@@ -95,17 +95,16 @@ namespace mamba
     {
     public:
 
-        inline static constexpr std::string_view default_scheme = "https";
-
-        enum class SchemeOpt
+        enum class StripScheme : bool
         {
-            leave_as_is,
-            add_if_abscent,
-            remove_if_present,
+            no,
+            yes,
         };
 
-        [[nodiscard]] static auto
-        parse(std::string_view url, SchemeOpt opt = SchemeOpt::leave_as_is) -> URL;
+        inline static constexpr std::string_view https = "https";
+        inline static constexpr std::string_view localhost = "localhost";
+
+        [[nodiscard]] static auto parse(std::string_view url) -> URL;
 
         URL() = default;
 
@@ -118,7 +117,7 @@ namespace mamba
         [[nodiscard]] auto user() const -> const std::string&;
         [[nodiscard]] auto password() const -> const std::string&;
 
-        [[nodiscard]] auto str(SchemeOpt opt = SchemeOpt::leave_as_is) const -> std::string;
+        [[nodiscard]] auto str(StripScheme opt = StripScheme::no) const -> std::string;
         [[nodiscard]] auto auth() const -> std::string;
 
         URL& set_scheme(std::string_view scheme);
@@ -132,10 +131,10 @@ namespace mamba
 
     private:
 
-        std::string m_scheme = {};
+        std::string m_scheme = std::string(https);
         std::string m_user = {};
         std::string m_password = {};
-        std::string m_host = {};
+        std::string m_host = std::string(localhost);
         std::string m_path = "/";
         std::string m_port = {};
         std::string m_query = {};

--- a/libmamba/include/mamba/core/url.hpp
+++ b/libmamba/include/mamba/core/url.hpp
@@ -82,7 +82,17 @@ namespace mamba
     {
     public:
 
-        [[nodiscard]] static auto parse(std::string_view url) -> URL;
+        inline static constexpr std::string_view default_scheme = "https";
+
+        enum class SchemeOpt
+        {
+            leave_as_is,
+            add_if_abscent,
+            remove_if_present,
+        };
+
+        [[nodiscard]] static auto
+        parse(std::string_view url, SchemeOpt opt = SchemeOpt::leave_as_is) -> URL;
 
         URL() = default;
 

--- a/libmamba/include/mamba/core/url.hpp
+++ b/libmamba/include/mamba/core/url.hpp
@@ -91,6 +91,11 @@ namespace mamba
     // Only returns a cache name without extension
     std::string cache_name_from_url(const std::string& url);
 
+    /**
+     * Class representing a URL.
+     *
+     * All URL have a non-empty scheme, host, and path.
+     */
     class URL
     {
     public:
@@ -106,30 +111,77 @@ namespace mamba
 
         [[nodiscard]] static auto parse(std::string_view url) -> URL;
 
+        /** Create a local URL. */
         URL() = default;
 
+        /** Return the scheme, always non-empty. */
         [[nodiscard]] auto scheme() const -> const std::string&;
-        [[nodiscard]] auto host() const -> const std::string&;
-        [[nodiscard]] auto path() const -> const std::string&;
-        [[nodiscard]] auto pretty_path() const -> std::string_view;
-        [[nodiscard]] auto port() const -> const std::string&;
-        [[nodiscard]] auto query() const -> const std::string&;
-        [[nodiscard]] auto fragment() const -> const std::string&;
+
+        /** Set a non-empty scheme. */
+        URL& set_scheme(std::string_view scheme);
+
+        /** Return the user, or empty if none. */
         [[nodiscard]] auto user() const -> const std::string&;
+
+        /** Set the user, or clear the user and password. */
+        URL& set_user(std::string_view user);
+
+        /** Return the password, or empty if none. */
         [[nodiscard]] auto password() const -> const std::string&;
 
-        [[nodiscard]] auto authority() const -> std::string;
-        [[nodiscard]] auto authentication() const -> std::string;
-        [[nodiscard]] auto str(StripScheme opt = StripScheme::no) const -> std::string;
-
-        URL& set_scheme(std::string_view scheme);
-        URL& set_host(std::string_view host);
-        URL& set_path(std::string_view path);
-        URL& set_port(std::string_view port);
-        URL& set_query(std::string_view query);
-        URL& set_fragment(std::string_view fragment);
-        URL& set_user(std::string_view user);
+        /** Set the password, user must be set first. */
         URL& set_password(std::string_view password);
+
+        /** Return the basic authetification string. */
+        [[nodiscard]] auto authentication() const -> std::string;
+
+        /** Return the host, always non-empty. */
+        [[nodiscard]] auto host() const -> const std::string&;
+
+        /** Set a non-empty host. */
+        URL& set_host(std::string_view host);
+
+        /** Return the port, or empty if none. */
+        [[nodiscard]] auto port() const -> const std::string&;
+
+        /** Set or clear the port. */
+        URL& set_port(std::string_view port);
+
+        /** Return the autority part of the URL. */
+        [[nodiscard]] auto authority() const -> std::string;
+
+        /** Return the path, always starts with a '/'. */
+        [[nodiscard]] auto path() const -> const std::string&;
+
+        /**
+         * Return the path.
+         *
+         * For a "file" scheme, with a Windows path containing a drive, the leading '/' is
+         * stripped.
+         */
+        [[nodiscard]] auto pretty_path() const -> std::string_view;
+
+        /** Set the path, a leading '/' is added if abscent. */
+        URL& set_path(std::string_view path);
+
+        /** Return the query, or empty if none. */
+        [[nodiscard]] auto query() const -> const std::string&;
+
+        /** Set or clear the query. */
+        URL& set_query(std::string_view query);
+
+        /** Return the fragment, or empty if none. */
+        [[nodiscard]] auto fragment() const -> const std::string&;
+
+        /** Set or clear the fragment. */
+        URL& set_fragment(std::string_view fragment);
+
+        /**
+         * Return the full url.
+         *
+         * @param strip If true, remove the scheme and "localhost" on file URI.
+         */
+        [[nodiscard]] auto str(StripScheme strip = StripScheme::no) const -> std::string;
 
     private:
 

--- a/libmamba/include/mamba/core/url.hpp
+++ b/libmamba/include/mamba/core/url.hpp
@@ -105,7 +105,7 @@ namespace mamba
         [[nodiscard]] auto user() const -> const std::string&;
         [[nodiscard]] auto password() const -> const std::string&;
 
-        [[nodiscard]] auto str(bool strip_scheme = false) const -> std::string;
+        [[nodiscard]] auto str(SchemeOpt opt = SchemeOpt::leave_as_is) const -> std::string;
         [[nodiscard]] auto auth() const -> std::string;
 
         URL& set_scheme(std::string_view scheme);
@@ -123,7 +123,7 @@ namespace mamba
         std::string m_user = {};
         std::string m_password = {};
         std::string m_host = {};
-        std::string m_path = {};
+        std::string m_path = "/";
         std::string m_port = {};
         std::string m_query = {};
         std::string m_fragment = {};

--- a/libmamba/include/mamba/core/url.hpp
+++ b/libmamba/include/mamba/core/url.hpp
@@ -78,7 +78,25 @@ namespace mamba
     template <class S, class... Args>
     std::string join_url(const S& s, const Args&... args);
 
-    std::string unc_url(const std::string& url);
+    /**
+     * Convert UNC2 file URI to UNC4.
+     *
+     * Windows paths can be expressed in a form, called UNC, where it is possible to express a
+     * server location, as in "\\hostname\folder\data.xml".
+     * This can be succefully encoded in a file URI like "file://hostname/folder/data.xml"
+     * since file URI contain a part for the hostname (empty hostname file URI must start with
+     * "file:///").
+     * Since CURL does not support hostname in file URI, we can encode UNC hostname as part
+     * of the path (called 4-slash), where it becomes "file:////hostname/folder/data.xml".
+     *
+     * This function leaves all non-matching URI (inluding a number of invalid URI for unkown
+     * legacy reasons taken from ``url_to_path`` in conda.common.path) unchanged.
+     *
+     * @see https://learn.microsoft.com/en-us/dotnet/standard/io/file-path-formats#unc-paths
+     * @see https://en.wikipedia.org/wiki/File_URI_scheme
+     */
+    std::string file_uri_unc2_to_unc4(std::string_view url);
+
     std::string encode_url(const std::string& url);
     std::string decode_url(const std::string& url);
     // Only returns a cache name without extension

--- a/libmamba/include/mamba/core/url.hpp
+++ b/libmamba/include/mamba/core/url.hpp
@@ -92,7 +92,7 @@ namespace mamba
         [[nodiscard]] auto user() const -> const std::string&;
         [[nodiscard]] auto password() const -> const std::string&;
 
-        [[nodiscard]] auto url(bool strip_scheme = false) -> std::string;
+        [[nodiscard]] auto str(bool strip_scheme = false) const -> std::string;
         [[nodiscard]] auto auth() const -> std::string;
 
         URL& set_scheme(std::string_view scheme);

--- a/libmamba/include/mamba/core/url.hpp
+++ b/libmamba/include/mamba/core/url.hpp
@@ -80,8 +80,9 @@ namespace mamba
     {
     public:
 
+        [[nodiscard]] static auto parse(std::string_view url) -> URL;
+
         URL() = default;
-        URL(std::string_view url);
 
         [[nodiscard]] auto scheme() const -> const std::string&;
         [[nodiscard]] auto host() const -> const std::string&;

--- a/libmamba/include/mamba/core/url.hpp
+++ b/libmamba/include/mamba/core/url.hpp
@@ -7,37 +7,11 @@
 #ifndef MAMBA_CORE_URL_HPP
 #define MAMBA_CORE_URL_HPP
 
-extern "C"
-{
-#include <curl/urlapi.h>
-}
-
-#include <limits>
 #include <optional>
-#include <stdexcept>
 #include <string>
+#include <string_view>
 #include <vector>
 
-// typedef enum {
-//   CURLUE_OK,
-//   CURLUE_BAD_HANDLE,          /* 1 */
-//   CURLUE_BAD_PARTPOINTER,     /* 2 */
-//   CURLUE_MALFORMED_INPUT,     /* 3 */
-//   CURLUE_BAD_PORT_NUMBER,     /* 4 */
-//   CURLUE_UNSUPPORTED_SCHEME,  /* 5 */
-//   CURLUE_URLDECODE,           /* 6 */
-//   CURLUE_OUT_OF_MEMORY,       /* 7 */
-//   CURLUE_USER_NOT_ALLOWED,    /* 8 */
-//   CURLUE_UNKNOWN_PART,        /* 9 */
-//   CURLUE_NO_SCHEME,           /* 10 */
-//   CURLUE_NO_USER,             /* 11 */
-//   CURLUE_NO_PASSWORD,         /* 12 */
-//   CURLUE_NO_OPTIONS,          /* 13 */
-//   CURLUE_NO_HOST,             /* 14 */
-//   CURLUE_NO_PORT,             /* 15 */
-//   CURLUE_NO_QUERY,            /* 16 */
-//   CURLUE_NO_FRAGMENT          /* 17 */
-// } CURLUcode;
 
 namespace mamba
 {
@@ -106,52 +80,40 @@ namespace mamba
     {
     public:
 
-        URLHandler(const std::string& url = "");
-        ~URLHandler();
+        URLHandler() = default;
+        URLHandler(std::string_view url);
 
-        URLHandler(const URLHandler&);
-        URLHandler& operator=(const URLHandler&);
+        [[nodiscard]] auto scheme() const -> const std::string&;
+        [[nodiscard]] auto host() const -> const std::string&;
+        [[nodiscard]] auto path() const -> const std::string&;
+        [[nodiscard]] auto port() const -> const std::string&;
+        [[nodiscard]] auto query() const -> const std::string&;
+        [[nodiscard]] auto fragment() const -> const std::string&;
+        [[nodiscard]] auto user() const -> const std::string&;
+        [[nodiscard]] auto password() const -> const std::string&;
 
-        URLHandler(URLHandler&&);
-        URLHandler& operator=(URLHandler&&);
+        [[nodiscard]] auto url(bool strip_scheme = false) -> std::string;
+        [[nodiscard]] auto auth() const -> std::string;
 
-        std::string url(bool strip_scheme = false);
-
-        std::string scheme() const;
-        std::string host() const;
-        std::string path() const;
-        std::string port() const;
-
-        std::string query() const;
-        std::string fragment() const;
-        std::string options() const;
-
-        std::string auth() const;
-        std::string user() const;
-        std::string password() const;
-        std::string zoneid() const;
-
-        URLHandler& set_scheme(const std::string& scheme);
-        URLHandler& set_host(const std::string& host);
-        URLHandler& set_path(const std::string& path);
-        URLHandler& set_port(const std::string& port);
-
-        URLHandler& set_query(const std::string& query);
-        URLHandler& set_fragment(const std::string& fragment);
-        URLHandler& set_options(const std::string& options);
-
-        URLHandler& set_user(const std::string& user);
-        URLHandler& set_password(const std::string& password);
-        URLHandler& set_zoneid(const std::string& zoneid);
+        URLHandler& set_scheme(std::string_view scheme);
+        URLHandler& set_host(std::string_view host);
+        URLHandler& set_path(std::string_view path);
+        URLHandler& set_port(std::string_view port);
+        URLHandler& set_query(std::string_view query);
+        URLHandler& set_fragment(std::string_view fragment);
+        URLHandler& set_user(std::string_view user);
+        URLHandler& set_password(std::string_view password);
 
     private:
 
-        std::string get_part(CURLUPart part) const;
-        void set_part(CURLUPart part, const std::string& s);
-
-        std::string m_url;
-        CURLU* m_handle;
-        bool m_has_scheme;
+        std::string m_scheme = {};
+        std::string m_user = {};
+        std::string m_password = {};
+        std::string m_host = {};
+        std::string m_path = {};
+        std::string m_port = {};
+        std::string m_query = {};
+        std::string m_fragment = {};
     };
 
     namespace detail

--- a/libmamba/include/mamba/util/string.hpp
+++ b/libmamba/include/mamba/util/string.hpp
@@ -99,6 +99,18 @@ namespace mamba::util
     template <typename StrRange>
     bool starts_with_any(std::wstring_view str, const StrRange& prefix);
 
+    /**
+     * Return a view to the input without the prefix if present.
+     */
+    std::string_view remove_prefix(std::string_view str, std::string_view prefix);
+    std::string_view remove_prefix(std::string_view str, std::string_view::value_type c);
+
+    /**
+     * Return a view to the input without the suffix if present.
+     */
+    std::string_view remove_suffix(std::string_view str, std::string_view suffix);
+    std::string_view remove_suffix(std::string_view str, std::string_view::value_type c);
+
     std::string_view lstrip(std::string_view input, char c);
     std::wstring_view lstrip(std::wstring_view input, wchar_t c);
     std::string_view lstrip(std::string_view input, std::string_view chars);

--- a/libmamba/include/mamba/util/url.hpp
+++ b/libmamba/include/mamba/util/url.hpp
@@ -41,7 +41,9 @@ namespace mamba::util
          * The fields of the URL must be percent encoded, otherwise use the individual
          * field setters to encode.
          * For instance, "https://user@email.com@mamba.org/" must be passed as
-         *"https://user%40email.com@mamba.org/".
+         *"https://user%40email.com@mamba.org/".The first '@' charater is part of the username
+         * "user@email.com" whereas the second is the URL specification for separating username
+         * and hostname.
          *
          * @see Encode
          * @see mamba::util::url_encode

--- a/libmamba/include/mamba/util/url.hpp
+++ b/libmamba/include/mamba/util/url.hpp
@@ -44,19 +44,19 @@ namespace mamba::util
         [[nodiscard]] auto scheme() const -> const std::string&;
 
         /** Set a non-empty scheme. */
-        URL& set_scheme(std::string_view scheme);
+        auto set_scheme(std::string_view scheme) -> URL&;
 
         /** Return the user, or empty if none. */
         [[nodiscard]] auto user() const -> const std::string&;
 
         /** Set or clear the user. */
-        URL& set_user(std::string_view user);
+        auto set_user(std::string_view user) -> URL&;
 
         /** Return the password, or empty if none. */
         [[nodiscard]] auto password() const -> const std::string&;
 
         /** Set or clear the password. */
-        URL& set_password(std::string_view password);
+        auto set_password(std::string_view password) -> URL&;
 
         /** Return the basic authetification string. */
         [[nodiscard]] auto authentication() const -> std::string;
@@ -65,13 +65,13 @@ namespace mamba::util
         [[nodiscard]] auto host() const -> const std::string&;
 
         /** Set a non-empty host. */
-        URL& set_host(std::string_view host);
+        auto set_host(std::string_view host) -> URL&;
 
         /** Return the port, or empty if none. */
         [[nodiscard]] auto port() const -> const std::string&;
 
         /** Set or clear the port. */
-        URL& set_port(std::string_view port);
+        auto set_port(std::string_view port) -> URL&;
 
         /** Return the autority part of the URL. */
         [[nodiscard]] auto authority() const -> std::string;
@@ -88,19 +88,27 @@ namespace mamba::util
         [[nodiscard]] auto pretty_path() const -> std::string_view;
 
         /** Set the path, a leading '/' is added if abscent. */
-        URL& set_path(std::string_view path);
+        auto set_path(std::string_view path) -> URL&;
+
+        /**
+         * Append a sub path to the current path.
+         *
+         * Contrary to `std::filesystem::path::append`, this always append and never replace
+         * the current path, even if @p subpath starts with a '/'.
+         */
+        auto append_path(std::string_view subpath) -> URL&;
 
         /** Return the query, or empty if none. */
         [[nodiscard]] auto query() const -> const std::string&;
 
         /** Set or clear the query. */
-        URL& set_query(std::string_view query);
+        auto set_query(std::string_view query) -> URL&;
 
         /** Return the fragment, or empty if none. */
         [[nodiscard]] auto fragment() const -> const std::string&;
 
         /** Set or clear the fragment. */
-        URL& set_fragment(std::string_view fragment);
+        auto set_fragment(std::string_view fragment) -> URL&;
 
         /**
          * Return the full url.
@@ -123,5 +131,9 @@ namespace mamba::util
 
     auto operator==(URL const& a, URL const& b) -> bool;
     auto operator!=(URL const& a, URL const& b) -> bool;
+
+    /** A functional equivalent to ``URL::append_path``. */
+    auto operator/(URL const& url, std::string_view subpath) -> URL;
+    auto operator/(URL&& url, std::string_view subpath) -> URL;
 }
 #endif

--- a/libmamba/include/mamba/util/url.hpp
+++ b/libmamba/include/mamba/util/url.hpp
@@ -77,11 +77,14 @@ namespace mamba::util
         /** Return the undecoded basic authentication string. */
         [[nodiscard]] auto authentication() const -> std::string;
 
-        /** Return the host, always non-empty. */
-        [[nodiscard]] auto host() const -> const std::string&;
+        /** Return the undecoded host, always non-empty. */
+        [[nodiscard]] auto host(Decode::no_type) const -> const std::string&;
+
+        /** Return the decoded host, always non-empty. */
+        [[nodiscard]] auto host(Decode::yes_type = Decode::yes) const -> std::string;
 
         /** Set a non-empty host. */
-        auto set_host(std::string_view host) -> URL&;
+        auto set_host(std::string_view host, Encode encode = Encode::yes) -> URL&;
 
         /** Return the port, or empty if none. */
         [[nodiscard]] auto port() const -> const std::string&;

--- a/libmamba/include/mamba/util/url.hpp
+++ b/libmamba/include/mamba/util/url.hpp
@@ -1,0 +1,124 @@
+// Copyright (c) 2023, QuantStack and Mamba Contributors
+//
+// Distributed under the terms of the BSD 3-Clause License.
+//
+// The full license is in the file LICENSE, distributed with this software.
+
+#ifndef MAMBA_UTIL_URL_HPP
+#define MAMBA_UTIL_URL_HPP
+
+#include <string>
+#include <string_view>
+
+
+namespace mamba::util
+{
+
+    [[nodiscard]] std::string encode_url(const std::string& url);
+    [[nodiscard]] std::string decode_url(const std::string& url);
+
+    /**
+     * Class representing a URL.
+     *
+     * All URL have a non-empty scheme, host, and path.
+     */
+    class URL
+    {
+    public:
+
+        enum class StripScheme : bool
+        {
+            no,
+            yes,
+        };
+
+        inline static constexpr std::string_view https = "https";
+        inline static constexpr std::string_view localhost = "localhost";
+
+        [[nodiscard]] static auto parse(std::string_view url) -> URL;
+
+        /** Create a local URL. */
+        URL() = default;
+
+        /** Return the scheme, always non-empty. */
+        [[nodiscard]] auto scheme() const -> const std::string&;
+
+        /** Set a non-empty scheme. */
+        URL& set_scheme(std::string_view scheme);
+
+        /** Return the user, or empty if none. */
+        [[nodiscard]] auto user() const -> const std::string&;
+
+        /** Set or clear the user. */
+        URL& set_user(std::string_view user);
+
+        /** Return the password, or empty if none. */
+        [[nodiscard]] auto password() const -> const std::string&;
+
+        /** Set or clear the password. */
+        URL& set_password(std::string_view password);
+
+        /** Return the basic authetification string. */
+        [[nodiscard]] auto authentication() const -> std::string;
+
+        /** Return the host, always non-empty. */
+        [[nodiscard]] auto host() const -> const std::string&;
+
+        /** Set a non-empty host. */
+        URL& set_host(std::string_view host);
+
+        /** Return the port, or empty if none. */
+        [[nodiscard]] auto port() const -> const std::string&;
+
+        /** Set or clear the port. */
+        URL& set_port(std::string_view port);
+
+        /** Return the autority part of the URL. */
+        [[nodiscard]] auto authority() const -> std::string;
+
+        /** Return the path, always starts with a '/'. */
+        [[nodiscard]] auto path() const -> const std::string&;
+
+        /**
+         * Return the path.
+         *
+         * For a "file" scheme, with a Windows path containing a drive, the leading '/' is
+         * stripped.
+         */
+        [[nodiscard]] auto pretty_path() const -> std::string_view;
+
+        /** Set the path, a leading '/' is added if abscent. */
+        URL& set_path(std::string_view path);
+
+        /** Return the query, or empty if none. */
+        [[nodiscard]] auto query() const -> const std::string&;
+
+        /** Set or clear the query. */
+        URL& set_query(std::string_view query);
+
+        /** Return the fragment, or empty if none. */
+        [[nodiscard]] auto fragment() const -> const std::string&;
+
+        /** Set or clear the fragment. */
+        URL& set_fragment(std::string_view fragment);
+
+        /**
+         * Return the full url.
+         *
+         * @param strip If true, remove the scheme and "localhost" on file URI.
+         */
+        [[nodiscard]] auto str(StripScheme strip = StripScheme::no) const -> std::string;
+
+    private:
+
+        std::string m_scheme = std::string(https);
+        std::string m_user = {};
+        std::string m_password = {};
+        std::string m_host = std::string(localhost);
+        std::string m_path = "/";
+        std::string m_port = {};
+        std::string m_query = {};
+        std::string m_fragment = {};
+    };
+}
+#endif

--- a/libmamba/include/mamba/util/url.hpp
+++ b/libmamba/include/mamba/util/url.hpp
@@ -10,26 +10,8 @@
 #include <string>
 #include <string_view>
 
-
 namespace mamba::util
 {
-
-    /**
-     * Escape reserved URL reserved characters with '%' encoding.
-     *
-     * Does not parse URL in any way so '/' in "http://mamba.org/page" get encoded.
-     *
-     * @see url_decode
-     */
-    [[nodiscard]] auto url_encode(std::string_view url) -> std::string;
-
-    /**
-     * Unescape percent encoded string to their URL reserved characters.
-     *
-     * @see url_encode
-     */
-    [[nodiscard]] auto url_decode(std::string_view url) -> std::string;
-
     /**
      * Class representing a URL.
      *

--- a/libmamba/include/mamba/util/url.hpp
+++ b/libmamba/include/mamba/util/url.hpp
@@ -23,6 +23,7 @@ namespace mamba::util
 
         // clang-format off
         enum class StripScheme : bool { no, yes };
+        enum class HidePassword : bool { no, yes };
         enum class Encode : bool { no, yes };
         struct Decode
         {
@@ -130,11 +131,16 @@ namespace mamba::util
         auto set_fragment(std::string_view fragment) -> URL&;
 
         /**
-         * Return the full url.
+         * Return the full encoded url.
          *
-         * @param strip If true, remove the scheme and "localhost" on file URI.
+         * @param strip_scheme If true, remove the scheme and "localhost" on file URI.
+         * @param rstrip_path If non-null, remove the given charaters at the end of the path.
+         * @param hide_password If true, hide password in the decoded string.
          */
-        [[nodiscard]] auto str(StripScheme strip = StripScheme::no) const -> std::string;
+        [[nodiscard]] auto
+        str(StripScheme strip_scheme = StripScheme::no,
+            char rstrip_path = 0,
+            HidePassword hide_password = HidePassword::no) const -> std::string;
 
     private:
 

--- a/libmamba/include/mamba/util/url.hpp
+++ b/libmamba/include/mamba/util/url.hpp
@@ -14,8 +14,21 @@
 namespace mamba::util
 {
 
-    [[nodiscard]] std::string encode_url(const std::string& url);
-    [[nodiscard]] std::string decode_url(const std::string& url);
+    /**
+     * Escape reserved URL reserved characters with '%' encoding.
+     *
+     * Does not parse URL in any way so '/' in "http://mamba.org/page" get encoded.
+     *
+     * @see url_decode
+     */
+    [[nodiscard]] auto url_encode(std::string_view url) -> std::string;
+
+    /**
+     * Unescape percent encoded string to their URL reserved characters.
+     *
+     * @see url_encode
+     */
+    [[nodiscard]] auto url_decode(std::string_view url) -> std::string;
 
     /**
      * Class representing a URL.

--- a/libmamba/include/mamba/util/url.hpp
+++ b/libmamba/include/mamba/util/url.hpp
@@ -65,13 +65,16 @@ namespace mamba::util
         /** Set or clear the user. */
         auto set_user(std::string_view user, Encode encode = Encode::yes) -> URL&;
 
-        /** Return the password, or empty if none. */
-        [[nodiscard]] auto password() const -> const std::string&;
+        /** Return the undecoded password, or empty if none. */
+        [[nodiscard]] auto password(Decode::no_type) const -> const std::string&;
+
+        /** Return the decoded password, or empty if none. */
+        [[nodiscard]] auto password(Decode::yes_type = Decode::yes) const -> std::string;
 
         /** Set or clear the password. */
-        auto set_password(std::string_view password) -> URL&;
+        auto set_password(std::string_view password, Encode encode = Encode::yes) -> URL&;
 
-        /** Return the basic authetification string. */
+        /** Return the undecoded basic authentication string. */
         [[nodiscard]] auto authentication() const -> std::string;
 
         /** Return the host, always non-empty. */

--- a/libmamba/include/mamba/util/url.hpp
+++ b/libmamba/include/mamba/util/url.hpp
@@ -21,15 +21,30 @@ namespace mamba::util
     {
     public:
 
-        enum class StripScheme : bool
+        // clang-format off
+        enum class StripScheme : bool { no, yes };
+        enum class Encode : bool { no, yes };
+        struct Decode
         {
-            no,
-            yes,
+            inline static constexpr struct yes_type {} yes = {};
+            inline static constexpr struct no_type {} no = {};
         };
+        // clang-format on
 
         inline static constexpr std::string_view https = "https";
         inline static constexpr std::string_view localhost = "localhost";
 
+        /**
+         * Create a URL from a string.
+         *
+         * The fields of the URL must be percent encoded, otherwise use the individual
+         * field setters to encode.
+         * For instance, "https://user@email.com@mamba.org/" must be passed as
+         *"https://user%40email.com@mamba.org/".
+         *
+         * @see Encode
+         * @see mamba::util::url_encode
+         */
         [[nodiscard]] static auto parse(std::string_view url) -> URL;
 
         /** Create a local URL. */
@@ -41,11 +56,14 @@ namespace mamba::util
         /** Set a non-empty scheme. */
         auto set_scheme(std::string_view scheme) -> URL&;
 
-        /** Return the user, or empty if none. */
-        [[nodiscard]] auto user() const -> const std::string&;
+        /** Return the undecoded user, or empty if none. */
+        [[nodiscard]] auto user(Decode::no_type) const -> const std::string&;
+
+        /** Retrun the decoded user, or empty if none. */
+        [[nodiscard]] auto user(Decode::yes_type = Decode::yes) const -> std::string;
 
         /** Set or clear the user. */
-        auto set_user(std::string_view user) -> URL&;
+        auto set_user(std::string_view user, Encode encode = Encode::yes) -> URL&;
 
         /** Return the password, or empty if none. */
         [[nodiscard]] auto password() const -> const std::string&;

--- a/libmamba/include/mamba/util/url.hpp
+++ b/libmamba/include/mamba/util/url.hpp
@@ -120,5 +120,8 @@ namespace mamba::util
         std::string m_query = {};
         std::string m_fragment = {};
     };
+
+    auto operator==(URL const& a, URL const& b) -> bool;
+    auto operator!=(URL const& a, URL const& b) -> bool;
 }
 #endif

--- a/libmamba/include/mamba/util/url.hpp
+++ b/libmamba/include/mamba/util/url.hpp
@@ -57,7 +57,7 @@ namespace mamba::util
         /** Set a non-empty scheme. */
         auto set_scheme(std::string_view scheme) -> URL&;
 
-        /** Return the undecoded user, or empty if none. */
+        /** Return the encoded user, or empty if none. */
         [[nodiscard]] auto user(Decode::no_type) const -> const std::string&;
 
         /** Retrun the decoded user, or empty if none. */
@@ -66,7 +66,7 @@ namespace mamba::util
         /** Set or clear the user. */
         auto set_user(std::string_view user, Encode encode = Encode::yes) -> URL&;
 
-        /** Return the undecoded password, or empty if none. */
+        /** Return the encoded password, or empty if none. */
         [[nodiscard]] auto password(Decode::no_type) const -> const std::string&;
 
         /** Return the decoded password, or empty if none. */
@@ -75,10 +75,10 @@ namespace mamba::util
         /** Set or clear the password. */
         auto set_password(std::string_view password, Encode encode = Encode::yes) -> URL&;
 
-        /** Return the undecoded basic authentication string. */
+        /** Return the encoded basic authentication string. */
         [[nodiscard]] auto authentication() const -> std::string;
 
-        /** Return the undecoded host, always non-empty. */
+        /** Return the encoded host, always non-empty. */
         [[nodiscard]] auto host(Decode::no_type) const -> const std::string&;
 
         /** Return the decoded host, always non-empty. */
@@ -93,7 +93,7 @@ namespace mamba::util
         /** Set or clear the port. */
         auto set_port(std::string_view port) -> URL&;
 
-        /** Return the autority part of the URL. */
+        /** Return the encoded autority part of the URL. */
         [[nodiscard]] auto authority() const -> std::string;
 
         /** Return the path, always starts with a '/'. */

--- a/libmamba/include/mamba/util/url_manip.hpp
+++ b/libmamba/include/mamba/util/url_manip.hpp
@@ -4,16 +4,32 @@
 //
 // The full license is in the file LICENSE, distributed with this software.
 
+#ifndef MAMBA_UTIL_URL_MANIP_HPP
+#define MAMBA_UTIL_URL_MANIP_HPP
+
 #include <optional>
 #include <string>
 #include <string_view>
 #include <vector>
 
-#ifndef MAMBA_UTIL_URL_MANIP_HPP
-#define MAMBA_UTIL_URL_MANIP_HPP
-
 namespace mamba::util
 {
+    /**
+     * Escape reserved URL reserved characters with '%' encoding.
+     *
+     * Does not parse URL in any way so '/' in "http://mamba.org/page" get encoded.
+     *
+     * @see url_decode
+     */
+    [[nodiscard]] auto url_encode(std::string_view url) -> std::string;
+
+    /**
+     * Unescape percent encoded string to their URL reserved characters.
+     *
+     * @see url_encode
+     */
+    [[nodiscard]] auto url_decode(std::string_view url) -> std::string;
+
     std::string concat_scheme_url(const std::string& scheme, const std::string& location);
 
     std::string build_url(

--- a/libmamba/include/mamba/util/url_manip.hpp
+++ b/libmamba/include/mamba/util/url_manip.hpp
@@ -85,8 +85,6 @@ namespace mamba::util
      */
     std::string file_uri_unc2_to_unc4(std::string_view url);
 
-    std::string encode_url(const std::string& url);
-    std::string decode_url(const std::string& url);
     // Only returns a cache name without extension
     std::string cache_name_from_url(const std::string& url);
 

--- a/libmamba/include/mamba/util/url_manip.hpp
+++ b/libmamba/include/mamba/util/url_manip.hpp
@@ -1,19 +1,18 @@
-// Copyright (c) 2019, QuantStack and Mamba Contributors
+// Copyright (c) 2023, QuantStack and Mamba Contributors
 //
 // Distributed under the terms of the BSD 3-Clause License.
 //
 // The full license is in the file LICENSE, distributed with this software.
-
-#ifndef MAMBA_CORE_URL_HPP
-#define MAMBA_CORE_URL_HPP
 
 #include <optional>
 #include <string>
 #include <string_view>
 #include <vector>
 
+#ifndef MAMBA_UTIL_URL_MANIP_HPP
+#define MAMBA_UTIL_URL_MANIP_HPP
 
-namespace mamba
+namespace mamba::util
 {
     std::string concat_scheme_url(const std::string& scheme, const std::string& location);
 
@@ -90,110 +89,6 @@ namespace mamba
     std::string decode_url(const std::string& url);
     // Only returns a cache name without extension
     std::string cache_name_from_url(const std::string& url);
-
-    /**
-     * Class representing a URL.
-     *
-     * All URL have a non-empty scheme, host, and path.
-     */
-    class URL
-    {
-    public:
-
-        enum class StripScheme : bool
-        {
-            no,
-            yes,
-        };
-
-        inline static constexpr std::string_view https = "https";
-        inline static constexpr std::string_view localhost = "localhost";
-
-        [[nodiscard]] static auto parse(std::string_view url) -> URL;
-
-        /** Create a local URL. */
-        URL() = default;
-
-        /** Return the scheme, always non-empty. */
-        [[nodiscard]] auto scheme() const -> const std::string&;
-
-        /** Set a non-empty scheme. */
-        URL& set_scheme(std::string_view scheme);
-
-        /** Return the user, or empty if none. */
-        [[nodiscard]] auto user() const -> const std::string&;
-
-        /** Set or clear the user. */
-        URL& set_user(std::string_view user);
-
-        /** Return the password, or empty if none. */
-        [[nodiscard]] auto password() const -> const std::string&;
-
-        /** Set or clear the password. */
-        URL& set_password(std::string_view password);
-
-        /** Return the basic authetification string. */
-        [[nodiscard]] auto authentication() const -> std::string;
-
-        /** Return the host, always non-empty. */
-        [[nodiscard]] auto host() const -> const std::string&;
-
-        /** Set a non-empty host. */
-        URL& set_host(std::string_view host);
-
-        /** Return the port, or empty if none. */
-        [[nodiscard]] auto port() const -> const std::string&;
-
-        /** Set or clear the port. */
-        URL& set_port(std::string_view port);
-
-        /** Return the autority part of the URL. */
-        [[nodiscard]] auto authority() const -> std::string;
-
-        /** Return the path, always starts with a '/'. */
-        [[nodiscard]] auto path() const -> const std::string&;
-
-        /**
-         * Return the path.
-         *
-         * For a "file" scheme, with a Windows path containing a drive, the leading '/' is
-         * stripped.
-         */
-        [[nodiscard]] auto pretty_path() const -> std::string_view;
-
-        /** Set the path, a leading '/' is added if abscent. */
-        URL& set_path(std::string_view path);
-
-        /** Return the query, or empty if none. */
-        [[nodiscard]] auto query() const -> const std::string&;
-
-        /** Set or clear the query. */
-        URL& set_query(std::string_view query);
-
-        /** Return the fragment, or empty if none. */
-        [[nodiscard]] auto fragment() const -> const std::string&;
-
-        /** Set or clear the fragment. */
-        URL& set_fragment(std::string_view fragment);
-
-        /**
-         * Return the full url.
-         *
-         * @param strip If true, remove the scheme and "localhost" on file URI.
-         */
-        [[nodiscard]] auto str(StripScheme strip = StripScheme::no) const -> std::string;
-
-    private:
-
-        std::string m_scheme = std::string(https);
-        std::string m_user = {};
-        std::string m_password = {};
-        std::string m_host = std::string(localhost);
-        std::string m_path = "/";
-        std::string m_port = {};
-        std::string m_query = {};
-        std::string m_fragment = {};
-    };
 
     namespace detail
     {

--- a/libmamba/src/core/channel.cpp
+++ b/libmamba/src/core/channel.cpp
@@ -85,7 +85,7 @@ namespace mamba
                 package_name = "";
             }
 
-            URLHandler handler(cleaned_url);
+            URL handler(cleaned_url);
             scheme = handler.scheme();
             host = handler.host();
             port = handler.port();
@@ -126,18 +126,15 @@ namespace mamba
             const std::string& path
         )
         {
-            std::string spath = std::string(util::rstrip(path, "/"));
-            std::string url = URLHandler()
-                                  .set_scheme(scheme)
-                                  .set_host(host)
-                                  .set_port(port)
-                                  .set_path(spath)
-                                  .url(true);
+            std::string spath = std::string(rstrip(path, "/"));
+            std::string url = URL().set_scheme(scheme).set_host(host).set_port(port).set_path(spath).url(
+                true
+            );
 
             // Case 1: No path given, channel name is ""
             if (spath == "")
             {
-                URLHandler handler;
+                URL handler;
                 handler.set_host(host).set_port(port);
                 return channel_configuration(
                     std::string(util::rstrip(handler.url(), "/")),
@@ -193,9 +190,9 @@ namespace mamba
             }
 
             // Case 7: fallback, channel_location = host:port and channel_name = path
-            spath = util::lstrip(spath, "/");
-            std::string location = URLHandler().set_host(host).set_port(port).url();
-            return channel_configuration(std::string(util::strip(location, "/")), spath, scheme, "", "");
+            spath = lstrip(spath, "/");
+            std::string location = URL().set_host(host).set_port(port).url();
+            return channel_configuration(std::string(strip(location, "/")), spath, scheme, "", "");
         }
 
         std::vector<std::string> take_platforms(std::string& value)
@@ -447,12 +444,9 @@ namespace mamba
             else
             {
                 std::string full_url = concat_scheme_url(scheme, location);
-                URLHandler parser(full_url);
-                location = util::rstrip(
-                    URLHandler().set_host(parser.host()).set_port(parser.port()).url(),
-                    "/"
-                );
-                name = util::lstrip(parser.path(), "/");
+                URL parser(full_url);
+                location = rstrip(URL().set_host(parser.host()).set_port(parser.port()).url(), "/");
+                name = lstrip(parser.path(), "/");
             }
         }
         name = name != "" ? util::strip(name, "/") : util::strip(channel_url, "/");

--- a/libmamba/src/core/channel.cpp
+++ b/libmamba/src/core/channel.cpp
@@ -132,7 +132,7 @@ namespace mamba
                                   .set_host(host)
                                   .set_port(port)
                                   .set_path(spath)
-                                  .str(URL::SchemeOpt::remove_if_present);
+                                  .str(URL::StripScheme::yes);
 
             // Case 1: No path given, channel name is ""
             if (spath == "")

--- a/libmamba/src/core/channel.cpp
+++ b/libmamba/src/core/channel.cpp
@@ -89,8 +89,8 @@ namespace mamba
             scheme = url_parsed.scheme();
             host = url_parsed.host();
             port = url_parsed.port();
-            path = url_parsed.path();
-            auth = url_parsed.auth();
+            path = url_parsed.pretty_path();
+            auth = url_parsed.authentication();
         }
 
         // Channel configuration
@@ -443,7 +443,7 @@ namespace mamba
                 std::string full_url = concat_scheme_url(scheme, location);
                 const auto parser = URL::parse(full_url);
                 location = rstrip(URL().set_host(parser.host()).set_port(parser.port()).str(), "/");
-                name = lstrip(parser.path(), "/");
+                name = lstrip(parser.pretty_path(), "/");
             }
         }
         name = name != "" ? util::strip(name, "/") : util::strip(channel_url, "/");

--- a/libmamba/src/core/channel.cpp
+++ b/libmamba/src/core/channel.cpp
@@ -126,7 +126,7 @@ namespace mamba
             const std::string& path
         )
         {
-            std::string spath = std::string(rstrip(path, "/"));
+            std::string spath = std::string(util::rstrip(path, "/"));
             std::string url = URL()  //
                                   .set_scheme(scheme)
                                   .set_host(host)
@@ -139,7 +139,13 @@ namespace mamba
             {
                 URL handler;
                 handler.set_host(host).set_port(port);
-                return channel_configuration(std::string(rstrip(handler.str(), "/")), "", scheme, "", "");
+                return channel_configuration(
+                    std::string(util::rstrip(handler.str(), "/")),
+                    "",
+                    scheme,
+                    "",
+                    ""
+                );
             }
 
             // Case 2: migrated_custom_channels not implemented yet
@@ -187,9 +193,9 @@ namespace mamba
             }
 
             // Case 7: fallback, channel_location = host:port and channel_name = path
-            spath = lstrip(spath, "/");
+            spath = util::lstrip(spath, "/");
             std::string location = URL().set_host(host).set_port(port).str();
-            return channel_configuration(std::string(strip(location, "/")), spath, scheme, "", "");
+            return channel_configuration(std::string(util::strip(location, "/")), spath, scheme, "", "");
         }
 
         std::vector<std::string> take_platforms(std::string& value)
@@ -442,8 +448,8 @@ namespace mamba
             {
                 std::string full_url = concat_scheme_url(scheme, location);
                 const auto parser = URL::parse(full_url);
-                location = rstrip(URL().set_host(parser.host()).set_port(parser.port()).str(), "/");
-                name = lstrip(parser.pretty_path(), "/");
+                location = util::rstrip(URL().set_host(parser.host()).set_port(parser.port()).str(), "/");
+                name = util::lstrip(parser.pretty_path(), "/");
             }
         }
         name = name != "" ? util::strip(name, "/") : util::strip(channel_url, "/");

--- a/libmamba/src/core/channel.cpp
+++ b/libmamba/src/core/channel.cpp
@@ -563,7 +563,7 @@ namespace mamba
         std::string value = in_value;
         auto platforms = take_platforms(value);
 
-        auto chan = has_scheme(value)        ? from_url(fix_win_path(value))
+        auto chan = url_has_scheme(value)    ? from_url(fix_win_path(value))
                     : is_path(value)         ? from_url(path_to_url(value))
                     : is_package_file(value) ? from_url(fix_win_path(value))
                                              : from_name(value);

--- a/libmamba/src/core/channel.cpp
+++ b/libmamba/src/core/channel.cpp
@@ -127,7 +127,7 @@ namespace mamba
         )
         {
             std::string spath = std::string(rstrip(path, "/"));
-            std::string url = URL().set_scheme(scheme).set_host(host).set_port(port).set_path(spath).url(
+            std::string url = URL().set_scheme(scheme).set_host(host).set_port(port).set_path(spath).str(
                 true
             );
 
@@ -136,13 +136,7 @@ namespace mamba
             {
                 URL handler;
                 handler.set_host(host).set_port(port);
-                return channel_configuration(
-                    std::string(util::rstrip(handler.url(), "/")),
-                    "",
-                    scheme,
-                    "",
-                    ""
-                );
+                return channel_configuration(std::string(rstrip(handler.str(), "/")), "", scheme, "", "");
             }
 
             // Case 2: migrated_custom_channels not implemented yet
@@ -191,7 +185,7 @@ namespace mamba
 
             // Case 7: fallback, channel_location = host:port and channel_name = path
             spath = lstrip(spath, "/");
-            std::string location = URL().set_host(host).set_port(port).url();
+            std::string location = URL().set_host(host).set_port(port).str();
             return channel_configuration(std::string(strip(location, "/")), spath, scheme, "", "");
         }
 
@@ -445,7 +439,7 @@ namespace mamba
             {
                 std::string full_url = concat_scheme_url(scheme, location);
                 URL parser(full_url);
-                location = rstrip(URL().set_host(parser.host()).set_port(parser.port()).url(), "/");
+                location = rstrip(URL().set_host(parser.host()).set_port(parser.port()).str(), "/");
                 name = lstrip(parser.path(), "/");
             }
         }

--- a/libmamba/src/core/channel.cpp
+++ b/libmamba/src/core/channel.cpp
@@ -85,12 +85,12 @@ namespace mamba
                 package_name = "";
             }
 
-            URL handler(cleaned_url);
-            scheme = handler.scheme();
-            host = handler.host();
-            port = handler.port();
-            path = handler.path();
-            auth = handler.auth();
+            const auto url_parsed = URL::parse(cleaned_url);
+            scheme = url_parsed.scheme();
+            host = url_parsed.host();
+            port = url_parsed.port();
+            path = url_parsed.path();
+            auth = url_parsed.auth();
         }
 
         // Channel configuration
@@ -438,7 +438,7 @@ namespace mamba
             else
             {
                 std::string full_url = concat_scheme_url(scheme, location);
-                URL parser(full_url);
+                const auto parser = URL::parse(full_url);
                 location = rstrip(URL().set_host(parser.host()).set_port(parser.port()).str(), "/");
                 name = lstrip(parser.path(), "/");
             }

--- a/libmamba/src/core/channel.cpp
+++ b/libmamba/src/core/channel.cpp
@@ -127,9 +127,12 @@ namespace mamba
         )
         {
             std::string spath = std::string(rstrip(path, "/"));
-            std::string url = URL().set_scheme(scheme).set_host(host).set_port(port).set_path(spath).str(
-                true
-            );
+            std::string url = URL()  //
+                                  .set_scheme(scheme)
+                                  .set_host(host)
+                                  .set_port(port)
+                                  .set_path(spath)
+                                  .str(URL::SchemeOpt::remove_if_present);
 
             // Case 1: No path given, channel name is ""
             if (spath == "")

--- a/libmamba/src/core/context.cpp
+++ b/libmamba/src/core/context.cpp
@@ -196,7 +196,7 @@ namespace mamba
                 if (util::ends_with(entry.path().filename().string(), ".token"))
                 {
                     found_tokens.push_back(entry.path());
-                    std::string token_url = util::decode_url(entry.path().filename().string());
+                    std::string token_url = util::url_decode(entry.path().filename().string());
 
                     // anaconda client writes out a token for https://api.anaconda.org...
                     // but we need the token for https://conda.anaconda.org

--- a/libmamba/src/core/context.cpp
+++ b/libmamba/src/core/context.cpp
@@ -20,7 +20,7 @@
 #include "mamba/core/util.hpp"
 #include "mamba/core/util_os.hpp"
 #include "mamba/util/string.hpp"
-#include "mamba/util/url.hpp"
+#include "mamba/util/url_manip.hpp"
 
 namespace mamba
 {

--- a/libmamba/src/core/context.cpp
+++ b/libmamba/src/core/context.cpp
@@ -17,10 +17,10 @@
 #include "mamba/core/execution.hpp"
 #include "mamba/core/output.hpp"
 #include "mamba/core/thread_utils.hpp"
-#include "mamba/core/url.hpp"
 #include "mamba/core/util.hpp"
 #include "mamba/core/util_os.hpp"
 #include "mamba/util/string.hpp"
+#include "mamba/util/url.hpp"
 
 namespace mamba
 {
@@ -196,7 +196,7 @@ namespace mamba
                 if (util::ends_with(entry.path().filename().string(), ".token"))
                 {
                     found_tokens.push_back(entry.path());
-                    std::string token_url = decode_url(entry.path().filename().string());
+                    std::string token_url = util::decode_url(entry.path().filename().string());
 
                     // anaconda client writes out a token for https://api.anaconda.org...
                     // but we need the token for https://conda.anaconda.org

--- a/libmamba/src/core/fetch.cpp
+++ b/libmamba/src/core/fetch.cpp
@@ -240,9 +240,9 @@ namespace mamba
         m_curl_handle->set_opt(CURLOPT_VERBOSE, Context::instance().output_params.verbosity >= 2);
 
         // get url host
-        const auto url_handler = URLHandler(url);
-        auto host = url_handler.host();
-        const auto port = url_handler.port();
+        const auto url_parsed = URL(url);
+        auto host = url_parsed.host();
+        const auto port = url_parsed.port();
         if (port.size())
         {
             host += ":" + port;

--- a/libmamba/src/core/fetch.cpp
+++ b/libmamba/src/core/fetch.cpp
@@ -61,7 +61,7 @@ namespace mamba
     DownloadTarget::DownloadTarget(const std::string& name, const std::string& url, const std::string& filename)
         : m_name(name)
         , m_filename(filename)
-        , m_url(unc_url(url))
+        , m_url(file_uri_unc2_to_unc4(url))
         , m_http_status(10000)
         , m_downloaded_size(0)
         , m_effective_url(nullptr)

--- a/libmamba/src/core/fetch.cpp
+++ b/libmamba/src/core/fetch.cpp
@@ -240,7 +240,7 @@ namespace mamba
         m_curl_handle->set_opt(CURLOPT_VERBOSE, Context::instance().output_params.verbosity >= 2);
 
         // get url host
-        const auto url_parsed = URL(url);
+        const auto url_parsed = URL::parse(url);
         auto host = url_parsed.host();
         const auto port = url_parsed.port();
         if (port.size())

--- a/libmamba/src/core/fetch.cpp
+++ b/libmamba/src/core/fetch.cpp
@@ -12,8 +12,9 @@
 #include "mamba/core/fetch.hpp"
 #include "mamba/core/output.hpp"
 #include "mamba/core/thread_utils.hpp"
-#include "mamba/core/url.hpp"
 #include "mamba/util/string.hpp"
+#include "mamba/util/url.hpp"
+#include "mamba/util/url_manip.hpp"
 
 #include "compression.hpp"
 #include "curl.hpp"
@@ -61,7 +62,7 @@ namespace mamba
     DownloadTarget::DownloadTarget(const std::string& name, const std::string& url, const std::string& filename)
         : m_name(name)
         , m_filename(filename)
-        , m_url(file_uri_unc2_to_unc4(url))
+        , m_url(util::file_uri_unc2_to_unc4(url))
         , m_http_status(10000)
         , m_downloaded_size(0)
         , m_effective_url(nullptr)
@@ -240,7 +241,7 @@ namespace mamba
         m_curl_handle->set_opt(CURLOPT_VERBOSE, Context::instance().output_params.verbosity >= 2);
 
         // get url host
-        const auto url_parsed = URL::parse(url);
+        const auto url_parsed = util::URL::parse(url);
         auto host = url_parsed.host();
         const auto port = url_parsed.port();
         if (port.size())

--- a/libmamba/src/core/match_spec.cpp
+++ b/libmamba/src/core/match_spec.cpp
@@ -10,8 +10,8 @@
 #include "mamba/core/environment.hpp"
 #include "mamba/core/match_spec.hpp"
 #include "mamba/core/output.hpp"
-#include "mamba/core/url.hpp"
 #include "mamba/util/string.hpp"
+#include "mamba/util/url_manip.hpp"
 
 namespace mamba
 {
@@ -79,10 +79,10 @@ namespace mamba
 
         if (is_package_file(spec_str))
         {
-            if (!url_has_scheme(spec_str))
+            if (!util::url_has_scheme(spec_str))
             {
                 LOG_INFO << "need to expand path!";
-                spec_str = path_to_url(fs::absolute(env::expand_user(spec_str)).string());
+                spec_str = util::path_to_url(fs::absolute(env::expand_user(spec_str)).string());
             }
             auto& parsed_channel = channel_context.make_channel(spec_str);
 

--- a/libmamba/src/core/match_spec.cpp
+++ b/libmamba/src/core/match_spec.cpp
@@ -79,7 +79,7 @@ namespace mamba
 
         if (is_package_file(spec_str))
         {
-            if (!has_scheme(spec_str))
+            if (!url_has_scheme(spec_str))
             {
                 LOG_INFO << "need to expand path!";
                 spec_str = path_to_url(fs::absolute(env::expand_user(spec_str)).string());

--- a/libmamba/src/core/output.cpp
+++ b/libmamba/src/core/output.cpp
@@ -24,9 +24,9 @@
 #include "mamba/core/output.hpp"
 #include "mamba/core/tasksync.hpp"
 #include "mamba/core/thread_utils.hpp"
-#include "mamba/core/url.hpp"
 #include "mamba/core/util.hpp"
 #include "mamba/util/string.hpp"
+#include "mamba/util/url_manip.hpp"
 
 #include "progress_bar_impl.hpp"
 
@@ -36,7 +36,7 @@ namespace mamba
     {
         std::string remaining_url, scheme, auth, token;
         // TODO maybe add some caching...
-        split_scheme_auth_token(full_url, remaining_url, scheme, auth, token);
+        util::split_scheme_auth_token(full_url, remaining_url, scheme, auth, token);
 
         if (util::starts_with(remaining_url, "conda.anaconda.org/"))
         {

--- a/libmamba/src/core/package_cache.cpp
+++ b/libmamba/src/core/package_cache.cpp
@@ -4,14 +4,14 @@
 //
 // The full license is in the file LICENSE, distributed with this software.
 
+#include <nlohmann/json.hpp>
+
 #include "mamba/core/context.hpp"
 #include "mamba/core/output.hpp"
 #include "mamba/core/package_cache.hpp"
 #include "mamba/core/package_handling.hpp"
-#include "mamba/core/url.hpp"
 #include "mamba/core/validate.hpp"
-
-#include "nlohmann/json.hpp"
+#include "mamba/util/url_manip.hpp"
 
 namespace mamba
 {
@@ -280,7 +280,10 @@ namespace mamba
                     {
                         if (!repodata_record["url"].get<std::string>().empty())
                         {
-                            if (!compare_cleaned_url(repodata_record["url"].get<std::string>(), s.url))
+                            if (!util::compare_cleaned_url(
+                                    repodata_record["url"].get<std::string>(),
+                                    s.url
+                                ))
                             {
                                 LOG_WARNING << "Extracted package cache '" << extracted_dir.string()
                                             << "' has invalid url";

--- a/libmamba/src/core/query.cpp
+++ b/libmamba/src/core/query.cpp
@@ -19,8 +19,8 @@
 #include "mamba/core/output.hpp"
 #include "mamba/core/package_info.hpp"
 #include "mamba/core/query.hpp"
-#include "mamba/core/url.hpp"
 #include "mamba/util/string.hpp"
+#include "mamba/util/url_manip.hpp"
 #include "solv-cpp/queue.hpp"
 
 namespace mamba
@@ -173,7 +173,7 @@ namespace mamba
             fmt::print(out, fmtstring, "Subdir", pkg.subdir);
 
             std::string url_remaining, url_scheme, url_auth, url_token;
-            split_scheme_auth_token(pkg.url, url_remaining, url_scheme, url_auth, url_token);
+            util::split_scheme_auth_token(pkg.url, url_remaining, url_scheme, url_auth, url_token);
 
             fmt::print(out, " {:<15} {}://{}\n", "URL", url_scheme, url_remaining);
 

--- a/libmamba/src/core/subdirdata.cpp
+++ b/libmamba/src/core/subdirdata.cpp
@@ -10,8 +10,8 @@
 #include "mamba/core/output.hpp"
 #include "mamba/core/package_cache.hpp"
 #include "mamba/core/subdirdata.hpp"
-#include "mamba/core/url.hpp"
 #include "mamba/util/string.hpp"
+#include "mamba/util/url_manip.hpp"
 
 #include "progress_bar_impl.hpp"
 
@@ -334,7 +334,7 @@ namespace mamba
         , m_loaded(false)
         , m_download_complete(false)
         , m_repodata_url(util::concat(url, "/", repodata_fn))
-        , m_name(join_url(channel.canonical_name(), platform))
+        , m_name(util::join_url(channel.canonical_name(), platform))
         , m_is_noarch(platform == "noarch")
         , p_channel(&channel)
     {
@@ -892,7 +892,7 @@ namespace mamba
 
     std::string cache_fn_url(const std::string& url)
     {
-        return cache_name_from_url(url) + ".json";
+        return util::cache_name_from_url(url) + ".json";
     }
 
     std::string create_cache_dir(const fs::u8path& cache_path)

--- a/libmamba/src/core/url.cpp
+++ b/libmamba/src/core/url.cpp
@@ -18,6 +18,10 @@
 namespace mamba
 {
 
+    /*******************
+     *  CURL wrappers  *
+     *******************/
+
     namespace
     {
         /**
@@ -45,7 +49,6 @@ namespace mamba
             CURLEasyHandle(CURLEasyHandle&&) = delete;
             CURLEasyHandle& operator=(CURLEasyHandle&&) = delete;
 
-            [[nodiscard]] auto raw() const -> const_pointer;
             [[nodiscard]] auto raw() -> pointer;
 
         private:
@@ -79,8 +82,6 @@ namespace mamba
             CURLStr& operator=(CURLStr&&) = delete;
 
             [[nodiscard]] auto raw_input() -> input_pointer;
-            [[nodiscard]] auto raw() const -> const_pointer;
-            [[nodiscard]] auto raw() -> pointer;
 
             [[nodiscard]] auto str() const -> std::optional<std::string_view>;
 
@@ -103,11 +104,6 @@ namespace mamba
         CURLEasyHandle::~CURLEasyHandle()
         {
             ::curl_easy_cleanup(m_handle);
-        }
-
-        auto CURLEasyHandle::raw() const -> const_pointer
-        {
-            return m_handle;
         }
 
         auto CURLEasyHandle::raw() -> pointer
@@ -138,16 +134,6 @@ namespace mamba
         {
             assert(m_data == nullptr);  // Otherwise we leak Curl memory
             return &m_data;
-        }
-
-        auto CURLStr::raw() const -> const_pointer
-        {
-            return m_data;
-        }
-
-        auto CURLStr::raw() -> pointer
-        {
-            return m_data;
         }
 
         auto CURLStr::str() const -> std::optional<std::string_view>

--- a/libmamba/src/core/url.cpp
+++ b/libmamba/src/core/url.cpp
@@ -601,7 +601,16 @@ namespace mamba
 
     URL& URL::set_path(std::string_view path)
     {
-        m_path = path;
+        if (!starts_with(path, '/'))
+        {
+            m_path.reserve(path.size() + 1);
+            m_path = '/';
+            m_path += path;
+        }
+        else
+        {
+            m_path = path;
+        }
         return *this;
     }
 

--- a/libmamba/src/core/url.cpp
+++ b/libmamba/src/core/url.cpp
@@ -353,7 +353,7 @@ namespace mamba
     {
         std::string cleaned_url;
         split_anaconda_token(url, cleaned_url, token);
-        URL url_parsed(cleaned_url);
+        URL url_parsed = URL::parse(cleaned_url);
         scheme = url_parsed.scheme();
         auth = url_parsed.auth();
         url_parsed.set_scheme("");
@@ -507,17 +507,19 @@ namespace mamba
      * URLHandler implementation *
      *****************************/
 
-    URL::URL(std::string_view url)
+    auto URL::parse(std::string_view url) -> URL
     {
         const CURLUrl handle = { file_uri_unc2_to_unc4(url), CURLU_NON_SUPPORT_SCHEME };
-        m_scheme = handle.get_part(CURLUPART_SCHEME).value_or("");
-        m_user = handle.get_part(CURLUPART_USER).value_or("");
-        m_password = handle.get_part(CURLUPART_PASSWORD).value_or("");
-        m_host = handle.get_part(CURLUPART_HOST).value_or("");
-        m_path = handle.get_part(CURLUPART_PATH).value_or("");
-        m_port = handle.get_part(CURLUPART_PORT).value_or("");
-        m_query = handle.get_part(CURLUPART_QUERY).value_or("");
-        m_fragment = handle.get_part(CURLUPART_FRAGMENT).value_or("");
+        auto out = URL();
+        out.set_scheme(handle.get_part(CURLUPART_SCHEME).value_or(""))
+            .set_user(handle.get_part(CURLUPART_USER).value_or(""))
+            .set_password(handle.get_part(CURLUPART_PASSWORD).value_or(""))
+            .set_host(handle.get_part(CURLUPART_HOST).value_or(""))
+            .set_path(handle.get_part(CURLUPART_PATH).value_or(""))
+            .set_port(handle.get_part(CURLUPART_PORT).value_or(""))
+            .set_query(handle.get_part(CURLUPART_QUERY).value_or(""))
+            .set_fragment(handle.get_part(CURLUPART_FRAGMENT).value_or(""));
+        return out;
     }
 
     auto URL::str(bool strip_scheme) const -> std::string

--- a/libmamba/src/core/url.cpp
+++ b/libmamba/src/core/url.cpp
@@ -317,9 +317,17 @@ namespace mamba
         cleaned_url = util::rstrip(cleaned_url, "/");
     }
 
-    bool has_scheme(const std::string& url)
+    auto has_scheme(std::string_view url) -> bool
     {
-        return std::regex_search(url, Context::instance().scheme_regex);
+        const auto sep = url.find("://");
+        if ((sep == std::string_view::npos) || (sep == 0))
+        {
+            return false;
+        }
+        auto scheme = url.substr(0, sep);
+        auto is_scheme_char = [](char c) -> bool
+        { return is_alphanum(c) || (c == '.') || (c == '-') || (c == '_'); };
+        return std::all_of(scheme.cbegin(), scheme.cend(), is_scheme_char);
     }
 
     void split_anaconda_token(const std::string& url, std::string& cleaned_url, std::string& token)

--- a/libmamba/src/core/url.cpp
+++ b/libmamba/src/core/url.cpp
@@ -320,7 +320,7 @@ namespace mamba
     auto url_get_scheme(std::string_view url) -> std::string_view
     {
         static constexpr auto is_scheme_char = [](char c) -> bool
-        { return is_alphanum(c) || (c == '.') || (c == '-') || (c == '_'); };
+        { return util::is_alphanum(c) || (c == '.') || (c == '-') || (c == '_'); };
 
         const auto sep = url.find("://");
         if ((0 < sep) && (sep < std::string_view::npos))
@@ -341,9 +341,9 @@ namespace mamba
 
     auto path_has_drive_letter(std::string_view path) -> bool
     {
-        static constexpr auto is_drive_char = [](char c) -> bool { return is_alphanum(c); };
+        static constexpr auto is_drive_char = [](char c) -> bool { return util::is_alphanum(c); };
 
-        auto [drive, rest] = lstrip_if_parts(path, is_drive_char);
+        auto [drive, rest] = util::lstrip_if_parts(path, is_drive_char);
         return !drive.empty() && (rest.size() >= 2) && (rest[0] == ':')
                && ((rest[1] == '/') || (rest[1] == '\\'));
     }
@@ -384,7 +384,7 @@ namespace mamba
         auth = url_parsed.authentication();
         url_parsed.set_user("");
         url_parsed.set_password("");
-        remaining_url = rstrip(url_parsed.str(URL::StripScheme::yes), '/');
+        remaining_url = util::rstrip(url_parsed.str(URL::StripScheme::yes), '/');
     }
 
     bool compare_cleaned_url(const std::string& url1, const std::string& url2)
@@ -429,13 +429,13 @@ namespace mamba
         static constexpr std::string_view file_scheme = "file:";
 
         // Not "file:" scheme
-        if (!starts_with(uri, file_scheme))
+        if (!util::starts_with(uri, file_scheme))
         {
             return std::string(uri);
         }
 
         // No hostname set in "file://hostname/path/to/data.xml"
-        auto [slashes, rest] = lstrip_parts(remove_prefix(uri, file_scheme), '/');
+        auto [slashes, rest] = util::lstrip_parts(util::remove_prefix(uri, file_scheme), '/');
         if (slashes.size() != 2)
         {
             return std::string(uri);
@@ -456,7 +456,7 @@ namespace mamba
 
         // '\' are used as path separator in "file://\\hostname\path\to\data.xml" (also not RFC
         // compliant)
-        if (starts_with(hostname, R"(\\)"))
+        if (util::starts_with(hostname, R"(\\)"))
         {
             return std::string(uri);
         }
@@ -468,7 +468,7 @@ namespace mamba
             return std::string(uri);
         }
 
-        return concat("file:////", rest);
+        return util::concat("file:////", rest);
     }
 
     std::string encode_url(const std::string& url)
@@ -600,7 +600,7 @@ namespace mamba
     {
         const auto& u = user();
         const auto& p = password();
-        return p.empty() ? u : concat(u, ':', p);
+        return p.empty() ? u : util::concat(u, ':', p);
     }
 
     auto URL::host() const -> const std::string&
@@ -631,7 +631,7 @@ namespace mamba
 
     auto URL::authority() const -> std::string
     {
-        return concat(
+        return util::concat(
             m_user,
             m_password.empty() ? "" : ":",
             m_password,
@@ -652,7 +652,7 @@ namespace mamba
         // All paths start with a '/' except those like "file://C:/folder/file.txt"
         if (m_scheme == "file")
         {
-            assert(starts_with(m_path, '/'));
+            assert(util::starts_with(m_path, '/'));
             auto path_no_slash = std::string_view(m_path).substr(1);
             if (path_has_drive_letter(path_no_slash))
             {
@@ -664,7 +664,7 @@ namespace mamba
 
     URL& URL::set_path(std::string_view path)
     {
-        if (!starts_with(path, '/'))
+        if (!util::starts_with(path, '/'))
         {
             m_path.reserve(path.size() + 1);
             m_path = '/';
@@ -713,7 +713,7 @@ namespace mamba
         {
             computed_path = pretty_path();
         }
-        return concat(
+        return util::concat(
             (strip == StripScheme::no) ? m_scheme : "",
             (strip == StripScheme::no) ? "://" : "",
             m_user,

--- a/libmamba/src/core/url.cpp
+++ b/libmamba/src/core/url.cpp
@@ -406,7 +406,7 @@ namespace mamba
 
     std::string path_to_url(const std::string& path)
     {
-        static const std::string file_scheme = "file://";
+        static constexpr std::string_view file_scheme = "file://";
         if (util::starts_with(path, file_scheme))
         {
             return path;
@@ -421,7 +421,7 @@ namespace mamba
         {
             util::replace_all(abs_path, "\\", "/");
         }
-        return file_scheme + abs_path;
+        return util::concat(file_scheme, abs_path);
     }
 
     std::string file_uri_unc2_to_unc4(std::string_view uri)

--- a/libmamba/src/core/url.cpp
+++ b/libmamba/src/core/url.cpp
@@ -556,9 +556,90 @@ namespace mamba
         return m_scheme;
     }
 
+    URL& URL::set_scheme(std::string_view scheme)
+    {
+        if (scheme.empty())
+        {
+            throw std::invalid_argument("Cannot set empty scheme");
+        }
+        m_scheme = scheme;
+        return *this;
+    }
+
+    auto URL::user() const -> const std::string&
+    {
+        return m_user;
+    }
+
+    URL& URL::set_user(std::string_view user)
+    {
+        if (user.empty())
+        {
+            m_password = "";
+        }
+        m_user = user;
+        return *this;
+    }
+
+    auto URL::password() const -> const std::string&
+    {
+        return m_password;
+    }
+
+    URL& URL::set_password(std::string_view password)
+    {
+        if (!password.empty() && m_user.empty())
+        {
+            throw std::invalid_argument("Cannot set password without user");
+        }
+        m_password = password;
+        return *this;
+    }
+
+    auto URL::authentication() const -> std::string
+    {
+        const auto& u = user();
+        const auto& p = password();
+        return p.empty() ? u : concat(u, ':', p);
+    }
+
     auto URL::host() const -> const std::string&
     {
         return m_host;
+    }
+
+    URL& URL::set_host(std::string_view host)
+    {
+        if (host.empty())
+        {
+            throw std::invalid_argument("Cannot set empty host");
+        }
+        m_host = host;
+        return *this;
+    }
+
+    auto URL::port() const -> const std::string&
+    {
+        return m_port;
+    }
+
+    URL& URL::set_port(std::string_view port)
+    {
+        m_port = port;
+        return *this;
+    }
+
+    auto URL::authority() const -> std::string
+    {
+        return concat(
+            m_user,
+            m_password.empty() ? "" : ":",
+            m_password,
+            m_user.empty() ? "" : "@",
+            m_host,
+            m_port.empty() ? "" : ":",
+            m_port
+        );
     }
 
     auto URL::path() const -> const std::string&
@@ -581,9 +662,19 @@ namespace mamba
         return m_path;
     }
 
-    auto URL::port() const -> const std::string&
+    URL& URL::set_path(std::string_view path)
     {
-        return m_port;
+        if (!starts_with(path, '/'))
+        {
+            m_path.reserve(path.size() + 1);
+            m_path = '/';
+            m_path += path;
+        }
+        else
+        {
+            m_path = path;
+        }
+        return *this;
     }
 
     auto URL::query() const -> const std::string&
@@ -591,26 +682,21 @@ namespace mamba
         return m_query;
     }
 
+    URL& URL::set_query(std::string_view query)
+    {
+        m_query = query;
+        return *this;
+    }
+
     auto URL::fragment() const -> const std::string&
     {
         return m_fragment;
     }
 
-    auto URL::user() const -> const std::string&
+    URL& URL::set_fragment(std::string_view fragment)
     {
-        return m_user;
-    }
-
-    auto URL::password() const -> const std::string&
-    {
-        return m_password;
-    }
-
-    auto URL::authentication() const -> std::string
-    {
-        const auto& u = user();
-        const auto& p = password();
-        return p.empty() ? u : concat(u, ':', p);
+        m_fragment = fragment;
+        return *this;
     }
 
     auto URL::str(StripScheme strip) const -> std::string
@@ -643,91 +729,5 @@ namespace mamba
             m_fragment.empty() ? "" : "#",
             m_fragment
         );
-    }
-
-    auto URL::authority() const -> std::string
-    {
-        return concat(
-            m_user,
-            m_password.empty() ? "" : ":",
-            m_password,
-            m_user.empty() ? "" : "@",
-            m_host,
-            m_port.empty() ? "" : ":",
-            m_port
-        );
-    }
-
-    URL& URL::set_scheme(std::string_view scheme)
-    {
-        if (scheme.empty())
-        {
-            throw std::invalid_argument("Cannot set empty scheme");
-        }
-        m_scheme = scheme;
-        return *this;
-    }
-
-    URL& URL::set_host(std::string_view host)
-    {
-        if (host.empty())
-        {
-            throw std::invalid_argument("Cannot set empty host");
-        }
-        m_host = host;
-        return *this;
-    }
-
-    URL& URL::set_path(std::string_view path)
-    {
-        if (!starts_with(path, '/'))
-        {
-            m_path.reserve(path.size() + 1);
-            m_path = '/';
-            m_path += path;
-        }
-        else
-        {
-            m_path = path;
-        }
-        return *this;
-    }
-
-    URL& URL::set_port(std::string_view port)
-    {
-        m_port = port;
-        return *this;
-    }
-
-    URL& URL::set_query(std::string_view query)
-    {
-        m_query = query;
-        return *this;
-    }
-
-    URL& URL::set_fragment(std::string_view fragment)
-    {
-        m_fragment = fragment;
-        return *this;
-    }
-
-    URL& URL::set_user(std::string_view user)
-    {
-        if (user.empty())
-        {
-            m_password = "";
-        }
-        m_user = user;
-        return *this;
-    }
-
-    URL& URL::set_password(std::string_view password)
-    {
-        if (!password.empty() && m_user.empty())
-        {
-            throw std::invalid_argument("Cannot set password without user");
-        }
-        m_password = password;
-        return *this;
     }
 }  // namespace mamba

--- a/libmamba/src/core/url.cpp
+++ b/libmamba/src/core/url.cpp
@@ -359,7 +359,7 @@ namespace mamba
         url_parsed.set_scheme("");
         url_parsed.set_user("");
         url_parsed.set_password("");
-        remaining_url = rstrip(url_parsed.url(), "/");
+        remaining_url = rstrip(url_parsed.str(), "/");
     }
 
     bool compare_cleaned_url(const std::string& url1, const std::string& url2)
@@ -520,7 +520,7 @@ namespace mamba
         m_fragment = handle.get_part(CURLUPART_FRAGMENT).value_or("");
     }
 
-    auto URL::url(bool strip_scheme) -> std::string
+    auto URL::str(bool strip_scheme) const -> std::string
     {
         return concat(
             strip_scheme ? "" : m_scheme.c_str(),

--- a/libmamba/src/core/url.cpp
+++ b/libmamba/src/core/url.cpp
@@ -339,6 +339,15 @@ namespace mamba
         return !get_scheme(url).empty();
     }
 
+    auto has_drive_letter(std::string_view path) -> bool
+    {
+        static constexpr auto is_drive_char = [](char c) -> bool { return is_alphanum(c); };
+
+        auto [drive, rest] = lstrip_if_parts(path, is_drive_char);
+        return !drive.empty() && (rest.size() >= 2) && (rest[0] == ':')
+               && ((rest[1] == '/') || (rest[1] == '\\'));
+    }
+
     void split_anaconda_token(const std::string& url, std::string& cleaned_url, std::string& token)
     {
         auto token_begin = std::sregex_iterator(url.begin(), url.end(), Context::instance().token_regex);

--- a/libmamba/src/core/url.cpp
+++ b/libmamba/src/core/url.cpp
@@ -573,10 +573,6 @@ namespace mamba
 
     URL& URL::set_user(std::string_view user)
     {
-        if (user.empty())
-        {
-            m_password = "";
-        }
         m_user = user;
         return *this;
     }
@@ -588,10 +584,6 @@ namespace mamba
 
     URL& URL::set_password(std::string_view password)
     {
-        if (!password.empty() && m_user.empty())
-        {
-            throw std::invalid_argument("Cannot set password without user");
-        }
         m_password = password;
         return *this;
     }

--- a/libmamba/src/core/url.cpp
+++ b/libmamba/src/core/url.cpp
@@ -317,7 +317,7 @@ namespace mamba
         cleaned_url = util::rstrip(cleaned_url, "/");
     }
 
-    auto get_scheme(std::string_view url) -> std::string_view
+    auto url_get_scheme(std::string_view url) -> std::string_view
     {
         static constexpr auto is_scheme_char = [](char c) -> bool
         { return is_alphanum(c) || (c == '.') || (c == '-') || (c == '_'); };
@@ -334,12 +334,12 @@ namespace mamba
         return "";
     }
 
-    auto has_scheme(std::string_view url) -> bool
+    auto url_has_scheme(std::string_view url) -> bool
     {
-        return !get_scheme(url).empty();
+        return !url_get_scheme(url).empty();
     }
 
-    auto has_drive_letter(std::string_view path) -> bool
+    auto path_has_drive_letter(std::string_view path) -> bool
     {
         static constexpr auto is_drive_char = [](char c) -> bool { return is_alphanum(c); };
 
@@ -542,7 +542,7 @@ namespace mamba
         if (opt == SchemeOpt::remove_if_present)
         {
         }
-        else if (auto scheme = get_scheme(url); !scheme.empty())
+        else if (auto scheme = url_get_scheme(url); !scheme.empty())
         {
             out.set_scheme(scheme);
         }

--- a/libmamba/src/core/url.cpp
+++ b/libmamba/src/core/url.cpp
@@ -551,38 +551,6 @@ namespace mamba
         return out;
     }
 
-    auto URL::str(StripScheme strip) const -> std::string
-    {
-        // Not showing "localhost" on file URI
-        std::string_view computed_host = m_host;
-        if ((m_scheme == "file") && (m_host == localhost))
-        {
-            computed_host = "";
-        }
-        // When stripping file scheme, not showing leading '/' for Windows path with drive
-        std::string_view computed_path = m_path;
-        if ((m_scheme == "file") && (strip == StripScheme::yes) && computed_host.empty())
-        {
-            computed_path = pretty_path();
-        }
-        return concat(
-            (strip == StripScheme::no) ? m_scheme : "",
-            (strip == StripScheme::no) ? "://" : "",
-            m_user,
-            m_password.empty() ? "" : ":",
-            m_password,
-            m_user.empty() ? "" : "@",
-            computed_host,
-            m_port.empty() ? "" : ":",
-            m_port,
-            computed_path,
-            m_query.empty() ? "" : "?",
-            m_query,
-            m_fragment.empty() ? "" : "#",
-            m_fragment
-        );
-    }
-
     auto URL::scheme() const -> const std::string&
     {
         return m_scheme;
@@ -628,13 +596,6 @@ namespace mamba
         return m_fragment;
     }
 
-    auto URL::authentication() const -> std::string
-    {
-        const auto& u = user();
-        const auto& p = password();
-        return p.empty() ? u : concat(u, ':', p);
-    }
-
     auto URL::user() const -> const std::string&
     {
         return m_user;
@@ -643,6 +604,58 @@ namespace mamba
     auto URL::password() const -> const std::string&
     {
         return m_password;
+    }
+
+    auto URL::authentication() const -> std::string
+    {
+        const auto& u = user();
+        const auto& p = password();
+        return p.empty() ? u : concat(u, ':', p);
+    }
+
+    auto URL::str(StripScheme strip) const -> std::string
+    {
+        // Not showing "localhost" on file URI
+        std::string_view computed_host = m_host;
+        if ((m_scheme == "file") && (m_host == localhost))
+        {
+            computed_host = "";
+        }
+        // When stripping file scheme, not showing leading '/' for Windows path with drive
+        std::string_view computed_path = m_path;
+        if ((m_scheme == "file") && (strip == StripScheme::yes) && computed_host.empty())
+        {
+            computed_path = pretty_path();
+        }
+        return concat(
+            (strip == StripScheme::no) ? m_scheme : "",
+            (strip == StripScheme::no) ? "://" : "",
+            m_user,
+            m_password.empty() ? "" : ":",
+            m_password,
+            m_user.empty() ? "" : "@",
+            computed_host,
+            m_port.empty() ? "" : ":",
+            m_port,
+            computed_path,
+            m_query.empty() ? "" : "?",
+            m_query,
+            m_fragment.empty() ? "" : "#",
+            m_fragment
+        );
+    }
+
+    auto URL::authority() const -> std::string
+    {
+        return concat(
+            m_user,
+            m_password.empty() ? "" : ":",
+            m_password,
+            m_user.empty() ? "" : "@",
+            m_host,
+            m_port.empty() ? "" : ":",
+            m_port
+        );
     }
 
     URL& URL::set_scheme(std::string_view scheme)

--- a/libmamba/src/core/url.cpp
+++ b/libmamba/src/core/url.cpp
@@ -353,13 +353,13 @@ namespace mamba
     {
         std::string cleaned_url;
         split_anaconda_token(url, cleaned_url, token);
-        URLHandler handler(cleaned_url);
-        scheme = handler.scheme();
-        auth = handler.auth();
-        handler.set_scheme("");
-        handler.set_user("");
-        handler.set_password("");
-        remaining_url = util::rstrip(handler.url(), "/");
+        URL url_parsed(cleaned_url);
+        scheme = url_parsed.scheme();
+        auth = url_parsed.auth();
+        url_parsed.set_scheme("");
+        url_parsed.set_user("");
+        url_parsed.set_password("");
+        remaining_url = rstrip(url_parsed.url(), "/");
     }
 
     bool compare_cleaned_url(const std::string& url1, const std::string& url2)
@@ -507,7 +507,7 @@ namespace mamba
      * URLHandler implementation *
      *****************************/
 
-    URLHandler::URLHandler(std::string_view url)
+    URL::URL(std::string_view url)
     {
         const CURLUrl handle = { file_uri_unc2_to_unc4(url), CURLU_NON_SUPPORT_SCHEME };
         m_scheme = handle.get_part(CURLUPART_SCHEME).value_or("");
@@ -520,7 +520,7 @@ namespace mamba
         m_fragment = handle.get_part(CURLUPART_FRAGMENT).value_or("");
     }
 
-    auto URLHandler::url(bool strip_scheme) -> std::string
+    auto URL::url(bool strip_scheme) -> std::string
     {
         return concat(
             strip_scheme ? "" : m_scheme.c_str(),
@@ -540,96 +540,96 @@ namespace mamba
         );
     }
 
-    auto URLHandler::scheme() const -> const std::string&
+    auto URL::scheme() const -> const std::string&
     {
         return m_scheme;
     }
 
-    auto URLHandler::host() const -> const std::string&
+    auto URL::host() const -> const std::string&
     {
         return m_host;
     }
 
-    auto URLHandler::path() const -> const std::string&
+    auto URL::path() const -> const std::string&
     {
         return m_path;
     }
 
-    auto URLHandler::port() const -> const std::string&
+    auto URL::port() const -> const std::string&
     {
         return m_port;
     }
 
-    auto URLHandler::query() const -> const std::string&
+    auto URL::query() const -> const std::string&
     {
         return m_query;
     }
 
-    auto URLHandler::fragment() const -> const std::string&
+    auto URL::fragment() const -> const std::string&
     {
         return m_fragment;
     }
 
-    auto URLHandler::auth() const -> std::string
+    auto URL::auth() const -> std::string
     {
         const auto& u = user();
         const auto& p = password();
         return (p != "") ? concat(u, ':', p) : u;
     }
 
-    auto URLHandler::user() const -> const std::string&
+    auto URL::user() const -> const std::string&
     {
         return m_user;
     }
 
-    auto URLHandler::password() const -> const std::string&
+    auto URL::password() const -> const std::string&
     {
         return m_password;
     }
 
-    URLHandler& URLHandler::set_scheme(std::string_view scheme)
+    URL& URL::set_scheme(std::string_view scheme)
     {
         m_scheme = scheme;
         return *this;
     }
 
-    URLHandler& URLHandler::set_host(std::string_view host)
+    URL& URL::set_host(std::string_view host)
     {
         m_host = host;
         return *this;
     }
 
-    URLHandler& URLHandler::set_path(std::string_view path)
+    URL& URL::set_path(std::string_view path)
     {
         m_path = path;
         return *this;
     }
 
-    URLHandler& URLHandler::set_port(std::string_view port)
+    URL& URL::set_port(std::string_view port)
     {
         m_port = port;
         return *this;
     }
 
-    URLHandler& URLHandler::set_query(std::string_view query)
+    URL& URL::set_query(std::string_view query)
     {
         m_query = query;
         return *this;
     }
 
-    URLHandler& URLHandler::set_fragment(std::string_view fragment)
+    URL& URL::set_fragment(std::string_view fragment)
     {
         m_fragment = fragment;
         return *this;
     }
 
-    URLHandler& URLHandler::set_user(std::string_view user)
+    URL& URL::set_user(std::string_view user)
     {
         m_user = user;
         return *this;
     }
 
-    URLHandler& URLHandler::set_password(std::string_view password)
+    URL& URL::set_password(std::string_view password)
     {
         m_password = password;
         return *this;

--- a/libmamba/src/core/url.cpp
+++ b/libmamba/src/core/url.cpp
@@ -556,11 +556,28 @@ namespace mamba
         return out;
     }
 
-    auto URL::str(bool strip_scheme) const -> std::string
+    auto URL::str(SchemeOpt opt) const -> std::string
     {
+        std::string_view const computed_scheme = [&]() -> std::string_view
+        {
+            if (opt == SchemeOpt::remove_if_present)
+            {
+                return "";
+            }
+            if (!m_scheme.empty())
+            {
+                return m_scheme;
+            }
+            else if (opt == SchemeOpt::add_if_abscent)
+            {
+                return URL::default_scheme;
+            }
+            return "";
+        }();
+
         return concat(
-            strip_scheme ? "" : m_scheme.c_str(),
-            (m_scheme.empty() || strip_scheme) ? "" : "://",
+            computed_scheme,
+            computed_scheme.empty() ? "" : "://",
             m_user,
             m_password.empty() ? "" : ":",
             m_password,

--- a/libmamba/src/core/url.cpp
+++ b/libmamba/src/core/url.cpp
@@ -317,17 +317,26 @@ namespace mamba
         cleaned_url = util::rstrip(cleaned_url, "/");
     }
 
+    auto get_scheme(std::string_view url) -> std::string_view
+    {
+        static constexpr auto is_scheme_char = [](char c) -> bool
+        { return is_alphanum(c) || (c == '.') || (c == '-') || (c == '_'); };
+
+        const auto sep = url.find("://");
+        if ((0 < sep) && (sep < std::string_view::npos))
+        {
+            auto scheme = url.substr(0, sep);
+            if (std::all_of(scheme.cbegin(), scheme.cend(), is_scheme_char))
+            {
+                return scheme;
+            }
+        }
+        return "";
+    }
+
     auto has_scheme(std::string_view url) -> bool
     {
-        const auto sep = url.find("://");
-        if ((sep == std::string_view::npos) || (sep == 0))
-        {
-            return false;
-        }
-        auto scheme = url.substr(0, sep);
-        auto is_scheme_char = [](char c) -> bool
-        { return is_alphanum(c) || (c == '.') || (c == '-') || (c == '_'); };
-        return std::all_of(scheme.cbegin(), scheme.cend(), is_scheme_char);
+        return !get_scheme(url).empty();
     }
 
     void split_anaconda_token(const std::string& url, std::string& cleaned_url, std::string& token)

--- a/libmamba/src/core/util.cpp
+++ b/libmamba/src/core/util.cpp
@@ -49,12 +49,12 @@ extern "C"
 #include "mamba/core/output.hpp"
 #include "mamba/core/shell_init.hpp"
 #include "mamba/core/thread_utils.hpp"
-#include "mamba/core/url.hpp"
 #include "mamba/core/util.hpp"
 #include "mamba/core/util_os.hpp"
 #include "mamba/core/util_random.hpp"
 #include "mamba/util/compare.hpp"
 #include "mamba/util/string.hpp"
+#include "mamba/util/url.hpp"
 
 namespace mamba
 {
@@ -1554,7 +1554,7 @@ namespace mamba
             return std::nullopt;
         }
 
-        const auto url_parsed = URL::parse(url);
+        const auto url_parsed = util::URL::parse(url);
         auto scheme = url_parsed.scheme();
         auto host = url_parsed.host();
         std::vector<std::string> options;

--- a/libmamba/src/core/util.cpp
+++ b/libmamba/src/core/util.cpp
@@ -1554,9 +1554,9 @@ namespace mamba
             return std::nullopt;
         }
 
-        auto handler = URLHandler(url);
-        auto scheme = handler.scheme();
-        auto host = handler.host();
+        auto url_parsed = URL(url);
+        auto scheme = url_parsed.scheme();
+        auto host = url_parsed.host();
         std::vector<std::string> options;
 
         if (host.empty())

--- a/libmamba/src/core/util.cpp
+++ b/libmamba/src/core/util.cpp
@@ -1554,7 +1554,7 @@ namespace mamba
             return std::nullopt;
         }
 
-        auto url_parsed = URL(url);
+        const auto url_parsed = URL::parse(url);
         auto scheme = url_parsed.scheme();
         auto host = url_parsed.host();
         std::vector<std::string> options;

--- a/libmamba/src/core/validate.cpp
+++ b/libmamba/src/core/validate.cpp
@@ -1441,7 +1441,7 @@ namespace mamba::validation
             auto tmp_dir = std::make_unique<mamba::TemporaryDirectory>();
             auto tmp_metadata_path = tmp_dir->path() / "key_mgr.json";
 
-            mamba::URL url(base_url + "/key_mgr.json");
+            const auto url = mamba::URL::parse(base_url + "/key_mgr.json");
 
             auto dl_target = std::make_unique<mamba::DownloadTarget>(
                 "key_mgr.json",
@@ -1604,7 +1604,7 @@ namespace mamba::validation
             auto tmp_dir = std::make_unique<mamba::TemporaryDirectory>();
             auto tmp_metadata_path = tmp_dir->path() / "pkg_mgr.json";
 
-            mamba::URL url(base_url + "/pkg_mgr.json");
+            const auto url = mamba::URL::parse(base_url + "/pkg_mgr.json");
 
             auto dl_target = std::make_unique<mamba::DownloadTarget>(
                 "pkg_mgr.json",

--- a/libmamba/src/core/validate.cpp
+++ b/libmamba/src/core/validate.cpp
@@ -1445,7 +1445,7 @@ namespace mamba::validation
 
             auto dl_target = std::make_unique<mamba::DownloadTarget>(
                 "key_mgr.json",
-                url.url(),
+                url.str(),
                 tmp_metadata_path.string()
             );
 
@@ -1608,7 +1608,7 @@ namespace mamba::validation
 
             auto dl_target = std::make_unique<mamba::DownloadTarget>(
                 "pkg_mgr.json",
-                url.url(),
+                url.str(),
                 tmp_metadata_path.string()
             );
 

--- a/libmamba/src/core/validate.cpp
+++ b/libmamba/src/core/validate.cpp
@@ -15,9 +15,9 @@
 
 #include "mamba/core/fetch.hpp"
 #include "mamba/core/output.hpp"
-#include "mamba/core/url.hpp"
 #include "mamba/core/validate.hpp"
 #include "mamba/util/string.hpp"
+#include "mamba/util/url.hpp"
 
 namespace mamba
 {
@@ -1441,7 +1441,7 @@ namespace mamba::validation
             auto tmp_dir = std::make_unique<mamba::TemporaryDirectory>();
             auto tmp_metadata_path = tmp_dir->path() / "key_mgr.json";
 
-            const auto url = mamba::URL::parse(base_url + "/key_mgr.json");
+            const auto url = mamba::util::URL::parse(base_url + "/key_mgr.json");
 
             auto dl_target = std::make_unique<mamba::DownloadTarget>(
                 "key_mgr.json",
@@ -1604,7 +1604,7 @@ namespace mamba::validation
             auto tmp_dir = std::make_unique<mamba::TemporaryDirectory>();
             auto tmp_metadata_path = tmp_dir->path() / "pkg_mgr.json";
 
-            const auto url = mamba::URL::parse(base_url + "/pkg_mgr.json");
+            const auto url = mamba::util::URL::parse(base_url + "/pkg_mgr.json");
 
             auto dl_target = std::make_unique<mamba::DownloadTarget>(
                 "pkg_mgr.json",

--- a/libmamba/src/core/validate.cpp
+++ b/libmamba/src/core/validate.cpp
@@ -1441,7 +1441,7 @@ namespace mamba::validation
             auto tmp_dir = std::make_unique<mamba::TemporaryDirectory>();
             auto tmp_metadata_path = tmp_dir->path() / "key_mgr.json";
 
-            mamba::URLHandler url(base_url + "/key_mgr.json");
+            mamba::URL url(base_url + "/key_mgr.json");
 
             auto dl_target = std::make_unique<mamba::DownloadTarget>(
                 "key_mgr.json",
@@ -1604,7 +1604,7 @@ namespace mamba::validation
             auto tmp_dir = std::make_unique<mamba::TemporaryDirectory>();
             auto tmp_metadata_path = tmp_dir->path() / "pkg_mgr.json";
 
-            mamba::URLHandler url(base_url + "/pkg_mgr.json");
+            mamba::URL url(base_url + "/pkg_mgr.json");
 
             auto dl_target = std::make_unique<mamba::DownloadTarget>(
                 "pkg_mgr.json",

--- a/libmamba/src/util/string.cpp
+++ b/libmamba/src/util/string.cpp
@@ -260,15 +260,55 @@ namespace mamba::util
         return (!str.empty()) && (str.front() == c);
     }
 
-    /*********************************************
-     *  Implementation of starts_with functions  *
-     *********************************************/
+    /*************************************************
+     *  Implementation of starts_with any functions  *
+     *************************************************/
 
     template bool any_starts_with(const std::vector<std::string>&, std::string_view);
     template bool any_starts_with(const std::vector<std::string_view>&, std::string_view);
 
     template bool starts_with_any(std::string_view, const std::vector<std::string>&);
     template bool starts_with_any(std::string_view, const std::vector<std::string_view>&);
+
+    /******************************************************
+     *  Implementation of remove prefix/suffix functions  *
+     ******************************************************/
+
+    std::string_view remove_prefix(std::string_view str, std::string_view prefix)
+    {
+        if (starts_with(str, prefix))
+        {
+            return str.substr(prefix.size());
+        }
+        return str;
+    }
+
+    std::string_view remove_prefix(std::string_view str, std::string_view::value_type c)
+    {
+        if (starts_with(str, c))
+        {
+            return str.substr(1);
+        }
+        return str;
+    }
+
+    std::string_view remove_suffix(std::string_view str, std::string_view suffix)
+    {
+        if (ends_with(str, suffix))
+        {
+            return str.substr(0, str.size() - suffix.size());
+        }
+        return str;
+    }
+
+    std::string_view remove_suffix(std::string_view str, std::string_view::value_type c)
+    {
+        if (ends_with(str, c))
+        {
+            return str.substr(0, str.size() - 1);
+        }
+        return str;
+    }
 
     /***************************************
      *  Implementation of strip functions  *

--- a/libmamba/src/util/url.cpp
+++ b/libmamba/src/util/url.cpp
@@ -27,38 +27,6 @@ namespace mamba::util
     namespace
     {
         /**
-         * A RAII ``CURL*`` created from ``curl_easy_handle``.
-         *
-         * Never null, throw exception at construction if creating the handle fails.
-         * This wrapper is not meant to handle more cases, it remains an implementation detail
-         * for url parsing, which we should ideally do without Curl.
-         * This differs from ``CURLHanlde`` in "curl.hpp" which is a fully-featured CURL wrapper
-         * for accessing the internet.
-         */
-        class CURLEasyHandle
-        {
-        public:
-
-            using value_type = ::CURL;
-            using pointer = value_type*;
-            using const_pointer = const value_type*;
-
-            CURLEasyHandle();
-            ~CURLEasyHandle();
-
-            CURLEasyHandle(const CURLEasyHandle&) = delete;
-            CURLEasyHandle& operator=(const CURLEasyHandle&) = delete;
-            CURLEasyHandle(CURLEasyHandle&&) = delete;
-            CURLEasyHandle& operator=(CURLEasyHandle&&) = delete;
-
-            [[nodiscard]] auto raw() -> pointer;
-
-        private:
-
-            pointer m_handle = nullptr;
-        };
-
-        /**
          * A RAII ``CURLU*`` created from ``curl_url``.
          *
          * Never null, throw exception at construction if creating the handle fails.
@@ -76,10 +44,10 @@ namespace mamba::util
             CURLUrl(const std::string& url, flag_type flags = 0);
             ~CURLUrl();
 
-            CURLUrl(const CURLEasyHandle&) = delete;
-            CURLUrl& operator=(const CURLEasyHandle&) = delete;
-            CURLUrl(CURLEasyHandle&&) = delete;
-            CURLUrl& operator=(CURLEasyHandle&&) = delete;
+            CURLUrl(const CURLUrl&) = delete;
+            CURLUrl& operator=(const CURLUrl&) = delete;
+            CURLUrl(CURLUrl&&) = delete;
+            CURLUrl& operator=(CURLUrl&&) = delete;
 
             [[nodiscard]] auto get_part(CURLUPart part, flag_type flags = 0) const
                 -> std::optional<std::string>;
@@ -124,25 +92,6 @@ namespace mamba::util
             // Only meaningful when > 0, otherwise, assume null terminated string
             size_type m_len = { -1 };
         };
-
-        CURLEasyHandle::CURLEasyHandle()
-        {
-            m_handle = ::curl_easy_init();
-            if (m_handle == nullptr)
-            {
-                throw std::runtime_error("Could not create CURL handle");
-            }
-        }
-
-        CURLEasyHandle::~CURLEasyHandle()
-        {
-            ::curl_easy_cleanup(m_handle);
-        }
-
-        auto CURLEasyHandle::raw() -> pointer
-        {
-            return m_handle;
-        }
 
         CURLUrl::CURLUrl()
         {

--- a/libmamba/src/util/url.cpp
+++ b/libmamba/src/util/url.cpp
@@ -180,7 +180,7 @@ namespace mamba::util
             };
             out.set_scheme(handle.get_part(CURLUPART_SCHEME).value_or(std::string(URL::https)))
                 .set_user(handle.get_part(CURLUPART_USER).value_or(""), Encode::no)
-                .set_password(handle.get_part(CURLUPART_PASSWORD).value_or(""))
+                .set_password(handle.get_part(CURLUPART_PASSWORD).value_or(""), Encode::no)
                 .set_host(handle.get_part(CURLUPART_HOST).value_or(std::string(URL::localhost)))
                 .set_path(handle.get_part(CURLUPART_PATH).value_or("/"))
                 .set_port(handle.get_part(CURLUPART_PORT).value_or(""))
@@ -228,14 +228,26 @@ namespace mamba::util
         return *this;
     }
 
-    auto URL::password() const -> const std::string&
+    auto URL::password(Decode::no_type) const -> const std::string&
     {
         return m_password;
     }
 
-    auto URL::set_password(std::string_view password) -> URL&
+    auto URL::password(Decode::yes_type) const -> std::string
     {
-        m_password = password;
+        return url_decode(m_password);
+    }
+
+    auto URL::set_password(std::string_view password, Encode encode) -> URL&
+    {
+        if (encode == Encode::yes)
+        {
+            m_password = url_encode(password);
+        }
+        else
+        {
+            m_password = password;
+        }
         return *this;
     }
 

--- a/libmamba/src/util/url.cpp
+++ b/libmamba/src/util/url.cpp
@@ -231,7 +231,7 @@ namespace mamba::util
         return m_scheme;
     }
 
-    URL& URL::set_scheme(std::string_view scheme)
+    auto URL::set_scheme(std::string_view scheme) -> URL&
     {
         if (scheme.empty())
         {
@@ -246,7 +246,7 @@ namespace mamba::util
         return m_user;
     }
 
-    URL& URL::set_user(std::string_view user)
+    auto URL::set_user(std::string_view user) -> URL&
     {
         m_user = user;
         return *this;
@@ -257,7 +257,7 @@ namespace mamba::util
         return m_password;
     }
 
-    URL& URL::set_password(std::string_view password)
+    auto URL::set_password(std::string_view password) -> URL&
     {
         m_password = password;
         return *this;
@@ -275,7 +275,7 @@ namespace mamba::util
         return m_host;
     }
 
-    URL& URL::set_host(std::string_view host)
+    auto URL::set_host(std::string_view host) -> URL&
     {
         if (host.empty())
         {
@@ -290,7 +290,7 @@ namespace mamba::util
         return m_port;
     }
 
-    URL& URL::set_port(std::string_view port)
+    auto URL::set_port(std::string_view port) -> URL&
     {
         if (!std::all_of(port.cbegin(), port.cend(), [](char c) { return util::is_digit(c); }))
         {
@@ -333,7 +333,7 @@ namespace mamba::util
         return m_path;
     }
 
-    URL& URL::set_path(std::string_view path)
+    auto URL::set_path(std::string_view path) -> URL&
     {
         if (!util::starts_with(path, '/'))
         {
@@ -348,12 +348,30 @@ namespace mamba::util
         return *this;
     }
 
+    auto URL::append_path(std::string_view subpath) -> URL&
+    {
+        subpath = util::strip(subpath);
+        m_path.reserve(m_path.size() + 1 + subpath.size());
+        const bool trailing = util::ends_with(m_path, '/');
+        const bool leading = util::starts_with(subpath, '/');
+        if (!trailing && !leading && !subpath.empty())
+        {
+            m_path += '/';
+        }
+        if (trailing && leading)
+        {
+            m_path.pop_back();
+        }
+        m_path += subpath;
+        return *this;
+    }
+
     auto URL::query() const -> const std::string&
     {
         return m_query;
     }
 
-    URL& URL::set_query(std::string_view query)
+    auto URL::set_query(std::string_view query) -> URL&
     {
         m_query = query;
         return *this;
@@ -364,7 +382,7 @@ namespace mamba::util
         return m_fragment;
     }
 
-    URL& URL::set_fragment(std::string_view fragment)
+    auto URL::set_fragment(std::string_view fragment) -> URL&
     {
         m_fragment = fragment;
         return *this;
@@ -416,6 +434,17 @@ namespace mamba::util
     auto operator!=(URL const& a, URL const& b) -> bool
     {
         return !(a == b);
+    }
+
+    auto operator/(URL const& url, std::string_view subpath) -> URL
+    {
+        return URL(url) / subpath;
+    }
+
+    auto operator/(URL&& url, std::string_view subpath) -> URL
+    {
+        url.append_path(subpath);
+        return URL(std::move(url));
     }
 
 }  // namespace mamba

--- a/libmamba/src/util/url.cpp
+++ b/libmamba/src/util/url.cpp
@@ -390,7 +390,8 @@ namespace mamba::util
         return *this;
     }
 
-    auto URL::str(StripScheme strip) const -> std::string
+    auto URL::str(StripScheme strip_scheme, char rstrip_path, HidePassword hide_password) const
+        -> std::string
     {
         // Not showing "localhost" on file URI
         std::string_view computed_host = m_host;
@@ -400,16 +401,17 @@ namespace mamba::util
         }
         // When stripping file scheme, not showing leading '/' for Windows path with drive
         std::string_view computed_path = m_path;
-        if ((m_scheme == "file") && (strip == StripScheme::yes) && computed_host.empty())
+        if ((m_scheme == "file") && (strip_scheme == StripScheme::yes) && computed_host.empty())
         {
             computed_path = pretty_path();
         }
+        computed_path = util::rstrip(computed_path, rstrip_path);
         return util::concat(
-            (strip == StripScheme::no) ? m_scheme : "",
-            (strip == StripScheme::no) ? "://" : "",
+            (strip_scheme == StripScheme::no) ? m_scheme : "",
+            (strip_scheme == StripScheme::no) ? "://" : "",
             m_user,
             m_password.empty() ? "" : ":",
-            m_password,
+            (hide_password == HidePassword::no) ? m_password : "*****",
             m_user.empty() ? "" : "@",
             computed_host,
             m_port.empty() ? "" : ":",

--- a/libmamba/src/util/url.cpp
+++ b/libmamba/src/util/url.cpp
@@ -258,18 +258,32 @@ namespace mamba::util
         return p.empty() ? u : util::concat(u, ':', p);
     }
 
-    auto URL::host() const -> const std::string&
+    auto URL::host(Decode::no_type) const -> const std::string&
     {
         return m_host;
     }
 
-    auto URL::set_host(std::string_view host) -> URL&
+    auto URL::host(Decode::yes_type) const -> std::string
     {
-        if (host.empty())
+        return url_decode(m_host);
+    }
+
+    auto URL::set_host(std::string_view host, Encode encode) -> URL&
+    {
+        std::string new_host = {};
+        if (encode == Encode::yes)
+        {
+            new_host = url_encode(host);
+        }
+        else
+        {
+            new_host = util::strip(host);  // spaces are illegal if not encoded
+        }
+        if (new_host.empty())
         {
             throw std::invalid_argument("Cannot set empty host");
         }
-        m_host = util::to_lower(util::rstrip(host));
+        m_host = util::to_lower(new_host);
         return *this;
     }
 

--- a/libmamba/src/util/url.cpp
+++ b/libmamba/src/util/url.cpp
@@ -1,25 +1,23 @@
-// Copyright (c) 2019, QuantStack and Mamba Contributors
+// Copyright (c) 2023, QuantStack and Mamba Contributors
 //
 // Distributed under the terms of the BSD 3-Clause License.
 //
 // The full license is in the file LICENSE, distributed with this software.
 
+#include <cassert>
 #include <optional>
-#include <regex>
 #include <stdexcept>
 #include <string>
 #include <string_view>
 
 #include <curl/urlapi.h>
 #include <fmt/format.h>
-#include <openssl/evp.h>
 
-#include "mamba/core/context.hpp"
-#include "mamba/core/url.hpp"
-#include "mamba/core/util.hpp"
 #include "mamba/util/string.hpp"
+#include "mamba/util/url.hpp"
+#include "mamba/util/url_manip.hpp"
 
-namespace mamba
+namespace mamba::util
 {
 
     /*******************
@@ -228,253 +226,9 @@ namespace mamba
         }
     }
 
-    /*********************
-     * Utility functions *
-     *********************/
-
-    // proper file scheme on Windows is `file:///C:/blabla`
-    // https://blogs.msdn.microsoft.com/ie/2006/12/06/file-uris-in-windows/
-    std::string concat_scheme_url(const std::string& scheme, const std::string& location)
-    {
-        if (scheme == "file" && location.size() > 1 && location[1] == ':')
-        {
-            return util::concat("file:///", location);
-        }
-        else
-        {
-            return util::concat(scheme, "://", location);
-        }
-    }
-
-    std::string build_url(
-        const std::optional<std::string>& auth,
-        const std::string& scheme,
-        const std::string& base,
-        bool with_credential
-    )
-    {
-        if (with_credential && auth)
-        {
-            return concat_scheme_url(scheme, util::concat(*auth, "@", base));
-        }
-        else
-        {
-            return concat_scheme_url(scheme, base);
-        }
-    }
-
-    void split_platform(
-        const std::vector<std::string>& known_platforms,
-        const std::string& url,
-        const std::string& context_platform,
-        std::string& cleaned_url,
-        std::string& platform
-    )
-    {
-        platform = "";
-
-        auto check_platform_position = [&url](std::size_t pos, const std::string& lplatform) -> bool
-        {
-            if (pos == std::string::npos)
-            {
-                return false;
-            }
-            if (pos > 0 && url[pos - 1] != '/')
-            {
-                return false;
-            }
-            if ((pos + lplatform.size()) < url.size() && url[pos + lplatform.size()] != '/')
-            {
-                return false;
-            }
-
-            return true;
-        };
-
-        std::size_t pos = url.find(context_platform);
-        if (check_platform_position(pos, context_platform))
-        {
-            platform = context_platform;
-        }
-        else
-        {
-            for (auto it = known_platforms.begin(); it != known_platforms.end(); ++it)
-            {
-                pos = url.find(*it);
-                if (check_platform_position(pos, *it))
-                {
-                    platform = *it;
-                    break;
-                }
-            }
-        }
-
-        cleaned_url = url;
-        if (pos != std::string::npos)
-        {
-            cleaned_url.replace(pos - 1, platform.size() + 1, "");
-        }
-        cleaned_url = util::rstrip(cleaned_url, "/");
-    }
-
-    auto url_get_scheme(std::string_view url) -> std::string_view
-    {
-        static constexpr auto is_scheme_char = [](char c) -> bool
-        { return util::is_alphanum(c) || (c == '.') || (c == '-') || (c == '_'); };
-
-        const auto sep = url.find("://");
-        if ((0 < sep) && (sep < std::string_view::npos))
-        {
-            auto scheme = url.substr(0, sep);
-            if (std::all_of(scheme.cbegin(), scheme.cend(), is_scheme_char))
-            {
-                return scheme;
-            }
-        }
-        return "";
-    }
-
-    auto url_has_scheme(std::string_view url) -> bool
-    {
-        return !url_get_scheme(url).empty();
-    }
-
-    auto path_has_drive_letter(std::string_view path) -> bool
-    {
-        static constexpr auto is_drive_char = [](char c) -> bool { return util::is_alphanum(c); };
-
-        auto [drive, rest] = util::lstrip_if_parts(path, is_drive_char);
-        return !drive.empty() && (rest.size() >= 2) && (rest[0] == ':')
-               && ((rest[1] == '/') || (rest[1] == '\\'));
-    }
-
-    void split_anaconda_token(const std::string& url, std::string& cleaned_url, std::string& token)
-    {
-        auto token_begin = std::sregex_iterator(url.begin(), url.end(), Context::instance().token_regex);
-        if (token_begin != std::sregex_iterator())
-        {
-            token = token_begin->str().substr(3u);
-            cleaned_url = std::regex_replace(
-                url,
-                Context::instance().token_regex,
-                "",
-                std::regex_constants::format_first_only
-            );
-        }
-        else
-        {
-            token = "";
-            cleaned_url = url;
-        }
-        cleaned_url = util::rstrip(cleaned_url, "/");
-    }
-
-    void split_scheme_auth_token(
-        const std::string& url,
-        std::string& remaining_url,
-        std::string& scheme,
-        std::string& auth,
-        std::string& token
-    )
-    {
-        std::string cleaned_url;
-        split_anaconda_token(url, cleaned_url, token);
-        URL url_parsed = URL::parse(cleaned_url);
-        scheme = url_parsed.scheme();
-        auth = url_parsed.authentication();
-        url_parsed.set_user("");
-        url_parsed.set_password("");
-        remaining_url = util::rstrip(url_parsed.str(URL::StripScheme::yes), '/');
-    }
-
-    bool compare_cleaned_url(const std::string& url1, const std::string& url2)
-    {
-        std::string u1_remaining, u1_scheme, u1_auth, u1_token;
-        std::string u2_remaining, u2_scheme, u2_auth, u2_token;
-        split_scheme_auth_token(url1, u1_remaining, u1_scheme, u1_auth, u1_token);
-        split_scheme_auth_token(url2, u2_remaining, u2_scheme, u2_auth, u2_token);
-        return u1_remaining == u2_remaining;
-    }
-
-    bool is_path(const std::string& input)
-    {
-        static const std::regex re(R"(\./|\.\.|~|/|[a-zA-Z]:[/\\]|\\\\|//)");
-        std::smatch sm;
-        std::regex_search(input, sm, re);
-        return !sm.empty() && sm.position(0) == 0 && input.find("://") == std::string::npos;
-    }
-
-    std::string path_to_url(const std::string& path)
-    {
-        static constexpr std::string_view file_scheme = "file://";
-        if (util::starts_with(path, file_scheme))
-        {
-            return path;
-        }
-
-        fs::u8path tmp_path = fs::u8path(path);
-        std::string abs_path = fs::absolute(tmp_path).string();
-
-        // TODO: handle percent encoding
-        // https://blogs.msdn.microsoft.com/ie/2006/12/06/file-uris-in-windows/
-        if (on_win)
-        {
-            util::replace_all(abs_path, "\\", "/");
-        }
-        return util::concat(file_scheme, abs_path);
-    }
-
-    std::string file_uri_unc2_to_unc4(std::string_view uri)
-    {
-        static constexpr std::string_view file_scheme = "file:";
-
-        // Not "file:" scheme
-        if (!util::starts_with(uri, file_scheme))
-        {
-            return std::string(uri);
-        }
-
-        // No hostname set in "file://hostname/path/to/data.xml"
-        auto [slashes, rest] = util::lstrip_parts(util::remove_prefix(uri, file_scheme), '/');
-        if (slashes.size() != 2)
-        {
-            return std::string(uri);
-        }
-
-        const auto s_idx = rest.find('/');
-        const auto c_idx = rest.find(':');
-
-        // ':' found before '/', a Windows drive is specified in "file://C:/path/to/data.xml" (not
-        // really URI compliant, they should have "file:///" or "file:/"). Otherwise no path in
-        // "file://hostname", also not URI compliant.
-        if (c_idx < s_idx)
-        {
-            return std::string(uri);
-        }
-
-        const auto hostname = rest.substr(0, s_idx);
-
-        // '\' are used as path separator in "file://\\hostname\path\to\data.xml" (also not RFC
-        // compliant)
-        if (util::starts_with(hostname, R"(\\)"))
-        {
-            return std::string(uri);
-        }
-
-        // Things that means localhost are kept for some reason in ``url_to_path``
-        // in ``conda.common.path``
-        if ((hostname == "localhost") || (hostname == "127.0.0.1") || (hostname == "::1"))
-        {
-            return std::string(uri);
-        }
-
-        return util::concat("file:////", rest);
-    }
-
     std::string encode_url(const std::string& url)
     {
-        CURLEasyHandle curl = {};
-        auto output = CURLStr(curl_easy_escape(curl.raw(), url.c_str(), static_cast<int>(url.size())));
+        auto output = CURLStr(curl_easy_escape(nullptr, url.c_str(), static_cast<int>(url.size())));
         if (auto str = output.str())
         {
             return std::string(*str);
@@ -484,14 +238,8 @@ namespace mamba
 
     std::string decode_url(const std::string& url)
     {
-        CURLEasyHandle curl = {};
         int out_length;
-        char* output = curl_easy_unescape(
-            curl.raw(),
-            url.c_str(),
-            static_cast<int>(url.size()),
-            &out_length
-        );
+        char* output = curl_easy_unescape(nullptr, url.c_str(), static_cast<int>(url.size()), &out_length);
         auto curl_str = CURLStr(output, out_length);
         if (auto str = curl_str.str())
         {
@@ -500,33 +248,6 @@ namespace mamba
         throw std::runtime_error("Could not url-unescape string.");
     }
 
-    std::string cache_name_from_url(const std::string& url)
-    {
-        std::string u = url;
-        if (u.empty() || (u.back() != '/' && !util::ends_with(u, ".json")))
-        {
-            u += '/';
-        }
-
-        // mimicking conda's behavior by special handling repodata.json
-        // todo support .zst
-        if (util::ends_with(u, "/repodata.json"))
-        {
-            u = u.substr(0, u.size() - 13);
-        }
-
-        unsigned char hash[16];
-
-        EVP_MD_CTX* mdctx;
-        mdctx = EVP_MD_CTX_create();
-        EVP_DigestInit_ex(mdctx, EVP_md5(), nullptr);
-        EVP_DigestUpdate(mdctx, u.c_str(), u.size());
-        EVP_DigestFinal_ex(mdctx, hash, nullptr);
-        EVP_MD_CTX_destroy(mdctx);
-
-        std::string hex_digest = util::hex_string(hash, 16);
-        return hex_digest.substr(0u, 8u);
-    }
 
     /*****************************
      * URLHandler implementation *

--- a/libmamba/src/util/url.cpp
+++ b/libmamba/src/util/url.cpp
@@ -253,8 +253,8 @@ namespace mamba::util
 
     auto URL::authentication() const -> std::string
     {
-        const auto& u = user();
-        const auto& p = password();
+        const auto& u = user(Decode::no);
+        const auto& p = password(Decode::no);
         return p.empty() ? u : util::concat(u, ':', p);
     }
 
@@ -304,12 +304,15 @@ namespace mamba::util
 
     auto URL::authority() const -> std::string
     {
+        const auto& l_user = user(Decode::no);
+        const auto& l_pass = password(Decode::no);
+        const auto& l_host = host(Decode::no);
         return util::concat(
-            m_user,
-            m_password.empty() ? "" : ":",
-            m_password,
-            m_user.empty() ? "" : "@",
-            m_host,
+            l_user,
+            l_pass.empty() ? "" : ":",
+            l_pass,
+            l_user.empty() ? "" : "@",
+            l_host,
             m_port.empty() ? "" : ":",
             m_port
         );

--- a/libmamba/src/util/url.cpp
+++ b/libmamba/src/util/url.cpp
@@ -204,20 +204,25 @@ namespace mamba::util
 
     auto URL::parse(std::string_view url) -> URL
     {
+        url = util::rstrip(url);
         auto out = URL();
-        // CURL fails to parse the URL if no scheme is given, unless CURLU_DEFAULT_SCHEME is given
-        const CURLUrl handle = {
-            file_uri_unc2_to_unc4(url),
-            CURLU_NON_SUPPORT_SCHEME | CURLU_DEFAULT_SCHEME,
-        };
-        out.set_scheme(handle.get_part(CURLUPART_SCHEME).value_or(std::string(URL::https)))
-            .set_user(handle.get_part(CURLUPART_USER).value_or(""))
-            .set_password(handle.get_part(CURLUPART_PASSWORD).value_or(""))
-            .set_host(handle.get_part(CURLUPART_HOST).value_or(std::string(URL::localhost)))
-            .set_path(handle.get_part(CURLUPART_PATH).value_or("/"))
-            .set_port(handle.get_part(CURLUPART_PORT).value_or(""))
-            .set_query(handle.get_part(CURLUPART_QUERY).value_or(""))
-            .set_fragment(handle.get_part(CURLUPART_FRAGMENT).value_or(""));
+        if (!url.empty())
+        {
+            // CURL fails to parse the URL if no scheme is given, unless CURLU_DEFAULT_SCHEME is
+            // given
+            const CURLUrl handle = {
+                file_uri_unc2_to_unc4(url),
+                CURLU_NON_SUPPORT_SCHEME | CURLU_DEFAULT_SCHEME,
+            };
+            out.set_scheme(handle.get_part(CURLUPART_SCHEME).value_or(std::string(URL::https)))
+                .set_user(handle.get_part(CURLUPART_USER).value_or(""))
+                .set_password(handle.get_part(CURLUPART_PASSWORD).value_or(""))
+                .set_host(handle.get_part(CURLUPART_HOST).value_or(std::string(URL::localhost)))
+                .set_path(handle.get_part(CURLUPART_PATH).value_or("/"))
+                .set_port(handle.get_part(CURLUPART_PORT).value_or(""))
+                .set_query(handle.get_part(CURLUPART_QUERY).value_or(""))
+                .set_fragment(handle.get_part(CURLUPART_FRAGMENT).value_or(""));
+        }
         return out;
     }
 
@@ -396,4 +401,21 @@ namespace mamba::util
             m_fragment
         );
     }
+
+    auto operator==(URL const& a, URL const& b) -> bool
+    {
+        return (a.scheme() == b.scheme())
+               && (a.user() == b.user())
+               // omitting password, is that desirable?
+               && (a.host() == b.host())
+               // Would it be desirable to account for default ports?
+               && (a.port() == b.port()) && (a.path() == b.path()) && (a.query() == b.query())
+               && (a.fragment() == b.fragment());
+    }
+
+    auto operator!=(URL const& a, URL const& b) -> bool
+    {
+        return !(a == b);
+    }
+
 }  // namespace mamba

--- a/libmamba/src/util/url.cpp
+++ b/libmamba/src/util/url.cpp
@@ -232,7 +232,7 @@ namespace mamba::util
         {
             throw std::invalid_argument("Cannot set empty scheme");
         }
-        m_scheme = scheme;
+        m_scheme = util::to_lower(util::rstrip(scheme));
         return *this;
     }
 
@@ -276,7 +276,7 @@ namespace mamba::util
         {
             throw std::invalid_argument("Cannot set empty host");
         }
-        m_host = host;
+        m_host = util::to_lower(util::rstrip(host));
         return *this;
     }
 
@@ -287,6 +287,10 @@ namespace mamba::util
 
     URL& URL::set_port(std::string_view port)
     {
+        if (!std::all_of(port.cbegin(), port.cend(), [](char c) { return util::is_digit(c); }))
+        {
+            throw std::invalid_argument(fmt::format(R"(Port must be a number, got "{}")", port));
+        }
         m_port = port;
         return *this;
     }

--- a/libmamba/src/util/url.cpp
+++ b/libmamba/src/util/url.cpp
@@ -179,7 +179,7 @@ namespace mamba::util
                 CURLU_NON_SUPPORT_SCHEME | CURLU_DEFAULT_SCHEME,
             };
             out.set_scheme(handle.get_part(CURLUPART_SCHEME).value_or(std::string(URL::https)))
-                .set_user(handle.get_part(CURLUPART_USER).value_or(""))
+                .set_user(handle.get_part(CURLUPART_USER).value_or(""), Encode::no)
                 .set_password(handle.get_part(CURLUPART_PASSWORD).value_or(""))
                 .set_host(handle.get_part(CURLUPART_HOST).value_or(std::string(URL::localhost)))
                 .set_path(handle.get_part(CURLUPART_PATH).value_or("/"))
@@ -205,14 +205,26 @@ namespace mamba::util
         return *this;
     }
 
-    auto URL::user() const -> const std::string&
+    auto URL::user(Decode::no_type) const -> const std::string&
     {
         return m_user;
     }
 
-    auto URL::set_user(std::string_view user) -> URL&
+    auto URL::user(Decode::yes_type) const -> std::string
     {
-        m_user = user;
+        return url_decode(m_user);
+    }
+
+    auto URL::set_user(std::string_view user, Encode encode) -> URL&
+    {
+        if (encode == Encode::yes)
+        {
+            m_user = url_encode(user);
+        }
+        else
+        {
+            m_user = user;
+        }
         return *this;
     }
 

--- a/libmamba/src/util/url_manip.cpp
+++ b/libmamba/src/util/url_manip.cpp
@@ -4,6 +4,8 @@
 //
 // The full license is in the file LICENSE, distributed with this software.
 
+#include <array>
+#include <cassert>
 #include <optional>
 #include <regex>
 #include <stdexcept>
@@ -20,6 +22,93 @@
 
 namespace mamba::util
 {
+    namespace
+    {
+        auto url_is_unreserved_char(char c) -> bool
+        {
+            // https://github.com/curl/curl/blob/67e9e3cb1ea498cb94071dddb7653ab5169734b2/lib/escape.c#L45
+            return util::is_alphanum(c) || (c == '-') || (c == '.') || (c == '_') || (c == '~');
+        }
+
+        auto url_encode_char(char c) -> std::array<char, 3>
+        {
+            // https://github.com/curl/curl/blob/67e9e3cb1ea498cb94071dddb7653ab5169734b2/lib/escape.c#L107
+            static constexpr auto hex = std::array{
+                '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F',
+            };
+            return std::array{
+                '%',
+                hex[static_cast<unsigned char>(c) >> 4],
+                hex[c & 0xf],
+            };
+        }
+
+        auto url_is_hex_char(char c) -> bool
+        {
+            return util::is_digit(c) || (('A' <= c) && (c <= 'F')) || (('a' <= c) && (c <= 'f'));
+        }
+
+        auto url_decode_char(char d10, char d1) -> char
+        {
+            // https://github.com/curl/curl/blob/67e9e3cb1ea498cb94071dddb7653ab5169734b2/lib/escape.c#L147
+            // Offset from char '0', contains '0' padding for incomplete values.
+            static constexpr std::array<unsigned char, 55> hex_offset = {
+                0, 1,  2,  3,  4,  5,  6,  7, 8, 9, 0, 0, 0, 0, 0, 0, /* 0x30 - 0x3f */
+                0, 10, 11, 12, 13, 14, 15, 0, 0, 0, 0, 0, 0, 0, 0, 0, /* 0x40 - 0x4f */
+                0, 0,  0,  0,  0,  0,  0,  0, 0, 0, 0, 0, 0, 0, 0, 0, /* 0x50 - 0x5f */
+                0, 10, 11, 12, 13, 14, 15                             /* 0x60 - 0x66 */
+            };
+            assert('0' <= d10);
+            assert('0' <= d1);
+            unsigned char idx10 = static_cast<unsigned char>(d10 - '0');
+            unsigned char idx1 = static_cast<unsigned char>(d1 - '0');
+            assert(idx10 < hex_offset.size());
+            assert(idx1 < hex_offset.size());
+            return static_cast<char>((hex_offset[idx10] << 4) | hex_offset[idx1]);
+        }
+
+    }
+
+    auto url_encode(std::string_view url) -> std::string
+    {
+        std::string out = {};
+        out.reserve(url.size());
+        for (char c : url)
+        {
+            if (url_is_unreserved_char(c))
+            {
+                out += c;
+            }
+            else
+            {
+                const auto encoding = url_encode_char(c);
+                out += std::string_view(encoding.cbegin(), encoding.size());
+            }
+        }
+        return out;
+    }
+
+    auto url_decode(std::string_view url) -> std::string
+    {
+        std::string out = {};
+        out.reserve(url.size());
+        const auto end = url.cend();
+        for (auto iter = url.cbegin(); iter < end; ++iter)
+        {
+            if (((iter + 2) < end) && (iter[0] == '%') && url_is_hex_char(iter[1])
+                && url_is_hex_char(iter[2]))
+            {
+                out.push_back(url_decode_char(iter[1], iter[2]));
+                iter += 2;
+            }
+            else
+            {
+                out.push_back(*iter);
+            }
+        }
+        return out;
+    }
+
     // proper file scheme on Windows is `file:///C:/blabla`
     // https://blogs.msdn.microsoft.com/ie/2006/12/06/file-uris-in-windows/
     std::string concat_scheme_url(const std::string& scheme, const std::string& location)

--- a/libmamba/src/util/url_manip.cpp
+++ b/libmamba/src/util/url_manip.cpp
@@ -1,0 +1,289 @@
+// Copyright (c) 2023, QuantStack and Mamba Contributors
+//
+// Distributed under the terms of the BSD 3-Clause License.
+//
+// The full license is in the file LICENSE, distributed with this software.
+
+#include <optional>
+#include <regex>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+
+#include <fmt/format.h>
+#include <openssl/evp.h>
+
+#include "mamba/core/context.hpp"
+#include "mamba/core/util.hpp"
+#include "mamba/util/string.hpp"
+#include "mamba/util/url.hpp"
+
+namespace mamba::util
+{
+    // proper file scheme on Windows is `file:///C:/blabla`
+    // https://blogs.msdn.microsoft.com/ie/2006/12/06/file-uris-in-windows/
+    std::string concat_scheme_url(const std::string& scheme, const std::string& location)
+    {
+        if (scheme == "file" && location.size() > 1 && location[1] == ':')
+        {
+            return util::concat("file:///", location);
+        }
+        else
+        {
+            return util::concat(scheme, "://", location);
+        }
+    }
+
+    std::string build_url(
+        const std::optional<std::string>& auth,
+        const std::string& scheme,
+        const std::string& base,
+        bool with_credential
+    )
+    {
+        if (with_credential && auth)
+        {
+            return concat_scheme_url(scheme, util::concat(*auth, "@", base));
+        }
+        else
+        {
+            return concat_scheme_url(scheme, base);
+        }
+    }
+
+    void split_platform(
+        const std::vector<std::string>& known_platforms,
+        const std::string& url,
+        const std::string& context_platform,
+        std::string& cleaned_url,
+        std::string& platform
+    )
+    {
+        platform = "";
+
+        auto check_platform_position = [&url](std::size_t pos, const std::string& lplatform) -> bool
+        {
+            if (pos == std::string::npos)
+            {
+                return false;
+            }
+            if (pos > 0 && url[pos - 1] != '/')
+            {
+                return false;
+            }
+            if ((pos + lplatform.size()) < url.size() && url[pos + lplatform.size()] != '/')
+            {
+                return false;
+            }
+
+            return true;
+        };
+
+        std::size_t pos = url.find(context_platform);
+        if (check_platform_position(pos, context_platform))
+        {
+            platform = context_platform;
+        }
+        else
+        {
+            for (auto it = known_platforms.begin(); it != known_platforms.end(); ++it)
+            {
+                pos = url.find(*it);
+                if (check_platform_position(pos, *it))
+                {
+                    platform = *it;
+                    break;
+                }
+            }
+        }
+
+        cleaned_url = url;
+        if (pos != std::string::npos)
+        {
+            cleaned_url.replace(pos - 1, platform.size() + 1, "");
+        }
+        cleaned_url = util::rstrip(cleaned_url, "/");
+    }
+
+    auto url_get_scheme(std::string_view url) -> std::string_view
+    {
+        static constexpr auto is_scheme_char = [](char c) -> bool
+        { return util::is_alphanum(c) || (c == '.') || (c == '-') || (c == '_'); };
+
+        const auto sep = url.find("://");
+        if ((0 < sep) && (sep < std::string_view::npos))
+        {
+            auto scheme = url.substr(0, sep);
+            if (std::all_of(scheme.cbegin(), scheme.cend(), is_scheme_char))
+            {
+                return scheme;
+            }
+        }
+        return "";
+    }
+
+    auto url_has_scheme(std::string_view url) -> bool
+    {
+        return !url_get_scheme(url).empty();
+    }
+
+    auto path_has_drive_letter(std::string_view path) -> bool
+    {
+        static constexpr auto is_drive_char = [](char c) -> bool { return util::is_alphanum(c); };
+
+        auto [drive, rest] = util::lstrip_if_parts(path, is_drive_char);
+        return !drive.empty() && (rest.size() >= 2) && (rest[0] == ':')
+               && ((rest[1] == '/') || (rest[1] == '\\'));
+    }
+
+    void split_anaconda_token(const std::string& url, std::string& cleaned_url, std::string& token)
+    {
+        auto token_begin = std::sregex_iterator(url.begin(), url.end(), Context::instance().token_regex);
+        if (token_begin != std::sregex_iterator())
+        {
+            token = token_begin->str().substr(3u);
+            cleaned_url = std::regex_replace(
+                url,
+                Context::instance().token_regex,
+                "",
+                std::regex_constants::format_first_only
+            );
+        }
+        else
+        {
+            token = "";
+            cleaned_url = url;
+        }
+        cleaned_url = util::rstrip(cleaned_url, "/");
+    }
+
+    void split_scheme_auth_token(
+        const std::string& url,
+        std::string& remaining_url,
+        std::string& scheme,
+        std::string& auth,
+        std::string& token
+    )
+    {
+        std::string cleaned_url;
+        split_anaconda_token(url, cleaned_url, token);
+        URL url_parsed = URL::parse(cleaned_url);
+        scheme = url_parsed.scheme();
+        auth = url_parsed.authentication();
+        url_parsed.set_user("");
+        url_parsed.set_password("");
+        remaining_url = util::rstrip(url_parsed.str(URL::StripScheme::yes), '/');
+    }
+
+    bool compare_cleaned_url(const std::string& url1, const std::string& url2)
+    {
+        std::string u1_remaining, u1_scheme, u1_auth, u1_token;
+        std::string u2_remaining, u2_scheme, u2_auth, u2_token;
+        split_scheme_auth_token(url1, u1_remaining, u1_scheme, u1_auth, u1_token);
+        split_scheme_auth_token(url2, u2_remaining, u2_scheme, u2_auth, u2_token);
+        return u1_remaining == u2_remaining;
+    }
+
+    bool is_path(const std::string& input)
+    {
+        static const std::regex re(R"(\./|\.\.|~|/|[a-zA-Z]:[/\\]|\\\\|//)");
+        std::smatch sm;
+        std::regex_search(input, sm, re);
+        return !sm.empty() && sm.position(0) == 0 && input.find("://") == std::string::npos;
+    }
+
+    std::string path_to_url(const std::string& path)
+    {
+        static constexpr std::string_view file_scheme = "file://";
+        if (util::starts_with(path, file_scheme))
+        {
+            return path;
+        }
+
+        fs::u8path tmp_path = fs::u8path(path);
+        std::string abs_path = fs::absolute(tmp_path).string();
+
+        // TODO: handle percent encoding
+        // https://blogs.msdn.microsoft.com/ie/2006/12/06/file-uris-in-windows/
+        if (on_win)
+        {
+            util::replace_all(abs_path, "\\", "/");
+        }
+        return util::concat(file_scheme, abs_path);
+    }
+
+    std::string file_uri_unc2_to_unc4(std::string_view uri)
+    {
+        static constexpr std::string_view file_scheme = "file:";
+
+        // Not "file:" scheme
+        if (!util::starts_with(uri, file_scheme))
+        {
+            return std::string(uri);
+        }
+
+        // No hostname set in "file://hostname/path/to/data.xml"
+        auto [slashes, rest] = util::lstrip_parts(util::remove_prefix(uri, file_scheme), '/');
+        if (slashes.size() != 2)
+        {
+            return std::string(uri);
+        }
+
+        const auto s_idx = rest.find('/');
+        const auto c_idx = rest.find(':');
+
+        // ':' found before '/', a Windows drive is specified in "file://C:/path/to/data.xml" (not
+        // really URI compliant, they should have "file:///" or "file:/"). Otherwise no path in
+        // "file://hostname", also not URI compliant.
+        if (c_idx < s_idx)
+        {
+            return std::string(uri);
+        }
+
+        const auto hostname = rest.substr(0, s_idx);
+
+        // '\' are used as path separator in "file://\\hostname\path\to\data.xml" (also not RFC
+        // compliant)
+        if (util::starts_with(hostname, R"(\\)"))
+        {
+            return std::string(uri);
+        }
+
+        // Things that means localhost are kept for some reason in ``url_to_path``
+        // in ``conda.common.path``
+        if ((hostname == "localhost") || (hostname == "127.0.0.1") || (hostname == "::1"))
+        {
+            return std::string(uri);
+        }
+
+        return util::concat("file:////", rest);
+    }
+
+    std::string cache_name_from_url(const std::string& url)
+    {
+        std::string u = url;
+        if (u.empty() || (u.back() != '/' && !util::ends_with(u, ".json")))
+        {
+            u += '/';
+        }
+
+        // mimicking conda's behavior by special handling repodata.json
+        // todo support .zst
+        if (util::ends_with(u, "/repodata.json"))
+        {
+            u = u.substr(0, u.size() - 13);
+        }
+
+        unsigned char hash[16];
+
+        EVP_MD_CTX* mdctx;
+        mdctx = EVP_MD_CTX_create();
+        EVP_DigestInit_ex(mdctx, EVP_md5(), nullptr);
+        EVP_DigestUpdate(mdctx, u.c_str(), u.size());
+        EVP_DigestFinal_ex(mdctx, hash, nullptr);
+        EVP_MD_CTX_destroy(mdctx);
+
+        std::string hex_digest = util::hex_string(hash, 16);
+        return hex_digest.substr(0u, 8u);
+    }
+}

--- a/libmamba/src/util/url_manip.cpp
+++ b/libmamba/src/util/url_manip.cpp
@@ -82,7 +82,7 @@ namespace mamba::util
             else
             {
                 const auto encoding = url_encode_char(c);
-                out += std::string_view(encoding.cbegin(), encoding.size());
+                out += std::string_view(encoding.data(), encoding.size());
             }
         }
         return out;

--- a/libmamba/tests/CMakeLists.txt
+++ b/libmamba/tests/CMakeLists.txt
@@ -29,6 +29,8 @@ set(LIBMAMBA_TEST_SRCS
     src/util/test_flat_bool_expr_tree.cpp
     src/util/test_graph.cpp
     src/util/test_iterator.cpp
+    src/util/test_url_manip.cpp
+    src/util/test_url.cpp
     # Implementation of version and matching specs
     src/specs/test_platform.cpp
     src/specs/test_version.cpp
@@ -50,7 +52,6 @@ set(LIBMAMBA_TEST_SRCS
     src/core/test_shell_init.cpp
     src/core/test_thread_utils.cpp
     src/core/test_transfer.cpp
-    src/core/test_url.cpp
     src/core/test_validate.cpp
     src/core/test_virtual_packages.cpp
     src/core/test_util.cpp

--- a/libmamba/tests/src/core/test_url.cpp
+++ b/libmamba/tests/src/core/test_url.cpp
@@ -13,329 +13,295 @@
 #include "mamba/core/mamba_fs.hpp"
 #endif
 
-namespace mamba
+using namespace mamba;
+
+TEST_SUITE("url")
 {
-    const std::vector<std::string> KNOWN_PLATFORMS = {
-        "noarch",       "linux-32",      "linux-64",    "linux-aarch64", "linux-armv6l",
-        "linux-armv7l", "linux-ppc64le", "linux-ppc64", "osx-64",        "osx-arm64",
-        "win-32",       "win-64",        "zos-z"
-    };
-
-    TEST_SUITE("url")
+    TEST_CASE("concat_scheme_url")
     {
-        TEST_CASE("concat_scheme_url")
+        auto url = concat_scheme_url("https", "mamba.com");
+        CHECK_EQ(url, "https://mamba.com");
+
+        url = concat_scheme_url("file", "C:/some_folder");
+        CHECK_EQ(url, "file:///C:/some_folder");
+
+        url = concat_scheme_url("file", "some_folder");
+        CHECK_EQ(url, "file://some_folder");
+    }
+
+    TEST_CASE("build_url")
+    {
+        auto url = build_url(std::nullopt, "https", "mamba.com", true);
+        CHECK_EQ(url, "https://mamba.com");
+
+        url = build_url(std::nullopt, "https", "mamba.com", false);
+        CHECK_EQ(url, "https://mamba.com");
+
+        url = build_url(std::optional<std::string>("auth"), "https", "mamba.com", false);
+        CHECK_EQ(url, "https://mamba.com");
+
+        url = build_url(std::optional<std::string>("auth"), "https", "mamba.com", true);
+        CHECK_EQ(url, "https://auth@mamba.com");
+
+        url = build_url(std::optional<std::string>(""), "https", "mamba.com", true);
+        CHECK_EQ(url, "https://@mamba.com");
+    }
+
+    TEST_CASE("split_platform")
+    {
+        auto& ctx = Context::instance();
+
+        std::string platform_found, cleaned_url;
+        split_platform(
+            { "noarch", "linux-64" },
+            "https://mamba.com/linux-64/package.tar.bz2",
+            ctx.platform,
+            cleaned_url,
+            platform_found
+        );
+
+        CHECK_EQ(platform_found, "linux-64");
+        CHECK_EQ(cleaned_url, "https://mamba.com/package.tar.bz2");
+
+        split_platform(
+            { "noarch", "linux-64" },
+            "https://mamba.com/linux-64/noarch-package.tar.bz2",
+            ctx.platform,
+            cleaned_url,
+            platform_found
+        );
+        CHECK_EQ(platform_found, "linux-64");
+        CHECK_EQ(cleaned_url, "https://mamba.com/noarch-package.tar.bz2");
+
+        split_platform(
+            { "linux-64", "osx-arm64", "noarch" },
+            "https://mamba.com/noarch/kernel_linux-64-package.tar.bz2",
+            ctx.platform,
+            cleaned_url,
+            platform_found
+        );
+        CHECK_EQ(platform_found, "noarch");
+        CHECK_EQ(cleaned_url, "https://mamba.com/kernel_linux-64-package.tar.bz2");
+
+        split_platform(
+            { "noarch", "linux-64" },
+            "https://mamba.com/linux-64",
+            ctx.platform,
+            cleaned_url,
+            platform_found
+        );
+
+        CHECK_EQ(platform_found, "linux-64");
+        CHECK_EQ(cleaned_url, "https://mamba.com");
+
+        split_platform(
+            { "noarch", "linux-64" },
+            "https://mamba.com/noarch",
+            ctx.platform,
+            cleaned_url,
+            platform_found
+        );
+
+        CHECK_EQ(platform_found, "noarch");
+        CHECK_EQ(cleaned_url, "https://mamba.com");
+    }
+
+    TEST_CASE("parse")
+    {
+        SUBCASE("http://mamba.org")
         {
-            auto url = concat_scheme_url("https", "mamba.com");
-            CHECK_EQ(url, "https://mamba.com");
-
-            url = concat_scheme_url("file", "C:/some_folder");
-            CHECK_EQ(url, "file:///C:/some_folder");
-
-            url = concat_scheme_url("file", "some_folder");
-            CHECK_EQ(url, "file://some_folder");
+            URL url("http://mamba.org");
+            CHECK_EQ(url.scheme(), "http");
+            CHECK_EQ(url.host(), "mamba.org");
+            CHECK_EQ(url.user(), "");
+            CHECK_EQ(url.password(), "");
+            CHECK_EQ(url.port(), "");
+            CHECK_EQ(url.path(), "/");
+            CHECK_EQ(url.query(), "");
         }
 
-        TEST_CASE("build_url")
+        SUBCASE("s3://userx123:üúßsajd@mamba.org")
         {
-            auto url = build_url(std::nullopt, "https", "mamba.com", true);
-            CHECK_EQ(url, "https://mamba.com");
-
-            url = build_url(std::nullopt, "https", "mamba.com", false);
-            CHECK_EQ(url, "https://mamba.com");
-
-            url = build_url(std::optional<std::string>("auth"), "https", "mamba.com", false);
-            CHECK_EQ(url, "https://mamba.com");
-
-            url = build_url(std::optional<std::string>("auth"), "https", "mamba.com", true);
-            CHECK_EQ(url, "https://auth@mamba.com");
-
-            url = build_url(std::optional<std::string>(""), "https", "mamba.com", true);
-            CHECK_EQ(url, "https://@mamba.com");
+            URL url("s3://userx123:üúßsajd@mamba.org");
+            CHECK_EQ(url.scheme(), "s3");
+            CHECK_EQ(url.path(), "/");
+            CHECK_EQ(url.host(), "mamba.org");
+            CHECK_EQ(url.user(), "userx123");
+            CHECK_EQ(url.password(), "üúßsajd");
         }
 
-        TEST_CASE("split_platform")
+        SUBCASE("http://user%40email.com:test@localhost:8000")
         {
-            auto& ctx = Context::instance();
-
-            std::string platform_found, cleaned_url;
-            split_platform(
-                { "noarch", "linux-64" },
-                "https://mamba.com/linux-64/package.tar.bz2",
-                ctx.platform,
-                cleaned_url,
-                platform_found
-            );
-
-            CHECK_EQ(platform_found, "linux-64");
-            CHECK_EQ(cleaned_url, "https://mamba.com/package.tar.bz2");
-
-            split_platform(
-                { "noarch", "linux-64" },
-                "https://mamba.com/linux-64/noarch-package.tar.bz2",
-                ctx.platform,
-                cleaned_url,
-                platform_found
-            );
-            CHECK_EQ(platform_found, "linux-64");
-            CHECK_EQ(cleaned_url, "https://mamba.com/noarch-package.tar.bz2");
-
-            split_platform(
-                { "linux-64", "osx-arm64", "noarch" },
-                "https://mamba.com/noarch/kernel_linux-64-package.tar.bz2",
-                ctx.platform,
-                cleaned_url,
-                platform_found
-            );
-            CHECK_EQ(platform_found, "noarch");
-            CHECK_EQ(cleaned_url, "https://mamba.com/kernel_linux-64-package.tar.bz2");
-
-            split_platform(
-                { "noarch", "linux-64" },
-                "https://mamba.com/linux-64",
-                ctx.platform,
-                cleaned_url,
-                platform_found
-            );
-
-            CHECK_EQ(platform_found, "linux-64");
-            CHECK_EQ(cleaned_url, "https://mamba.com");
-
-            split_platform(
-                { "noarch", "linux-64" },
-                "https://mamba.com/noarch",
-                ctx.platform,
-                cleaned_url,
-                platform_found
-            );
-
-            CHECK_EQ(platform_found, "noarch");
-            CHECK_EQ(cleaned_url, "https://mamba.com");
+            URL url("http://user%40email.com:test@localhost:8000");
+            CHECK_EQ(url.scheme(), "http");
+            CHECK_EQ(url.path(), "/");
+            CHECK_EQ(url.host(), "localhost");
+            CHECK_EQ(url.port(), "8000");
+            CHECK_EQ(url.user(), "user%40email.com");
+            CHECK_EQ(url.password(), "test");
         }
 
-        TEST_CASE("parse")
+        SUBCASE("https://mamba🆒🔬.org/this/is/a/path/?query=123&xyz=3333")
         {
-            {
-                URL m("http://mamba.org");
-                CHECK_EQ(m.scheme(), "http");
-                CHECK_EQ(m.path(), "/");
-                CHECK_EQ(m.host(), "mamba.org");
-            }
-            {
-                URL m("s3://userx123:üúßsajd@mamba.org");
-                CHECK_EQ(m.scheme(), "s3");
-                CHECK_EQ(m.path(), "/");
-                CHECK_EQ(m.host(), "mamba.org");
-                CHECK_EQ(m.user(), "userx123");
-                CHECK_EQ(m.password(), "üúßsajd");
-            }
-            // {
-            //     URLHandler m("http://user@email.com:test@localhost:8000");
-            //     CHECK_EQ(m.scheme(), "http");
-            //     CHECK_EQ(m.path(), "/");
-            //     CHECK_EQ(m.host(), "localhost");
-            //     CHECK_EQ(m.port(), "8000");
-            //     CHECK_EQ(m.user(), "user@email.com");
-            //     CHECK_EQ(m.password(), "test");
-            // }
-            {
-                URL m("https://mamba🆒🔬.org/this/is/a/path/?query=123&xyz=3333");
-                CHECK_EQ(m.scheme(), "https");
-                CHECK_EQ(m.path(), "/this/is/a/path/");
-                CHECK_EQ(m.host(), "mamba🆒🔬.org");
-                CHECK_EQ(m.query(), "query=123&xyz=3333");
-            }
-            {
+            URL url("https://mamba🆒🔬.org/this/is/a/path/?query=123&xyz=3333");
+            CHECK_EQ(url.scheme(), "https");
+            CHECK_EQ(url.path(), "/this/is/a/path/");
+            CHECK_EQ(url.host(), "mamba🆒🔬.org");
+            CHECK_EQ(url.query(), "query=123&xyz=3333");
+        }
+
+        SUBCASE("file://C:/Users/wolfv/test/document.json")
+        {
 #ifdef _WIN32
-                URLHandler m("file://C:/Users/wolfv/test/document.json");
-                CHECK_EQ(m.scheme(), "file");
-                CHECK_EQ(m.path(), "C:/Users/wolfv/test/document.json");
-#else
-                URL m("file:///home/wolfv/test/document.json");
-                CHECK_EQ(m.scheme(), "file");
-                CHECK_EQ(m.path(), "/home/wolfv/test/document.json");
+            URL url("file://C:/Users/wolfv/test/document.json");
+            CHECK_EQ(url.scheme(), "file");
+            CHECK_EQ(url.path(), "C:/Users/wolfv/test/document.json");
 #endif
-            }
         }
 
-        TEST_CASE("path_to_url")
+        SUBCASE("file:///home/wolfv/test/document.json")
         {
-            auto url = path_to_url("/users/test/miniconda3");
 #ifndef _WIN32
-            CHECK_EQ(url, "file:///users/test/miniconda3");
-#else
-            std::string driveletter = fs::absolute(fs::u8path("/")).string().substr(0, 1);
-            CHECK_EQ(url, std::string("file://") + driveletter + ":/users/test/miniconda3");
-            auto url2 = path_to_url("D:\\users\\test\\miniconda3");
-            CHECK_EQ(url2, "file://D:/users/test/miniconda3");
+            URL url("file:///home/wolfv/test/document.json");
+            CHECK_EQ(url.scheme(), "file");
+            CHECK_EQ(url.path(), "/home/wolfv/test/document.json");
 #endif
-        }
-
-        TEST_CASE("file_uri_unc2_to_unc4")
-        {
-            for (std::string const uri : {
-                     "http://example.com/test",
-                     R"(file://C:/Program\ (x74)/Users/hello\ world)",
-                     R"(file:///C:/Program\ (x74)/Users/hello\ world)",
-                     "file:////server/share",
-                     "file:///path/to/data.xml",
-                     "file:///absolute/path",
-                     R"(file://\\server\path)",
-                 })
-            {
-                CAPTURE(uri);
-                CHECK_EQ(file_uri_unc2_to_unc4(uri), uri);
-            }
-            CHECK_EQ(file_uri_unc2_to_unc4("file://server/share"), "file:////server/share");
-            CHECK_EQ(file_uri_unc2_to_unc4("file://server"), "file:////server");
-        }
-
-        TEST_CASE("has_scheme")
-        {
-            std::string url = "http://mamba.org";
-            std::string not_url = "mamba.org";
-
-            CHECK(has_scheme(url));
-            CHECK_FALSE(has_scheme(not_url));
-            CHECK_FALSE(has_scheme(""));
-        }
-
-        TEST_CASE("value_semantic")
-        {
-            {
-                URL in("s3://userx123:üúßsajd@mamba.org");
-                URL m(in);
-                CHECK_EQ(m.scheme(), "s3");
-                CHECK_EQ(m.path(), "/");
-                CHECK_EQ(m.host(), "mamba.org");
-                CHECK_EQ(m.user(), "userx123");
-                CHECK_EQ(m.password(), "üúßsajd");
-            }
-
-            {
-                URL m("http://mamba.org");
-                URL in("s3://userx123:üúßsajd@mamba.org");
-                m = in;
-                CHECK_EQ(m.scheme(), "s3");
-                CHECK_EQ(m.path(), "/");
-                CHECK_EQ(m.host(), "mamba.org");
-                CHECK_EQ(m.user(), "userx123");
-                CHECK_EQ(m.password(), "üúßsajd");
-            }
-
-            {
-                URL in("s3://userx123:üúßsajd@mamba.org");
-                URL m(std::move(in));
-                CHECK_EQ(m.scheme(), "s3");
-                CHECK_EQ(m.path(), "/");
-                CHECK_EQ(m.host(), "mamba.org");
-                CHECK_EQ(m.user(), "userx123");
-                CHECK_EQ(m.password(), "üúßsajd");
-            }
-
-            {
-                URL m("http://mamba.org");
-                URL in("s3://userx123:üúßsajd@mamba.org");
-                m = std::move(in);
-                CHECK_EQ(m.scheme(), "s3");
-                CHECK_EQ(m.path(), "/");
-                CHECK_EQ(m.host(), "mamba.org");
-                CHECK_EQ(m.user(), "userx123");
-                CHECK_EQ(m.password(), "üúßsajd");
-            }
-        }
-
-        TEST_CASE("split_ananconda_token")
-        {
-            std::string input, cleaned_url, token;
-            {
-                input = "https://1.2.3.4/t/tk-123-456/path";
-                split_anaconda_token(input, cleaned_url, token);
-                CHECK_EQ(cleaned_url, "https://1.2.3.4/path");
-                CHECK_EQ(token, "tk-123-456");
-            }
-
-            {
-                input = "https://1.2.3.4/t//path";
-                split_anaconda_token(input, cleaned_url, token);
-                CHECK_EQ(cleaned_url, "https://1.2.3.4/path");
-                CHECK_EQ(token, "");
-            }
-
-            {
-                input = "https://some.domain/api/t/tk-123-456/path";
-                split_anaconda_token(input, cleaned_url, token);
-                CHECK_EQ(cleaned_url, "https://some.domain/api/path");
-                CHECK_EQ(token, "tk-123-456");
-            }
-
-            {
-                input = "https://1.2.3.4/conda/t/tk-123-456/path";
-                split_anaconda_token(input, cleaned_url, token);
-                CHECK_EQ(cleaned_url, "https://1.2.3.4/conda/path");
-                CHECK_EQ(token, "tk-123-456");
-            }
-
-            {
-                input = "https://1.2.3.4/path";
-                split_anaconda_token(input, cleaned_url, token);
-                CHECK_EQ(cleaned_url, "https://1.2.3.4/path");
-                CHECK_EQ(token, "");
-            }
-
-            {
-                input = "https://10.2.3.4:8080/conda/t/tk-123-45";
-                split_anaconda_token(input, cleaned_url, token);
-                CHECK_EQ(cleaned_url, "https://10.2.3.4:8080/conda");
-                CHECK_EQ(token, "tk-123-45");
-            }
-        }
-
-        TEST_CASE("split_scheme_auth_token")
-        {
-            std::string input = "https://u:p@conda.io/t/x1029384756/more/path";
-            std::string input2 = "https://u:p@conda.io/t/a_-12345-absdj12345-xyxyxyx/more/path";
-            std::string remaining_url, scheme, auth, token;
-            split_scheme_auth_token(input, remaining_url, scheme, auth, token);
-            CHECK_EQ(remaining_url, "conda.io/more/path");
-            CHECK_EQ(scheme, "https");
-            CHECK_EQ(auth, "u:p");
-            CHECK_EQ(token, "x1029384756");
-
-            split_scheme_auth_token(input2, remaining_url, scheme, auth, token);
-            CHECK_EQ(remaining_url, "conda.io/more/path");
-            CHECK_EQ(scheme, "https");
-            CHECK_EQ(auth, "u:p");
-            CHECK_EQ(token, "a_-12345-absdj12345-xyxyxyx");
-
-#ifdef _WIN32
-            split_scheme_auth_token("file://C:/Users/wolfv/test.json", remaining_url, scheme, auth, token);
-            CHECK_EQ(remaining_url, "C:/Users/wolfv/test.json");
-            CHECK_EQ(scheme, "file");
-            CHECK_EQ(auth, "");
-            CHECK_EQ(token, "");
-#else
-            split_scheme_auth_token("file:///home/wolfv/test.json", remaining_url, scheme, auth, token);
-            CHECK_EQ(remaining_url, "/home/wolfv/test.json");
-            CHECK_EQ(scheme, "file");
-            CHECK_EQ(auth, "");
-            CHECK_EQ(token, "");
-#endif
-        }
-
-        TEST_CASE("is_path")
-        {
-            CHECK(is_path("./"));
-            CHECK(is_path(".."));
-            CHECK(is_path("~"));
-            CHECK(is_path("/"));
-            CHECK_FALSE(is_path("file://makefile"));
-        }
-
-        TEST_CASE("cache_name_from_url")
-        {
-            CHECK_EQ(cache_name_from_url("http://test.com/1234/"), "302f0a61");
-            CHECK_EQ(cache_name_from_url("http://test.com/1234/repodata.json"), "302f0a61");
-            CHECK_EQ(cache_name_from_url("http://test.com/1234/current_repodata.json"), "78a8cce9");
         }
     }
-}  // namespace mamba
+
+    TEST_CASE("path_to_url")
+    {
+        auto url = path_to_url("/users/test/miniconda3");
+#ifndef _WIN32
+        CHECK_EQ(url, "file:///users/test/miniconda3");
+#else
+        std::string driveletter = fs::absolute(fs::u8path("/")).string().substr(0, 1);
+        CHECK_EQ(url, std::string("file://") + driveletter + ":/users/test/miniconda3");
+        auto url2 = path_to_url("D:\\users\\test\\miniconda3");
+        CHECK_EQ(url2, "file://D:/users/test/miniconda3");
+#endif
+    }
+
+    TEST_CASE("file_uri_unc2_to_unc4")
+    {
+        for (std::string const uri : {
+                 "http://example.com/test",
+                 R"(file://C:/Program\ (x74)/Users/hello\ world)",
+                 R"(file:///C:/Program\ (x74)/Users/hello\ world)",
+                 "file:////server/share",
+                 "file:///path/to/data.xml",
+                 "file:///absolute/path",
+                 R"(file://\\server\path)",
+             })
+        {
+            CAPTURE(uri);
+            CHECK_EQ(file_uri_unc2_to_unc4(uri), uri);
+        }
+        CHECK_EQ(file_uri_unc2_to_unc4("file://server/share"), "file:////server/share");
+        CHECK_EQ(file_uri_unc2_to_unc4("file://server"), "file:////server");
+    }
+
+    TEST_CASE("has_scheme")
+    {
+        std::string url = "http://mamba.org";
+        std::string not_url = "mamba.org";
+
+        CHECK(has_scheme(url));
+        CHECK_FALSE(has_scheme(not_url));
+        CHECK_FALSE(has_scheme(""));
+    }
+
+    TEST_CASE("split_ananconda_token")
+    {
+        std::string input, cleaned_url, token;
+        {
+            input = "https://1.2.3.4/t/tk-123-456/path";
+            split_anaconda_token(input, cleaned_url, token);
+            CHECK_EQ(cleaned_url, "https://1.2.3.4/path");
+            CHECK_EQ(token, "tk-123-456");
+        }
+
+        {
+            input = "https://1.2.3.4/t//path";
+            split_anaconda_token(input, cleaned_url, token);
+            CHECK_EQ(cleaned_url, "https://1.2.3.4/path");
+            CHECK_EQ(token, "");
+        }
+
+        {
+            input = "https://some.domain/api/t/tk-123-456/path";
+            split_anaconda_token(input, cleaned_url, token);
+            CHECK_EQ(cleaned_url, "https://some.domain/api/path");
+            CHECK_EQ(token, "tk-123-456");
+        }
+
+        {
+            input = "https://1.2.3.4/conda/t/tk-123-456/path";
+            split_anaconda_token(input, cleaned_url, token);
+            CHECK_EQ(cleaned_url, "https://1.2.3.4/conda/path");
+            CHECK_EQ(token, "tk-123-456");
+        }
+
+        {
+            input = "https://1.2.3.4/path";
+            split_anaconda_token(input, cleaned_url, token);
+            CHECK_EQ(cleaned_url, "https://1.2.3.4/path");
+            CHECK_EQ(token, "");
+        }
+
+        {
+            input = "https://10.2.3.4:8080/conda/t/tk-123-45";
+            split_anaconda_token(input, cleaned_url, token);
+            CHECK_EQ(cleaned_url, "https://10.2.3.4:8080/conda");
+            CHECK_EQ(token, "tk-123-45");
+        }
+    }
+
+    TEST_CASE("split_scheme_auth_token")
+    {
+        std::string input = "https://u:p@conda.io/t/x1029384756/more/path";
+        std::string input2 = "https://u:p@conda.io/t/a_-12345-absdj12345-xyxyxyx/more/path";
+        std::string remaining_url, scheme, auth, token;
+        split_scheme_auth_token(input, remaining_url, scheme, auth, token);
+        CHECK_EQ(remaining_url, "conda.io/more/path");
+        CHECK_EQ(scheme, "https");
+        CHECK_EQ(auth, "u:p");
+        CHECK_EQ(token, "x1029384756");
+
+        split_scheme_auth_token(input2, remaining_url, scheme, auth, token);
+        CHECK_EQ(remaining_url, "conda.io/more/path");
+        CHECK_EQ(scheme, "https");
+        CHECK_EQ(auth, "u:p");
+        CHECK_EQ(token, "a_-12345-absdj12345-xyxyxyx");
+
+#ifdef _WIN32
+        split_scheme_auth_token("file://C:/Users/wolfv/test.json", remaining_url, scheme, auth, token);
+        CHECK_EQ(remaining_url, "C:/Users/wolfv/test.json");
+        CHECK_EQ(scheme, "file");
+        CHECK_EQ(auth, "");
+        CHECK_EQ(token, "");
+#else
+        split_scheme_auth_token("file:///home/wolfv/test.json", remaining_url, scheme, auth, token);
+        CHECK_EQ(remaining_url, "/home/wolfv/test.json");
+        CHECK_EQ(scheme, "file");
+        CHECK_EQ(auth, "");
+        CHECK_EQ(token, "");
+#endif
+    }
+
+    TEST_CASE("is_path")
+    {
+        CHECK(is_path("./"));
+        CHECK(is_path(".."));
+        CHECK(is_path("~"));
+        CHECK(is_path("/"));
+        CHECK_FALSE(is_path("file://makefile"));
+    }
+
+    TEST_CASE("cache_name_from_url")
+    {
+        CHECK_EQ(cache_name_from_url("http://test.com/1234/"), "302f0a61");
+        CHECK_EQ(cache_name_from_url("http://test.com/1234/repodata.json"), "302f0a61");
+        CHECK_EQ(cache_name_from_url("http://test.com/1234/current_repodata.json"), "78a8cce9");
+    }
+}

--- a/libmamba/tests/src/core/test_url.cpp
+++ b/libmamba/tests/src/core/test_url.cpp
@@ -115,13 +115,13 @@ namespace mamba
         TEST_CASE("parse")
         {
             {
-                URLHandler m("http://mamba.org");
+                URL m("http://mamba.org");
                 CHECK_EQ(m.scheme(), "http");
                 CHECK_EQ(m.path(), "/");
                 CHECK_EQ(m.host(), "mamba.org");
             }
             {
-                URLHandler m("s3://userx123:üúßsajd@mamba.org");
+                URL m("s3://userx123:üúßsajd@mamba.org");
                 CHECK_EQ(m.scheme(), "s3");
                 CHECK_EQ(m.path(), "/");
                 CHECK_EQ(m.host(), "mamba.org");
@@ -138,7 +138,7 @@ namespace mamba
             //     CHECK_EQ(m.password(), "test");
             // }
             {
-                URLHandler m("https://mamba🆒🔬.org/this/is/a/path/?query=123&xyz=3333");
+                URL m("https://mamba🆒🔬.org/this/is/a/path/?query=123&xyz=3333");
                 CHECK_EQ(m.scheme(), "https");
                 CHECK_EQ(m.path(), "/this/is/a/path/");
                 CHECK_EQ(m.host(), "mamba🆒🔬.org");
@@ -150,7 +150,7 @@ namespace mamba
                 CHECK_EQ(m.scheme(), "file");
                 CHECK_EQ(m.path(), "C:/Users/wolfv/test/document.json");
 #else
-                URLHandler m("file:///home/wolfv/test/document.json");
+                URL m("file:///home/wolfv/test/document.json");
                 CHECK_EQ(m.scheme(), "file");
                 CHECK_EQ(m.path(), "/home/wolfv/test/document.json");
 #endif
@@ -202,8 +202,8 @@ namespace mamba
         TEST_CASE("value_semantic")
         {
             {
-                URLHandler in("s3://userx123:üúßsajd@mamba.org");
-                URLHandler m(in);
+                URL in("s3://userx123:üúßsajd@mamba.org");
+                URL m(in);
                 CHECK_EQ(m.scheme(), "s3");
                 CHECK_EQ(m.path(), "/");
                 CHECK_EQ(m.host(), "mamba.org");
@@ -212,8 +212,8 @@ namespace mamba
             }
 
             {
-                URLHandler m("http://mamba.org");
-                URLHandler in("s3://userx123:üúßsajd@mamba.org");
+                URL m("http://mamba.org");
+                URL in("s3://userx123:üúßsajd@mamba.org");
                 m = in;
                 CHECK_EQ(m.scheme(), "s3");
                 CHECK_EQ(m.path(), "/");
@@ -223,8 +223,8 @@ namespace mamba
             }
 
             {
-                URLHandler in("s3://userx123:üúßsajd@mamba.org");
-                URLHandler m(std::move(in));
+                URL in("s3://userx123:üúßsajd@mamba.org");
+                URL m(std::move(in));
                 CHECK_EQ(m.scheme(), "s3");
                 CHECK_EQ(m.path(), "/");
                 CHECK_EQ(m.host(), "mamba.org");
@@ -233,8 +233,8 @@ namespace mamba
             }
 
             {
-                URLHandler m("http://mamba.org");
-                URLHandler in("s3://userx123:üúßsajd@mamba.org");
+                URL m("http://mamba.org");
+                URL in("s3://userx123:üúßsajd@mamba.org");
                 m = std::move(in);
                 CHECK_EQ(m.scheme(), "s3");
                 CHECK_EQ(m.path(), "/");

--- a/libmamba/tests/src/core/test_url.cpp
+++ b/libmamba/tests/src/core/test_url.cpp
@@ -151,6 +151,30 @@ TEST_SUITE("url")
 
     TEST_CASE("URL::parse")
     {
+        SUBCASE("scheme options")
+        {
+            CHECK_EQ(URL::parse("mamba.org", URL::SchemeOpt::leave_as_is).scheme(), "");
+            CHECK_EQ(URL::parse("mamba.org", URL::SchemeOpt::add_if_abscent).scheme(), "https");
+            CHECK_EQ(URL::parse("mamba.org", URL::SchemeOpt::remove_if_present).scheme(), "");
+
+            CHECK_EQ(URL::parse("ftp://mamba.org", URL::SchemeOpt::leave_as_is).scheme(), "ftp");
+            CHECK_EQ(URL::parse("ftp://mamba.org", URL::SchemeOpt::add_if_abscent).scheme(), "ftp");
+            CHECK_EQ(URL::parse("ftp://mamba.org", URL::SchemeOpt::remove_if_present).scheme(), "");
+        }
+
+        SUBCASE("mamba.org")
+        {
+            const URL url = URL::parse("mamba.org");
+            CHECK_EQ(url.scheme(), "");
+            CHECK_EQ(url.host(), "mamba.org");
+            CHECK_EQ(url.path(), "/");
+            CHECK_EQ(url.user(), "");
+            CHECK_EQ(url.password(), "");
+            CHECK_EQ(url.port(), "");
+            CHECK_EQ(url.query(), "");
+            CHECK_EQ(url.fragment(), "");
+        }
+
         SUBCASE("http://mamba.org")
         {
             const URL url = URL::parse("http://mamba.org");

--- a/libmamba/tests/src/core/test_url.cpp
+++ b/libmamba/tests/src/core/test_url.cpp
@@ -268,11 +268,12 @@ TEST_SUITE("url")
 
     TEST_CASE("has_scheme")
     {
-        std::string url = "http://mamba.org";
-        std::string not_url = "mamba.org";
-
-        CHECK(has_scheme(url));
-        CHECK_FALSE(has_scheme(not_url));
+        CHECK(has_scheme("http://mamba.org"));
+        CHECK(has_scheme("file:///folder/file.txt"));
+        CHECK(has_scheme("s3://bucket/file.txt"));
+        CHECK_FALSE(has_scheme("mamba.org"));
+        CHECK_FALSE(has_scheme("://"));
+        CHECK_FALSE(has_scheme("f#gre://"));
         CHECK_FALSE(has_scheme(""));
     }
 

--- a/libmamba/tests/src/core/test_url.cpp
+++ b/libmamba/tests/src/core/test_url.cpp
@@ -118,6 +118,7 @@ TEST_SUITE("url")
             CHECK_EQ(url.scheme(), URL::https);
             CHECK_EQ(url.host(), URL::localhost);
             CHECK_EQ(url.path(), "/");
+            CHECK_EQ(url.pretty_path(), "/");
             CHECK_EQ(url.user(), "");
             CHECK_EQ(url.password(), "");
             CHECK_EQ(url.port(), "");
@@ -141,6 +142,7 @@ TEST_SUITE("url")
             CHECK_EQ(url.password(), "password");
             CHECK_EQ(url.port(), "8080");
             CHECK_EQ(url.path(), "/folder/file.html");
+            CHECK_EQ(url.pretty_path(), "/folder/file.html");
             CHECK_EQ(url.query(), "param=value");
             CHECK_EQ(url.fragment(), "fragment");
         }
@@ -150,13 +152,15 @@ TEST_SUITE("url")
             URL url{};
             url.set_path("path/");
             CHECK_EQ(url.path(), "/path/");
+            CHECK_EQ(url.pretty_path(), "/path/");
         }
 
         SUBCASE("Windows path")
         {
             URL url{};
             url.set_scheme("file").set_path("C:/folder/file.txt");
-            CHECK_EQ(url.path(), "C:/folder/file.txt");
+            CHECK_EQ(url.path(), "/C:/folder/file.txt");
+            CHECK_EQ(url.pretty_path(), "C:/folder/file.txt");
         }
 
         SUBCASE("Invalid")
@@ -176,6 +180,7 @@ TEST_SUITE("url")
             CHECK_EQ(url.scheme(), URL::https);
             CHECK_EQ(url.host(), "mamba.org");
             CHECK_EQ(url.path(), "/");
+            CHECK_EQ(url.pretty_path(), "/");
             CHECK_EQ(url.user(), "");
             CHECK_EQ(url.password(), "");
             CHECK_EQ(url.port(), "");
@@ -189,6 +194,7 @@ TEST_SUITE("url")
             CHECK_EQ(url.scheme(), "http");
             CHECK_EQ(url.host(), "mamba.org");
             CHECK_EQ(url.path(), "/");
+            CHECK_EQ(url.pretty_path(), "/");
             CHECK_EQ(url.user(), "");
             CHECK_EQ(url.password(), "");
             CHECK_EQ(url.port(), "");
@@ -202,6 +208,7 @@ TEST_SUITE("url")
             CHECK_EQ(url.scheme(), "s3");
             CHECK_EQ(url.host(), "mamba.org");
             CHECK_EQ(url.path(), "/");
+            CHECK_EQ(url.pretty_path(), "/");
             CHECK_EQ(url.user(), "userx123");
             CHECK_EQ(url.password(), "üúßsajd");
             CHECK_EQ(url.port(), "");
@@ -215,6 +222,7 @@ TEST_SUITE("url")
             CHECK_EQ(url.scheme(), "http");
             CHECK_EQ(url.host(), "localhost");
             CHECK_EQ(url.path(), "/");
+            CHECK_EQ(url.pretty_path(), "/");
             CHECK_EQ(url.user(), "user%40email.com");
             CHECK_EQ(url.password(), "test");
             CHECK_EQ(url.port(), "8000");
@@ -228,6 +236,7 @@ TEST_SUITE("url")
             CHECK_EQ(url.scheme(), "https");
             CHECK_EQ(url.host(), "mamba🆒🔬.org");
             CHECK_EQ(url.path(), "/this/is/a/path/");
+            CHECK_EQ(url.pretty_path(), "/this/is/a/path/");
             CHECK_EQ(url.user(), "");
             CHECK_EQ(url.password(), "");
             CHECK_EQ(url.port(), "");
@@ -241,7 +250,8 @@ TEST_SUITE("url")
             const URL url = URL::parse("file://C:/Users/wolfv/test/document.json");
             CHECK_EQ(url.scheme(), "file");
             CHECK_EQ(url.host(), URL::localhost);
-            CHECK_EQ(url.path(), "C:/Users/wolfv/test/document.json");
+            CHECK_EQ(url.path(), "/C:/Users/wolfv/test/document.json");
+            CHECK_EQ(url.pretty_path(), "C:/Users/wolfv/test/document.json");
             CHECK_EQ(url.user(), "");
             CHECK_EQ(url.password(), "");
             CHECK_EQ(url.port(), "");
@@ -257,6 +267,7 @@ TEST_SUITE("url")
             CHECK_EQ(url.scheme(), "file");
             CHECK_EQ(url.host(), URL::localhost);
             CHECK_EQ(url.path(), "/home/wolfv/test/document.json");
+            CHECK_EQ(url.pretty_path(), "/home/wolfv/test/document.json");
             CHECK_EQ(url.user(), "");
             CHECK_EQ(url.password(), "");
             CHECK_EQ(url.port(), "");
@@ -337,13 +348,23 @@ TEST_SUITE("url")
             CHECK_EQ(url.str(URL::StripScheme::yes), "/folder/file.txt");
         }
 
-        SUBCASE("file://C:/folder/file.txt")
+        SUBCASE("file:///C:/folder/file.txt")
         {
             URL url{};
             url.set_scheme("file").set_path("C:/folder/file.txt");
-            CHECK_EQ(url.str(), "file://C:/folder/file.txt");
+            CHECK_EQ(url.str(), "file:///C:/folder/file.txt");
             CHECK_EQ(url.str(URL::StripScheme::yes), "C:/folder/file.txt");
         }
+    }
+
+    TEST_CASE("URL::authentication")
+    {
+        URL url{};
+        CHECK_EQ(url.authentication(), "");
+        url.set_user("user");
+        CHECK_EQ(url.authentication(), "user");
+        url.set_password("password");
+        CHECK_EQ(url.authentication(), "user:password");
     }
 
     TEST_CASE("path_to_url")

--- a/libmamba/tests/src/core/test_url.cpp
+++ b/libmamba/tests/src/core/test_url.cpp
@@ -106,48 +106,101 @@ TEST_SUITE("url")
         CHECK_EQ(cleaned_url, "https://mamba.com");
     }
 
-    TEST_CASE("parse")
+    TEST_CASE("URL builder")
+    {
+        SUBCASE("empty")
+        {
+            URL url{};
+            CHECK_EQ(url.scheme(), "");
+            CHECK_EQ(url.host(), "");
+            CHECK_EQ(url.path(), "");
+            CHECK_EQ(url.user(), "");
+            CHECK_EQ(url.password(), "");
+            CHECK_EQ(url.port(), "");
+            CHECK_EQ(url.query(), "");
+        }
+
+        SUBCASE("complete")
+        {
+            URL url{};
+            url.set_scheme("https")
+                .set_host("mamba.org")
+                .set_user("user")
+                .set_password("password")
+                .set_port("8080")
+                .set_path("/folder/file.html")
+                .set_query("param=value")
+                .set_fragment("fragment");
+            CHECK_EQ(url.scheme(), "https");
+            CHECK_EQ(url.host(), "mamba.org");
+            CHECK_EQ(url.user(), "user");
+            CHECK_EQ(url.password(), "password");
+            CHECK_EQ(url.port(), "8080");
+            CHECK_EQ(url.path(), "/folder/file.html");
+            CHECK_EQ(url.query(), "param=value");
+            CHECK_EQ(url.fragment(), "fragment");
+        }
+
+        SUBCASE("path")
+        {
+            URL url{};
+            url.set_path("path/");
+            CHECK_EQ(url.path(), "/path/");
+        }
+    }
+
+    TEST_CASE("URL::parse")
     {
         SUBCASE("http://mamba.org")
         {
             URL url("http://mamba.org");
             CHECK_EQ(url.scheme(), "http");
             CHECK_EQ(url.host(), "mamba.org");
+            CHECK_EQ(url.path(), "/");
             CHECK_EQ(url.user(), "");
             CHECK_EQ(url.password(), "");
             CHECK_EQ(url.port(), "");
-            CHECK_EQ(url.path(), "/");
             CHECK_EQ(url.query(), "");
+            CHECK_EQ(url.fragment(), "");
         }
 
         SUBCASE("s3://userx123:üúßsajd@mamba.org")
         {
             URL url("s3://userx123:üúßsajd@mamba.org");
             CHECK_EQ(url.scheme(), "s3");
-            CHECK_EQ(url.path(), "/");
             CHECK_EQ(url.host(), "mamba.org");
+            CHECK_EQ(url.path(), "/");
             CHECK_EQ(url.user(), "userx123");
             CHECK_EQ(url.password(), "üúßsajd");
+            CHECK_EQ(url.port(), "");
+            CHECK_EQ(url.query(), "");
+            CHECK_EQ(url.fragment(), "");
         }
 
         SUBCASE("http://user%40email.com:test@localhost:8000")
         {
             URL url("http://user%40email.com:test@localhost:8000");
             CHECK_EQ(url.scheme(), "http");
-            CHECK_EQ(url.path(), "/");
             CHECK_EQ(url.host(), "localhost");
-            CHECK_EQ(url.port(), "8000");
+            CHECK_EQ(url.path(), "/");
             CHECK_EQ(url.user(), "user%40email.com");
             CHECK_EQ(url.password(), "test");
+            CHECK_EQ(url.port(), "8000");
+            CHECK_EQ(url.query(), "");
+            CHECK_EQ(url.fragment(), "");
         }
 
         SUBCASE("https://mamba🆒🔬.org/this/is/a/path/?query=123&xyz=3333")
         {
             URL url("https://mamba🆒🔬.org/this/is/a/path/?query=123&xyz=3333");
             CHECK_EQ(url.scheme(), "https");
-            CHECK_EQ(url.path(), "/this/is/a/path/");
             CHECK_EQ(url.host(), "mamba🆒🔬.org");
+            CHECK_EQ(url.path(), "/this/is/a/path/");
+            CHECK_EQ(url.user(), "");
+            CHECK_EQ(url.password(), "");
+            CHECK_EQ(url.port(), "");
             CHECK_EQ(url.query(), "query=123&xyz=3333");
+            CHECK_EQ(url.fragment(), "");
         }
 
         SUBCASE("file://C:/Users/wolfv/test/document.json")
@@ -155,7 +208,13 @@ TEST_SUITE("url")
 #ifdef _WIN32
             URL url("file://C:/Users/wolfv/test/document.json");
             CHECK_EQ(url.scheme(), "file");
+            CHECK_EQ(url.host(), "");
             CHECK_EQ(url.path(), "C:/Users/wolfv/test/document.json");
+            CHECK_EQ(url.user(), "");
+            CHECK_EQ(url.password(), "");
+            CHECK_EQ(url.port(), "");
+            CHECK_EQ(url.query(), "");
+            CHECK_EQ(url.fragment(), "");
 #endif
         }
 
@@ -163,8 +222,15 @@ TEST_SUITE("url")
         {
 #ifndef _WIN32
             URL url("file:///home/wolfv/test/document.json");
+
             CHECK_EQ(url.scheme(), "file");
+            CHECK_EQ(url.host(), "");
             CHECK_EQ(url.path(), "/home/wolfv/test/document.json");
+            CHECK_EQ(url.user(), "");
+            CHECK_EQ(url.password(), "");
+            CHECK_EQ(url.port(), "");
+            CHECK_EQ(url.query(), "");
+            CHECK_EQ(url.fragment(), "");
 #endif
         }
     }

--- a/libmamba/tests/src/core/test_url.cpp
+++ b/libmamba/tests/src/core/test_url.cpp
@@ -368,6 +368,16 @@ TEST_SUITE("url")
         CHECK_FALSE(has_scheme(""));
     }
 
+    TEST_CASE("has_drive_letter")
+    {
+        CHECK(has_drive_letter("C:/folder/file"));
+        CHECK(has_drive_letter(R"(C:\folder\file)"));
+        CHECK_FALSE(has_drive_letter("/folder/file"));
+        CHECK_FALSE(has_drive_letter("folder/file"));
+        CHECK_FALSE(has_drive_letter(R"(\folder\file)"));
+        CHECK_FALSE(has_drive_letter(R"(folder\file)"));
+    }
+
     TEST_CASE("split_ananconda_token")
     {
         std::string input, cleaned_url, token;

--- a/libmamba/tests/src/core/test_url.cpp
+++ b/libmamba/tests/src/core/test_url.cpp
@@ -170,36 +170,23 @@ namespace mamba
 #endif
         }
 
-        TEST_CASE("unc_url")
+        TEST_CASE("file_uri_unc2_to_unc4")
         {
+            for (std::string const uri : {
+                     "http://example.com/test",
+                     R"(file://C:/Program\ (x74)/Users/hello\ world)",
+                     R"(file:///C:/Program\ (x74)/Users/hello\ world)",
+                     "file:////server/share",
+                     "file:///path/to/data.xml",
+                     "file:///absolute/path",
+                     R"(file://\\server\path)",
+                 })
             {
-                auto out = unc_url("http://example.com/test");
-                CHECK_EQ(out, "http://example.com/test");
+                CAPTURE(uri);
+                CHECK_EQ(file_uri_unc2_to_unc4(uri), uri);
             }
-            {
-                auto out = unc_url("file://C:/Program\\ (x74)/Users/hello\\ world");
-                CHECK_EQ(out, "file://C:/Program\\ (x74)/Users/hello\\ world");
-            }
-            {
-                auto out = unc_url("file:///C:/Program\\ (x74)/Users/hello\\ world");
-                CHECK_EQ(out, "file:///C:/Program\\ (x74)/Users/hello\\ world");
-            }
-            {
-                auto out = unc_url("file:////server/share");
-                CHECK_EQ(out, "file:////server/share");
-            }
-            {
-                auto out = unc_url("file:///absolute/path");
-                CHECK_EQ(out, "file:///absolute/path");
-            }
-            {
-                auto out = unc_url("file://server/share");
-                CHECK_EQ(out, "file:////server/share");
-            }
-            {
-                auto out = unc_url("file://server");
-                CHECK_EQ(out, "file:////server");
-            }
+            CHECK_EQ(file_uri_unc2_to_unc4("file://server/share"), "file:////server/share");
+            CHECK_EQ(file_uri_unc2_to_unc4("file://server"), "file:////server");
         }
 
         TEST_CASE("has_scheme")

--- a/libmamba/tests/src/core/test_url.cpp
+++ b/libmamba/tests/src/core/test_url.cpp
@@ -266,6 +266,17 @@ TEST_SUITE("url")
         CHECK_EQ(file_uri_unc2_to_unc4("file://server"), "file:////server");
     }
 
+    TEST_CASE("get_scheme")
+    {
+        CHECK_EQ(get_scheme("http://mamba.org"), "http");
+        CHECK_EQ(get_scheme("file:///folder/file.txt"), "file");
+        CHECK_EQ(get_scheme("s3://bucket/file.txt"), "s3");
+        CHECK_EQ(get_scheme("mamba.org"), "");
+        CHECK_EQ(get_scheme("://"), "");
+        CHECK_EQ(get_scheme("f#gre://"), "");
+        CHECK_EQ(get_scheme(""), "");
+    }
+
     TEST_CASE("has_scheme")
     {
         CHECK(has_scheme("http://mamba.org"));

--- a/libmamba/tests/src/core/test_url.cpp
+++ b/libmamba/tests/src/core/test_url.cpp
@@ -168,7 +168,6 @@ TEST_SUITE("url")
             URL url{};
             CHECK_THROWS_AS(url.set_scheme(""), std::invalid_argument);
             CHECK_THROWS_AS(url.set_host(""), std::invalid_argument);
-            CHECK_THROWS_AS(url.set_password("password"), std::invalid_argument);  // No user
         }
     }
 
@@ -225,6 +224,20 @@ TEST_SUITE("url")
             CHECK_EQ(url.pretty_path(), "/");
             CHECK_EQ(url.user(), "user%40email.com");
             CHECK_EQ(url.password(), "test");
+            CHECK_EQ(url.port(), "8000");
+            CHECK_EQ(url.query(), "");
+            CHECK_EQ(url.fragment(), "");
+        }
+
+        SUBCASE("http://:pass@localhost:8000")
+        {
+            const URL url = URL::parse("http://:pass@localhost:8000");
+            CHECK_EQ(url.scheme(), "http");
+            CHECK_EQ(url.host(), "localhost");
+            CHECK_EQ(url.path(), "/");
+            CHECK_EQ(url.pretty_path(), "/");
+            CHECK_EQ(url.user(), "");
+            CHECK_EQ(url.password(), "pass");
             CHECK_EQ(url.port(), "8000");
             CHECK_EQ(url.query(), "");
             CHECK_EQ(url.fragment(), "");

--- a/libmamba/tests/src/core/test_url.cpp
+++ b/libmamba/tests/src/core/test_url.cpp
@@ -275,6 +275,35 @@ TEST_SUITE("url")
             CHECK_EQ(url.fragment(), "");
 #endif
         }
+
+        SUBCASE("https://169.254.0.0/page")
+        {
+            const URL url = URL::parse("https://169.254.0.0/page");
+            CHECK_EQ(url.scheme(), "https");
+            CHECK_EQ(url.host(), "169.254.0.0");
+            CHECK_EQ(url.path(), "/page");
+            CHECK_EQ(url.pretty_path(), "/page");
+            CHECK_EQ(url.user(), "");
+            CHECK_EQ(url.password(), "");
+            CHECK_EQ(url.port(), "");
+            CHECK_EQ(url.query(), "");
+            CHECK_EQ(url.fragment(), "");
+        }
+
+        SUBCASE("ftp://user:pass@[2001:db8:85a3:8d3:1319:0:370:7348]:9999/page")
+        {
+            const URL url = URL::parse("ftp://user:pass@[2001:db8:85a3:8d3:1319:0:370:7348]:9999/page"
+            );
+            CHECK_EQ(url.scheme(), "ftp");
+            CHECK_EQ(url.host(), "[2001:db8:85a3:8d3:1319:0:370:7348]");
+            CHECK_EQ(url.path(), "/page");
+            CHECK_EQ(url.pretty_path(), "/page");
+            CHECK_EQ(url.user(), "user");
+            CHECK_EQ(url.password(), "pass");
+            CHECK_EQ(url.port(), "9999");
+            CHECK_EQ(url.query(), "");
+            CHECK_EQ(url.fragment(), "");
+        }
     }
 
     TEST_CASE("URL::str")

--- a/libmamba/tests/src/core/test_url.cpp
+++ b/libmamba/tests/src/core/test_url.cpp
@@ -113,7 +113,7 @@ TEST_SUITE("url")
             URL url{};
             CHECK_EQ(url.scheme(), "");
             CHECK_EQ(url.host(), "");
-            CHECK_EQ(url.path(), "");
+            CHECK_EQ(url.path(), "/");
             CHECK_EQ(url.user(), "");
             CHECK_EQ(url.password(), "");
             CHECK_EQ(url.port(), "");
@@ -255,6 +255,62 @@ TEST_SUITE("url")
             CHECK_EQ(url.query(), "");
             CHECK_EQ(url.fragment(), "");
 #endif
+        }
+    }
+
+    TEST_CASE("URL::str")
+    {
+        SUBCASE("scheme option")
+        {
+            URL url = {};
+            url.set_host("mamba.org");
+
+            SUBCASE("without scheme")
+            {
+                CHECK_EQ(url.str(URL::SchemeOpt::leave_as_is), "mamba.org/");
+                CHECK_EQ(url.str(URL::SchemeOpt::add_if_abscent), "https://mamba.org/");
+                CHECK_EQ(url.str(URL::SchemeOpt::remove_if_present), "mamba.org/");
+            }
+
+            SUBCASE("with scheme")
+            {
+                url.set_scheme("ftp");
+                CHECK_EQ(url.str(URL::SchemeOpt::leave_as_is), "ftp://mamba.org/");
+                CHECK_EQ(url.str(URL::SchemeOpt::add_if_abscent), "ftp://mamba.org/");
+                CHECK_EQ(url.str(URL::SchemeOpt::remove_if_present), "mamba.org/");
+            }
+        }
+
+        SUBCASE("https://user:password@mamba.org:8080/folder/file.html?param=value#fragment")
+        {
+            URL url{};
+            url.set_scheme("https")
+                .set_host("mamba.org")
+                .set_user("user")
+                .set_password("password")
+                .set_port("8080")
+                .set_path("/folder/file.html")
+                .set_query("param=value")
+                .set_fragment("fragment");
+
+            CHECK_EQ(
+                url.str(),
+                "https://user:password@mamba.org:8080/folder/file.html?param=value#fragment"
+            );
+        }
+
+        SUBCASE("user@mamba.org")
+        {
+            URL url{};
+            url.set_host("mamba.org").set_user("user");
+            CHECK_EQ(url.str(), "user@mamba.org/");
+        }
+
+        SUBCASE("https://mamba.org")
+        {
+            URL url{};
+            url.set_scheme("https").set_host("mamba.org");
+            CHECK_EQ(url.str(), "https://mamba.org/");
         }
     }
 

--- a/libmamba/tests/src/core/test_url.cpp
+++ b/libmamba/tests/src/core/test_url.cpp
@@ -367,6 +367,23 @@ TEST_SUITE("url")
         CHECK_EQ(url.authentication(), "user:password");
     }
 
+    TEST_CASE("URL::authority")
+    {
+        URL url{};
+        url.set_scheme("https")
+            .set_host("mamba.org")
+            .set_path("/folder/file.html")
+            .set_query("param=value")
+            .set_fragment("fragment");
+        CHECK_EQ(url.authority(), "mamba.org");
+        url.set_port("8000");
+        CHECK_EQ(url.authority(), "mamba.org:8000");
+        url.set_user("user");
+        CHECK_EQ(url.authority(), "user@mamba.org:8000");
+        url.set_password("password");
+        CHECK_EQ(url.authority(), "user:password@mamba.org:8000");
+    }
+
     TEST_CASE("path_to_url")
     {
         auto url = path_to_url("/users/test/miniconda3");

--- a/libmamba/tests/src/core/test_url.cpp
+++ b/libmamba/tests/src/core/test_url.cpp
@@ -153,7 +153,7 @@ TEST_SUITE("url")
     {
         SUBCASE("http://mamba.org")
         {
-            URL url("http://mamba.org");
+            const URL url = URL::parse("http://mamba.org");
             CHECK_EQ(url.scheme(), "http");
             CHECK_EQ(url.host(), "mamba.org");
             CHECK_EQ(url.path(), "/");
@@ -166,7 +166,7 @@ TEST_SUITE("url")
 
         SUBCASE("s3://userx123:üúßsajd@mamba.org")
         {
-            URL url("s3://userx123:üúßsajd@mamba.org");
+            const URL url = URL::parse("s3://userx123:üúßsajd@mamba.org");
             CHECK_EQ(url.scheme(), "s3");
             CHECK_EQ(url.host(), "mamba.org");
             CHECK_EQ(url.path(), "/");
@@ -179,7 +179,7 @@ TEST_SUITE("url")
 
         SUBCASE("http://user%40email.com:test@localhost:8000")
         {
-            URL url("http://user%40email.com:test@localhost:8000");
+            const URL url = URL::parse("http://user%40email.com:test@localhost:8000");
             CHECK_EQ(url.scheme(), "http");
             CHECK_EQ(url.host(), "localhost");
             CHECK_EQ(url.path(), "/");
@@ -192,7 +192,7 @@ TEST_SUITE("url")
 
         SUBCASE("https://mamba🆒🔬.org/this/is/a/path/?query=123&xyz=3333")
         {
-            URL url("https://mamba🆒🔬.org/this/is/a/path/?query=123&xyz=3333");
+            const URL url = URL::parse("https://mamba🆒🔬.org/this/is/a/path/?query=123&xyz=3333");
             CHECK_EQ(url.scheme(), "https");
             CHECK_EQ(url.host(), "mamba🆒🔬.org");
             CHECK_EQ(url.path(), "/this/is/a/path/");
@@ -206,7 +206,7 @@ TEST_SUITE("url")
         SUBCASE("file://C:/Users/wolfv/test/document.json")
         {
 #ifdef _WIN32
-            URL url("file://C:/Users/wolfv/test/document.json");
+            const URL url = URL::parse("file://C:/Users/wolfv/test/document.json");
             CHECK_EQ(url.scheme(), "file");
             CHECK_EQ(url.host(), "");
             CHECK_EQ(url.path(), "C:/Users/wolfv/test/document.json");
@@ -221,8 +221,7 @@ TEST_SUITE("url")
         SUBCASE("file:///home/wolfv/test/document.json")
         {
 #ifndef _WIN32
-            URL url("file:///home/wolfv/test/document.json");
-
+            const URL url = URL::parse("file:///home/wolfv/test/document.json");
             CHECK_EQ(url.scheme(), "file");
             CHECK_EQ(url.host(), "");
             CHECK_EQ(url.path(), "/home/wolfv/test/document.json");

--- a/libmamba/tests/src/core/test_url.cpp
+++ b/libmamba/tests/src/core/test_url.cpp
@@ -346,36 +346,36 @@ TEST_SUITE("url")
         CHECK_EQ(file_uri_unc2_to_unc4("file://server"), "file:////server");
     }
 
-    TEST_CASE("get_scheme")
+    TEST_CASE("url_get_scheme")
     {
-        CHECK_EQ(get_scheme("http://mamba.org"), "http");
-        CHECK_EQ(get_scheme("file:///folder/file.txt"), "file");
-        CHECK_EQ(get_scheme("s3://bucket/file.txt"), "s3");
-        CHECK_EQ(get_scheme("mamba.org"), "");
-        CHECK_EQ(get_scheme("://"), "");
-        CHECK_EQ(get_scheme("f#gre://"), "");
-        CHECK_EQ(get_scheme(""), "");
+        CHECK_EQ(url_get_scheme("http://mamba.org"), "http");
+        CHECK_EQ(url_get_scheme("file:///folder/file.txt"), "file");
+        CHECK_EQ(url_get_scheme("s3://bucket/file.txt"), "s3");
+        CHECK_EQ(url_get_scheme("mamba.org"), "");
+        CHECK_EQ(url_get_scheme("://"), "");
+        CHECK_EQ(url_get_scheme("f#gre://"), "");
+        CHECK_EQ(url_get_scheme(""), "");
     }
 
-    TEST_CASE("has_scheme")
+    TEST_CASE("url_has_scheme")
     {
-        CHECK(has_scheme("http://mamba.org"));
-        CHECK(has_scheme("file:///folder/file.txt"));
-        CHECK(has_scheme("s3://bucket/file.txt"));
-        CHECK_FALSE(has_scheme("mamba.org"));
-        CHECK_FALSE(has_scheme("://"));
-        CHECK_FALSE(has_scheme("f#gre://"));
-        CHECK_FALSE(has_scheme(""));
+        CHECK(url_has_scheme("http://mamba.org"));
+        CHECK(url_has_scheme("file:///folder/file.txt"));
+        CHECK(url_has_scheme("s3://bucket/file.txt"));
+        CHECK_FALSE(url_has_scheme("mamba.org"));
+        CHECK_FALSE(url_has_scheme("://"));
+        CHECK_FALSE(url_has_scheme("f#gre://"));
+        CHECK_FALSE(url_has_scheme(""));
     }
 
-    TEST_CASE("has_drive_letter")
+    TEST_CASE("path_has_drive_letter")
     {
-        CHECK(has_drive_letter("C:/folder/file"));
-        CHECK(has_drive_letter(R"(C:\folder\file)"));
-        CHECK_FALSE(has_drive_letter("/folder/file"));
-        CHECK_FALSE(has_drive_letter("folder/file"));
-        CHECK_FALSE(has_drive_letter(R"(\folder\file)"));
-        CHECK_FALSE(has_drive_letter(R"(folder\file)"));
+        CHECK(path_has_drive_letter("C:/folder/file"));
+        CHECK(path_has_drive_letter(R"(C:\folder\file)"));
+        CHECK_FALSE(path_has_drive_letter("/folder/file"));
+        CHECK_FALSE(path_has_drive_letter("folder/file"));
+        CHECK_FALSE(path_has_drive_letter(R"(\folder\file)"));
+        CHECK_FALSE(path_has_drive_letter(R"(folder\file)"));
     }
 
     TEST_CASE("split_ananconda_token")

--- a/libmamba/tests/src/util/test_string.cpp
+++ b/libmamba/tests/src/util/test_string.cpp
@@ -72,6 +72,34 @@ namespace mamba::util
             CHECK(contains("", ""));  // same as Python ``"" in ""``
         }
 
+        TEST_CASE("remove_prefix")
+        {
+            CHECK_EQ(remove_prefix("", ""), "");
+            CHECK_EQ(remove_prefix("hello", ""), "hello");
+            CHECK_EQ(remove_prefix("hello", "hello"), "");
+            CHECK_EQ(remove_prefix("", "hello"), "");
+            CHECK_EQ(remove_prefix("https://localhost", "https://"), "localhost");
+            CHECK_EQ(remove_prefix("https://localhost", "http://"), "https://localhost");
+            CHECK_EQ(remove_prefix("aabb", "a"), "abb");
+            CHECK_EQ(remove_prefix("", 'a'), "");
+            CHECK_EQ(remove_prefix("a", 'a'), "");
+            CHECK_EQ(remove_prefix("aaa", 'a'), "aa");
+        }
+
+        TEST_CASE("remove_suffix")
+        {
+            CHECK_EQ(remove_suffix("", ""), "");
+            CHECK_EQ(remove_suffix("hello", ""), "hello");
+            CHECK_EQ(remove_suffix("hello", "hello"), "");
+            CHECK_EQ(remove_suffix("", "hello"), "");
+            CHECK_EQ(remove_suffix("localhost:8080", ":8080"), "localhost");
+            CHECK_EQ(remove_suffix("localhost:8080", ":80"), "localhost:8080");
+            CHECK_EQ(remove_suffix("aabb", "b"), "aab");
+            CHECK_EQ(remove_suffix("", 'b'), "");
+            CHECK_EQ(remove_suffix("b", 'b'), "");
+            CHECK_EQ(remove_suffix("bbb", 'b'), "bb");
+        }
+
         TEST_CASE("any_starts_with")
         {
             using StrVec = std::vector<std::string_view>;

--- a/libmamba/tests/src/util/test_string.cpp
+++ b/libmamba/tests/src/util/test_string.cpp
@@ -16,7 +16,7 @@
 
 namespace mamba::util
 {
-    TEST_SUITE("util_string")
+    TEST_SUITE("util::string")
     {
         TEST_CASE("to_lower")
         {
@@ -84,6 +84,7 @@ namespace mamba::util
             CHECK_EQ(remove_prefix("", 'a'), "");
             CHECK_EQ(remove_prefix("a", 'a'), "");
             CHECK_EQ(remove_prefix("aaa", 'a'), "aa");
+            CHECK_EQ(remove_prefix("aabb", 'b'), "aabb");
         }
 
         TEST_CASE("remove_suffix")
@@ -98,6 +99,7 @@ namespace mamba::util
             CHECK_EQ(remove_suffix("", 'b'), "");
             CHECK_EQ(remove_suffix("b", 'b'), "");
             CHECK_EQ(remove_suffix("bbb", 'b'), "bb");
+            CHECK_EQ(remove_suffix("aabb", 'a'), "aabb");
         }
 
         TEST_CASE("any_starts_with")

--- a/libmamba/tests/src/util/test_url.cpp
+++ b/libmamba/tests/src/util/test_url.cpp
@@ -84,6 +84,14 @@ TEST_SUITE("util::URL")
             CHECK_THROWS_AS(url.set_host(""), std::invalid_argument);
             CHECK_THROWS_AS(url.set_port("not-a-number"), std::invalid_argument);
         }
+
+        SUBCASE("Encoding")
+        {
+            URL url{};
+            url.set_user("micro@mamba.pm", URL::Encode::yes);
+            CHECK_EQ(url.user(URL::Decode::no), "micro%40mamba.pm");
+            CHECK_EQ(url.user(URL::Decode::yes), "micro@mamba.pm");
+        }
     }
 
     TEST_CASE("parse")
@@ -151,7 +159,7 @@ TEST_SUITE("util::URL")
             CHECK_EQ(url.host(), "localhost");
             CHECK_EQ(url.path(), "/");
             CHECK_EQ(url.pretty_path(), "/");
-            CHECK_EQ(url.user(), "user%40email.com");
+            CHECK_EQ(url.user(), "user@email.com");
             CHECK_EQ(url.password(), "test");
             CHECK_EQ(url.port(), "8000");
             CHECK_EQ(url.query(), "");

--- a/libmamba/tests/src/util/test_url.cpp
+++ b/libmamba/tests/src/util/test_url.cpp
@@ -91,6 +91,9 @@ TEST_SUITE("util::URL")
             url.set_user("micro@mamba.pm", URL::Encode::yes);
             CHECK_EQ(url.user(URL::Decode::no), "micro%40mamba.pm");
             CHECK_EQ(url.user(URL::Decode::yes), "micro@mamba.pm");
+            url.set_password(R"(#!$&'"ab23)", URL::Encode::yes);
+            CHECK_EQ(url.password(URL::Decode::no), "%23%21%24%26%27%22ab23");
+            CHECK_EQ(url.password(URL::Decode::yes), R"(#!$&'"ab23)");
         }
     }
 

--- a/libmamba/tests/src/util/test_url.cpp
+++ b/libmamba/tests/src/util/test_url.cpp
@@ -16,22 +16,6 @@ using namespace mamba::util;
 
 TEST_SUITE("util::URL")
 {
-    TEST_CASE("encoding")
-    {
-        CHECK_EQ(url_encode(""), "");
-        CHECK_EQ(url_encode("page"), "page");
-        CHECK_EQ(url_encode(" /word%"), "%20%2Fword%25");
-        CHECK_EQ(url_encode("user@email.com"), "user%40email.com");
-        // Does NOT parse URL
-        CHECK_EQ(url_encode("https://foo/"), "https%3A%2F%2Ffoo%2F");
-
-        CHECK_EQ(url_decode(""), "");
-        CHECK_EQ(url_decode("page"), "page");
-        CHECK_EQ(url_decode("%20%2Fword%25"), " /word%");
-        CHECK_EQ(url_decode("user%40email.com"), "user@email.com");
-        CHECK_EQ(url_decode("https%3A%2F%2Ffoo%2F"), "https://foo/");
-    }
-
     TEST_CASE("URL builder")
     {
         SUBCASE("Empty")

--- a/libmamba/tests/src/util/test_url.cpp
+++ b/libmamba/tests/src/util/test_url.cpp
@@ -94,6 +94,9 @@ TEST_SUITE("util::URL")
             url.set_password(R"(#!$&'"ab23)", URL::Encode::yes);
             CHECK_EQ(url.password(URL::Decode::no), "%23%21%24%26%27%22ab23");
             CHECK_EQ(url.password(URL::Decode::yes), R"(#!$&'"ab23)");
+            url.set_host("micro#mamba.org", URL::Encode::yes);
+            CHECK_EQ(url.host(URL::Decode::no), "micro%23mamba.org");
+            CHECK_EQ(url.host(URL::Decode::yes), "micro#mamba.org");
         }
     }
 

--- a/libmamba/tests/src/util/test_url.cpp
+++ b/libmamba/tests/src/util/test_url.cpp
@@ -369,4 +369,25 @@ TEST_SUITE("util::URL")
         CHECK_NE(URL::parse("mamba.org/page"), URL::parse("mamba.org/page?q=v"));
         CHECK_NE(URL::parse("mamba.org/page"), URL::parse("mamba.org/page#there"));
     }
+
+    TEST_CASE("Append path")
+    {
+        auto url = URL();
+
+        CHECK_EQ(url.path(), "/");
+        CHECK_EQ((url / "").path(), "/");
+        CHECK_EQ((url / "   ").path(), "/");
+        CHECK_EQ((url / "/").path(), "/");
+        CHECK_EQ((url / "page").path(), "/page");
+        CHECK_EQ((url / "/page").path(), "/page");
+        CHECK_EQ((url / " /page").path(), "/page");
+        CHECK_EQ(url.path(), "/");  // unchanged
+
+        url.append_path("folder");
+        CHECK_EQ(url.path(), "/folder");
+        CHECK_EQ((url / "").path(), "/folder");
+        CHECK_EQ((url / "/").path(), "/folder/");
+        CHECK_EQ((url / "page").path(), "/folder/page");
+        CHECK_EQ((url / "/page").path(), "/folder/page");
+    }
 }

--- a/libmamba/tests/src/util/test_url.cpp
+++ b/libmamba/tests/src/util/test_url.cpp
@@ -283,6 +283,31 @@ TEST_SUITE("util::URL")
             }
         }
 
+        SUBCASE("rstrip option")
+        {
+            URL url = {};
+            url.set_host("mamba.org");
+            CHECK_EQ(url.str(URL::StripScheme::no, 0), "https://mamba.org/");
+            CHECK_EQ(url.str(URL::StripScheme::no, '/'), "https://mamba.org");
+            url.set_path("/page/");
+            CHECK_EQ(url.str(URL::StripScheme::no, ':'), "https://mamba.org/page/");
+            CHECK_EQ(url.str(URL::StripScheme::no, '/'), "https://mamba.org/page");
+        }
+
+        SUBCASE("Hide password option")
+        {
+            URL url = {};
+            url.set_user("user").set_password("pass");
+            CHECK_EQ(
+                url.str(URL::StripScheme::no, 0, URL::HidePassword::no),
+                "https://user:pass@localhost/"
+            );
+            CHECK_EQ(
+                url.str(URL::StripScheme::no, 0, URL::HidePassword::yes),
+                "https://user:*****@localhost/"
+            );
+        }
+
         SUBCASE("https://user:password@mamba.org:8080/folder/file.html?param=value#fragment")
         {
             URL url{};

--- a/libmamba/tests/src/util/test_url.cpp
+++ b/libmamba/tests/src/util/test_url.cpp
@@ -88,6 +88,20 @@ TEST_SUITE("util::URL")
 
     TEST_CASE("parse")
     {
+        SUBCASE("Empty")
+        {
+            const URL url = URL::parse("");
+            CHECK_EQ(url.scheme(), URL::https);
+            CHECK_EQ(url.host(), URL::localhost);
+            CHECK_EQ(url.path(), "/");
+            CHECK_EQ(url.pretty_path(), "/");
+            CHECK_EQ(url.user(), "");
+            CHECK_EQ(url.password(), "");
+            CHECK_EQ(url.port(), "");
+            CHECK_EQ(url.query(), "");
+            CHECK_EQ(url.fragment(), "");
+        }
+
         SUBCASE("mamba.org")
         {
             const URL url = URL::parse("mamba.org");
@@ -339,5 +353,20 @@ TEST_SUITE("util::URL")
         CHECK_EQ(url.authority(), "user@mamba.org:8000");
         url.set_password("password");
         CHECK_EQ(url.authority(), "user:password@mamba.org:8000");
+    }
+
+    TEST_CASE("Equality")
+    {
+        CHECK_EQ(URL(), URL());
+        CHECK_EQ(URL::parse("https://169.254.0.0/page"), URL::parse("https://169.254.0.0/page"));
+        CHECK_EQ(URL::parse("mamba.org"), URL::parse("mamba.org/"));
+        CHECK_EQ(URL::parse("mAmba.oRg"), URL::parse("mamba.org/"));
+        CHECK_EQ(URL::parse("localhost/page"), URL::parse("https://localhost/page"));
+
+        CHECK_NE(URL::parse("mamba.org/page"), URL::parse("mamba.org/"));
+        CHECK_NE(URL::parse("mamba.org"), URL::parse("mamba.org:9999"));
+        CHECK_NE(URL::parse("user@mamba.org"), URL::parse("mamba.org"));
+        CHECK_NE(URL::parse("mamba.org/page"), URL::parse("mamba.org/page?q=v"));
+        CHECK_NE(URL::parse("mamba.org/page"), URL::parse("mamba.org/page#there"));
     }
 }

--- a/libmamba/tests/src/util/test_url.cpp
+++ b/libmamba/tests/src/util/test_url.cpp
@@ -16,6 +16,22 @@ using namespace mamba::util;
 
 TEST_SUITE("util::URL")
 {
+    TEST_CASE("encoding")
+    {
+        CHECK_EQ(url_encode(""), "");
+        CHECK_EQ(url_encode("page"), "page");
+        CHECK_EQ(url_encode(" /word%"), "%20%2Fword%25");
+        CHECK_EQ(url_encode("user@email.com"), "user%40email.com");
+        // Does NOT parse URL
+        CHECK_EQ(url_encode("https://foo/"), "https%3A%2F%2Ffoo%2F");
+
+        CHECK_EQ(url_decode(""), "");
+        CHECK_EQ(url_decode("page"), "page");
+        CHECK_EQ(url_decode("%20%2Fword%25"), " /word%");
+        CHECK_EQ(url_decode("user%40email.com"), "user@email.com");
+        CHECK_EQ(url_decode("https%3A%2F%2Ffoo%2F"), "https://foo/");
+    }
+
     TEST_CASE("URL builder")
     {
         SUBCASE("Empty")

--- a/libmamba/tests/src/util/test_url.cpp
+++ b/libmamba/tests/src/util/test_url.cpp
@@ -172,6 +172,16 @@ TEST_SUITE("util::URL")
             CHECK_EQ(url.fragment(), "");
         }
 
+        SUBCASE("http://user@40email.com:test@localhost")
+        {
+            // Fails before "user@email.com" needs to be percent encoded, otherwise parsing is
+            // ill defined.
+
+            // Silencing [[nodiscard]] warning
+            auto failure = [](std::string_view str) { [[maybe_unused]] auto url = URL::parse(str); };
+            CHECK_THROWS_AS(failure("http://user@40email.com:test@localhost"), std::invalid_argument);
+        }
+
         SUBCASE("http://:pass@localhost:8000")
         {
             const URL url = URL::parse("http://:pass@localhost:8000");
@@ -259,6 +269,20 @@ TEST_SUITE("util::URL")
             CHECK_EQ(url.port(), "9999");
             CHECK_EQ(url.query(), "");
             CHECK_EQ(url.fragment(), "");
+        }
+
+        SUBCASE("https://mamba.org/page#the-fragment")
+        {
+            const URL url = URL::parse("https://mamba.org/page#the-fragment");
+            CHECK_EQ(url.scheme(), "https");
+            CHECK_EQ(url.host(), "mamba.org");
+            CHECK_EQ(url.path(), "/page");
+            CHECK_EQ(url.pretty_path(), "/page");
+            CHECK_EQ(url.user(), "");
+            CHECK_EQ(url.password(), "");
+            CHECK_EQ(url.port(), "");
+            CHECK_EQ(url.query(), "");
+            CHECK_EQ(url.fragment(), "the-fragment");
         }
     }
 

--- a/libmamba/tests/src/util/test_url.cpp
+++ b/libmamba/tests/src/util/test_url.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, QuantStack and Mamba Contributors
+// Copyright (c) 2023, QuantStack and Mamba Contributors
 //
 // Distributed under the terms of the BSD 3-Clause License.
 //
@@ -10,106 +10,12 @@
 
 #include <doctest/doctest.h>
 
-#include "mamba/core/context.hpp"
-#include "mamba/core/url.hpp"
+#include "mamba/util/url.hpp"
 
-#ifdef _WIN32
-#include "mamba/core/mamba_fs.hpp"
-#endif
+using namespace mamba::util;
 
-using namespace mamba;
-
-TEST_SUITE("url")
+TEST_SUITE("util::URL")
 {
-    TEST_CASE("concat_scheme_url")
-    {
-        auto url = concat_scheme_url("https", "mamba.com");
-        CHECK_EQ(url, "https://mamba.com");
-
-        url = concat_scheme_url("file", "C:/some_folder");
-        CHECK_EQ(url, "file:///C:/some_folder");
-
-        url = concat_scheme_url("file", "some_folder");
-        CHECK_EQ(url, "file://some_folder");
-    }
-
-    TEST_CASE("build_url")
-    {
-        auto url = build_url(std::nullopt, "https", "mamba.com", true);
-        CHECK_EQ(url, "https://mamba.com");
-
-        url = build_url(std::nullopt, "https", "mamba.com", false);
-        CHECK_EQ(url, "https://mamba.com");
-
-        url = build_url(std::optional<std::string>("auth"), "https", "mamba.com", false);
-        CHECK_EQ(url, "https://mamba.com");
-
-        url = build_url(std::optional<std::string>("auth"), "https", "mamba.com", true);
-        CHECK_EQ(url, "https://auth@mamba.com");
-
-        url = build_url(std::optional<std::string>(""), "https", "mamba.com", true);
-        CHECK_EQ(url, "https://@mamba.com");
-    }
-
-    TEST_CASE("split_platform")
-    {
-        auto& ctx = Context::instance();
-
-        std::string platform_found, cleaned_url;
-        split_platform(
-            { "noarch", "linux-64" },
-            "https://mamba.com/linux-64/package.tar.bz2",
-            ctx.platform,
-            cleaned_url,
-            platform_found
-        );
-
-        CHECK_EQ(platform_found, "linux-64");
-        CHECK_EQ(cleaned_url, "https://mamba.com/package.tar.bz2");
-
-        split_platform(
-            { "noarch", "linux-64" },
-            "https://mamba.com/linux-64/noarch-package.tar.bz2",
-            ctx.platform,
-            cleaned_url,
-            platform_found
-        );
-        CHECK_EQ(platform_found, "linux-64");
-        CHECK_EQ(cleaned_url, "https://mamba.com/noarch-package.tar.bz2");
-
-        split_platform(
-            { "linux-64", "osx-arm64", "noarch" },
-            "https://mamba.com/noarch/kernel_linux-64-package.tar.bz2",
-            ctx.platform,
-            cleaned_url,
-            platform_found
-        );
-        CHECK_EQ(platform_found, "noarch");
-        CHECK_EQ(cleaned_url, "https://mamba.com/kernel_linux-64-package.tar.bz2");
-
-        split_platform(
-            { "noarch", "linux-64" },
-            "https://mamba.com/linux-64",
-            ctx.platform,
-            cleaned_url,
-            platform_found
-        );
-
-        CHECK_EQ(platform_found, "linux-64");
-        CHECK_EQ(cleaned_url, "https://mamba.com");
-
-        split_platform(
-            { "noarch", "linux-64" },
-            "https://mamba.com/noarch",
-            ctx.platform,
-            cleaned_url,
-            platform_found
-        );
-
-        CHECK_EQ(platform_found, "noarch");
-        CHECK_EQ(cleaned_url, "https://mamba.com");
-    }
-
     TEST_CASE("URL builder")
     {
         SUBCASE("Empty")
@@ -171,7 +77,7 @@ TEST_SUITE("url")
         }
     }
 
-    TEST_CASE("URL::parse")
+    TEST_CASE("parse")
     {
         SUBCASE("mamba.org")
         {
@@ -319,7 +225,7 @@ TEST_SUITE("url")
         }
     }
 
-    TEST_CASE("URL::str")
+    TEST_CASE("str")
     {
         SUBCASE("scheme option")
         {
@@ -399,7 +305,7 @@ TEST_SUITE("url")
         }
     }
 
-    TEST_CASE("URL::authentication")
+    TEST_CASE("authentication")
     {
         URL url{};
         CHECK_EQ(url.authentication(), "");
@@ -409,7 +315,7 @@ TEST_SUITE("url")
         CHECK_EQ(url.authentication(), "user:password");
     }
 
-    TEST_CASE("URL::authority")
+    TEST_CASE("authority")
     {
         URL url{};
         url.set_scheme("https")
@@ -424,163 +330,5 @@ TEST_SUITE("url")
         CHECK_EQ(url.authority(), "user@mamba.org:8000");
         url.set_password("password");
         CHECK_EQ(url.authority(), "user:password@mamba.org:8000");
-    }
-
-    TEST_CASE("path_to_url")
-    {
-        auto url = path_to_url("/users/test/miniconda3");
-#ifndef _WIN32
-        CHECK_EQ(url, "file:///users/test/miniconda3");
-#else
-        std::string driveletter = fs::absolute(fs::u8path("/")).string().substr(0, 1);
-        CHECK_EQ(url, std::string("file://") + driveletter + ":/users/test/miniconda3");
-        auto url2 = path_to_url("D:\\users\\test\\miniconda3");
-        CHECK_EQ(url2, "file://D:/users/test/miniconda3");
-#endif
-    }
-
-    TEST_CASE("file_uri_unc2_to_unc4")
-    {
-        for (std::string const uri : {
-                 "http://example.com/test",
-                 R"(file://C:/Program\ (x74)/Users/hello\ world)",
-                 R"(file:///C:/Program\ (x74)/Users/hello\ world)",
-                 "file:////server/share",
-                 "file:///path/to/data.xml",
-                 "file:///absolute/path",
-                 R"(file://\\server\path)",
-             })
-        {
-            CAPTURE(uri);
-            CHECK_EQ(file_uri_unc2_to_unc4(uri), uri);
-        }
-        CHECK_EQ(file_uri_unc2_to_unc4("file://server/share"), "file:////server/share");
-        CHECK_EQ(file_uri_unc2_to_unc4("file://server"), "file:////server");
-    }
-
-    TEST_CASE("url_get_scheme")
-    {
-        CHECK_EQ(url_get_scheme("http://mamba.org"), "http");
-        CHECK_EQ(url_get_scheme("file:///folder/file.txt"), "file");
-        CHECK_EQ(url_get_scheme("s3://bucket/file.txt"), "s3");
-        CHECK_EQ(url_get_scheme("mamba.org"), "");
-        CHECK_EQ(url_get_scheme("://"), "");
-        CHECK_EQ(url_get_scheme("f#gre://"), "");
-        CHECK_EQ(url_get_scheme(""), "");
-    }
-
-    TEST_CASE("url_has_scheme")
-    {
-        CHECK(url_has_scheme("http://mamba.org"));
-        CHECK(url_has_scheme("file:///folder/file.txt"));
-        CHECK(url_has_scheme("s3://bucket/file.txt"));
-        CHECK_FALSE(url_has_scheme("mamba.org"));
-        CHECK_FALSE(url_has_scheme("://"));
-        CHECK_FALSE(url_has_scheme("f#gre://"));
-        CHECK_FALSE(url_has_scheme(""));
-    }
-
-    TEST_CASE("path_has_drive_letter")
-    {
-        CHECK(path_has_drive_letter("C:/folder/file"));
-        CHECK(path_has_drive_letter(R"(C:\folder\file)"));
-        CHECK_FALSE(path_has_drive_letter("/folder/file"));
-        CHECK_FALSE(path_has_drive_letter("folder/file"));
-        CHECK_FALSE(path_has_drive_letter(R"(\folder\file)"));
-        CHECK_FALSE(path_has_drive_letter(R"(folder\file)"));
-    }
-
-    TEST_CASE("split_ananconda_token")
-    {
-        std::string input, cleaned_url, token;
-        {
-            input = "https://1.2.3.4/t/tk-123-456/path";
-            split_anaconda_token(input, cleaned_url, token);
-            CHECK_EQ(cleaned_url, "https://1.2.3.4/path");
-            CHECK_EQ(token, "tk-123-456");
-        }
-
-        {
-            input = "https://1.2.3.4/t//path";
-            split_anaconda_token(input, cleaned_url, token);
-            CHECK_EQ(cleaned_url, "https://1.2.3.4/path");
-            CHECK_EQ(token, "");
-        }
-
-        {
-            input = "https://some.domain/api/t/tk-123-456/path";
-            split_anaconda_token(input, cleaned_url, token);
-            CHECK_EQ(cleaned_url, "https://some.domain/api/path");
-            CHECK_EQ(token, "tk-123-456");
-        }
-
-        {
-            input = "https://1.2.3.4/conda/t/tk-123-456/path";
-            split_anaconda_token(input, cleaned_url, token);
-            CHECK_EQ(cleaned_url, "https://1.2.3.4/conda/path");
-            CHECK_EQ(token, "tk-123-456");
-        }
-
-        {
-            input = "https://1.2.3.4/path";
-            split_anaconda_token(input, cleaned_url, token);
-            CHECK_EQ(cleaned_url, "https://1.2.3.4/path");
-            CHECK_EQ(token, "");
-        }
-
-        {
-            input = "https://10.2.3.4:8080/conda/t/tk-123-45";
-            split_anaconda_token(input, cleaned_url, token);
-            CHECK_EQ(cleaned_url, "https://10.2.3.4:8080/conda");
-            CHECK_EQ(token, "tk-123-45");
-        }
-    }
-
-    TEST_CASE("split_scheme_auth_token")
-    {
-        std::string input = "https://u:p@conda.io/t/x1029384756/more/path";
-        std::string input2 = "https://u:p@conda.io/t/a_-12345-absdj12345-xyxyxyx/more/path";
-        std::string remaining_url, scheme, auth, token;
-        split_scheme_auth_token(input, remaining_url, scheme, auth, token);
-        CHECK_EQ(remaining_url, "conda.io/more/path");
-        CHECK_EQ(scheme, "https");
-        CHECK_EQ(auth, "u:p");
-        CHECK_EQ(token, "x1029384756");
-
-        split_scheme_auth_token(input2, remaining_url, scheme, auth, token);
-        CHECK_EQ(remaining_url, "conda.io/more/path");
-        CHECK_EQ(scheme, "https");
-        CHECK_EQ(auth, "u:p");
-        CHECK_EQ(token, "a_-12345-absdj12345-xyxyxyx");
-
-#ifdef _WIN32
-        split_scheme_auth_token("file://C:/Users/wolfv/test.json", remaining_url, scheme, auth, token);
-        CHECK_EQ(remaining_url, "C:/Users/wolfv/test.json");
-        CHECK_EQ(scheme, "file");
-        CHECK_EQ(auth, "");
-        CHECK_EQ(token, "");
-#else
-        split_scheme_auth_token("file:///home/wolfv/test.json", remaining_url, scheme, auth, token);
-        CHECK_EQ(remaining_url, "/home/wolfv/test.json");
-        CHECK_EQ(scheme, "file");
-        CHECK_EQ(auth, "");
-        CHECK_EQ(token, "");
-#endif
-    }
-
-    TEST_CASE("is_path")
-    {
-        CHECK(is_path("./"));
-        CHECK(is_path(".."));
-        CHECK(is_path("~"));
-        CHECK(is_path("/"));
-        CHECK_FALSE(is_path("file://makefile"));
-    }
-
-    TEST_CASE("cache_name_from_url")
-    {
-        CHECK_EQ(cache_name_from_url("http://test.com/1234/"), "302f0a61");
-        CHECK_EQ(cache_name_from_url("http://test.com/1234/repodata.json"), "302f0a61");
-        CHECK_EQ(cache_name_from_url("http://test.com/1234/current_repodata.json"), "78a8cce9");
     }
 }

--- a/libmamba/tests/src/util/test_url.cpp
+++ b/libmamba/tests/src/util/test_url.cpp
@@ -69,11 +69,20 @@ TEST_SUITE("util::URL")
             CHECK_EQ(url.pretty_path(), "C:/folder/file.txt");
         }
 
+        SUBCASE("Case")
+        {
+            URL url{};
+            url.set_scheme("FtP").set_host("sOme_Host.COM");
+            CHECK_EQ(url.scheme(), "ftp");
+            CHECK_EQ(url.host(), "some_host.com");
+        }
+
         SUBCASE("Invalid")
         {
             URL url{};
             CHECK_THROWS_AS(url.set_scheme(""), std::invalid_argument);
             CHECK_THROWS_AS(url.set_host(""), std::invalid_argument);
+            CHECK_THROWS_AS(url.set_port("not-a-number"), std::invalid_argument);
         }
     }
 

--- a/libmamba/tests/src/util/test_url.cpp
+++ b/libmamba/tests/src/util/test_url.cpp
@@ -371,10 +371,10 @@ TEST_SUITE("util::URL")
     {
         URL url{};
         CHECK_EQ(url.authentication(), "");
-        url.set_user("user");
-        CHECK_EQ(url.authentication(), "user");
+        url.set_user("user@email.com");
+        CHECK_EQ(url.authentication(), "user%40email.com");
         url.set_password("password");
-        CHECK_EQ(url.authentication(), "user:password");
+        CHECK_EQ(url.authentication(), "user%40email.com:password");
     }
 
     TEST_CASE("authority")
@@ -388,10 +388,10 @@ TEST_SUITE("util::URL")
         CHECK_EQ(url.authority(), "mamba.org");
         url.set_port("8000");
         CHECK_EQ(url.authority(), "mamba.org:8000");
-        url.set_user("user");
-        CHECK_EQ(url.authority(), "user@mamba.org:8000");
+        url.set_user("user@email.com");
+        CHECK_EQ(url.authority(), "user%40email.com@mamba.org:8000");
         url.set_password("password");
-        CHECK_EQ(url.authority(), "user:password@mamba.org:8000");
+        CHECK_EQ(url.authority(), "user%40email.com:password@mamba.org:8000");
     }
 
     TEST_CASE("Equality")

--- a/libmamba/tests/src/util/test_url_manip.cpp
+++ b/libmamba/tests/src/util/test_url_manip.cpp
@@ -26,6 +26,10 @@ TEST_SUITE("util::url_manip")
         CHECK_EQ(url_encode("page"), "page");
         CHECK_EQ(url_encode(" /word%"), "%20%2Fword%25");
         CHECK_EQ(url_encode("user@email.com"), "user%40email.com");
+        CHECK_EQ(
+            url_encode(R"(#!$&'"(ab23)*+,/:;=?@[])"),
+            "%23%21%24%26%27%22%28ab23%29%2A%2B%2C%2F%3A%3B%3D%3F%40%5B%5D"
+        );
         // Does NOT parse URL
         CHECK_EQ(url_encode("https://foo/"), "https%3A%2F%2Ffoo%2F");
 
@@ -34,6 +38,10 @@ TEST_SUITE("util::url_manip")
         CHECK_EQ(url_decode("%20%2Fword%25"), " /word%");
         CHECK_EQ(url_decode("user%40email.com"), "user@email.com");
         CHECK_EQ(url_decode("https%3A%2F%2Ffoo%2F"), "https://foo/");
+        CHECK_EQ(
+            url_decode("%23%21%24%26%27%22%28ab23%29%2A%2B%2C%2F%3A%3B%3D%3F%40%5B%5D"),
+            R"(#!$&'"(ab23)*+,/:;=?@[])"
+        );
     }
 
     TEST_CASE("concat_scheme_url")

--- a/libmamba/tests/src/util/test_url_manip.cpp
+++ b/libmamba/tests/src/util/test_url_manip.cpp
@@ -20,6 +20,22 @@ using namespace mamba::util;
 
 TEST_SUITE("util::url_manip")
 {
+    TEST_CASE("encoding")
+    {
+        CHECK_EQ(url_encode(""), "");
+        CHECK_EQ(url_encode("page"), "page");
+        CHECK_EQ(url_encode(" /word%"), "%20%2Fword%25");
+        CHECK_EQ(url_encode("user@email.com"), "user%40email.com");
+        // Does NOT parse URL
+        CHECK_EQ(url_encode("https://foo/"), "https%3A%2F%2Ffoo%2F");
+
+        CHECK_EQ(url_decode(""), "");
+        CHECK_EQ(url_decode("page"), "page");
+        CHECK_EQ(url_decode("%20%2Fword%25"), " /word%");
+        CHECK_EQ(url_decode("user%40email.com"), "user@email.com");
+        CHECK_EQ(url_decode("https%3A%2F%2Ffoo%2F"), "https://foo/");
+    }
+
     TEST_CASE("concat_scheme_url")
     {
         auto url = concat_scheme_url("https", "mamba.com");

--- a/libmamba/tests/src/util/test_url_manip.cpp
+++ b/libmamba/tests/src/util/test_url_manip.cpp
@@ -4,13 +4,12 @@
 //
 // The full license is in the file LICENSE, distributed with this software.
 
-#include <stdexcept>
 #include <string>
 #include <string_view>
 
 #include <doctest/doctest.h>
 
-#include "mamba/core/context.hpp"
+#include "mamba/specs/platform.hpp"
 #include "mamba/util/url_manip.hpp"
 
 #ifdef _WIN32
@@ -19,7 +18,7 @@
 
 using namespace mamba::util;
 
-TEST_SUITE("url")
+TEST_SUITE("util::url_manip")
 {
     TEST_CASE("concat_scheme_url")
     {
@@ -53,13 +52,11 @@ TEST_SUITE("url")
 
     TEST_CASE("split_platform")
     {
-        auto& ctx = mamba::Context::instance();
-
         std::string platform_found, cleaned_url;
         split_platform(
             { "noarch", "linux-64" },
             "https://mamba.com/linux-64/package.tar.bz2",
-            ctx.platform,
+            std::string(mamba::specs::build_platform_name()),
             cleaned_url,
             platform_found
         );
@@ -70,7 +67,7 @@ TEST_SUITE("url")
         split_platform(
             { "noarch", "linux-64" },
             "https://mamba.com/linux-64/noarch-package.tar.bz2",
-            ctx.platform,
+            std::string(mamba::specs::build_platform_name()),
             cleaned_url,
             platform_found
         );
@@ -80,7 +77,7 @@ TEST_SUITE("url")
         split_platform(
             { "linux-64", "osx-arm64", "noarch" },
             "https://mamba.com/noarch/kernel_linux-64-package.tar.bz2",
-            ctx.platform,
+            std::string(mamba::specs::build_platform_name()),
             cleaned_url,
             platform_found
         );
@@ -90,7 +87,7 @@ TEST_SUITE("url")
         split_platform(
             { "noarch", "linux-64" },
             "https://mamba.com/linux-64",
-            ctx.platform,
+            std::string(mamba::specs::build_platform_name()),
             cleaned_url,
             platform_found
         );
@@ -101,7 +98,7 @@ TEST_SUITE("url")
         split_platform(
             { "noarch", "linux-64" },
             "https://mamba.com/noarch",
-            ctx.platform,
+            std::string(mamba::specs::build_platform_name()),
             cleaned_url,
             platform_found
         );

--- a/libmamba/tests/src/util/test_url_manip.cpp
+++ b/libmamba/tests/src/util/test_url_manip.cpp
@@ -1,0 +1,270 @@
+// Copyright (c) 2022, QuantStack and Mamba Contributors
+//
+// Distributed under the terms of the BSD 3-Clause License.
+//
+// The full license is in the file LICENSE, distributed with this software.
+
+#include <stdexcept>
+#include <string>
+#include <string_view>
+
+#include <doctest/doctest.h>
+
+#include "mamba/core/context.hpp"
+#include "mamba/util/url_manip.hpp"
+
+#ifdef _WIN32
+#include "mamba/core/mamba_fs.hpp"
+#endif
+
+using namespace mamba::util;
+
+TEST_SUITE("url")
+{
+    TEST_CASE("concat_scheme_url")
+    {
+        auto url = concat_scheme_url("https", "mamba.com");
+        CHECK_EQ(url, "https://mamba.com");
+
+        url = concat_scheme_url("file", "C:/some_folder");
+        CHECK_EQ(url, "file:///C:/some_folder");
+
+        url = concat_scheme_url("file", "some_folder");
+        CHECK_EQ(url, "file://some_folder");
+    }
+
+    TEST_CASE("build_url")
+    {
+        auto url = build_url(std::nullopt, "https", "mamba.com", true);
+        CHECK_EQ(url, "https://mamba.com");
+
+        url = build_url(std::nullopt, "https", "mamba.com", false);
+        CHECK_EQ(url, "https://mamba.com");
+
+        url = build_url(std::optional<std::string>("auth"), "https", "mamba.com", false);
+        CHECK_EQ(url, "https://mamba.com");
+
+        url = build_url(std::optional<std::string>("auth"), "https", "mamba.com", true);
+        CHECK_EQ(url, "https://auth@mamba.com");
+
+        url = build_url(std::optional<std::string>(""), "https", "mamba.com", true);
+        CHECK_EQ(url, "https://@mamba.com");
+    }
+
+    TEST_CASE("split_platform")
+    {
+        auto& ctx = mamba::Context::instance();
+
+        std::string platform_found, cleaned_url;
+        split_platform(
+            { "noarch", "linux-64" },
+            "https://mamba.com/linux-64/package.tar.bz2",
+            ctx.platform,
+            cleaned_url,
+            platform_found
+        );
+
+        CHECK_EQ(platform_found, "linux-64");
+        CHECK_EQ(cleaned_url, "https://mamba.com/package.tar.bz2");
+
+        split_platform(
+            { "noarch", "linux-64" },
+            "https://mamba.com/linux-64/noarch-package.tar.bz2",
+            ctx.platform,
+            cleaned_url,
+            platform_found
+        );
+        CHECK_EQ(platform_found, "linux-64");
+        CHECK_EQ(cleaned_url, "https://mamba.com/noarch-package.tar.bz2");
+
+        split_platform(
+            { "linux-64", "osx-arm64", "noarch" },
+            "https://mamba.com/noarch/kernel_linux-64-package.tar.bz2",
+            ctx.platform,
+            cleaned_url,
+            platform_found
+        );
+        CHECK_EQ(platform_found, "noarch");
+        CHECK_EQ(cleaned_url, "https://mamba.com/kernel_linux-64-package.tar.bz2");
+
+        split_platform(
+            { "noarch", "linux-64" },
+            "https://mamba.com/linux-64",
+            ctx.platform,
+            cleaned_url,
+            platform_found
+        );
+
+        CHECK_EQ(platform_found, "linux-64");
+        CHECK_EQ(cleaned_url, "https://mamba.com");
+
+        split_platform(
+            { "noarch", "linux-64" },
+            "https://mamba.com/noarch",
+            ctx.platform,
+            cleaned_url,
+            platform_found
+        );
+
+        CHECK_EQ(platform_found, "noarch");
+        CHECK_EQ(cleaned_url, "https://mamba.com");
+    }
+
+    TEST_CASE("path_to_url")
+    {
+        auto url = path_to_url("/users/test/miniconda3");
+#ifndef _WIN32
+        CHECK_EQ(url, "file:///users/test/miniconda3");
+#else
+        std::string driveletter = fs::absolute(fs::u8path("/")).string().substr(0, 1);
+        CHECK_EQ(url, std::string("file://") + driveletter + ":/users/test/miniconda3");
+        auto url2 = path_to_url("D:\\users\\test\\miniconda3");
+        CHECK_EQ(url2, "file://D:/users/test/miniconda3");
+#endif
+    }
+
+    TEST_CASE("file_uri_unc2_to_unc4")
+    {
+        for (std::string const uri : {
+                 "http://example.com/test",
+                 R"(file://C:/Program\ (x74)/Users/hello\ world)",
+                 R"(file:///C:/Program\ (x74)/Users/hello\ world)",
+                 "file:////server/share",
+                 "file:///path/to/data.xml",
+                 "file:///absolute/path",
+                 R"(file://\\server\path)",
+             })
+        {
+            CAPTURE(uri);
+            CHECK_EQ(file_uri_unc2_to_unc4(uri), uri);
+        }
+        CHECK_EQ(file_uri_unc2_to_unc4("file://server/share"), "file:////server/share");
+        CHECK_EQ(file_uri_unc2_to_unc4("file://server"), "file:////server");
+    }
+
+    TEST_CASE("url_get_scheme")
+    {
+        CHECK_EQ(url_get_scheme("http://mamba.org"), "http");
+        CHECK_EQ(url_get_scheme("file:///folder/file.txt"), "file");
+        CHECK_EQ(url_get_scheme("s3://bucket/file.txt"), "s3");
+        CHECK_EQ(url_get_scheme("mamba.org"), "");
+        CHECK_EQ(url_get_scheme("://"), "");
+        CHECK_EQ(url_get_scheme("f#gre://"), "");
+        CHECK_EQ(url_get_scheme(""), "");
+    }
+
+    TEST_CASE("url_has_scheme")
+    {
+        CHECK(url_has_scheme("http://mamba.org"));
+        CHECK(url_has_scheme("file:///folder/file.txt"));
+        CHECK(url_has_scheme("s3://bucket/file.txt"));
+        CHECK_FALSE(url_has_scheme("mamba.org"));
+        CHECK_FALSE(url_has_scheme("://"));
+        CHECK_FALSE(url_has_scheme("f#gre://"));
+        CHECK_FALSE(url_has_scheme(""));
+    }
+
+    TEST_CASE("path_has_drive_letter")
+    {
+        CHECK(path_has_drive_letter("C:/folder/file"));
+        CHECK(path_has_drive_letter(R"(C:\folder\file)"));
+        CHECK_FALSE(path_has_drive_letter("/folder/file"));
+        CHECK_FALSE(path_has_drive_letter("folder/file"));
+        CHECK_FALSE(path_has_drive_letter(R"(\folder\file)"));
+        CHECK_FALSE(path_has_drive_letter(R"(folder\file)"));
+    }
+
+    TEST_CASE("split_ananconda_token")
+    {
+        std::string input, cleaned_url, token;
+        {
+            input = "https://1.2.3.4/t/tk-123-456/path";
+            split_anaconda_token(input, cleaned_url, token);
+            CHECK_EQ(cleaned_url, "https://1.2.3.4/path");
+            CHECK_EQ(token, "tk-123-456");
+        }
+
+        {
+            input = "https://1.2.3.4/t//path";
+            split_anaconda_token(input, cleaned_url, token);
+            CHECK_EQ(cleaned_url, "https://1.2.3.4/path");
+            CHECK_EQ(token, "");
+        }
+
+        {
+            input = "https://some.domain/api/t/tk-123-456/path";
+            split_anaconda_token(input, cleaned_url, token);
+            CHECK_EQ(cleaned_url, "https://some.domain/api/path");
+            CHECK_EQ(token, "tk-123-456");
+        }
+
+        {
+            input = "https://1.2.3.4/conda/t/tk-123-456/path";
+            split_anaconda_token(input, cleaned_url, token);
+            CHECK_EQ(cleaned_url, "https://1.2.3.4/conda/path");
+            CHECK_EQ(token, "tk-123-456");
+        }
+
+        {
+            input = "https://1.2.3.4/path";
+            split_anaconda_token(input, cleaned_url, token);
+            CHECK_EQ(cleaned_url, "https://1.2.3.4/path");
+            CHECK_EQ(token, "");
+        }
+
+        {
+            input = "https://10.2.3.4:8080/conda/t/tk-123-45";
+            split_anaconda_token(input, cleaned_url, token);
+            CHECK_EQ(cleaned_url, "https://10.2.3.4:8080/conda");
+            CHECK_EQ(token, "tk-123-45");
+        }
+    }
+
+    TEST_CASE("split_scheme_auth_token")
+    {
+        std::string input = "https://u:p@conda.io/t/x1029384756/more/path";
+        std::string input2 = "https://u:p@conda.io/t/a_-12345-absdj12345-xyxyxyx/more/path";
+        std::string remaining_url, scheme, auth, token;
+        split_scheme_auth_token(input, remaining_url, scheme, auth, token);
+        CHECK_EQ(remaining_url, "conda.io/more/path");
+        CHECK_EQ(scheme, "https");
+        CHECK_EQ(auth, "u:p");
+        CHECK_EQ(token, "x1029384756");
+
+        split_scheme_auth_token(input2, remaining_url, scheme, auth, token);
+        CHECK_EQ(remaining_url, "conda.io/more/path");
+        CHECK_EQ(scheme, "https");
+        CHECK_EQ(auth, "u:p");
+        CHECK_EQ(token, "a_-12345-absdj12345-xyxyxyx");
+
+#ifdef _WIN32
+        split_scheme_auth_token("file://C:/Users/wolfv/test.json", remaining_url, scheme, auth, token);
+        CHECK_EQ(remaining_url, "C:/Users/wolfv/test.json");
+        CHECK_EQ(scheme, "file");
+        CHECK_EQ(auth, "");
+        CHECK_EQ(token, "");
+#else
+        split_scheme_auth_token("file:///home/wolfv/test.json", remaining_url, scheme, auth, token);
+        CHECK_EQ(remaining_url, "/home/wolfv/test.json");
+        CHECK_EQ(scheme, "file");
+        CHECK_EQ(auth, "");
+        CHECK_EQ(token, "");
+#endif
+    }
+
+    TEST_CASE("is_path")
+    {
+        CHECK(is_path("./"));
+        CHECK(is_path(".."));
+        CHECK(is_path("~"));
+        CHECK(is_path("/"));
+        CHECK_FALSE(is_path("file://makefile"));
+    }
+
+    TEST_CASE("cache_name_from_url")
+    {
+        CHECK_EQ(cache_name_from_url("http://test.com/1234/"), "302f0a61");
+        CHECK_EQ(cache_name_from_url("http://test.com/1234/repodata.json"), "302f0a61");
+        CHECK_EQ(cache_name_from_url("http://test.com/1234/current_repodata.json"), "78a8cce9");
+    }
+}

--- a/micromamba/src/constructor.cpp
+++ b/micromamba/src/constructor.cpp
@@ -12,9 +12,9 @@
 #include "mamba/core/channel.hpp"
 #include "mamba/core/package_handling.hpp"
 #include "mamba/core/package_info.hpp"
-#include "mamba/core/url.hpp"
 #include "mamba/core/util.hpp"
 #include "mamba/util/string.hpp"
+#include "mamba/util/url_manip.hpp"
 
 
 using namespace mamba;  // NOLINT(build/namespaces)
@@ -126,7 +126,10 @@ construct(Configuration& config, const fs::u8path& prefix, bool extract_conda_pk
             {
                 channel_url = pkg_info.url.substr(0, pkg_info.url.size() - pkg_info.fn.size());
             }
-            std::string repodata_cache_name = util::concat(cache_name_from_url(channel_url), ".json");
+            std::string repodata_cache_name = util::concat(
+                util::cache_name_from_url(channel_url),
+                ".json"
+            );
             fs::u8path repodata_location = pkgs_dir / "cache" / repodata_cache_name;
 
             nlohmann::json repodata_record;

--- a/micromamba/src/env.cpp
+++ b/micromamba/src/env.cpp
@@ -12,8 +12,8 @@
 #include "mamba/core/channel.hpp"
 #include "mamba/core/environments_manager.hpp"
 #include "mamba/core/prefix_data.hpp"
-#include "mamba/core/url.hpp"
 #include "mamba/util/string.hpp"
+#include "mamba/util/url_manip.hpp"
 
 #include "common_options.hpp"
 
@@ -94,7 +94,7 @@ set_env_command(CLI::App* com, Configuration& config)
                 for (const auto& record : records)
                 {
                     std::string clean_url, token;
-                    split_anaconda_token(record.url, clean_url, token);
+                    util::split_anaconda_token(record.url, clean_url, token);
                     std::cout << clean_url;
                     if (!no_md5)
                     {

--- a/micromamba/src/login.cpp
+++ b/micromamba/src/login.cpp
@@ -10,9 +10,9 @@
 
 #include "mamba/core/environment.hpp"
 #include "mamba/core/output.hpp"
-#include "mamba/core/url.hpp"
 #include "mamba/core/util.hpp"
 #include "mamba/util/string.hpp"
+#include "mamba/util/url.hpp"
 
 
 std::string
@@ -36,7 +36,7 @@ read_stdin()
 std::string
 get_token_base(const std::string& host)
 {
-    const auto url = mamba::URL::parse(host);
+    const auto url = mamba::util::URL::parse(host);
 
     std::string maybe_colon_and_port{};
     if (!url.port().empty())

--- a/micromamba/src/login.cpp
+++ b/micromamba/src/login.cpp
@@ -44,14 +44,7 @@ get_token_base(const std::string& host)
         maybe_colon_and_port.push_back(':');
         maybe_colon_and_port.append(url.port());
     }
-    // Removing the trailing slashes
-    std::string maybe_path = url.path();
-    while ((!maybe_path.empty()) && (maybe_path.back() == '/'))
-    {
-        maybe_path.pop_back();
-    }
-
-    return mamba::concat(url.host(), maybe_colon_and_port, maybe_path);
+    return mamba::concat(url.host(), maybe_colon_and_port, mamba::rstrip(url.pretty_path(), '/'));
 }
 
 void

--- a/micromamba/src/login.cpp
+++ b/micromamba/src/login.cpp
@@ -44,7 +44,11 @@ get_token_base(const std::string& host)
         maybe_colon_and_port.push_back(':');
         maybe_colon_and_port.append(url.port());
     }
-    return mamba::concat(url.host(), maybe_colon_and_port, mamba::rstrip(url.pretty_path(), '/'));
+    return mamba::util::concat(
+        url.host(),
+        maybe_colon_and_port,
+        mamba::util::rstrip(url.pretty_path(), '/')
+    );
 }
 
 void

--- a/micromamba/src/login.cpp
+++ b/micromamba/src/login.cpp
@@ -36,7 +36,7 @@ read_stdin()
 std::string
 get_token_base(const std::string& host)
 {
-    mamba::URL url(host);
+    const auto url = mamba::URL::parse(host);
 
     std::string maybe_colon_and_port{};
     if (!url.port().empty())

--- a/micromamba/src/login.cpp
+++ b/micromamba/src/login.cpp
@@ -36,22 +36,22 @@ read_stdin()
 std::string
 get_token_base(const std::string& host)
 {
-    mamba::URLHandler url_handler(host);
+    mamba::URL url(host);
 
     std::string maybe_colon_and_port{};
-    if (!url_handler.port().empty())
+    if (!url.port().empty())
     {
         maybe_colon_and_port.push_back(':');
-        maybe_colon_and_port.append(url_handler.port());
+        maybe_colon_and_port.append(url.port());
     }
     // Removing the trailing slashes
-    std::string maybe_path = url_handler.path();
+    std::string maybe_path = url.path();
     while ((!maybe_path.empty()) && (maybe_path.back() == '/'))
     {
         maybe_path.pop_back();
     }
 
-    return mamba::util::concat(url_handler.host(), maybe_colon_and_port, maybe_path);
+    return mamba::concat(url.host(), maybe_colon_and_port, maybe_path);
 }
 
 void


### PR DESCRIPTION
- Hide CURL
- Refactor `URLHandler` as a `URL` class with strong invariant.
- Manage '%' encoding.
- Rewrite a number of function to make them independent of CURL / <regex>
- Add many tests
- Close #2611