### PR TITLE
Support multiple env yaml specs

### DIFF
--- a/dev/environment-micromamba-static.yml
+++ b/dev/environment-micromamba-static.yml
@@ -1,6 +1,7 @@
 channels:
   - conda-forge
 dependencies:
+  - python >=3.12
   # libmamba build dependencies
   - cxx-compiler
   - cmake >=3.16

--- a/docs/source/installation/micromamba-installation.rst
+++ b/docs/source/installation/micromamba-installation.rst
@@ -188,7 +188,7 @@ To build from source, install the development dependencies, using a Conda compat
 
 .. code-block:: bash
 
-  micromamba create -n mamba --file dev/environment-static.yml
+  micromamba create -n mamba --file dev/environment-micromamba-static.yml
   micromamba activate -n mamba
 
 Use CMake from this environment to drive the build:

--- a/docs/source/user_guide/micromamba.rst
+++ b/docs/source/user_guide/micromamba.rst
@@ -167,8 +167,8 @@ They are used the same way as text files:
 .. note::
   CLI options will keep :ref:`precedence<precedence-resolution>` over *target prefix* or *channels* specified in spec files.
 
-.. warning::
-  ``YAML`` spec files do not allow multiple files.
+.. note::
+  You can pass multiple ``YAML`` spec files by repeating the ``-f,--file`` argument.
 
 Explicit spec files
 *******************

--- a/libmamba/src/api/install.cpp
+++ b/libmamba/src/api/install.cpp
@@ -813,11 +813,33 @@ namespace mamba
 
             auto& context = config.context();
 
-            mamba::detail::SpecType spec_type = mamba::detail::unknown;
-
             if (file_specs.size() == 0)
             {
                 return;
+            }
+
+            mamba::detail::SpecType spec_type = mamba::detail::unknown;
+            for (auto& file : file_specs)
+            {
+                mamba::detail::SpecType current_file_spec_type = mamba::detail::unknown;
+                if (is_env_lockfile_name(file))
+                {
+                    current_file_spec_type = mamba::detail::env_lockfile;
+                }
+                else if (is_yaml_file_name(file))
+                {
+                    current_file_spec_type = mamba::detail::yaml;
+                }
+                else
+                {
+                    current_file_spec_type = mamba::detail::other;
+                }
+
+                if (spec_type != mamba::detail::unknown && spec_type != current_file_spec_type) {
+                    throw std::runtime_error("found multiple spec file types, all spec files must be of same format (yaml, txt, explicit spec, etc.)");
+                }
+
+                spec_type = current_file_spec_type;
             }
 
             for (auto& file : file_specs)
