### PR TITLE
fix: added missing `hook_preamble()` for powershell hook

### DIFF
--- a/libmamba/src/core/activation.cpp
+++ b/libmamba/src/core/activation.cpp
@@ -691,7 +691,7 @@ namespace mamba
         std::stringstream builder;
         if (is_powershell(this) && fs::exists(hook_source_path()))
         {
-            builder << read_contents(hook_source_path()) << "\n";
+            builder << hook_preamble() << "\n" << read_contents(hook_source_path()) << "\n";
         }
         else
         {


### PR DESCRIPTION
Close #2696
Fix #2651

Detailed in https://github.com/mamba-org/mamba/issues/2651#issuecomment-1682665046

`micromamba 'shell' 'hook' -s 'powershell'` generates,

before:

```powershell
Import-Module "$Env:MAMBA_ROOT_PREFIX\condabin\Mamba.psm1" -ArgumentList $MambaModuleArgs

Remove-Variable MambaModuleArgs
```

after:

when `changeps1` is set to true,
```powershell
$MambaModuleArgs = @{ChangePs1 = $True}
Import-Module "$Env:MAMBA_ROOT_PREFIX\condabin\Mamba.psm1" -ArgumentList $MambaModuleArgs

Remove-Variable MambaModuleArgs
```

when `changeps1` is set to false,
```powershell
$MambaModuleArgs = @{ChangePs1 = $False}
Import-Module "$Env:MAMBA_ROOT_PREFIX\condabin\Mamba.psm1" -ArgumentList $MambaModuleArgs

Remove-Variable MambaModuleArgs
```
