### PR TITLE
Default to hide credentials

### DIFF
--- a/libmamba/include/mamba/core/subdirdata.hpp
+++ b/libmamba/include/mamba/core/subdirdata.hpp
@@ -149,7 +149,7 @@ namespace mamba
 
         void
         load(MultiPackageCache& caches, ChannelContext& channel_context, const specs::Channel& channel);
-        void load_cache(MultiPackageCache& caches, ChannelContext& channel_context);
+        void load_cache(MultiPackageCache& caches);
         void update_metadata_zst(ChannelContext& context, const specs::Channel& channel);
 
         MultiDownloadRequest build_check_requests();

--- a/libmamba/include/mamba/specs/conda_url.hpp
+++ b/libmamba/include/mamba/specs/conda_url.hpp
@@ -207,7 +207,7 @@ namespace mamba::specs
         auto clear_package() -> bool;
 
         /** Return the full, exact, encoded URL. */
-        [[nodiscard]] auto str(Credentials credentials = Credentials::Show) const -> std::string;
+        [[nodiscard]] auto str(Credentials credentials = Credentials::Hide) const -> std::string;
 
         /**
          * Return the full decoded url.

--- a/libmamba/include/mamba/specs/conda_url.hpp
+++ b/libmamba/include/mamba/specs/conda_url.hpp
@@ -222,7 +222,7 @@ namespace mamba::specs
         [[nodiscard]] auto pretty_str(
             StripScheme strip_scheme = StripScheme::no,
             char rstrip_path = 0,
-            Credentials credentials = Credentials::Show
+            Credentials credentials = Credentials::Hide
         ) const -> std::string;
 
 

--- a/libmamba/include/mamba/util/url.hpp
+++ b/libmamba/include/mamba/util/url.hpp
@@ -166,7 +166,7 @@ namespace mamba::util
         auto clear_port() -> std::string;
 
         /** Return the encoded autority part of the URL. */
-        [[nodiscard]] auto authority(Credentials = Credentials::Show) const -> std::string;
+        [[nodiscard]] auto authority(Credentials = Credentials::Hide) const -> std::string;
 
         /** Return the encoded path, always starts with a '/'. */
         [[nodiscard]] auto path(Decode::no_type) const -> const std::string&;
@@ -233,7 +233,7 @@ namespace mamba::util
         auto clear_fragment() -> std::string;
 
         /** Return the full, exact, encoded URL. */
-        [[nodiscard]] auto str(Credentials credentials = Credentials::Show) const -> std::string;
+        [[nodiscard]] auto str(Credentials credentials = Credentials::Hide) const -> std::string;
 
         /**
          * Return the full decoded url.
@@ -246,7 +246,7 @@ namespace mamba::util
         [[nodiscard]] auto pretty_str(
             StripScheme strip_scheme = StripScheme::no,
             char rstrip_path = 0,
-            Credentials credentials = Credentials::Show
+            Credentials credentials = Credentials::Hide
         ) const -> std::string;
 
     protected:

--- a/libmamba/src/api/channel_loader.cpp
+++ b/libmamba/src/api/channel_loader.cpp
@@ -70,7 +70,7 @@ namespace mamba
                         pool.channel_context(),
                         channel,
                         platform,
-                        channel.platform_url(platform).str(),
+                        channel.platform_url(platform).str(specs::CondaURL::Credentials::Show),
                         package_caches,
                         "repodata.json"
                     );

--- a/libmamba/src/api/info.cpp
+++ b/libmamba/src/api/info.cpp
@@ -161,6 +161,7 @@ namespace mamba
 
             // Always append context channels
             std::vector<std::string> channel_urls;
+            using Credentials = specs::CondaURL::Credentials;
             channel_urls.reserve(ctx.channels.size() * 2);  // Lower bound * (platform + noarch)
             for (const auto& loc : ctx.channels)
             {
@@ -168,7 +169,7 @@ namespace mamba
                 {
                     for (auto url : channel.platform_urls())
                     {
-                        channel_urls.push_back(std::move(url).str());
+                        channel_urls.push_back(std::move(url).str(Credentials::Remove));
                     }
                 }
             }

--- a/libmamba/src/core/package_cache.cpp
+++ b/libmamba/src/core/package_cache.cpp
@@ -21,17 +21,13 @@ namespace mamba
     {
         bool compare_cleaned_url(std::string_view url_str1, std::string_view url_str2)
         {
+            using Credentials = specs::CondaURL::Credentials;
             auto url1 = specs::CondaURL::parse(url_str1);
             url1.set_scheme("https");
-            url1.clear_token();
-            url1.clear_password();
-            url1.clear_user();
             auto url2 = specs::CondaURL::parse(url_str2);
             url2.set_scheme("https");
-            url2.clear_token();
-            url2.clear_password();
-            url2.clear_user();
-            return util::rstrip(url1.str(), '/') == util::rstrip(url2.str(), '/');
+            return util::rstrip(url1.str(Credentials::Remove), '/')
+                   == util::rstrip(url2.str(Credentials::Remove), '/');
         }
     }
 

--- a/libmamba/src/core/package_fetcher.cpp
+++ b/libmamba/src/core/package_fetcher.cpp
@@ -68,11 +68,7 @@ namespace mamba
      * PatckageFetcher *
      *******************/
 
