### PR TITLE
Fix `search` output

### DIFF
--- a/libmamba/src/core/query.cpp
+++ b/libmamba/src/core/query.cpp
@@ -5,6 +5,7 @@
 // The full license is in the file LICENSE, distributed with this software.
 
 #include <iostream>
+#include <sstream>
 #include <stack>
 #include <unordered_set>
 
@@ -157,21 +158,6 @@ namespace mamba
 
     namespace
     {
-<<<<<<< Updated upstream
-        auto print_solvable(const PackageInfo& pkg)
-        {
-            auto out = Console::stream();
-            std::string header = fmt::format("{} {} {}", pkg.name, pkg.version, pkg.build_string);
-            fmt::print(out, "{:^40}\n{:-^{}}\n\n", header, "", header.size() > 40 ? header.size() : 40);
-
-            static constexpr const char* fmtstring = " {:<15} {}\n";
-            fmt::print(out, fmtstring, "File Name", pkg.fn);
-            fmt::print(out, fmtstring, "Name", pkg.name);
-            fmt::print(out, fmtstring, "Version", pkg.version);
-            fmt::print(out, fmtstring, "Build", pkg.build_string);
-            fmt::print(out, fmtstring, "Build Number", pkg.build_number);
-            fmt::print(out, " {:<15} {} Kb\n", "Size", pkg.size / 1000);
-=======
         auto print_solvable(
             const PackageInfo& pkg,
             const std::vector<PackageInfo>& otherBuilds,
@@ -210,9 +196,9 @@ namespace mamba
             fmt::print(out, fmtstring, "Version", pkg.version);
             fmt::print(out, fmtstring, "Build", pkg.build_string);
             fmt::print(out, " {:<15} {} kB\n", "Size", pkg.size / 1000);
->>>>>>> Stashed changes
             fmt::print(out, fmtstring, "License", pkg.license);
             fmt::print(out, fmtstring, "Subdir", pkg.subdir);
+            fmt::print(out, fmtstring, "File Name", pkg.fn);
 
             std::string url_remaining, url_scheme, url_auth, url_token;
             util::split_scheme_auth_token(pkg.url, url_remaining, url_scheme, url_auth, url_token);
@@ -229,6 +215,15 @@ namespace mamba
             // std::cout << fmt::format<char>(
             // " {:<15} {:%Y-%m-%d %H:%M:%S} UTC\n", "Timestamp", fmt::gmtime(pkg.timestamp));
 
+            if (!pkg.constrains.empty())
+            {
+                fmt::print(out, "\n Run Constraints:\n");
+                for (auto& c : pkg.constrains)
+                {
+                    fmt::print(out, "  - {}\n", c);
+                }
+            }
+
             if (!pkg.depends.empty())
             {
                 fmt::print(out, "\n Dependencies:\n");
@@ -238,14 +233,8 @@ namespace mamba
                 }
             }
 
-            if (!pkg.constrains.empty())
+            if (!buildsByVersion.empty())
             {
-<<<<<<< Updated upstream
-                fmt::print(out, "\n Run Constraints:\n");
-                for (auto& c : pkg.constrains)
-                {
-                    fmt::print(out, "  - {}\n", c);
-=======
                 fmt::print(out, "\n Other Versions ({}):\n\n", buildsByVersion.size());
 
                 std::stringstream buffer;
@@ -298,7 +287,6 @@ namespace mamba
                 while (std::getline(buffer, line))
                 {
                     out << " " << line << std::endl;
->>>>>>> Stashed changes
                 }
             }
 
@@ -505,7 +493,16 @@ namespace mamba
 
     std::ostream& query_result::table(std::ostream& out) const
     {
-        return table(out, { "Name", "Version", "Build", "Channel" });
+        return table(
+            out,
+            { "Name",
+              "Version",
+              "Build",
+              printers::alignmentMarker(printers::alignment::left),
+              printers::alignmentMarker(printers::alignment::right),
+              "Channel",
+              "Subdir" }
+        );
     }
 
     namespace
@@ -516,9 +513,16 @@ namespace mamba
             return util::split(str, "/", 1).front();  // Has at least one element
         }
 
+        /** Get subdir from channel name. */
+        auto get_subdir(std::string_view str) -> std::string
+        {
+            return util::split(str, "/").back();
+        }
+
     }
 
-    std::ostream& query_result::table(std::ostream& out, const std::vector<std::string>& fmt) const
+    std::ostream&
+    query_result::table(std::ostream& out, const std::vector<std::string_view>& columns) const
     {
         if (m_pkg_id_list.empty())
         {
@@ -526,25 +530,43 @@ namespace mamba
         }
 
         std::vector<mamba::printers::FormattedString> headers;
-        std::vector<std::string> cmds, args;
-        for (auto& f : fmt)
+        std::vector<std::string_view> cmds, args;
+        std::vector<mamba::printers::alignment> alignments;
+        for (auto& col : columns)
         {
-            if (f.find_first_of(":") == f.npos)
+            if (col == printers::alignmentMarker(printers::alignment::right)
+                || col == printers::alignmentMarker(printers::alignment::left))
             {
-                headers.push_back(f);
-                cmds.push_back(f);
+                // If an alignment marker is passed, we remove the column name.
+                headers.push_back("");
+                cmds.push_back("");
+                args.push_back("");
+                // We only check for the right alignment marker, as left alignment is set the
+                // default.
+                if (col == printers::alignmentMarker(printers::alignment::right))
+                {
+                    alignments.push_back(printers::alignment::right);
+                    continue;
+                }
+            }
+            else if (col.find_first_of(":") == col.npos)
+            {
+                headers.push_back(col);
+                cmds.push_back(col);
                 args.push_back("");
             }
             else
             {
-                auto sfmt = util::split(f, ":", 1);
+                auto sfmt = util::split(col, ":", 1);
                 headers.push_back(sfmt[0]);
                 cmds.push_back(sfmt[0]);
                 args.push_back(sfmt[1]);
             }
+            // By default, columns are left aligned.
+            alignments.push_back(printers::alignment::left);
         }
 
-        auto format_row = [&](const PackageInfo& pkg)
+        auto format_row = [&](const PackageInfo& pkg, const std::vector<PackageInfo>& builds)
         {
             std::vector<mamba::printers::FormattedString> row;
             for (std::size_t i = 0; i < cmds.size(); ++i)
@@ -561,10 +583,24 @@ namespace mamba
                 else if (cmd == "Build")
                 {
                     row.push_back(pkg.build_string);
+                    if (builds.size() > 1)
+                    {
+                        row.push_back("(+");
+                        row.push_back(fmt::format("{} builds)", builds.size() - 1));
+                    }
+                    else
+                    {
+                        row.push_back("");
+                        row.push_back("");
+                    }
                 }
                 else if (cmd == "Channel")
                 {
                     row.push_back(cut_subdir(cut_repo_name(pkg.channel)));
+                }
+                else if (cmd == "Subdir")
+                {
+                    row.push_back(get_subdir(pkg.channel));
                 }
                 else if (cmd == "Depends")
                 {
@@ -584,21 +620,16 @@ namespace mamba
         };
 
         printers::Table printer(headers);
+        printer.set_alignment(alignments);
 
         if (!m_ordered_pkg_id_list.empty())
         {
-<<<<<<< Updated upstream
-=======
             std::map<std::string, std::map<std::string, std::vector<PackageInfo>>> packageBuildsByVersion;
             std::unordered_set<std::string> distinctBuildSHAs;
->>>>>>> Stashed changes
             for (auto& entry : m_ordered_pkg_id_list)
             {
                 for (const auto& id : entry.second)
                 {
-<<<<<<< Updated upstream
-                    printer.add_row(format_row(m_dep_graph.node(id)));
-=======
                     auto package = m_dep_graph.node(id);
                     if (distinctBuildSHAs.insert(package.sha256).second)
                     {
@@ -613,7 +644,6 @@ namespace mamba
                 for (auto it = entry.second.rbegin(); it != entry.second.rend(); ++it)
                 {
                     printer.add_row(format_row(it->second[0], it->second));
->>>>>>> Stashed changes
                 }
             }
         }
@@ -621,11 +651,14 @@ namespace mamba
         {
             for (const auto& id : m_pkg_id_list)
             {
-                printer.add_row(format_row(m_dep_graph.node(id)));
+                printer.add_row(format_row(m_dep_graph.node(id), {}));
             }
         }
+
         return printer.print(out);
     }
+
+    using GraphicsParams = Context::GraphicsParams;
 
     class graph_printer
     {
@@ -634,9 +667,10 @@ namespace mamba
         using graph_type = query_result::dependency_graph;
         using node_id = graph_type::node_id;
 
-        explicit graph_printer(std::ostream& out)
+        explicit graph_printer(std::ostream& out, GraphicsParams graphics)
             : m_is_last(false)
             , m_out(out)
+            , m_graphics(std::move(graphics))
         {
         }
 
@@ -681,8 +715,7 @@ namespace mamba
         void forward_or_cross_edge(node_id, node_id to, const graph_type& g)
         {
             print_prefix(to);
-            m_out << g.node(to).name
-                  << fmt::format(Context::instance().graphics_params.palette.shown, " already visited\n");
+            m_out << g.node(to).name << fmt::format(m_graphics.palette.shown, " already visited\n");
         }
 
         void finish_edge(node_id /*from*/, node_id to, const graph_type& /*g*/)
@@ -721,14 +754,15 @@ namespace mamba
         std::vector<std::string> m_prefix_stack;
         bool m_is_last;
         std::ostream& m_out;
+        const GraphicsParams m_graphics;
     };
 
-    std::ostream& query_result::tree(std::ostream& out) const
+    std::ostream& query_result::tree(std::ostream& out, const GraphicsParams& graphics) const
     {
         bool use_graph = (m_dep_graph.number_of_nodes() > 0) && !m_dep_graph.successors(0).empty();
         if (use_graph)
         {
-            graph_printer printer(out);
+            graph_printer printer{ out, graphics };
             dfs_raw(m_dep_graph, printer, /* start= */ node_id(0));
         }
         else if (!m_pkg_id_list.empty())
@@ -790,11 +824,25 @@ namespace mamba
 
     std::ostream& query_result::pretty(std::ostream& out) const
     {
-        if (!m_pkg_id_list.empty())
+        if (m_pkg_id_list.empty())
         {
+            out << "No entries matching \"" << m_query << "\" found" << std::endl;
+        }
+        else
+        {
+            std::map<std::string, std::vector<PackageInfo>> packages;
             for (const auto& id : m_pkg_id_list)
             {
-                print_solvable(m_dep_graph.node(id));
+                auto package = m_dep_graph.node(id);
+                packages[package.name].push_back(package);
+            }
+
+            for (const auto& entry : packages)
+            {
+                print_solvable(
+                    entry.second[0],
+                    std::vector(entry.second.begin() + 1, entry.second.end())
+                );
             }
         }
         return out;


### PR DESCRIPTION
# Motivation

Mainly some aesthetics in the current `micromamba search` output.

# Changes

- Fix duplicate build SHAs for packages from multiple channels 
- Fix padding in single package view
- Change underscore to unicode dash `─`

# TODO

- Move build SHA deduplication into its own helper function
- Add `--show-all-builds` flag to pretty (single package) output -> shows all versions/builds
