### PR TITLE
Handle null and false noarch values

### DIFF
--- a/libmamba/src/core/link.cpp
+++ b/libmamba/src/core/link.cpp
@@ -861,11 +861,13 @@ namespace mamba
 
         // handle noarch packages
         NoarchType noarch_type = NoarchType::NOT_A_NOARCH;
-        if (index_json.find("noarch") != index_json.end())
+        if (index_json.find("noarch") != index_json.end() && index_json["noarch"].type() != nlohmann::json::value_t::null)
         {
             if (index_json["noarch"].type() == nlohmann::json::value_t::boolean)
             {
-                noarch_type = NoarchType::GENERIC_V1;
+                if (index_json["noarch"].get<bool>()) {
+                    noarch_type = NoarchType::GENERIC_V1;
+                }
             }
             else
             {


### PR DESCRIPTION
Fixes #2834.

Imitating logic from https://github.com/conda/conda/blob/fb7775e936cdc1e9996d31662ad1c0c356bd9b1f/conda/models/records.py#L200-L212.