-    PackageFetcher::PackageFetcher(
-        const PackageInfo& pkg_info,
-        // ChannelContext& channel_context,
-        MultiPackageCache& caches
-    )
+    PackageFetcher::PackageFetcher(const PackageInfo& pkg_info, MultiPackageCache& caches)
 
         : m_package_info(pkg_info)
     {

--- a/libmamba/src/core/prefix_data.cpp
+++ b/libmamba/src/core/prefix_data.cpp
@@ -13,6 +13,7 @@
 #include "mamba/core/output.hpp"
 #include "mamba/core/prefix_data.hpp"
 #include "mamba/core/util.hpp"
+#include "mamba/specs/conda_url.hpp"
 #include "mamba/util/graph.hpp"
 #include "mamba/util/string.hpp"
 
@@ -169,7 +170,8 @@ namespace mamba
         // If someone wrote multichannel names in repodata_record, we don't know which one is the
         // correct URL. This is must never happen!
         assert(channels.size() == 1);
-        prec.channel = channels.front().platform_url(prec.subdir).str();
+        using Credentials = specs::CondaURL::Credentials;
+        prec.channel = channels.front().platform_url(prec.subdir).str(Credentials::Remove);
         m_package_records.insert({ prec.name, std::move(prec) });
     }
 }  // namespace mamba

--- a/libmamba/src/core/subdirdata.cpp
+++ b/libmamba/src/core/subdirdata.cpp
@@ -556,7 +556,7 @@ namespace mamba
     {
         if (!forbid_cache(m_repodata_url))
         {
-            load_cache(caches, channel_context);
+            load_cache(caches);
         }
 
         if (m_loaded)
@@ -575,7 +575,7 @@ namespace mamba
         }
     }
 
-    void MSubdirData::load_cache(MultiPackageCache& caches, ChannelContext& channel_context)
+    void MSubdirData::load_cache(MultiPackageCache& caches)
     {
         LOG_INFO << "Searching index cache file for repo '" << m_repodata_url << "'";
         file_time_point now = fs::file_time_type::clock::now();

--- a/libmamba/src/core/transaction.cpp
+++ b/libmamba/src/core/transaction.cpp
@@ -893,10 +893,11 @@ namespace mamba
                     // FIXME: only do this for micromamba for now
                     if (ctx.command_params.is_micromamba)
                     {
+                        using Credentials = typename specs::CondaURL::Credentials;
                         auto l_pkg = pkg;
                         auto channels = channel_context.make_channel(pkg.url);
                         assert(channels.size() == 1);  // A URL can only resolve to one channel
-                        l_pkg.url = channels.front().platform_urls().at(0).str();
+                        l_pkg.url = channels.front().platform_urls().at(0).str(Credentials::Show);
                         fetchers.emplace_back(l_pkg, multi_cache);
                     }
                     else

--- a/libmamba/tests/src/specs/test_conda_url.cpp
+++ b/libmamba/tests/src/specs/test_conda_url.cpp
@@ -463,7 +463,7 @@ TEST_SUITE("specs::CondaURL")
             );
             CHECK_EQ(
                 url.pretty_str(),
-                "https://user:password@mamba.org:8080/folder/file.html?param=value#fragment"
+                "https://user:*****@mamba.org:8080/folder/file.html?param=value#fragment"
             );
         }
 