@@ -825,12 +847,6 @@ namespace mamba
                 // read specs from file :)
                 if (is_env_lockfile_name(file))
                 {
-                    if (spec_type != mamba::detail::unknown && spec_type != mamba::detail::env_lockfile) {
-                        throw std::runtime_error("found multiple spec file types, all spec files must be of same format (yaml, txt, explicit spec, etc.)");
-                    }
-
-                    spec_type = mamba::detail::env_lockfile;
-
                     if (util::starts_with(file, "http"))
                     {
                         context.env_lockfile = file;
@@ -844,12 +860,6 @@ namespace mamba
                 }
                 else if (is_yaml_file_name(file))
                 {
-                    if (spec_type != mamba::detail::unknown && spec_type != mamba::detail::yaml) {
-                        throw std::runtime_error("found multiple spec file types, all spec files must be of same format (yaml, txt, explicit spec, etc.)");
-                    }
-
-                    spec_type = mamba::detail::yaml;
-
                     const auto parse_result = read_yaml_file(file, context.platform);
 
                     if (parse_result.channels.size() != 0)
@@ -893,12 +903,6 @@ namespace mamba
                 }
                 else
                 {
-                    if (spec_type != mamba::detail::unknown && spec_type != mamba::detail::other) {
-                        throw std::runtime_error("found multiple spec file types, all spec files must be of same format (yaml, txt, explicit spec, etc.)");
-                    }
-
-                    spec_type = mamba::detail::other;
-
                     const std::vector<std::string> file_contents = read_lines(file);
                     if (file_contents.size() == 0)
                     {

--- a/libmamba/src/api/install.cpp
+++ b/libmamba/src/api/install.cpp
@@ -816,14 +816,6 @@ namespace mamba
                 return;
             }
 
-            for (const auto& file : file_specs)
-            {
-                if (is_yaml_file_name(file) && file_specs.size() != 1)
-                {
-                    throw std::runtime_error("Can only handle 1 yaml file!");
-                }
-            }
-
             for (auto& file : file_specs)
             {
                 // read specs from file :)
@@ -858,9 +850,13 @@ namespace mamba
                         channels.set_cli_value(updated_channels);
                     }
 
-                    if (parse_result.name.size() != 0)
+                    if (parse_result.name.size() != 0 && !env_name.configured())
                     {
                         env_name.set_cli_yaml_value(parse_result.name);
+                    }
+                    else if (parse_result.name.size() != 0 && parse_result.name != env_name.value<std::string>())
+                    {
+                        LOG_WARNING << "YAML specs have different environment names. Using " << env_name.value<std::string>();
                     }
 
                     if (parse_result.dependencies.size() != 0)

--- a/libmamba/src/api/install.cpp
+++ b/libmamba/src/api/install.cpp
@@ -782,7 +782,13 @@ namespace mamba
 
     namespace detail
     {
-        enum SpecType { unknown, env_lockfile, yaml, other };
+        enum SpecType
+        {
+            unknown,
+            env_lockfile,
+            yaml,
+            other
+        };
 
         void create_empty_target(const Context& context, const fs::u8path& prefix)
         {
@@ -835,8 +841,11 @@ namespace mamba
                     current_file_spec_type = mamba::detail::other;
                 }
 
-                if (spec_type != mamba::detail::unknown && spec_type != current_file_spec_type) {
-                    throw std::runtime_error("found multiple spec file types, all spec files must be of same format (yaml, txt, explicit spec, etc.)");
+                if (spec_type != mamba::detail::unknown && spec_type != current_file_spec_type)
+                {
+                    throw std::runtime_error(
+                        "found multiple spec file types, all spec files must be of same format (yaml, txt, explicit spec, etc.)"
+                    );
                 }
 
                 spec_type = current_file_spec_type;
@@ -882,7 +891,8 @@ namespace mamba
                     }
                     else if (parse_result.name.size() != 0 && parse_result.name != env_name.value<std::string>())
                     {
-                        LOG_WARNING << "YAML specs have different environment names. Using " << env_name.value<std::string>();
+                        LOG_WARNING << "YAML specs have different environment names. Using "
+                                    << env_name.value<std::string>();
                     }
 
                     if (parse_result.dependencies.size() != 0)

--- a/micromamba/tests/test_create.py
+++ b/micromamba/tests/test_create.py
@@ -335,9 +335,7 @@ def test_multiple_spec_files_different_types(tmp_home, tmp_root_prefix, tmp_path
     spec_file_1.write_text("dependencies: [xtensor]")
 
     spec_file_2 = tmp_path / f"env2.txt"
-    file_content = ["xsimd"]
-    with open(spec_file_2, "w") as f:
-        f.write("\n".join(file_content))
+    spec_file_2.write_text("xsimd")
 
     cmd += ["-f", spec_file_1, "-f", spec_file_2]
 

--- a/micromamba/tests/test_create.py
+++ b/micromamba/tests/test_create.py
@@ -351,17 +351,13 @@ def test_multiple_yaml_specs_only_one_has_channels(tmp_home, tmp_root_prefix, tm
     cmd = ["-p", env_prefix]
 
     spec_file_1 = tmp_path / f"env1.yaml"
-    file_content = ["dependencies: [xtensor]"]
-    with open(spec_file_1, "w") as f:
-        f.write("\n".join(file_content))
+    spec_file_1.write_text("dependencies: [xtensor]")
 
     spec_file_2 = tmp_path / f"env2.yaml"
-    file_content = [
-        "dependencies: [xsimd]",
+    spec_file_2.write_text(
+        "dependencies: [xsimd]\n"
         "channels: [bioconda]",
-    ]
-    with open(spec_file_2, "w") as f:
-        f.write("\n".join(file_content))
+    )
 
     cmd += ["-f", spec_file_1, "-f", spec_file_2]
 

--- a/micromamba/tests/test_create.py
+++ b/micromamba/tests/test_create.py
@@ -318,15 +318,34 @@ def test_multiple_spec_files(tmp_home, tmp_root_prefix, tmp_path, type):
 
         cmd += ["-f", spec_file]
 
-    if type == "yaml":
-        with pytest.raises(subprocess.CalledProcessError):
-            helpers.create(*cmd, "--print-config-only")
-    else:
+    res = helpers.create(*cmd, "--print-config-only")
+    if type == "yaml" or type == "classic":
+        assert res["specs"] == specs
+    else:  # explicit
+        assert res["specs"] == [explicit_specs[0]]
+
+
+@pytest.mark.parametrize("shared_pkgs_dirs", [True], indirect=True)
+def test_multiple_spec_files_different_types(tmp_home, tmp_root_prefix, tmp_path):
+    env_prefix = tmp_path / "myenv"
+
+    cmd = ["-p", env_prefix]
+
+    spec_file_1 = tmp_path / f"env1.yaml"
+    file_content = ["dependencies: [xtensor]"]
+    with open(spec_file_1, "w") as f:
+        f.write("\n".join(file_content))
+
+    spec_file_2 = tmp_path / f"env2.txt"
+    file_content = ["xsimd"]
+    with open(spec_file_2, "w") as f:
+        f.write("\n".join(file_content))
+
+    cmd += ["-f", spec_file_1, "-f", spec_file_2]
+
+    with pytest.raises(subprocess.CalledProcessError) as info:
         res = helpers.create(*cmd, "--print-config-only")
-        if type == "classic":
-            assert res["specs"] == specs
-        else:  # explicit
-            assert res["specs"] == [explicit_specs[0]]
+    assert "found multiple spec file types" in info.value.stderr.decode()
 
 
 def test_multiprocessing():

--- a/micromamba/tests/test_create.py
+++ b/micromamba/tests/test_create.py
@@ -348,6 +348,36 @@ def test_multiple_spec_files_different_types(tmp_home, tmp_root_prefix, tmp_path
     assert "found multiple spec file types" in info.value.stderr.decode()
 
 
+@pytest.mark.parametrize("shared_pkgs_dirs", [True], indirect=True)
+def test_multiple_yaml_specs_only_one_has_channels(tmp_home, tmp_root_prefix, tmp_path):
+    env_prefix = tmp_path / "myenv"
+
+    cmd = ["-p", env_prefix]
+
+    spec_file_1 = tmp_path / f"env1.yaml"
+    file_content = ["dependencies: [xtensor]"]
+    with open(spec_file_1, "w") as f:
+        f.write("\n".join(file_content))
+
+    spec_file_2 = tmp_path / f"env2.yaml"
+    file_content = [
+        "dependencies: [xsimd]",
+        "channels: [bioconda]",
+    ]
+    with open(spec_file_2, "w") as f:
+        f.write("\n".join(file_content))
+
+    cmd += ["-f", spec_file_1, "-f", spec_file_2]
+
+    res = helpers.create(
+        *cmd,
+        "--print-config-only",
+        default_channel=False
+    )
+    assert res['channels'] == ['bioconda']
+    assert res['specs'] == ['xtensor', 'xsimd']
+
+
 def test_multiprocessing():
     if platform.system() == "Windows":
         return

--- a/micromamba/tests/test_create.py
+++ b/micromamba/tests/test_create.py
@@ -332,9 +332,7 @@ def test_multiple_spec_files_different_types(tmp_home, tmp_root_prefix, tmp_path
     cmd = ["-p", env_prefix]
 
     spec_file_1 = tmp_path / f"env1.yaml"
-    file_content = ["dependencies: [xtensor]"]
-    with open(spec_file_1, "w") as f:
-        f.write("\n".join(file_content))
+    spec_file_1.write_text("dependencies: [xtensor]")
 
     spec_file_2 = tmp_path / f"env2.txt"
     file_content = ["xsimd"]

--- a/micromamba/tests/test_create.py
+++ b/micromamba/tests/test_create.py
@@ -331,16 +331,16 @@ def test_multiple_spec_files_different_types(tmp_home, tmp_root_prefix, tmp_path
 
     cmd = ["-p", env_prefix]
 
-    spec_file_1 = tmp_path / f"env1.yaml"
+    spec_file_1 = tmp_path / "env1.yaml"
     spec_file_1.write_text("dependencies: [xtensor]")
 
-    spec_file_2 = tmp_path / f"env2.txt"
+    spec_file_2 = tmp_path / "env2.txt"
     spec_file_2.write_text("xsimd")
 
     cmd += ["-f", spec_file_1, "-f", spec_file_2]
 
     with pytest.raises(subprocess.CalledProcessError) as info:
-        res = helpers.create(*cmd, "--print-config-only")
+        helpers.create(*cmd, "--print-config-only")
     assert "found multiple spec file types" in info.value.stderr.decode()
 
 
@@ -350,24 +350,19 @@ def test_multiple_yaml_specs_only_one_has_channels(tmp_home, tmp_root_prefix, tm
 
     cmd = ["-p", env_prefix]
 
-    spec_file_1 = tmp_path / f"env1.yaml"
+    spec_file_1 = tmp_path / "env1.yaml"
     spec_file_1.write_text("dependencies: [xtensor]")
 
-    spec_file_2 = tmp_path / f"env2.yaml"
+    spec_file_2 = tmp_path / "env2.yaml"
     spec_file_2.write_text(
-        "dependencies: [xsimd]\n"
-        "channels: [bioconda]",
+        "dependencies: [xsimd]\nchannels: [bioconda]",
     )
 
     cmd += ["-f", spec_file_1, "-f", spec_file_2]
 
-    res = helpers.create(
-        *cmd,
-        "--print-config-only",
-        default_channel=False
-    )
-    assert res['channels'] == ['bioconda']
-    assert res['specs'] == ['xtensor', 'xsimd']
+    res = helpers.create(*cmd, "--print-config-only", default_channel=False)
+    assert res["channels"] == ["bioconda"]
+    assert res["specs"] == ["xtensor", "xsimd"]
 
 
 def test_multiprocessing():

--- a/micromamba/tests/test_install.py
+++ b/micromamba/tests/test_install.py
@@ -266,15 +266,11 @@ class TestInstall:
 
             cmd += ["-f", file]
 
-        if type == "yaml":
-            with pytest.raises(subprocess.CalledProcessError):
-                helpers.install(*cmd, "--print-config-only")
-        else:
-            res = helpers.install(*cmd, "--print-config-only")
-            if type == "classic":
-                assert res["specs"] == specs
-            else:  # explicit
-                assert res["specs"] == [explicit_specs[0]]
+        res = helpers.install(*cmd, "--print-config-only")
+        if type == "yaml" or type == "classic":
+            assert res["specs"] == specs
+        else:  # explicit
+            assert res["specs"] == [explicit_specs[0]]
 
     @pytest.mark.parametrize("priority", (None, "disabled", "flexible", "strict"))
     @pytest.mark.parametrize("no_priority", (None, True))

--- a/micromamba/tests/test_update.py
+++ b/micromamba/tests/test_update.py
@@ -461,15 +461,11 @@ class TestUpdateConfig:
 
             cmd += ["-f", file]
 
-        if type == "yaml":
-            with pytest.raises(helpers.subprocess.CalledProcessError):
-                helpers.install(*cmd, "--print-config-only")
-        else:
-            res = helpers.install(*cmd, "--print-config-only")
-            if type == "classic":
-                assert res["specs"] == specs
-            else:  # explicit
-                assert res["specs"] == [explicit_specs[0]]
+        res = helpers.install(*cmd, "--print-config-only")
+        if type == "yaml" or type == "classic":
+            assert res["specs"] == specs
+        else:  # explicit
+            assert res["specs"] == [explicit_specs[0]]
 
     def test_channel_specific(self, env_created):
         helpers.install("quantstack::sphinx", no_dry_run=True)


### PR DESCRIPTION
Tested:

testmultiyml/env1.yml 
```yaml
channels:
  - conda-forge
dependencies:
  - python >=3.12
```

testmultiyml/env2.yml 
```yaml
channels:
  - conda-forge
dependencies:
  - pandas >=2.1.1
```

```
(mamba) mambauser@6eb769d94efc:/work$ ./build/micromamba/micromamba create -n multiymltest -f testmultiyml/env1.yml -f testmultiyml/env2.yml 
(mamba) mambauser@6eb769d94efc:/work$     micromamba activate multiymltest
(multiymltest) mambauser@6eb769d94efc:/work$ python3
Python 3.12.0 | packaged by conda-forge | (main, Oct  3 2023, 08:43:22) [GCC 12.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import pandas as pd
```

Not sure if there's other edge cases worth considering or test cases that would be helpful.