### PR TITLE
Pin yaml-cpp <0.8

### DIFF
--- a/libmamba/environment-dev.yml
+++ b/libmamba/environment-dev.yml
@@ -13,7 +13,7 @@ dependencies:
   - doctest
   - cpp-expected
   - reproc-cpp
-  - yaml-cpp
+  - yaml-cpp <0.8
   - cli11 >=2.2
   - spdlog
   - fmt

--- a/libmambapy/environment-dev.yml
+++ b/libmambapy/environment-dev.yml
@@ -14,7 +14,7 @@ dependencies:
   - gmock
   - cpp-expected
   - reproc-cpp
-  - yaml-cpp
+  - yaml-cpp <0.8
   - cli11 >=2.2
   - spdlog
   - fmt

--- a/mamba/environment-dev.yml
+++ b/mamba/environment-dev.yml
@@ -14,7 +14,7 @@ dependencies:
   - gmock
   - cpp-expected
   - reproc-cpp
-  - yaml-cpp
+  - yaml-cpp <0.8
   - cli11 >=2.2
   - spdlog
   - fmt

--- a/micromamba/environment-dev.yml
+++ b/micromamba/environment-dev.yml
@@ -15,7 +15,7 @@ dependencies:
   - gmock
   - cpp-expected
   - reproc-cpp
-  - yaml-cpp
+  - yaml-cpp <0.8
   - cli11 >=2.2
   - pytest >=7.3.0
   - pytest-asyncio


### PR DESCRIPTION
yaml-cpp 0.8 is broken on Windows: `find_package` set the library to `yaml-cpp.lib` instead of the full path.