### PR TITLE
Drop unneeded dependencies

### DIFF
--- a/libmamba/CMakeLists.txt
+++ b/libmamba/CMakeLists.txt
@@ -541,12 +541,6 @@ macro(libmamba_create_target target_name linkage output_name)
             PUBLIC
                 ${LIBSOLV_LIBRARIES}
                 ${LIBSOLVEXT_LIBRARIES}
-                ${LibArchive_LIBRARIES}
-                zstd::libzstd_shared
-                ${CURL_LIBRARIES}
-                ${OPENSSL_LIBRARIES}
-                zstd::libzstd_shared
-                BZip2::BZip2
                 yaml-cpp::yaml-cpp
                 fmt::fmt
                 # Since conda-forge spdlog is built with a bundled version of fmt we use the header
@@ -555,7 +549,15 @@ macro(libmamba_create_target target_name linkage output_name)
                 spdlog::spdlog_header_only
                 solv::libsolv
                 solv::libsolvext
-            PRIVATE reproc reproc++ simdjson::simdjson
+            PRIVATE
+                ${LibArchive_LIBRARIES}
+                ${CURL_LIBRARIES}
+                ${OPENSSL_LIBRARIES}
+                BZip2::BZip2
+                reproc
+                reproc++
+                simdjson::simdjson
+                zstd::libzstd_shared
         )
     endif()
 

--- a/libmamba/libmambaConfig.cmake.in
+++ b/libmamba/libmambaConfig.cmake.in
@@ -22,18 +22,11 @@ set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR};${CMAKE_MODULE_PATH}")
 @LIBMAMBA_CONFIG_CODE@
 
 include(CMakeFindDependencyMacro)
-find_dependency(CURL)
-find_dependency(LibArchive)
-find_dependency(zstd)
-find_dependency(BZip2)
-find_dependency(OpenSSL)
 find_dependency(fmt)
 find_dependency(spdlog)
 find_dependency(tl-expected)
 find_dependency(nlohmann_json)
-find_dependency(simdjson)
 find_dependency(yaml-cpp)
-find_dependency(reproc)
 find_dependency(reproc++)
 find_dependency(Libsolv MODULE)
 


### PR DESCRIPTION
This is an attempt to fix #3014 .  I'm not sure I understand all of the ramifications of this change yet, but it does allow me to build libmambapy with a reduced set of dependencies.