@@ -476,7 +476,7 @@ TEST_SUITE("specs::CondaURL")
             url.set_password("pw%rd");
             url.set_path("/some /path$/");
             CHECK_EQ(url.str(), "https://user%40email.com:pw%25rd@mamba.org/some%20/path%24/");
-            CHECK_EQ(url.pretty_str(), "https://user@email.com:pw%rd@mamba.org/some /path$/");
+            CHECK_EQ(url.pretty_str(), "https://user@email.com:*****@mamba.org/some /path$/");
         }
     }
 }

--- a/libmamba/tests/src/specs/test_conda_url.cpp
+++ b/libmamba/tests/src/specs/test_conda_url.cpp
@@ -459,6 +459,10 @@ TEST_SUITE("specs::CondaURL")
 
             CHECK_EQ(
                 url.str(),
+                "https://user:*****@mamba.org:8080/folder/file.html?param=value#fragment"
+            );
+            CHECK_EQ(
+                url.str(CondaURL::Credentials::Show),
                 "https://user:password@mamba.org:8080/folder/file.html?param=value#fragment"
             );
             CHECK_EQ(
@@ -475,7 +479,11 @@ TEST_SUITE("specs::CondaURL")
             url.set_user("user@email.com");
             url.set_password("pw%rd");
             url.set_path("/some /path$/");
-            CHECK_EQ(url.str(), "https://user%40email.com:pw%25rd@mamba.org/some%20/path%24/");
+            CHECK_EQ(url.str(), "https://user%40email.com:*****@mamba.org/some%20/path%24/");
+            CHECK_EQ(
+                url.str(CondaURL::Credentials::Show),
+                "https://user%40email.com:pw%25rd@mamba.org/some%20/path%24/"
+            );
             CHECK_EQ(url.pretty_str(), "https://user@email.com:*****@mamba.org/some /path$/");
         }
     }

--- a/libmamba/tests/src/util/test_url.cpp
+++ b/libmamba/tests/src/util/test_url.cpp
@@ -514,11 +514,23 @@ TEST_SUITE("util::URL")
 
             CHECK_EQ(
                 url.str(),
+                "https://user:*****@mamba.org:8080/folder/file.html?param=value#fragment"
+            );
+            CHECK_EQ(
+                url.str(URL::Credentials::Show),
                 "https://user:password@mamba.org:8080/folder/file.html?param=value#fragment"
             );
             CHECK_EQ(
+                url.str(URL::Credentials::Hide),
+                "https://user:*****@mamba.org:8080/folder/file.html?param=value#fragment"
+            );
+            CHECK_EQ(
+                url.str(URL::Credentials::Remove),
+                "https://mamba.org:8080/folder/file.html?param=value#fragment"
+            );
+            CHECK_EQ(
                 url.pretty_str(),
-                "https://user:password@mamba.org:8080/folder/file.html?param=value#fragment"
+                "https://user:*****@mamba.org:8080/folder/file.html?param=value#fragment"
             );
         }
 
@@ -527,9 +539,19 @@ TEST_SUITE("util::URL")
             URL url{};
             url.set_host("mamba.org");
             url.set_user("user");
