### PR TITLE
Update GitHub Actions steps to open Issues for failed scheduled jobs

### DIFF
--- a/.github/workflows/conda_canary.yml
+++ b/.github/workflows/conda_canary.yml
@@ -73,8 +73,8 @@ jobs:
           mamba env update -f mamba/tests/update_env.yml
 
       - uses: JasonEtco/create-an-issue@1a16035489d05041b9af40b970f02e301c52ffba
-        if: failure()
+        if: failure() && github.repository_owner == 'mamba-org' && github.event_name == 'schedule'
         with:
-          filename: mamba/.github/workflows/bot_issue_template.md
+          filename: .github/workflows/bot_issue_template.md
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/conda_canary.yml
+++ b/.github/workflows/conda_canary.yml
@@ -4,6 +4,12 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '0 10 * * 0'
+  push:
+    paths:
+      - '.github/workflows/conda_canary.yml'
+  pull_request:
+    paths:
+      - '.github/workflows/conda_canary.yml'
 
 permissions:
   contents: read

--- a/.github/workflows/test_micro.mamba.pm.yml
+++ b/.github/workflows/test_micro.mamba.pm.yml
@@ -51,6 +51,6 @@ jobs:
       - uses: actions/checkout@v3
       - uses: JasonEtco/create-an-issue@1a16035489d05041b9af40b970f02e301c52ffba
         with:
-          filename: mamba/.github/workflows/bot_issue_template.md
+          filename: .github/workflows/bot_issue_template.md
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test_micro.mamba.pm.yml
+++ b/.github/workflows/test_micro.mamba.pm.yml
@@ -1,6 +1,7 @@
 name: Test micro.mamba.pm
 
 on:
+  workflow_dispatch:
   schedule:
     - cron: '0 10 * * *'
 
@@ -42,8 +43,13 @@ jobs:
         # use either -l or -i to source .bash_profile or .bashrc/.zshrc
         run: |
           ${{ matrix.shell }} ${{ matrix.shell-source-param }} -ec micromamba
+  issue:
+    runs-on: ubuntu-latest
+    needs: test_micro_mamba_pm
+    if: failure() && github.repository_owner == 'mamba-org' && github.event_name == 'schedule'
+    steps:
+      - uses: actions/checkout@v3
       - uses: JasonEtco/create-an-issue@1a16035489d05041b9af40b970f02e301c52ffba
-        if: failure()
         with:
           filename: mamba/.github/workflows/bot_issue_template.md
         env:

--- a/.github/workflows/test_micro.mamba.pm.yml
+++ b/.github/workflows/test_micro.mamba.pm.yml
@@ -4,6 +4,12 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '0 10 * * *'
+  push:
+    paths:
+      - '.github/workflows/test_micro.mamba.pm.yml'
+  pull_request:
+    paths:
+      - '.github/workflows/test_micro.mamba.pm.yml'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
The recent conda release 23.9.0 broke the interface with mamba (#2882, #2878). This issue was first detected by the [nightly job against conda-canary](https://github.com/mamba-org/mamba/blob/0fbb0e4fab2d65a68c1bcd388b377feaa20f5370/.github/workflows/conda_canary.yml) back on [August 27th](https://github.com/mamba-org/mamba/actions/runs/5990241039/job/16247352587#step:9:43). However, an Issue was never opened because the path to the issue template file was incorrect. Similarly, the [scheduled jobs to test micro.mamba.pm](https://github.com/mamba-org/mamba/actions/workflows/test_micro.mamba.pm.yml?query=event%3Aschedule) have been failing for weeks, but never open an Issue because the repository is not cloned in that job.

This PR does the following:

* `conda_canary.yml`
  * Fix path to issue template file
  * Only open an Issue for a scheduled job on the mamba-org owned repo (this avoids opening Issues on forks, and also opening unnecessary issues from manually triggered workflow runs)
* `test_micro.mamba.pm.yml`
  * Separates the issue opening step into its own job that will be executed if any of the upstream matrix of jobs fails
  * Checkout the repo to obtain the issue template file
  * Only open an Issue for a scheduled job on the mamba-org owned repo
