### PR TITLE
Prototype two-file "index plus updates" repodata format

### DIFF
--- a/libmamba/include/mamba/core/repo.hpp
+++ b/libmamba/include/mamba/core/repo.hpp
@@ -84,6 +84,16 @@ namespace mamba
             RepodataParser parser = RepodataParser::automatic,
             LibsolvCache use_cache = LibsolvCache::yes
         );
+        MRepo(
+            MPool& pool,
+            const std::string& name,
+            const fs::u8path& filename,
+            const fs::u8path& overlay,
+            const RepoMetadata& meta,
+            RepodataParser parser = RepodataParser::automatic,
+            LibsolvCache use_cache = LibsolvCache::yes
+        );
+
         MRepo(MPool& pool, const PrefixData& prefix_data);
         MRepo(MPool& pool, const std::string& name, const std::vector<PackageInfo>& uris);
 
@@ -117,9 +127,16 @@ namespace mamba
 
         void add_pip_as_python_dependency();
         void clear(bool reuse_ids = true);
-        void load_file(const fs::u8path& filename, RepodataParser parser, LibsolvCache use_cache);
+        void load_file(
+            const fs::u8path& filename,
+            RepodataParser parser,
+            LibsolvCache use_cache,
+            const fs::u8path* overlay = nullptr
+        );
         void libsolv_read_json(const fs::u8path& filename);
         void mamba_read_json(const fs::u8path& filename);
+        void
+        mamba_read_json_plus_overlay(const mamba::fs::u8path& filename, const mamba::fs::u8path& overlay);
         bool read_solv(const fs::u8path& filename);
         void write_solv(fs::u8path path);
 

--- a/libmamba/src/core/repo.cpp
+++ b/libmamba/src/core/repo.cpp
@@ -327,6 +327,11 @@ namespace mamba
                     remember_packages->insert(std::string(fn));
                 }
 
+                // packages in the overlay may be null as a deletion marker
+                if (pkg.type() == dom::element_type::NULL_VALUE) {
+                    continue;
+                }
+
                 auto [id, solv] = repo.add_solvable();
                 const bool parsed = set_solvable(pool, solv, repo_url, fn, default_subdir, pkg, tmp_buffer);
                 if (parsed)

--- a/libmambapy/src/libmambapy/bindings/legacy.cpp
+++ b/libmambapy/src/libmambapy/bindings/legacy.cpp
@@ -340,6 +340,12 @@ bind_submodule_impl(pybind11::module_ m)
             [](MPool& pool, const std::string& name, const std::string& filename, const std::string& url
             ) { return MRepo(pool, name, filename, RepoMetadata{ /* .url=*/url }); }
         ))
+        .def(py::init([](MPool& pool,
+                         const std::string& name,
+                         const std::string& filename,
+                         const std::string overlay,
+                         const std::string& url)
+                      { return MRepo(pool, name, filename, overlay, RepoMetadata{ /* .url=*/url }); }))
         .def(py::init<MPool&, const PrefixData&>())
         .def("add_extra_pkg_info", &MRepo::py_add_extra_pkg_info)
         .def("set_installed", &MRepo::set_installed)


### PR DESCRIPTION
Attempt to add libmamba support for https://github.com/conda/conda/blob/b8ef64e4ad27b36d39e519188203d0e2ff43925b/conda/gateways/repodata/jlap/README.md

Which collects patches into a second, smaller repodata.json overlay to avoid the problem of having to re-serialize the entire file all the time. If a package exists in the overlay, we skip loading it from the upstream repodata.

My C++ is rusty. I haven't yet had luck importing the mamba refactor's Python bindings. I appreciate the C++ parser compared to what libsolv is doing.