### PR TITLE
Fix broken tcsh aliases

### DIFF
--- a/libmamba/data/micromamba.csh
+++ b/libmamba/data/micromamba.csh
@@ -5,40 +5,40 @@ alias __mamba_exe '"$MAMBA_EXE" "\!*"'
 
 alias __mamba_hashr 'rehash'
 
-alias __mamba_xctivate '
-    set ask_conda="`(setenv prompt "${prompt}"; __mamba_exe shell "\!*" --shell csh)`"
-    if ("${status}" != 0) then
-        return
-     endif
-         eval "${ask_conda}"
-     __mamba_hashr
+alias __mamba_xctivate '\\
+    set ask_conda="`(setenv prompt "${prompt}"; __mamba_exe shell "\!*" --shell csh)`"\\
+    if ("${status}" != 0) then\\
+        return\\
+     endif\\
+         eval "${ask_conda}"\\
+     __mamba_hashr\\
 '
 
-alias micromamba '
-    switch ("${1}")
-        case activate | reactivate | deactivate:
-            __mamba_xctivate "\!*"
-            breaksw
-        case install | update | upgrade | remove | uninstall:
-            __mamba_exe "\!*"
-            if ("${status}" != 0) then
-                return
-             endif
-            __mamba_xctivate reactivate
-            breaksw
-        case self-update:
-            __mamba_exe "\!*"
-            if ("${status}" != 0) then
-                return
-             endif
-             if (-f "$MAMBA_EXE.bkup") then
-                rm -f "$MAMBA_EXE.bkup"
-             endif
-            breaksw
-        default:
-            __mamba_exe "\!*"
-            breaksw
-    endsw
+alias micromamba '\\
+    switch ("${1}")\\
+        case activate | reactivate | deactivate:\\
+            __mamba_xctivate "\!*"\\
+            breaksw\\
+        case install | update | upgrade | remove | uninstall:\\
+            __mamba_exe "\!*"\\
+            if ("${status}" != 0) then\\
+                return\\
+             endif\\
+            __mamba_xctivate reactivate\\
+            breaksw\\
+        case self-update:\\
+            __mamba_exe "\!*"\\
+            if ("${status}" != 0) then\\
+                return\\
+             endif\\
+             if (-f "$MAMBA_EXE.bkup") then\\
+                rm -f "$MAMBA_EXE.bkup"\\
+             endif\\
+            breaksw\\
+        default:\\
+            __mamba_exe "\!*"\\
+            breaksw\\
+    endsw\\
 '
 
 if (! $?CONDA_SHLVL) then


### PR DESCRIPTION
Fix broken csh and tcsh multiline aliases, in order for tcsh hook to be run as separate file. The hook still needs to be written to be written to an xternal file then sourced because the parentheses in the first row of the comments will cause an error, but this is a temporary fix until the tcsh script is ported from conda.