### PR TITLE
Parse subdirs in CLI match specs

### DIFF
--- a/libmamba/include/mamba/core/channel.hpp
+++ b/libmamba/include/mamba/core/channel.hpp
@@ -18,6 +18,7 @@
 
 namespace mamba
 {
+    std::vector<std::string> get_known_platforms();
     // Note: Channels can only be created using ChannelContext.
     class Channel
     {

--- a/libmamba/src/core/channel.cpp
+++ b/libmamba/src/core/channel.cpp
@@ -231,18 +231,17 @@ namespace mamba
                 // that already contains the platform
                 else
                 {
-                    std::string cleaned_url = "", platform = "";
+                    std::string platform = "";
                     util::split_platform(
-                        KNOWN_PLATFORMS,
+                        get_known_platforms(),
                         value,
                         Context::instance().platform,
-                        cleaned_url,
+                        value,
                         platform
                     );
                     if (!platform.empty())
                     {
                         platforms.push_back(std::move(platform));
-                        value = cleaned_url;
                     }
                 }
             }
@@ -254,6 +253,11 @@ namespace mamba
             return platforms;
         }
     }  // namespace
+
+    std::vector<std::string> get_known_platforms()
+    {
+        return KNOWN_PLATFORMS;
+    }
 
     /**************************
      * Channel implementation *

--- a/libmamba/src/core/match_spec.cpp
+++ b/libmamba/src/core/match_spec.cpp
@@ -7,6 +7,7 @@
 #include <regex>
 
 #include "mamba/core/channel.hpp"
+#include "mamba/core/context.hpp"
 #include "mamba/core/environment.hpp"
 #include "mamba/core/match_spec.hpp"
 #include "mamba/core/output.hpp"
@@ -177,17 +178,14 @@ namespace mamba
         {
             throw std::runtime_error("Parsing of channel / namespace / subdir failed.");
         }
-        // TODO implement Channel, and parsing of the channel here!
-        // channel = subdir = channel_str;
-        // channel, subdir = _parse_channel(channel_str)
-        // if 'channel' in brackets:
-        //     b_channel, b_subdir = _parse_channel(brackets.pop('channel'))
-        //     if b_channel:
-        //         channel = b_channel
-        //     if b_subdir:
-        //         subdir = b_subdir
-        // if 'subdir' in brackets:
-        //     subdir = brackets.pop('subdir')
+
+        std::string cleaned_url;
+        std::string platform;
+        util::split_platform(get_known_platforms(), channel, Context::instance().platform, channel, platform);
+        if (!platform.empty())
+        {
+            subdir = platform;
+        }
 
         // support faulty conda matchspecs such as `libblas=[build=*mkl]`, which is
         // the repr of `libblas=*=*mkl`
@@ -279,7 +277,10 @@ namespace mamba
             }
             else if (k == "subdir")
             {
-                subdir = v;
+                if (platform.empty())
+                {
+                    subdir = v;
+                }
             }
             else if (k == "url")
             {

--- a/libmamba/tests/src/core/test_cpp.cpp
+++ b/libmamba/tests/src/core/test_cpp.cpp
@@ -234,6 +234,31 @@ namespace mamba
                 MatchSpec ms("numpy=1.20", channel_context);
                 CHECK_EQ(ms.str(), "numpy=1.20");
             }
+
+            {
+                MatchSpec ms("conda-forge::tzdata", channel_context);
+                CHECK_EQ(ms.str(), "conda-forge::tzdata");
+            }
+            {
+                MatchSpec ms("conda-forge::noarch/tzdata", channel_context);
+                CHECK_EQ(ms.str(), "conda-forge::noarch/tzdata");
+            }
+            {
+                MatchSpec ms("pkgs/main::tzdata", channel_context);
+                CHECK_EQ(ms.str(), "pkgs/main::tzdata");
+            }
+            {
+                MatchSpec ms("pkgs/main/noarch::tzdata", channel_context);
+                CHECK_EQ(ms.str(), "pkgs/main/noarch::tzdata");
+            }
+            {
+                MatchSpec ms("conda-forge/noarch::tzdata[subdir=linux64]", channel_context);
+                CHECK_EQ(ms.str(), "conda-forge/noarch::tzdata");
+            }
+            {
+                MatchSpec ms("conda-forge::tzdata[subdir=linux64]", channel_context);
+                CHECK_EQ(ms.str(), "conda-forge/linux64::tzdata");
+            }
         }
 
         TEST_CASE("is_simple")

--- a/libmamba/tests/src/util/test_url_manip.cpp
+++ b/libmamba/tests/src/util/test_url_manip.cpp
@@ -129,6 +129,26 @@ TEST_SUITE("util::url_manip")
 
         CHECK_EQ(platform_found, "noarch");
         CHECK_EQ(cleaned_url, "https://mamba.com");
+
+        split_platform(
+            { "noarch", "linux-64" },
+            "https://conda.anaconda.org/conda-forge/noarch",
+            std::string(mamba::specs::build_platform_name()),
+            cleaned_url,
+            platform_found
+        );
+        CHECK_EQ(platform_found, "noarch");
+        CHECK_EQ(cleaned_url, "https://conda.anaconda.org/conda-forge");
+
+        split_platform(
+            { "noarch", "linux-64" },
+            "https://conda.anaconda.org/pkgs/main/noarch",
+            std::string(mamba::specs::build_platform_name()),
+            cleaned_url,
+            platform_found
+        );
+        CHECK_EQ(platform_found, "noarch");
+        CHECK_EQ(cleaned_url, "https://conda.anaconda.org/pkgs/main");
     }
 
     TEST_CASE("path_to_url")


### PR DESCRIPTION
https://github.com/mamba-org/mamba/pull/2798 without the interface changes.

Fixes #2792

For example, the channel in `install conda-forge/noarch::tzdata` would previously be parsed as `conda-forge/noarch` while it should be parsed as `conda-forge` with `noarch` subdir.