### PR TITLE
Revert failing test

### DIFF
--- a/micromamba/tests/test_virtual_pkgs.py
+++ b/micromamba/tests/test_virtual_pkgs.py
@@ -21,11 +21,3 @@ class TestVirtualPkgs:
             assert "__glibc" in infos
             linux_ver = platform.release().split("-", 1)[0]
             assert f"__linux={linux_ver}=0" in infos
-
-    def test_virtual_linux(self):
-        infos = info()
-        if platform.system() == "Linux":
-            assert "__linux=" in infos
-            assert "__linux=0=0" not in infos
-        else:
-            assert "__linux=0=0" in infos


### PR DESCRIPTION
Revert a wrong test I introduced in https://github.com/mamba-org/mamba/pull/2749.

I'm very sorry about this. I should have waited for CI to be green. We had a red CI for the previous commits and I blindly assumed that my changes weren't responsible for the red CI.