### PR TITLE
Bring back repodata_use_zst

### DIFF
--- a/libmamba/include/mamba/core/context.hpp
+++ b/libmamba/include/mamba/core/context.hpp
@@ -224,6 +224,7 @@ namespace mamba
 
         bool use_only_tar_bz2 = false;
 
+        bool repodata_use_zst = true;
         std::vector<std::string> repodata_has_zst = { "https://conda.anaconda.org/conda-forge" };
 
         // usernames on anaconda.org can have a underscore, which influences the

--- a/libmamba/src/api/configuration.cpp
+++ b/libmamba/src/api/configuration.cpp
@@ -1244,7 +1244,12 @@ namespace mamba
                    .group("Channels")
                    .set_rc_configurable()
                    .set_env_var_names()
-                   .description("Permit use of the --overide-channels command-line flag"));
+                   .description("Permit use of the --override-channels command-line flag"));
+
+        insert(Configurable("repodata_use_zst", &ctx.repodata_use_zst)
+                   .group("Repodata")
+                   .set_rc_configurable()
+                   .description("Use zstd encoded repodata when fetching"));
 
         insert(Configurable("repodata_has_zst", &ctx.repodata_has_zst)
                    .group("Repodata")

--- a/libmamba/src/core/subdirdata.cpp
+++ b/libmamba/src/core/subdirdata.cpp
@@ -600,30 +600,33 @@ namespace mamba
             auto& ctx = Context::instance();
             if (!ctx.offline || forbid_cache())
             {
-                bool has_value = m_metadata.has_zst.has_value();
-                bool is_expired = m_metadata.has_zst.has_value()
-                                  && m_metadata.has_zst.value().has_expired();
-                bool has_zst = m_metadata.check_zst(channel_context, p_channel);
-                if (!has_zst && (is_expired || !has_value))
+                if (ctx.repodata_use_zst)
                 {
-                    m_check_targets.push_back(std::make_unique<DownloadTarget>(
-                        m_name + " (check zst)",
-                        m_repodata_url + ".zst",
-                        ""
-                    ));
-                    m_check_targets.back()->set_head_only(true);
-                    m_check_targets.back()->set_finalize_callback(&MSubdirData::finalize_check, this);
-                    m_check_targets.back()->set_ignore_failure(true);
-                    if (!(ctx.graphics_params.no_progress_bars || ctx.output_params.quiet
-                          || ctx.output_params.json))
+                    bool has_value = m_metadata.has_zst.has_value();
+                    bool is_expired = m_metadata.has_zst.has_value()
+                                      && m_metadata.has_zst.value().has_expired();
+                    bool has_zst = m_metadata.check_zst(channel_context, p_channel);
+                    if (!has_zst && (is_expired || !has_value))
                     {
-                        m_progress_bar_check = Console::instance().add_progress_bar(
-                            m_name + " (check zst)"
-                        );
-                        m_check_targets.back()->set_progress_bar(m_progress_bar_check);
-                        m_progress_bar_check.repr().postfix.set_value("Checking");
+                        m_check_targets.push_back(std::make_unique<DownloadTarget>(
+                            m_name + " (check zst)",
+                            m_repodata_url + ".zst",
+                            ""
+                        ));
+                        m_check_targets.back()->set_head_only(true);
+                        m_check_targets.back()->set_finalize_callback(&MSubdirData::finalize_check, this);
+                        m_check_targets.back()->set_ignore_failure(true);
+                        if (!(ctx.graphics_params.no_progress_bars || ctx.output_params.quiet
+                              || ctx.output_params.json))
+                        {
+                            m_progress_bar_check = Console::instance().add_progress_bar(
+                                m_name + " (check zst)"
+                            );
+                            m_check_targets.back()->set_progress_bar(m_progress_bar_check);
+                            m_progress_bar_check.repr().postfix.set_value("Checking");
+                        }
+                        return true;
                     }
-                    return true;
                 }
                 create_target();
             }


### PR DESCRIPTION
Some enterprise Conda channel sources like Artifactory don't properly invalidate the `repodata.json.zst`. This adds back the flag to disable reading the `zst` file