### PR TITLE
[1.x] fix: Parse `remote_connect_timeout_secs` as a double

### DIFF
--- a/libmamba/include/mamba/core/context.hpp
+++ b/libmamba/include/mamba/core/context.hpp
@@ -74,7 +74,7 @@ namespace mamba
 
             std::string user_agent{ "mamba/" LIBMAMBA_VERSION_STRING };
 
-            int connect_timeout_secs{ 10 };
+            double connect_timeout_secs{ 10. };
             // int read_timeout_secs { 60 };
             int retry_timeout{ 2 };  // seconds
             int retry_backoff{ 3 };  // retry_timeout * retry_backoff

--- a/libmamba/src/core/curl.cpp
+++ b/libmamba/src/core/curl.cpp
@@ -22,7 +22,7 @@ namespace mamba
             CURL* handle,
             const std::string& url,
             const bool set_low_speed_opt,
-            const long connect_timeout_secs,
+            const double connect_timeout_secs,
             const bool set_ssl_no_revoke,
             const std::optional<std::string>& proxy,
             const std::string& ssl_verify
@@ -122,7 +122,7 @@ namespace mamba
         bool check_resource_exists(
             const std::string& url,
             const bool set_low_speed_opt,
-            const long connect_timeout_secs,
+            const double connect_timeout_secs,
             const bool set_ssl_no_revoke,
             const std::optional<std::string>& proxy,
             const std::string& ssl_verify
@@ -391,7 +391,7 @@ namespace mamba
     void CURLHandle::configure_handle(
         const std::string& url,
         const bool set_low_speed_opt,
-        const long connect_timeout_secs,
+        const double connect_timeout_secs,
         const bool set_ssl_no_revoke,
         const std::optional<std::string>& proxy,
         const std::string& ssl_verify

--- a/libmamba/src/core/curl.hpp
+++ b/libmamba/src/core/curl.hpp
@@ -29,7 +29,7 @@ namespace mamba
             CURL* handle,
             const std::string& url,
             const bool set_low_speed_opt,
-            const long connect_timeout_secs,
+            const double connect_timeout_secs,
             const bool set_ssl_no_revoke,
             const std::optional<std::string>& proxy,
             const std::string& ssl_verify
@@ -38,7 +38,7 @@ namespace mamba
         bool check_resource_exists(
             const std::string& url,
             const bool set_low_speed_opt,
-            const long connect_timeout_secs,
+            const double connect_timeout_secs,
             const bool set_ssl_no_revoke,
             const std::optional<std::string>& proxy,
             const std::string& ssl_verify
@@ -116,7 +116,7 @@ namespace mamba
         void configure_handle(
             const std::string& url,
             const bool set_low_speed_opt,
-            const long connect_timeout_secs,
+            const double connect_timeout_secs,
             const bool set_ssl_no_revoke,
             const std::optional<std::string>& proxy,
             const std::string& ssl_verify

--- a/libmamba/tests/data/config/.condarc
+++ b/libmamba/tests/data/config/.condarc
@@ -1,2 +1,6 @@
 channels:
   - https://repo.mamba.pm/conda-forge
+
+
+# See: https://github.com/mamba-org/mamba/issues/2934
+remote_connect_timeout_secs: 9.15

--- a/libmamba/tests/src/core/test_configuration.cpp
+++ b/libmamba/tests/src/core/test_configuration.cpp
@@ -157,6 +157,17 @@ namespace mamba
                 CHECK_EQ(config.dump(MAMBA_SHOW_CONFIG_VALUES | MAMBA_SHOW_CONFIG_SRCS), "");
             }
 
+            // Regression test for https://github.com/mamba-org/mamba/issues/2934
+            TEST_CASE_FIXTURE(Configuration, "parse_condarc")
+            {
+                std::vector<fs::u8path> possible_rc_paths = {
+                    test_data_dir / "config/.condarc",
+                };
+
+                config.set_rc_values(possible_rc_paths, RCConfigLevel::kTargetPrefix);
+            };
+
+
             TEST_CASE_FIXTURE(Configuration, "load_rc_files")
             {
                 std::string rc1 = unindent(R"(

--- a/libmambapy/libmambapy/__init__.pyi
+++ b/libmambapy/libmambapy/__init__.pyi
@@ -442,12 +442,12 @@ class Context:
     class RemoteFetchParams:
         def __init__(self) -> None: ...
         @property
-        def connect_timeout_secs(self) -> int:
+        def connect_timeout_secs(self) -> float:
             """
-            :type: int
+            :type: float
             """
         @connect_timeout_secs.setter
-        def connect_timeout_secs(self, arg0: int) -> None:
+        def connect_timeout_secs(self, arg0: float) -> None:
             pass
         @property
         def max_retries(self) -> int:
@@ -572,12 +572,12 @@ class Context:
     def conda_prefix(self, arg1: Path) -> None:
         pass
     @property
-    def connect_timeout_secs(self) -> int:
+    def connect_timeout_secs(self) -> float:
         """
-        :type: int
+        :type: float
         """
     @connect_timeout_secs.setter
-    def connect_timeout_secs(self, arg1: int) -> None:
+    def connect_timeout_secs(self, arg1: float) -> None:
         pass
     @property
     def custom_channels(self) -> typing.Dict[str, str]:

--- a/libmambapy/src/main.cpp
+++ b/libmambapy/src/main.cpp
@@ -684,7 +684,7 @@ PYBIND11_MODULE(bindings, m)
                 deprecated("Use `remote_fetch_params.connect_timeout_secs` instead.");
                 return self.remote_fetch_params.connect_timeout_secs;
             },
-            [](Context& self, int cts)
+            [](Context& self, double cts)
             {
                 deprecated("Use `remote_fetch_params.connect_timeout_secs` instead.");
                 self.remote_fetch_params.connect_timeout_secs = cts;

--- a/mamba/mamba/utils.py
+++ b/mamba/mamba/utils.py
@@ -267,7 +267,9 @@ def init_api_context(use_mamba_experimental=False):
     api_ctx.pkgs_dirs = context.pkgs_dirs
     api_ctx.envs_dirs = context.envs_dirs
 
-    api_ctx.remote_fetch_params.connect_timeout_secs = context.remote_connect_timeout_secs
+    api_ctx.remote_fetch_params.connect_timeout_secs = (
+        context.remote_connect_timeout_secs
+    )
     api_ctx.remote_fetch_params.max_retries = context.remote_max_retries
     api_ctx.remote_fetch_params.retry_backoff = context.remote_backoff_factor
     api_ctx.add_pip_as_python_dependency = context.add_pip_as_python_dependency

--- a/mamba/mamba/utils.py
+++ b/mamba/mamba/utils.py
@@ -267,9 +267,7 @@ def init_api_context(use_mamba_experimental=False):
     api_ctx.pkgs_dirs = context.pkgs_dirs
     api_ctx.envs_dirs = context.envs_dirs
 
-    api_ctx.remote_fetch_params.connect_timeout_secs = int(
-        round(context.remote_connect_timeout_secs)
-    )
+    api_ctx.remote_fetch_params.connect_timeout_secs = context.remote_connect_timeout_secs
     api_ctx.remote_fetch_params.max_retries = context.remote_max_retries
     api_ctx.remote_fetch_params.retry_backoff = context.remote_backoff_factor
     api_ctx.add_pip_as_python_dependency = context.add_pip_as_python_dependency


### PR DESCRIPTION
Backport #2949 to `1.x`