### PR TITLE
add `context.register_envs` to control whether environments are registered to `environments.txt` or not

### DIFF
--- a/libmamba/include/mamba/core/context.hpp
+++ b/libmamba/include/mamba/core/context.hpp
@@ -154,6 +154,7 @@ namespace mamba
         bool allow_softlinks = false;
         bool always_copy = false;
         bool always_softlink = false;
+        bool register_envs = true;
 
         // solver options
         bool allow_uninstall = true;

--- a/libmamba/src/core/environments_manager.cpp
+++ b/libmamba/src/core/environments_manager.cpp
@@ -23,6 +23,11 @@ namespace mamba
 
     void EnvironmentsManager::register_env(const fs::u8path& location)
     {
+        if (!Context::instance().register_envs)
+        {
+            return;
+        }
+
         fs::u8path env_txt_file = get_environments_txt_file(env::home_directory());
         fs::u8path final_location = fs::absolute(location);
         fs::u8path folder = final_location.parent_path();


### PR DESCRIPTION
Closes #2783 

xref https://github.com/conda/conda/pull/12924
xref https://github.com/conda/constructor/pull/716