### PR TITLE
Fix micromamba test dependency conda-package-handling

### DIFF
--- a/dev/environment-dev.yml
+++ b/dev/environment-dev.yml
@@ -30,6 +30,7 @@ dependencies:
   - pytest-xprocess
   - sel(win): pywin32
   - conda-content-trust
+  - conda-package-handling
   - cryptography<40.0  # Or breaks conda-content-trust
   - pip:
     - securesystemslib


### PR DESCRIPTION
Previously it was not possible to run micromamba tests locally just by
following the instructions given here:
https://mamba.readthedocs.io/en/latest/developer_zone/build_locally.html#id1

```
$ pytest micromamba/tests/
============================= test session starts =============================
platform linux -- Python 3.11.6, pytest-7.4.3, pluggy-1.3.0
rootdir: /home/rominf/dev/mamba
configfile: pyproject.toml
plugins: lazy-fixture-0.6.3, asyncio-0.21.1, xprocess-0.23.0
asyncio: mode=Mode.STRICT
collected 2156 items / 1 error / 1 skipped

=================================== ERRORS ====================================
______________ ERROR collecting micromamba/tests/test_package.py ______________
ImportError while importing test module '/home/rominf/dev/mamba/micromamba/tests/test_package.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
../../micromamba/envs/mamba/lib/python3.11/importlib/__init__.py:126: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
micromamba/tests/test_package.py:11: in <module>
    from conda_package_handling import api as cph
E   ModuleNotFoundError: No module named 'conda_package_handling'
=========================== short test summary info ===========================
ERROR micromamba/tests/test_package.py
!!!!!!!!!!!!!!!!!!! Interrupted: 1 error during collection !!!!!!!!!!!!!!!!!!!!
========================= 1 skipped, 1 error in 0.63s =========================
```

The reason is that first
`micromamba/tests/envlockfile-check-step-1-lock.yaml` with
`conda-package-handling` dependency was introduced, then during the CI
run it was installed, cached, then the import was introduced (it worked
because of the caching). It looks like nobody ran tests locally since
then and this error was unnoticed.

This change adds the required dependency.