-            CHECK_EQ(url.pretty_str(), "https://user@mamba.org/");
-            CHECK_EQ(url.str(), "https://user@mamba.org/");
-            CHECK_EQ(url.pretty_str(URL::StripScheme::yes), "user@mamba.org/");
+            CHECK_EQ(url.str(URL::Credentials::Show), "https://user@mamba.org/");
+            CHECK_EQ(url.str(URL::Credentials::Hide), "https://user:*****@mamba.org/");
+            CHECK_EQ(url.pretty_str(), "https://user:*****@mamba.org/");
+            CHECK_EQ(url.pretty_str(URL::StripScheme::yes), "user:*****@mamba.org/");
+            CHECK_EQ(
+                url.pretty_str(URL::StripScheme::yes, '\0', URL::Credentials::Hide),
+                "user:*****@mamba.org/"
+            );
+            CHECK_EQ(
+                url.pretty_str(URL::StripScheme::yes, '\0', URL::Credentials::Show),
+                "user@mamba.org/"
+            );
+            CHECK_EQ(url.pretty_str(URL::StripScheme::yes, '\0', URL::Credentials::Remove), "mamba.org/");
         }
 
         SUBCASE("https://mamba.org")
@@ -594,8 +616,14 @@ TEST_SUITE("util::URL")
             url.set_user("user@email.com");
             url.set_password("pw%rd");
             url.set_path("/some /path$/");
-            CHECK_EQ(url.str(), "https://user%40email.com:pw%25rd@mamba.org/some%20/path%24/");
-            CHECK_EQ(url.pretty_str(), "https://user@email.com:pw%rd@mamba.org/some /path$/");
+            CHECK_EQ(
+                url.str(URL::Credentials::Show),
+                "https://user%40email.com:pw%25rd@mamba.org/some%20/path%24/"
+            );
+            CHECK_EQ(
+                url.pretty_str(URL::StripScheme::no, '/', URL::Credentials::Show),
+                "https://user@email.com:pw%rd@mamba.org/some /path$"
+            );
         }
     }
 
@@ -629,13 +657,13 @@ TEST_SUITE("util::URL")
         CHECK_EQ(url.authority(URL::Credentials::Remove), "mamba.org:8000");
 
         url.set_user("user@email.com");
-        CHECK_EQ(url.authority(), "user%40email.com@mamba.org:8000");
+        CHECK_EQ(url.authority(), "user%40email.com:*****@mamba.org:8000");
         CHECK_EQ(url.authority(URL::Credentials::Show), "user%40email.com@mamba.org:8000");
         CHECK_EQ(url.authority(URL::Credentials::Hide), "user%40email.com:*****@mamba.org:8000");
         CHECK_EQ(url.authority(URL::Credentials::Remove), "mamba.org:8000");
 
         url.set_password("pass");
-        CHECK_EQ(url.authority(), "user%40email.com:pass@mamba.org:8000");
+        CHECK_EQ(url.authority(), "user%40email.com:*****@mamba.org:8000");
         CHECK_EQ(url.authority(URL::Credentials::Show), "user%40email.com:pass@mamba.org:8000");
         CHECK_EQ(url.authority(URL::Credentials::Hide), "user%40email.com:*****@mamba.org:8000");
         CHECK_EQ(url.authority(URL::Credentials::Remove), "mamba.org:8000");

--- a/micromamba/src/env.cpp
+++ b/micromamba/src/env.cpp
@@ -145,7 +145,7 @@ set_env_command(CLI::App* com, Configuration& config)
                 for (const auto& record : records)
                 {
                     using Credentials = typename specs::CondaURL::Credentials;
-                    std::cout << specs::CondaURL::parse(record.url).str(Credentials::Hide);
+                    std::cout << specs::CondaURL::parse(record.url).str(Credentials::Remove);
                     if (no_md5 != 1)
                     {
                         std::cout << "#" << record.md5;


### PR DESCRIPTION
Have the default option of `URL::str` (and the like) to hide credentials, to avoid accidentally leaking them.