### PR TITLE
Fix linking on Windows when Scripts folder is missing

### DIFF
--- a/libmamba/src/core/link.cpp
+++ b/libmamba/src/core/link.cpp
@@ -153,6 +153,10 @@ namespace mamba
             m_clobber_warnings.push_back(fs::relative(script_path, m_context->target_prefix).string());
             fs::remove(script_path);
         }
+        if (!fs::is_directory(script_path.parent_path()))
+        {
+            fs::create_directories(script_path.parent_path());
+        }
         std::ofstream out_file = open_ofstream(script_path);
 
         fs::u8path python_path;

--- a/micromamba/tests/test_linking.py
+++ b/micromamba/tests/test_linking.py
@@ -130,3 +130,8 @@ class TestLinking:
 
         os.remove(linked_file)
         remove("xtensor", "-n", TestLinking.env_name)
+
+    def test_link_missing_scripts_dir(self):  # issue 2808
+        create(
+            "python=3.7", "pypy", "-n", TestLinking.env_name, "--json", no_dry_run=True
+        )


### PR DESCRIPTION
Fixes #2808.