### PR TITLE
fix: Shell completion section title missing

### DIFF
--- a/docs/source/micromamba-installation.rst
+++ b/docs/source/micromamba-installation.rst
@@ -178,7 +178,7 @@ image can be used to run ``micromamba`` without installing it:
 .. _shell_completion:
 
 Shell completion
-================
+****************
 
 For now, only ``micromamba`` provides shell completion on ``bash`` and ``zsh``.
 


### PR DESCRIPTION
The `Shell completion` section title is missing in the latest docs.  I'm not sure whether my edits is right or not. I just follow the style above.