### PR TITLE
Refactor (some) OpenSSL functions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,7 @@ if(MSVC)
     # project.
     set(
         CMAKE_CXX_FLAGS
-        "${CMAKE_CXX_FLAGS} /D_CRT_SECURE_NO_WARNINGS /DNOMINMAX /EHsc /Zc:__cplusplus /MP /experimental:external /external:I $ENV{CONDA_PREFIX}"
+        "${CMAKE_CXX_FLAGS} /D_CRT_SECURE_NO_WARNINGS /DNOMINMAX /EHsc /Zc:__cplusplus /utf-8 /MP /experimental:external /external:I $ENV{CONDA_PREFIX}"
     )
     # Force release mode to avoid debug libraries to be linked
     set(

--- a/libmamba/CMakeLists.txt
+++ b/libmamba/CMakeLists.txt
@@ -153,6 +153,7 @@ set(
     # Filesystem library
     ${LIBMAMBA_SOURCE_DIR}/fs/filesystem.cpp
     # C++ utility library
+    ${LIBMAMBA_SOURCE_DIR}/util/cryptography.cpp
     ${LIBMAMBA_SOURCE_DIR}/util/environment.cpp
     ${LIBMAMBA_SOURCE_DIR}/util/os_win.cpp
     ${LIBMAMBA_SOURCE_DIR}/util/path_manip.cpp
@@ -252,6 +253,7 @@ set(
     ${LIBMAMBA_INCLUDE_DIR}/mamba/util/build.hpp
     ${LIBMAMBA_INCLUDE_DIR}/mamba/util/cast.hpp
     ${LIBMAMBA_INCLUDE_DIR}/mamba/util/compare.hpp
+    ${LIBMAMBA_INCLUDE_DIR}/mamba/util/cryptography.hpp
     ${LIBMAMBA_INCLUDE_DIR}/mamba/util/deprecation.hpp
     ${LIBMAMBA_INCLUDE_DIR}/mamba/util/environment.hpp
     ${LIBMAMBA_INCLUDE_DIR}/mamba/util/flat_binary_tree.hpp

--- a/libmamba/CMakeLists.txt
+++ b/libmamba/CMakeLists.txt
@@ -154,6 +154,7 @@ set(
     ${LIBMAMBA_SOURCE_DIR}/fs/filesystem.cpp
     # C++ utility library
     ${LIBMAMBA_SOURCE_DIR}/util/cryptography.cpp
+    ${LIBMAMBA_SOURCE_DIR}/util/encoding.cpp
     ${LIBMAMBA_SOURCE_DIR}/util/environment.cpp
     ${LIBMAMBA_SOURCE_DIR}/util/os_win.cpp
     ${LIBMAMBA_SOURCE_DIR}/util/path_manip.cpp
@@ -255,6 +256,7 @@ set(
     ${LIBMAMBA_INCLUDE_DIR}/mamba/util/compare.hpp
     ${LIBMAMBA_INCLUDE_DIR}/mamba/util/cryptography.hpp
     ${LIBMAMBA_INCLUDE_DIR}/mamba/util/deprecation.hpp
+    ${LIBMAMBA_INCLUDE_DIR}/mamba/util/encoding.hpp
     ${LIBMAMBA_INCLUDE_DIR}/mamba/util/environment.hpp
     ${LIBMAMBA_INCLUDE_DIR}/mamba/util/flat_binary_tree.hpp
     ${LIBMAMBA_INCLUDE_DIR}/mamba/util/flat_bool_expr_tree.hpp

--- a/libmamba/include/mamba/core/package_fetcher.hpp
+++ b/libmamba/include/mamba/core/package_fetcher.hpp
@@ -99,13 +99,7 @@ namespace mamba
 
     private:
 
-        struct CheckSumParams
-        {
-            std::string expected;
-            std::string actual;
-            std::string name;
-            ValidationResult error;
-        };
+        struct CheckSumParams;
 
         const std::string& filename() const;
         const std::string& url() const;
@@ -114,7 +108,7 @@ namespace mamba
         std::size_t expected_size() const;
 
         ValidationResult validate_size(std::size_t downloaded_size) const;
-        ValidationResult validate_checksum(CheckSumParams params) const;
+        ValidationResult validate_checksum(const CheckSumParams& params) const;
 
         void write_repodata_record(const fs::u8path& base_path) const;
         void update_urls_txt() const;

--- a/libmamba/include/mamba/core/subdirdata.hpp
+++ b/libmamba/include/mamba/core/subdirdata.hpp
@@ -178,6 +178,8 @@ namespace mamba
         const Context* p_context;
     };
 
+    [[nodiscard]] std::string cache_name_from_url(std::string_view url);
+
     // Contrary to conda original function, this one expects a full url
     // (that is channel url + / + repodata_fn). It is not the
     // responsibility of this function to decide whether it should

--- a/libmamba/include/mamba/core/util.hpp
+++ b/libmamba/include/mamba/core/util.hpp
@@ -331,9 +331,6 @@ namespace mamba
     void split_package_extension(const std::string& file, std::string& name, std::string& extension);
     fs::u8path strip_package_extension(const std::string& file);
 
-    tl::expected<std::string, mamba_error> encode_base64(std::string_view input);
-    tl::expected<std::string, mamba_error> decode_base64(std::string_view input);
-
     std::string
     quote_for_shell(const std::vector<std::string>& arguments, const std::string& shell = "");
 

--- a/libmamba/include/mamba/core/validate.hpp
+++ b/libmamba/include/mamba/core/validate.hpp
@@ -19,10 +19,10 @@
 
 namespace mamba::validation
 {
-    std::string sha256sum(const fs::u8path& path);
-    std::string md5sum(const fs::u8path& path);
-    bool sha256(const fs::u8path& path, const std::string& validation);
-    bool md5(const fs::u8path& path, const std::string& validation);
+    [[nodiscard]] auto sha256sum(const fs::u8path& path) -> std::string_view;
+
+    [[nodiscard]] auto md5sum(const fs::u8path& path) -> std::string_view;
+
     bool file_size(const fs::u8path& path, std::uintmax_t validation);
 
     inline constexpr std::size_t MAMBA_SHA256_SIZE_HEX = 64;

--- a/libmamba/include/mamba/core/validate.hpp
+++ b/libmamba/include/mamba/core/validate.hpp
@@ -45,13 +45,7 @@ namespace mamba::validation
     int sign(const std::string& data, const std::string& sk, std::string& signature);
 
     std::array<unsigned char, MAMBA_ED25519_SIGSIZE_BYTES>
-    ed25519_sig_hex_to_bytes(const std::string& sig_hex) noexcept;
-
-    std::array<unsigned char, MAMBA_ED25519_SIGSIZE_BYTES>
     ed25519_sig_hex_to_bytes(const std::string& sig_hex, int& error_code) noexcept;
-
-    std::array<unsigned char, MAMBA_ED25519_KEYSIZE_BYTES>
-    ed25519_key_hex_to_bytes(const std::string& key_hex) noexcept;
 
     std::array<unsigned char, MAMBA_ED25519_KEYSIZE_BYTES>
     ed25519_key_hex_to_bytes(const std::string& key_hex, int& error_code) noexcept;

--- a/libmamba/include/mamba/util/cryptography.hpp
+++ b/libmamba/include/mamba/util/cryptography.hpp
@@ -17,10 +17,13 @@
 
 #include "mamba/util/encoding.hpp"
 
-using EVP_MD_CTX = struct evp_md_ctx_st;
+using EVP_MD_CTX = struct evp_md_ctx_st;  // OpenSSL impl
 
 namespace mamba::util
 {
+    /**
+     * Provide high-level hashing functions over a digest hashing algorithm.
+     */
     template <typename Digester>
     class DigestHasher
     {
@@ -42,34 +45,82 @@ namespace mamba::util
             std::size_t size;
         };
 
+        /**
+         * Hash a blob of data and write the hashed bytes to the provided ouput.
+         */
         void blob_bytes_to(blob_type blob, std::byte* out);
 
+        /**
+         * Hash a blob of data and return the hashed bytes as an array.
+         */
         [[nodiscard]] auto blob_bytes(blob_type blob) -> bytes_array;
 
+        /**
+         * Hash a blob of data and write the hashed bytes with hexadecimal encoding to the output.
+         */
         void blob_hex_to(blob_type blob, char* out);
 
+        /**
+         * Hash a blob of data and return the hashed bytes with hexadecimal encoding as an array.
+         */
         [[nodiscard]] auto blob_hex(blob_type blob) -> hex_array;
 
+        /**
+         * Hash a blob of data and return the hashed bytes with hexadecimal encoding as a string.
+         */
         [[nodiscard]] auto blob_hex_str(blob_type blob) -> std::string;
 
+        /**
+         * Hash a string and write the hashed bytes to the provided ouput.
+         */
         void str_bytes_to(std::string_view data, std::byte* out);
 
+        /**
+         * Hash a string and return the hashed bytes as an array.
+         */
         [[nodiscard]] auto str_bytes(std::string_view data) -> bytes_array;
 
+        /**
+         * Hash a string and write the hashed bytes with hexadecimal encoding to the output.
+         */
         void str_hex_to(std::string_view data, char* out);
 
+        /**
+         * Hash a string and return the hashed bytes with hexadecimal encoding as an array.
+         */
         [[nodiscard]] auto str_hex(std::string_view data) -> hex_array;
 
+        /**
+         * Hash a string and return the hashed bytes with hexadecimal encoding as a string.
+         */
         [[nodiscard]] auto str_hex_str(std::string_view data) -> std::string;
 
+        /**
+         * Incrementally hash a file and write the hashed bytes to the provided ouput.
+         */
         void file_bytes_to(std::ifstream& file, std::byte* out);
 
+        /**
+         * Incrementally hash a file and return the hashed bytes as an array.
+         */
         [[nodiscard]] auto file_bytes(std::ifstream& file) -> bytes_array;
 
+        /**
+         * Incrementally hash a file and write the hashed bytes with hexadecimal encoding to the
+         * output.
+         */
         void file_hex_to(std::ifstream& infile, char* out);
 
+        /**
+         * Incrementally hash a file and return the hashed bytes with hexadecimal encoding as an
+         * array.
+         */
         [[nodiscard]] auto file_hex(std::ifstream& file) -> hex_array;
 
+        /**
+         * Incrementally hash a file and return the hashed bytes with hexadecimal encoding as a
+         * string.
+         */
         [[nodiscard]] auto file_hex_str(std::ifstream& file) -> std::string;
 
     private:

--- a/libmamba/include/mamba/util/cryptography.hpp
+++ b/libmamba/include/mamba/util/cryptography.hpp
@@ -144,7 +144,7 @@ namespace mamba::util
             EVPDigester(Algorithm algo);
 
             void digest_start();
-            void digest_update(std::byte* buffer, std::size_t count);
+            void digest_update(const std::byte* buffer, std::size_t count);
             void digest_finalize_to(std::byte* hash);
 
         private:

--- a/libmamba/include/mamba/util/cryptography.hpp
+++ b/libmamba/include/mamba/util/cryptography.hpp
@@ -159,12 +159,16 @@ namespace mamba::util
         };
     }
 
-    class Sha256Digester : public detail::EVPDigester
+    class Sha256Digester : private detail::EVPDigester
     {
     public:
 
         inline static constexpr std::size_t bytes_size = 32;
         inline static constexpr std::size_t digest_size = 32768;
+
+        using detail::EVPDigester::digest_start;
+        using detail::EVPDigester::digest_update;
+        using detail::EVPDigester::digest_finalize_to;
 
         Sha256Digester()
             : EVPDigester(detail::EVPDigester::Algorithm::sha256)
@@ -174,12 +178,16 @@ namespace mamba::util
 
     using Sha256Hasher = DigestHasher<Sha256Digester>;
 
-    class Md5Digester : public detail::EVPDigester
+    class Md5Digester : private detail::EVPDigester
     {
     public:
 
         inline static constexpr std::size_t bytes_size = 16;
         inline static constexpr std::size_t digest_size = 32768;
+
+        using detail::EVPDigester::digest_start;
+        using detail::EVPDigester::digest_update;
+        using detail::EVPDigester::digest_finalize_to;
 
         Md5Digester()
             : EVPDigester(detail::EVPDigester::Algorithm::md5)

--- a/libmamba/include/mamba/util/cryptography.hpp
+++ b/libmamba/include/mamba/util/cryptography.hpp
@@ -13,12 +13,12 @@
 #include <memory>
 #include <vector>
 
+#include "mamba/util/encoding.hpp"
+
 using EVP_MD_CTX = struct evp_md_ctx_st;
 
 namespace mamba::util
 {
-    void bytes_to_hex_to(const std::byte* first, const std::byte* last, char* out);
-
     template <typename Digester>
     class DigestHasher
     {

--- a/libmamba/include/mamba/util/cryptography.hpp
+++ b/libmamba/include/mamba/util/cryptography.hpp
@@ -1,0 +1,32 @@
+// Copyright (c) 2023, QuantStack and Mamba Contributors
+//
+// Distributed under the terms of the BSD 3-Clause License.
+//
+// The full license is in the file LICENSE, distributed with this software.
+
+#ifndef MAMBA_UTIL_CRYPTOGRAPHY_HPP
+#define MAMBA_UTIL_CRYPTOGRAPHY_HPP
+
+#include <array>
+#include <cstddef>
+#include <iosfwd>
+#include <vector>
+
+namespace mamba::util
+{
+    void bytes_to_hex_to(const std::byte* first, const std::byte* last, char* out);
+
+    inline constexpr std::size_t SHA256_SIZE_BYTES = 32;
+    using sha256bytes_array = std::array<std::byte, SHA256_SIZE_BYTES>;
+    inline constexpr std::size_t SHA256_SIZE_HEX = 64;
+    using sha256hex_array = std::array<char, SHA256_SIZE_HEX>;
+
+    void sha256bytes_file_to(std::ifstream& file, std::byte* out, std::vector<std::byte>& tmp_buffer);
+
+    void sha256bytes_file_to(std::ifstream& file, std::byte* out);
+
+    [[nodiscard]] auto sha256bytes_file(std::ifstream& file) -> sha256bytes_array;
+
+    [[nodiscard]] auto sha256hex_file(std::ifstream& file) -> sha256hex_array;
+}
+#endif

--- a/libmamba/include/mamba/util/cryptography.hpp
+++ b/libmamba/include/mamba/util/cryptography.hpp
@@ -9,24 +9,146 @@
 
 #include <array>
 #include <cstddef>
-#include <iosfwd>
+#include <fstream>
+#include <memory>
 #include <vector>
+
+using EVP_MD_CTX = struct evp_md_ctx_st;
 
 namespace mamba::util
 {
     void bytes_to_hex_to(const std::byte* first, const std::byte* last, char* out);
 
-    inline constexpr std::size_t SHA256_SIZE_BYTES = 32;
-    using sha256bytes_array = std::array<std::byte, SHA256_SIZE_BYTES>;
-    inline constexpr std::size_t SHA256_SIZE_HEX = 64;
-    using sha256hex_array = std::array<char, SHA256_SIZE_HEX>;
+    template <typename Digester>
+    class DigestHasher
+    {
+    public:
 
-    void sha256bytes_file_to(std::ifstream& file, std::byte* out, std::vector<std::byte>& tmp_buffer);
+        using digester_type = Digester;
 
-    void sha256bytes_file_to(std::ifstream& file, std::byte* out);
+        inline static constexpr std::size_t bytes_size = digester_type::bytes_size;
+        inline static constexpr std::size_t hex_size = 2 * bytes_size;
+        inline static constexpr std::size_t digest_size = digester_type::digest_size;
 
-    [[nodiscard]] auto sha256bytes_file(std::ifstream& file) -> sha256bytes_array;
+        using bytes_array = std::array<std::byte, bytes_size>;
+        using hex_array = std::array<char, hex_size>;
 
-    [[nodiscard]] auto sha256hex_file(std::ifstream& file) -> sha256hex_array;
+        void file_bytes_to(std::ifstream& file, std::byte* out);
+
+        [[nodiscard]] auto file_bytes(std::ifstream& file) -> bytes_array;
+
+        [[nodiscard]] auto file_hex(std::ifstream& file) -> hex_array;
+
+    private:
+
+        std::vector<std::byte> m_digest_buffer = {};
+        digester_type m_digester = {};
+    };
+
+    namespace detail
+    {
+        class EVPDigester
+        {
+        public:
+
+            enum struct Algorithm
+            {
+                sha256,
+                md5
+            };
+
+            EVPDigester(Algorithm algo);
+
+            void digest_start();
+            void digest_update(std::byte* buffer, std::size_t count);
+            void digest_finalize_to(std::byte* hash);
+
+        private:
+
+            struct EVPContextDeleter
+            {
+                void operator()(::EVP_MD_CTX* ptr) const;
+            };
+
+            std::unique_ptr<::EVP_MD_CTX, EVPContextDeleter> m_ctx;
+            Algorithm m_algorithm;
+        };
+    }
+
+    class Sha256Digester : public detail::EVPDigester
+    {
+    public:
+
+        inline static constexpr std::size_t bytes_size = 32;
+        inline static constexpr std::size_t digest_size = 32768;
+
+        Sha256Digester()
+            : EVPDigester(detail::EVPDigester::Algorithm::sha256)
+        {
+        }
+    };
+
+    using Sha256Hasher = DigestHasher<Sha256Digester>;
+
+    class Md5Digester : public detail::EVPDigester
+    {
+    public:
+
+        inline static constexpr std::size_t bytes_size = 16;
+        inline static constexpr std::size_t digest_size = 32768;
+
+        Md5Digester()
+            : EVPDigester(detail::EVPDigester::Algorithm::md5)
+        {
+        }
+    };
+
+    using Md5Hasher = DigestHasher<Md5Digester>;
+
+    /************************************
+     *  Implementation of DigestHasher  *
+     ************************************/
+
+    template <typename D>
+    void DigestHasher<D>::file_bytes_to(std::ifstream& infile, std::byte* out)
+    {
+        m_digest_buffer.assign(digest_size, std::byte(0));
+        m_digester.digest_start();
+
+        while (infile)
+        {
+            infile.read(reinterpret_cast<char*>(m_digest_buffer.data()), digest_size);
+            const auto count = static_cast<std::size_t>(infile.gcount());
+            if (!count)
+            {
+                break;
+            }
+            m_digester.digest_update(m_digest_buffer.data(), count);
+        }
+        return m_digester.digest_finalize_to(out);
+    }
+
+    template <typename D>
+    auto DigestHasher<D>::file_bytes(std::ifstream& infile) -> bytes_array
+    {
+        auto out = bytes_array{};
+        file_bytes_to(infile, out.data());
+        return out;
+    }
+
+    template <typename D>
+    auto DigestHasher<D>::file_hex(std::ifstream& infile) -> hex_array
+    {
+        auto out = hex_array{};
+
+        // Reusing the output array to write the temporary bytes
+        static_assert(hex_size >= 2 * bytes_size);
+        auto bytes_first = reinterpret_cast<std::byte*>(out.data()) + bytes_size;
+        auto bytes_last = bytes_first + bytes_size;
+        file_bytes_to(infile, bytes_first);
+
+        bytes_to_hex_to(bytes_first, bytes_last, out.data());
+        return out;
+    }
 }
 #endif

--- a/libmamba/include/mamba/util/encoding.hpp
+++ b/libmamba/include/mamba/util/encoding.hpp
@@ -1,0 +1,16 @@
+// Copyright (c) 2023, QuantStack and Mamba Contributors
+//
+// Distributed under the terms of the BSD 3-Clause License.
+//
+// The full license is in the file LICENSE, distributed with this software.
+
+#ifndef MAMBA_UTIL_ENCODING_HPP
+#define MAMBA_UTIL_ENCODING_HPP
+
+#include <cstddef>
+
+namespace mamba::util
+{
+    void bytes_to_hex_to(const std::byte* first, const std::byte* last, char* out);
+}
+#endif

--- a/libmamba/include/mamba/util/encoding.hpp
+++ b/libmamba/include/mamba/util/encoding.hpp
@@ -19,7 +19,17 @@ namespace mamba::util
     {
     };
 
+    /**
+     * Convert a buffer of bytes to a hexadecimal string written in the @p out paremeter.
+     *
+     * The @p out parameter must be allocated with twice the size of the input byte buffer.
+     */
     void bytes_to_hex_to(const std::byte* first, const std::byte* last, char* out);
+
+    /**
+     * Convert a buffer of bytes to a hexadecimal string.
+     */
+    [[nodiscard]] auto bytes_to_hex_str(const std::byte* first, const std::byte* last) -> std::string;
 
     /**
      * Escape reserved URL reserved characters with '%' encoding.
@@ -41,9 +51,15 @@ namespace mamba::util
      */
     [[nodiscard]] auto decode_percent(std::string_view url) -> std::string;
 
+    /**
+     * Convert a string to base64 encoding.
+     */
     [[nodiscard]] auto encode_base64(std::string_view input)
         -> tl::expected<std::string, EncodingError>;
 
+    /**
+     * Convert a string from base64 back to its original representation.
+     */
     [[nodiscard]] auto decode_base64(std::string_view input)
         -> tl::expected<std::string, EncodingError>;
 }

--- a/libmamba/include/mamba/util/encoding.hpp
+++ b/libmamba/include/mamba/util/encoding.hpp
@@ -8,9 +8,23 @@
 #define MAMBA_UTIL_ENCODING_HPP
 
 #include <cstddef>
+#include <string>
+#include <string_view>
+
+#include <tl/expected.hpp>
 
 namespace mamba::util
 {
+    struct EncodingError
+    {
+    };
+
     void bytes_to_hex_to(const std::byte* first, const std::byte* last, char* out);
+
+    [[nodiscard]] auto encode_base64(std::string_view input)
+        -> tl::expected<std::string, EncodingError>;
+
+    [[nodiscard]] auto decode_base64(std::string_view input)
+        -> tl::expected<std::string, EncodingError>;
 }
 #endif

--- a/libmamba/include/mamba/util/encoding.hpp
+++ b/libmamba/include/mamba/util/encoding.hpp
@@ -15,21 +15,67 @@
 
 namespace mamba::util
 {
-    struct EncodingError
+    enum struct EncodingError
     {
+        Ok,
+        InvalidInput,
     };
+
+    /**
+     * Convert the lower nibble to a hexadecimal representation.
+     */
+    [[nodiscard]] auto nibble_to_hex(std::byte b) noexcept -> char;
 
     /**
      * Convert a buffer of bytes to a hexadecimal string written in the @p out paremeter.
      *
      * The @p out parameter must be allocated with twice the size of the input byte buffer.
      */
-    void bytes_to_hex_to(const std::byte* first, const std::byte* last, char* out);
+    void bytes_to_hex_to(const std::byte* first, const std::byte* last, char* out) noexcept;
 
     /**
      * Convert a buffer of bytes to a hexadecimal string.
      */
     [[nodiscard]] auto bytes_to_hex_str(const std::byte* first, const std::byte* last) -> std::string;
+
+    /**
+     * Convert a hexadecimal character to a lower nibble.
+     */
+    [[nodiscard]] auto hex_to_nibble(char c, EncodingError& error) noexcept -> std::byte;
+
+    /**
+     * Convert a hexadecimal character to a lower nibble.
+     */
+    [[nodiscard]] auto hex_to_nibble(char c) noexcept -> tl::expected<std::byte, EncodingError>;
+
+    /**
+     * Convert two hexadecimal characters to a byte.
+     */
+    [[nodiscard]] auto two_hex_to_byte(char high, char low, EncodingError& error) noexcept
+        -> std::byte;
+
+    /**
+     * Convert two hexadecimal characters to a byte.
+     */
+    [[nodiscard]] auto two_hex_to_byte(char high, char low) noexcept
+        -> tl::expected<std::byte, EncodingError>;
+
+    /**
+     * Convert hexadecimal characters to a bytes and write it to the given output.
+     *
+     * The number of hexadecimal characters must be even and out must be allocated with half the
+     * number of hexadecimal characters.
+     */
+    void hex_to_bytes_to(std::string_view hex, std::byte* out, EncodingError& error) noexcept;
+
+    /**
+     * Convert hexadecimal characters to a bytes and write it to the given output.
+     *
+     * The number of hexadecimal characters must be even and out must be allocated with half the
+     * number of hexadecimal characters.
+     */
+    [[nodiscard]] auto hex_to_bytes_to(std::string_view hex, std::byte* out) noexcept
+        -> tl::expected<void, EncodingError>;
 
     /**
      * Escape reserved URL reserved characters with '%' encoding.

--- a/libmamba/include/mamba/util/encoding.hpp
+++ b/libmamba/include/mamba/util/encoding.hpp
@@ -21,6 +21,26 @@ namespace mamba::util
 
     void bytes_to_hex_to(const std::byte* first, const std::byte* last, char* out);
 
+    /**
+     * Escape reserved URL reserved characters with '%' encoding.
+     *
+     * The secons argument can be used to specify characters to exclude from encoding,
+     * so that for instance path can be encoded without splitting them (if they have no '/' other
+     * than separators).
+     *
+     * @see url_decode
+     */
+    [[nodiscard]] auto encode_percent(std::string_view url) -> std::string;
+    [[nodiscard]] auto encode_percent(std::string_view url, std::string_view exclude) -> std::string;
+    [[nodiscard]] auto encode_percent(std::string_view url, char exclude) -> std::string;
+
+    /**
+     * Unescape percent encoded string to their URL reserved characters.
+     *
+     * @see encode_percent
+     */
+    [[nodiscard]] auto decode_percent(std::string_view url) -> std::string;
+
     [[nodiscard]] auto encode_base64(std::string_view input)
         -> tl::expected<std::string, EncodingError>;
 

--- a/libmamba/include/mamba/util/string.hpp
+++ b/libmamba/include/mamba/util/string.hpp
@@ -656,25 +656,6 @@ namespace mamba::util
         ((result += args), ...);
         return result;
     }
-
-    template <class B>
-    std::string hex_string(const B& buffer, std::size_t size)
-    {
-        std::ostringstream oss;
-        oss << std::hex;
-        for (std::size_t i = 0; i < size; ++i)
-        {
-            oss << std::setw(2) << std::setfill('0') << static_cast<int>(buffer[i]);
-        }
-        return oss.str();
-    }
-
-    template <class B>
-    std::string hex_string(const B& buffer)
-    {
-        return hex_string(buffer, buffer.size());
-    }
-
 }
 
 #endif

--- a/libmamba/include/mamba/util/url_manip.hpp
+++ b/libmamba/include/mamba/util/url_manip.hpp
@@ -102,10 +102,7 @@ namespace mamba::util
      * @see https://learn.microsoft.com/en-us/dotnet/standard/io/file-path-formats#unc-paths
      * @see https://en.wikipedia.org/wiki/File_URI_scheme
      */
-    std::string file_uri_unc2_to_unc4(std::string_view url);
-
-    // Only returns a cache name without extension
-    std::string cache_name_from_url(const std::string& url);
+    [[nodiscard]] auto file_uri_unc2_to_unc4(std::string_view url) -> std::string;
 
     namespace detail
     {

--- a/libmamba/include/mamba/util/url_manip.hpp
+++ b/libmamba/include/mamba/util/url_manip.hpp
@@ -14,34 +14,6 @@
 namespace mamba::util
 {
     /**
-     * Escape reserved URL reserved characters with '%' encoding.
-     *
-     * The secons argument can be used to specify characters to exclude from encoding,
-     * so that for instance path can be encoded without splitting them (if they have no '/' other
-     * than separators).
-     *
-     * @see url_decode
-     */
-    [[nodiscard]] auto url_encode(std::string_view url) -> std::string;
-    [[nodiscard]] auto url_encode(std::string_view url, std::string_view exclude) -> std::string;
-    [[nodiscard]] auto url_encode(std::string_view url, char exclude) -> std::string;
-
-    /**
-     * Unescape percent encoded string to their URL reserved characters.
-     *
-     * @see url_encode
-     */
-    [[nodiscard]] auto url_decode(std::string_view url) -> std::string;
-
-    void split_platform(
-        const std::vector<std::string>& known_platforms,
-        const std::string& url,
-        const std::string& context_platform,
-        std::string& cleaned_url,
-        std::string& platform
-    );
-
-    /**
      * If @p url starts with a scheme, return it, otherwise return empty string.
      *
      * Does not include "://"
@@ -81,6 +53,14 @@ namespace mamba::util
      * Does nothing if the input is already has a URL scheme.
      */
     [[nodiscard]] auto path_or_url_to_url(std::string_view path) -> std::string;
+
+    void split_platform(
+        const std::vector<std::string>& known_platforms,
+        const std::string& url,
+        const std::string& context_platform,
+        std::string& cleaned_url,
+        std::string& platform
+    );
 
     template <class S, class... Args>
     std::string join_url(const S& s, const Args&... args);

--- a/libmamba/src/core/context.cpp
+++ b/libmamba/src/core/context.cpp
@@ -211,7 +211,7 @@ namespace mamba
                 if (util::ends_with(entry.path().filename().string(), ".token"))
                 {
                     found_tokens.push_back(entry.path());
-                    std::string token_url = util::url_decode(entry.path().filename().string());
+                    std::string token_url = util::decode_percent(entry.path().filename().string());
 
                     // anaconda client writes out a token for https://api.anaconda.org...
                     // but we need the token for https://conda.anaconda.org

--- a/libmamba/src/core/context.cpp
+++ b/libmamba/src/core/context.cpp
@@ -18,6 +18,7 @@
 #include "mamba/core/thread_utils.hpp"
 #include "mamba/core/util.hpp"
 #include "mamba/core/util_os.hpp"
+#include "mamba/util/encoding.hpp"
 #include "mamba/util/environment.hpp"
 #include "mamba/util/path_manip.hpp"
 #include "mamba/util/string.hpp"
@@ -256,7 +257,7 @@ namespace mamba
                     else if (type == "BasicHTTPAuthentication")
                     {
                         const auto& user = el.value("user", "");
-                        auto pass = decode_base64(el["password"].get<std::string>());
+                        auto pass = util::decode_base64(el["password"].get<std::string>());
                         if (pass)
                         {
                             info = specs::BasicHTTPAuthentication{

--- a/libmamba/src/core/link.cpp
+++ b/libmamba/src/core/link.cpp
@@ -749,7 +749,7 @@ namespace mamba
                 codesign(dst, m_context->context().output_params.verbosity > 1);
             }
 #endif
-            return std::make_tuple(validation::sha256sum(dst), rel_dst.string());
+            return std::make_tuple(std::string(validation::sha256sum(dst)), rel_dst.string());
         }
 
         if ((path_data.path_type == PathType::HARDLINK) || path_data.no_link)
@@ -811,7 +811,7 @@ namespace mamba
             );
         }
         return std::make_tuple(
-            path_data.sha256.empty() ? validation::sha256sum(dst) : path_data.sha256,
+            path_data.sha256.empty() ? std::string(validation::sha256sum(dst)) : path_data.sha256,
             rel_dst.string()
         );
     }

--- a/libmamba/src/core/link.cpp
+++ b/libmamba/src/core/link.cpp
@@ -608,7 +608,7 @@ namespace mamba
             // Sometimes we might want to raise here ...
             m_clobber_warnings.push_back(rel_dst.string());
 #ifdef _WIN32
-            return std::make_tuple(validation::sha256sum(dst), rel_dst.string());
+            return std::make_tuple(std::string(validation::sha256sum(dst)), rel_dst.string());
 #endif
             fs::remove(dst);
         }
@@ -700,7 +700,7 @@ namespace mamba
                         fo << launcher << shebang << (buffer.c_str() + arc_pos);
                         fo.close();
                     }
-                    return std::make_tuple(validation::sha256sum(dst), rel_dst.string());
+                    return std::make_tuple(std::string(validation::sha256sum(dst)), rel_dst.string());
                 }
 #else
                 std::size_t padding_size = (path_data.prefix_placeholder.size() > new_prefix.size())

--- a/libmamba/src/core/package_cache.cpp
+++ b/libmamba/src/core/package_cache.cpp
@@ -147,11 +147,11 @@ namespace mamba
             valid = s.size == 0 || validation::file_size(tarball_path, s.size);
             if (!s.md5.empty())
             {
-                valid = valid && validation::md5(tarball_path, s.md5);
+                valid = valid && (validation::md5sum(tarball_path) == s.md5);
             }
             else if (!s.sha256.empty())
             {
-                valid = valid && validation::sha256(tarball_path, s.md5);
+                valid = valid && (validation::sha256sum(tarball_path) == s.sha256);
             }
             else
             {

--- a/libmamba/src/core/package_handling.cpp
+++ b/libmamba/src/core/package_handling.cpp
@@ -882,7 +882,7 @@ namespace mamba
                         }
                     }
                     if (full_validation && !is_invalid && p.path_type != PathType::SOFTLINK
-                        && !validation::sha256(full_path, p.sha256))
+                        && !(validation::sha256sum(full_path) == p.sha256))
                     {
                         LOG_WARNING << "Invalid package cache, file '" << full_path.string()
                                     << "' has incorrect SHA-256 checksum";

--- a/libmamba/src/core/util.cpp
+++ b/libmamba/src/core/util.cpp
@@ -49,7 +49,6 @@ extern "C"
 #endif
 
 #include <nlohmann/json.hpp>
-#include <openssl/evp.h>
 #include <tl/expected.hpp>
 
 #include "mamba/core/context.hpp"
@@ -1568,43 +1567,6 @@ namespace mamba
     {
         return util::ends_with(filename, ".yml") || util::ends_with(filename, ".yaml");
     }
-
-    tl::expected<std::string, mamba_error> encode_base64(std::string_view input)
-    {
-        const auto pl = 4 * ((input.size() + 2) / 3);
-        std::vector<unsigned char> output(pl + 1);
-        const auto ol = EVP_EncodeBlock(
-            output.data(),
-            reinterpret_cast<const unsigned char*>(input.data()),
-            static_cast<int>(input.size())
-        );
-
-        if (util::cmp_not_equal(pl, ol))
-        {
-            return make_unexpected("Could not encode base64 string", mamba_error_code::openssl_failed);
-        }
-
-        return std::string(reinterpret_cast<const char*>(output.data()));
-    }
-
-    tl::expected<std::string, mamba_error> decode_base64(std::string_view input)
-    {
-        const auto pl = 3 * input.size() / 4;
-
-        std::vector<unsigned char> output(pl + 1);
-        const auto ol = EVP_DecodeBlock(
-            output.data(),
-            reinterpret_cast<const unsigned char*>(input.data()),
-            static_cast<int>(input.size())
-        );
-        if (util::cmp_not_equal(pl, ol))
-        {
-            return make_unexpected("Could not decode base64 string", mamba_error_code::openssl_failed);
-        }
-
-        return std::string(reinterpret_cast<const char*>(output.data()));
-    }
-
 
     std::optional<std::string>
     proxy_match(const std::string& url, const std::map<std::string, std::string>& proxy_servers)

--- a/libmamba/src/core/validate.cpp
+++ b/libmamba/src/core/validate.cpp
@@ -261,8 +261,14 @@ namespace mamba::validation
 
     std::pair<std::string, std::string> generate_ed25519_keypair_hex()
     {
-        auto pair = generate_ed25519_keypair();
-        return { ::mamba::util::hex_string(pair.first), ::mamba::util::hex_string(pair.second) };
+        auto [first, second] = generate_ed25519_keypair();
+        // TODO change function signature to use std::byte
+        const auto first_data = reinterpret_cast<const std::byte*>(first.data());
+        const auto second_data = reinterpret_cast<const std::byte*>(second.data());
+        return {
+            util::bytes_to_hex_str(first_data, first_data + first.size()),
+            util::bytes_to_hex_str(second_data, second_data + second.size()),
+        };
     }
 
     int sign(const std::string& data, const unsigned char* sk, unsigned char* signature)
@@ -318,7 +324,10 @@ namespace mamba::validation
         std::array<unsigned char, MAMBA_ED25519_SIGSIZE_BYTES> sig;
 
         error_code = sign(data, bin_sk.data(), sig.data());
-        signature = ::mamba::util::hex_string(sig, MAMBA_ED25519_SIGSIZE_BYTES);
+
+        // TODO change function signature to use std::byte
+        const auto sig_data = reinterpret_cast<const std::byte*>(sig.data());
+        signature = util::bytes_to_hex_str(sig_data, sig_data + sig.size());
 
         return error_code;
     }
@@ -1386,7 +1395,10 @@ namespace mamba::validation
         {
             std::array<unsigned char, MAMBA_ED25519_SIGSIZE_BYTES> sig_bin;
             sign(j.dump(), sk, sig_bin.data());
-            auto sig_hex = ::mamba::util::hex_string(sig_bin);
+
+            // TODO change function signatures to use std::byte
+            const auto sig_bin_data = reinterpret_cast<const std::byte*>(sig_bin.data());
+            auto sig_hex = util::bytes_to_hex_str(sig_bin_data, sig_bin_data + sig_bin.size());
 
             return { pk, sig_hex };
         }

--- a/libmamba/src/core/validate.cpp
+++ b/libmamba/src/core/validate.cpp
@@ -86,30 +86,6 @@ namespace mamba::validation
     {
     }
 
-    namespace
-    {
-        struct EVPContextDeleter
-        {
-            using value_type = ::EVP_MD_CTX;
-            using pointer_type = value_type*;
-
-            void operator()(pointer_type ptr) const
-            {
-                if (ptr)
-                {
-                    ::EVP_MD_CTX_destroy(ptr);
-                }
-            }
-        };
-
-        auto make_EVP_context()
-        {
-            auto ptr = std::unique_ptr<::EVP_MD_CTX, EVPContextDeleter>();
-            ptr.reset(::EVP_MD_CTX_create());
-            return ptr;
-        }
-    }
-
     std::string sha256sum(const fs::u8path& path)
     {
         // TODO deprecate, hasher should be reused between calls.
@@ -439,6 +415,30 @@ namespace mamba::validation
         auto pk_bin = ed25519_key_hex_to_bytes(pk);
 
         return verify_gpg_hashed_msg(data, pk_bin.data(), signature_bin.data());
+    }
+
+    namespace
+    {
+        struct EVPContextDeleter
+        {
+            using value_type = ::EVP_MD_CTX;
+            using pointer_type = value_type*;
+
+            void operator()(pointer_type ptr) const
+            {
+                if (ptr)
+                {
+                    ::EVP_MD_CTX_destroy(ptr);
+                }
+            }
+        };
+
+        auto make_EVP_context()
+        {
+            auto ptr = std::unique_ptr<::EVP_MD_CTX, EVPContextDeleter>();
+            ptr.reset(::EVP_MD_CTX_create());
+            return ptr;
+        }
     }
 
     int verify_gpg(

--- a/libmamba/src/core/validate.cpp
+++ b/libmamba/src/core/validate.cpp
@@ -86,32 +86,20 @@ namespace mamba::validation
     {
     }
 
-    std::string sha256sum(const fs::u8path& path)
+    auto sha256sum(const fs::u8path& path) -> std::string_view
     {
-        // TODO deprecate, hasher should be reused between calls.
         std::ifstream infile = mamba::open_ifstream(path);
-        auto hasher = util::Sha256Hasher();
-        auto hash = hasher.file_hex(infile);
+        thread_local auto hasher = util::Sha256Hasher();
+        thread_local auto hash = hasher.file_hex(infile);
         return { hash.data(), hash.size() };
     }
 
-    std::string md5sum(const fs::u8path& path)
+    auto md5sum(const fs::u8path& path) -> std::string_view
     {
-        // TODO deprecate, hasher should be reused between calls.
         std::ifstream infile = mamba::open_ifstream(path);
-        auto hasher = util::Md5Hasher();
-        auto hash = hasher.file_hex(infile);
+        thread_local auto hasher = util::Md5Hasher();
+        thread_local auto hash = hasher.file_hex(infile);
         return { hash.data(), hash.size() };
-    }
-
-    bool sha256(const fs::u8path& path, const std::string& validation)
-    {
-        return sha256sum(path) == validation;
-    }
-
-    bool md5(const fs::u8path& path, const std::string& validation)
-    {
-        return md5sum(path) == validation;
     }
 
     bool file_size(const fs::u8path& path, std::uintmax_t validation)

--- a/libmamba/src/specs/conda_url.cpp
+++ b/libmamba/src/specs/conda_url.cpp
@@ -13,8 +13,8 @@
 
 #include "mamba/specs/archive.hpp"
 #include "mamba/specs/conda_url.hpp"
+#include "mamba/util/encoding.hpp"
 #include "mamba/util/string.hpp"
-#include "mamba/util/url_manip.hpp"
 
 namespace mamba::specs
 {
@@ -236,7 +236,7 @@ namespace mamba::specs
 
     auto CondaURL::path_without_token(Decode::yes_type) const -> std::string
     {
-        return util::url_decode(path_without_token(Decode::no));
+        return util::decode_percent(path_without_token(Decode::no));
     }
 
     void CondaURL::set_path_without_token(std::string_view new_path, Encode::no_type)
@@ -341,7 +341,7 @@ namespace mamba::specs
 
     auto CondaURL::package(Decode::yes_type) const -> std::string
     {
-        return util::url_decode(package(Decode::no));
+        return util::decode_percent(package(Decode::no));
     }
 
     auto CondaURL::package(Decode::no_type) const -> std::string_view
@@ -358,7 +358,7 @@ namespace mamba::specs
 
     void CondaURL::set_package(std::string_view pkg, Encode::yes_type)
     {
-        return set_package(util::url_encode(pkg), Encode::no);
+        return set_package(util::encode_percent(pkg), Encode::no);
     }
 
     void CondaURL::set_package(std::string_view pkg, Encode::no_type)

--- a/libmamba/src/util/cryptography.cpp
+++ b/libmamba/src/util/cryptography.cpp
@@ -46,7 +46,7 @@ namespace mamba::util::detail
         assert(status != 0);
     }
 
-    void EVPDigester::digest_update(std::byte* buffer, std::size_t count)
+    void EVPDigester::digest_update(const std::byte* buffer, std::size_t count)
     {
         ::EVP_DigestUpdate(m_ctx.get(), buffer, count);
     }

--- a/libmamba/src/util/cryptography.cpp
+++ b/libmamba/src/util/cryptography.cpp
@@ -4,7 +4,6 @@
 //
 // The full license is in the file LICENSE, distributed with this software.
 
-#include <array>
 #include <cassert>
 #include <memory>
 
@@ -12,66 +11,48 @@
 
 #include "mamba/util/cryptography.hpp"
 
-namespace mamba::util
+namespace mamba::util::detail
 {
-
-    // TODO(C++20): use std::span
-    void bytes_to_hex_to(const std::byte* first, const std::byte* last, char* out)
+    void EVPDigester::EVPContextDeleter::operator()(::EVP_MD_CTX* ptr) const
     {
-        constexpr auto hex_chars = std::array{ '0', '1', '2', '3', '4', '5', '6', '7',
-                                               '8', '9', 'a', 'b', 'c', 'd', 'e', 'f' };
-        while (first != last)
+        if (ptr)
         {
-            const auto byte = static_cast<std::uint8_t>(*first);
-            *out++ = hex_chars[byte >> 4];
-            *out++ = hex_chars[byte & 0xF];
-            ++first;
+            ::EVP_MD_CTX_destroy(ptr);
         }
     }
 
-    namespace detail
+    EVPDigester::EVPDigester(Algorithm algo)
+        : m_algorithm(algo)
     {
-        void EVPDigester::EVPContextDeleter::operator()(::EVP_MD_CTX* ptr) const
+        m_ctx.reset(::EVP_MD_CTX_create());
+    }
+
+    void EVPDigester::digest_start()
+    {
+        [[maybe_unused]] int status = 0;
+        switch (m_algorithm)
         {
-            if (ptr)
+            case (Algorithm::sha256):
             {
-                ::EVP_MD_CTX_destroy(ptr);
+                status = ::EVP_DigestInit_ex(m_ctx.get(), EVP_sha256(), nullptr);
+                break;
+            }
+            case (Algorithm::md5):
+            {
+                status = ::EVP_DigestInit_ex(m_ctx.get(), EVP_md5(), nullptr);
+                break;
             }
         }
+        assert(status != 0);
+    }
 
-        EVPDigester::EVPDigester(Algorithm algo)
-            : m_algorithm(algo)
-        {
-            m_ctx.reset(::EVP_MD_CTX_create());
-        }
+    void EVPDigester::digest_update(std::byte* buffer, std::size_t count)
+    {
+        ::EVP_DigestUpdate(m_ctx.get(), buffer, count);
+    }
 
-        void EVPDigester::digest_start()
-        {
-            [[maybe_unused]] int status = 0;
-            switch (m_algorithm)
-            {
-                case (Algorithm::sha256):
-                {
-                    status = ::EVP_DigestInit_ex(m_ctx.get(), EVP_sha256(), nullptr);
-                    break;
-                }
-                case (Algorithm::md5):
-                {
-                    status = ::EVP_DigestInit_ex(m_ctx.get(), EVP_md5(), nullptr);
-                    break;
-                }
-            }
-            assert(status != 0);
-        }
-
-        void EVPDigester::digest_update(std::byte* buffer, std::size_t count)
-        {
-            ::EVP_DigestUpdate(m_ctx.get(), buffer, count);
-        }
-
-        void EVPDigester::digest_finalize_to(std::byte* hash)
-        {
-            ::EVP_DigestFinal_ex(m_ctx.get(), reinterpret_cast<unsigned char*>(hash), nullptr);
-        }
+    void EVPDigester::digest_finalize_to(std::byte* hash)
+    {
+        ::EVP_DigestFinal_ex(m_ctx.get(), reinterpret_cast<unsigned char*>(hash), nullptr);
     }
 }

--- a/libmamba/src/util/cryptography.cpp
+++ b/libmamba/src/util/cryptography.cpp
@@ -1,0 +1,111 @@
+// Copyright (c) 2023, QuantStack and Mamba Contributors
+//
+// Distributed under the terms of the BSD 3-Clause License.
+//
+// The full license is in the file LICENSE, distributed with this software.
+
+#include <array>
+#include <cassert>
+#include <fstream>
+#include <memory>
+#include <vector>
+
+#include <openssl/evp.h>
+
+#include "mamba/util/cryptography.hpp"
+
+namespace mamba::util
+{
+
+    // TODO(C++20): use std::span
+    void bytes_to_hex_to(const std::byte* first, const std::byte* last, char* out)
+    {
+        constexpr auto hex_chars = std::array{ '0', '1', '2', '3', '4', '5', '6', '7',
+                                               '8', '9', 'a', 'b', 'c', 'd', 'e', 'f' };
+        while (first != last)
+        {
+            const auto byte = static_cast<std::uint8_t>(*first);
+            *out++ = hex_chars[byte >> 4];
+            *out++ = hex_chars[byte & 0xF];
+            ++first;
+        }
+    }
+
+    namespace
+    {
+        struct EVPContextDeleter
+        {
+            using value_type = ::EVP_MD_CTX;
+            using pointer_type = value_type*;
+
+            void operator()(pointer_type ptr) const
+            {
+                if (ptr)
+                {
+                    ::EVP_MD_CTX_destroy(ptr);
+                }
+            }
+        };
+
+        auto make_EVP_context()
+        {
+            auto ptr = std::unique_ptr<::EVP_MD_CTX, EVPContextDeleter>();
+            ptr.reset(::EVP_MD_CTX_create());
+            return ptr;
+        }
+
+    }
+
+    void
+    sha256bytes_file_to(std::ifstream& infile, std::byte* out, std::vector<std::byte>& tmp_buffer)
+    {
+        assert(infile.good());
+
+        static constexpr std::size_t EVP_BUFSIZE = 32768;
+        tmp_buffer.assign(EVP_BUFSIZE, std::byte(0));
+
+        auto mdctx = make_EVP_context();
+        ::EVP_DigestInit_ex(mdctx.get(), EVP_sha256(), nullptr);
+
+        while (infile)
+        {
+            infile.read(reinterpret_cast<char*>(tmp_buffer.data()), EVP_BUFSIZE);
+            const auto count = static_cast<std::size_t>(infile.gcount());
+            if (!count)
+            {
+                break;
+            }
+            ::EVP_DigestUpdate(mdctx.get(), tmp_buffer.data(), count);
+        }
+
+        ::EVP_DigestFinal_ex(mdctx.get(), reinterpret_cast<unsigned char*>(out), nullptr);
+    }
+
+    void sha256bytes_file_to(std::ifstream& infile, std::byte* out)
+    {
+        auto buffer = std::vector<std::byte>();
+        return sha256bytes_file_to(infile, out, buffer);
+    }
+
+    auto sha256bytes_file(std::ifstream& infile) -> sha256bytes_array
+    {
+        auto out = sha256bytes_array{};
+        sha256bytes_file_to(infile, out.data());
+        return out;
+    }
+
+    auto sha256hex_file(std::ifstream& infile) -> sha256hex_array
+    {
+        auto out = sha256hex_array{};
+
+        // Reusing the output array to write the temprary bytes
+        assert(out.size() == 2 * SHA256_SIZE_BYTES);
+        auto bytes_first = reinterpret_cast<std::byte*>(out.data()) + SHA256_SIZE_BYTES;
+        auto bytes_last = bytes_first + SHA256_SIZE_BYTES;
+
+        sha256bytes_file_to(infile, bytes_first);
+
+        bytes_to_hex_to(bytes_first, bytes_last, out.data());
+        return out;
+    }
+}

--- a/libmamba/src/util/encoding.cpp
+++ b/libmamba/src/util/encoding.cpp
@@ -30,6 +30,14 @@ namespace mamba::util
         }
     }
 
+    // TODO(C++20): use std::span
+    auto bytes_to_hex_str(const std::byte* first, const std::byte* last) -> std::string
+    {
+        auto out = std::string(static_cast<std::size_t>(last - first) * 2, 'x');
+        bytes_to_hex_to(first, last, out.data());
+        return out;
+    }
+
     namespace
     {
         auto url_is_unreserved_char(char c) -> bool

--- a/libmamba/src/util/encoding.cpp
+++ b/libmamba/src/util/encoding.cpp
@@ -7,6 +7,7 @@
 #include <array>
 #include <cstdint>
 #include <cstring>
+#include <type_traits>
 
 #include <openssl/evp.h>
 
@@ -16,16 +17,61 @@
 
 namespace mamba::util
 {
-    // TODO(C++20): use std::span
-    void bytes_to_hex_to(const std::byte* first, const std::byte* last, char* out)
+    namespace
+    {
+        inline static constexpr auto nibble_low_mask = std::byte{ 0x0F };
+
+        [[nodiscard]] auto low_nibble(std::byte b) noexcept -> std::byte
+        {
+            return b & nibble_low_mask;
+        }
+
+        [[nodiscard]] auto high_nibble(std::byte b) noexcept -> std::byte
+        {
+            return (b >> 4) & nibble_low_mask;
+        }
+
+        [[nodiscard]] auto concat_nibbles(std::byte high, std::byte low) noexcept -> std::byte
+        {
+            high <<= 4;
+            high |= low & nibble_low_mask;
+            return high;
+        }
+
+        template <typename Int>
+        [[nodiscard]] auto if_else(bool condition, Int true_val, Int false_val) noexcept -> Int
+        {
+            if constexpr (std::is_enum_v<Int>)
+            {
+                using int_t = std::underlying_type_t<Int>;
+                return static_cast<Int>(
+                    if_else(condition, static_cast<int_t>(true_val), static_cast<int_t>(false_val))
+                );
+            }
+            else
+            {
+                using int_t = Int;
+                return static_cast<int_t>(condition) * true_val
+                       + (int_t(1) - static_cast<int_t>(condition)) * false_val;
+            }
+        }
+    }
+
+    auto nibble_to_hex(std::byte b) noexcept -> char
     {
         constexpr auto hex_chars = std::array{ '0', '1', '2', '3', '4', '5', '6', '7',
                                                '8', '9', 'a', 'b', 'c', 'd', 'e', 'f' };
+        return hex_chars[static_cast<std::uint8_t>(low_nibble(b))];
+    }
+
+    // TODO(C++20): use std::span
+    void bytes_to_hex_to(const std::byte* first, const std::byte* last, char* out) noexcept
+    {
         while (first != last)
         {
-            const auto byte = static_cast<std::uint8_t>(*first);
-            *out++ = hex_chars[byte >> 4];
-            *out++ = hex_chars[byte & 0xF];
+            const auto b = *first;
+            *out++ = nibble_to_hex(high_nibble(b));
+            *out++ = nibble_to_hex(low_nibble(b));
             ++first;
         }
     }
@@ -36,6 +82,94 @@ namespace mamba::util
         auto out = std::string(static_cast<std::size_t>(last - first) * 2, 'x');
         bytes_to_hex_to(first, last, out.data());
         return out;
+    }
+
+    auto hex_to_nibble(char c, EncodingError& error) noexcept -> std::byte
+    {
+        using int_t = std::int_fast8_t;
+        static constexpr auto val_0 = static_cast<int_t>('0');
+        static constexpr auto val_9 = static_cast<int_t>('9');
+        static constexpr auto val_a = static_cast<int_t>('a');
+        static constexpr auto val_f = static_cast<int_t>('f');
+        static constexpr auto val_A = static_cast<int_t>('A');
+        static constexpr auto val_F = static_cast<int_t>('F');
+        static constexpr auto val_error = static_cast<int_t>(16);
+
+        const auto val = static_cast<int_t>(c);
+        auto num = if_else<int_t>(
+            (val_0 <= val) && (val <= val_9),
+            static_cast<int_t>(val - val_0),
+            if_else<int_t>(
+                (val_a <= val) && (val <= val_f),
+                static_cast<int_t>(val - val_a + 10),
+                if_else<int_t>(  //
+                    (val_A <= val) && (val <= val_F),
+                    static_cast<int_t>(val - val_A + 10),
+                    val_error
+                )
+            )
+        );
+        // We mapped errors onto val_error, if no error leave unset so that user can chain
+        error = if_else(num == val_error, EncodingError::InvalidInput, error);
+        // Promised a nibble so we do not write higher nibble
+        num = if_else(num == val_error, int_t(0), num);
+        return static_cast<std::byte>(num);
+    }
+
+    auto hex_to_nibble(char c) noexcept -> tl::expected<std::byte, EncodingError>
+    {
+        auto error = EncodingError::Ok;
+        auto nibble = hex_to_nibble(c, error);
+        if (error != EncodingError::Ok)
+        {
+            return tl::make_unexpected(error);
+        }
+        return nibble;
+    }
+
+    auto two_hex_to_byte(char high, char low, EncodingError& error) noexcept -> std::byte
+    {
+        return concat_nibbles(hex_to_nibble(high, error), hex_to_nibble(low, error));
+    }
+
+    auto two_hex_to_byte(char high, char low) noexcept -> tl::expected<std::byte, EncodingError>
+    {
+        auto error = EncodingError::Ok;
+        auto b = two_hex_to_byte(high, low, error);
+        if (error != EncodingError::Ok)
+        {
+            return tl::make_unexpected(error);
+        }
+        return b;
+    }
+
+    void hex_to_bytes_to(std::string_view hex, std::byte* out, EncodingError& error) noexcept
+    {
+        if (hex.size() % 2 == 0)
+        {
+            const auto end = hex.cend();
+            for (auto it = hex.cbegin(); it < end; it += 2)
+            {
+                *out = two_hex_to_byte(it[0], it[1], error);
+                ++out;
+            }
+        }
+        else
+        {
+            error = EncodingError::InvalidInput;
+        }
+    }
+
+    auto hex_to_bytes_to(std::string_view hex, std::byte* out) noexcept
+        -> tl::expected<void, EncodingError>
+    {
+        auto error = EncodingError::Ok;
+        hex_to_bytes_to(hex, out, error);
+        if (error != EncodingError::Ok)
+        {
+            return tl::make_unexpected(error);
+        }
+        return {};
     }
 
     namespace

--- a/libmamba/src/util/encoding.cpp
+++ b/libmamba/src/util/encoding.cpp
@@ -64,7 +64,7 @@ namespace mamba::util
         return hex_chars[static_cast<std::uint8_t>(low_nibble(b))];
     }
 
-    // TODO(C++20): use std::span
+    // TODO(C++20): use std::span and iterators
     void bytes_to_hex_to(const std::byte* first, const std::byte* last, char* out) noexcept
     {
         while (first != last)
@@ -76,7 +76,7 @@ namespace mamba::util
         }
     }
 
-    // TODO(C++20): use std::span
+    // TODO(C++20): use std::span and iterators
     auto bytes_to_hex_str(const std::byte* first, const std::byte* last) -> std::string
     {
         auto out = std::string(static_cast<std::size_t>(last - first) * 2, 'x');
@@ -143,6 +143,7 @@ namespace mamba::util
         return b;
     }
 
+    // TODO(C++20): use iterators return type
     void hex_to_bytes_to(std::string_view hex, std::byte* out, EncodingError& error) noexcept
     {
         if (hex.size() % 2 == 0)
@@ -160,6 +161,7 @@ namespace mamba::util
         }
     }
 
+    // TODO(C++20): use iterators return type
     auto hex_to_bytes_to(std::string_view hex, std::byte* out) noexcept
         -> tl::expected<void, EncodingError>
     {

--- a/libmamba/src/util/encoding.cpp
+++ b/libmamba/src/util/encoding.cpp
@@ -1,0 +1,27 @@
+// Copyright (c) 2023, QuantStack and Mamba Contributors
+//
+// Distributed under the terms of the BSD 3-Clause License.
+//
+// The full license is in the file LICENSE, distributed with this software.
+
+#include <array>
+#include <cstdint>
+
+#include "mamba/util/encoding.hpp"
+
+namespace mamba::util
+{
+    // TODO(C++20): use std::span
+    void bytes_to_hex_to(const std::byte* first, const std::byte* last, char* out)
+    {
+        constexpr auto hex_chars = std::array{ '0', '1', '2', '3', '4', '5', '6', '7',
+                                               '8', '9', 'a', 'b', 'c', 'd', 'e', 'f' };
+        while (first != last)
+        {
+            const auto byte = static_cast<std::uint8_t>(*first);
+            *out++ = hex_chars[byte >> 4];
+            *out++ = hex_chars[byte & 0xF];
+            ++first;
+        }
+    }
+}

--- a/libmamba/src/util/url.cpp
+++ b/libmamba/src/util/url.cpp
@@ -16,6 +16,7 @@
 #include <fmt/format.h>
 
 #include "mamba/util/build.hpp"
+#include "mamba/util/encoding.hpp"
 #include "mamba/util/path_manip.hpp"
 #include "mamba/util/string.hpp"
 #include "mamba/util/tuple_hash.hpp"
@@ -235,12 +236,12 @@ namespace mamba::util
 
     auto URL::user(Decode::yes_type) const -> std::string
     {
-        return url_decode(user(Decode::no));
+        return decode_percent(user(Decode::no));
     }
 
     void URL::set_user(std::string_view user, Encode::yes_type)
     {
-        return set_user(url_encode(user), Encode::no);
+        return set_user(encode_percent(user), Encode::no);
     }
 
     void URL::set_user(std::string user, Encode::no_type)
@@ -265,12 +266,12 @@ namespace mamba::util
 
     auto URL::password(Decode::yes_type) const -> std::string
     {
-        return url_decode(password(Decode::no));
+        return decode_percent(password(Decode::no));
     }
 
     void URL::set_password(std::string_view password, Encode::yes_type)
     {
-        return set_password(url_encode(password), Encode::no);
+        return set_password(encode_percent(password), Encode::no);
     }
 
     void URL::set_password(std::string password, Encode::no_type)
@@ -359,12 +360,12 @@ namespace mamba::util
 
     auto URL::host(Decode::yes_type) const -> std::string
     {
-        return url_decode(host(Decode::no));
+        return decode_percent(host(Decode::no));
     }
 
     void URL::set_host(std::string_view host, Encode::yes_type)
     {
-        return set_host(url_encode(host), Encode::no);
+        return set_host(encode_percent(host), Encode::no);
     }
 
     void URL::set_host(std::string host, Encode::no_type)
@@ -460,7 +461,7 @@ namespace mamba::util
 
     auto URL::path(Decode::yes_type) const -> std::string
     {
-        return url_decode(path(Decode::no));
+        return decode_percent(path(Decode::no));
     }
 
     void URL::set_path(std::string_view path, Encode::yes_type)
@@ -475,13 +476,13 @@ namespace mamba::util
                     concat(
                         slashes.empty() ? "/" : slashes,
                         no_slash_path.substr(0, 2),
-                        url_encode(no_slash_path.substr(2), '/')
+                        encode_percent(no_slash_path.substr(2), '/')
                     ),
                     Encode::no
                 );
             }
         }
-        return set_path(url_encode(path, '/'), Encode::no);
+        return set_path(encode_percent(path, '/'), Encode::no);
     }
 
     void URL::set_path(std::string path, Encode::no_type)
@@ -504,13 +505,13 @@ namespace mamba::util
         if (on_win && scheme() == "file")
         {
             assert(util::starts_with(m_path, '/'));
-            auto path_no_slash = url_decode(std::string_view(m_path).substr(1));
+            auto path_no_slash = decode_percent(std::string_view(m_path).substr(1));
             if (path_has_drive_letter(path_no_slash))
             {
                 return path_no_slash;
             }
         }
-        return url_decode(m_path);
+        return decode_percent(m_path);
     }
 
     void URL::append_path(std::string_view subpath, Encode::yes_type)
@@ -520,7 +521,7 @@ namespace mamba::util
             // Allow handling of Windows drive letter encoding
             return set_path(std::string(subpath), Encode::yes);
         }
-        return append_path(url_encode(subpath, '/'), Encode::no);
+        return append_path(encode_percent(subpath, '/'), Encode::no);
     }
 
     void URL::append_path(std::string_view subpath, Encode::no_type)

--- a/libmamba/src/util/url_manip.cpp
+++ b/libmamba/src/util/url_manip.cpp
@@ -9,9 +9,6 @@
 #include <string>
 #include <string_view>
 
-#include <fmt/format.h>
-#include <openssl/evp.h>
-
 #include "mamba/fs/filesystem.hpp"
 #include "mamba/util/build.hpp"
 #include "mamba/util/path_manip.hpp"
@@ -290,33 +287,5 @@ namespace mamba::util
         }
 
         return util::concat("file:////", rest);
-    }
-
-    std::string cache_name_from_url(const std::string& url)
-    {
-        std::string u = url;
-        if (u.empty() || (u.back() != '/' && !util::ends_with(u, ".json")))
-        {
-            u += '/';
-        }
-
-        // mimicking conda's behavior by special handling repodata.json
-        // todo support .zst
-        if (util::ends_with(u, "/repodata.json"))
-        {
-            u = u.substr(0, u.size() - 13);
-        }
-
-        unsigned char hash[16];
-
-        EVP_MD_CTX* mdctx;
-        mdctx = EVP_MD_CTX_create();
-        EVP_DigestInit_ex(mdctx, EVP_md5(), nullptr);
-        EVP_DigestUpdate(mdctx, u.c_str(), u.size());
-        EVP_DigestFinal_ex(mdctx, hash, nullptr);
-        EVP_MD_CTX_destroy(mdctx);
-
-        std::string hex_digest = util::hex_string(hash, 16);
-        return hex_digest.substr(0u, 8u);
     }
 }

--- a/libmamba/src/util/url_manip.cpp
+++ b/libmamba/src/util/url_manip.cpp
@@ -5,120 +5,18 @@
 // The full license is in the file LICENSE, distributed with this software.
 
 #include <array>
-#include <cassert>
 #include <string>
 #include <string_view>
 
 #include "mamba/fs/filesystem.hpp"
 #include "mamba/util/build.hpp"
+#include "mamba/util/encoding.hpp"
 #include "mamba/util/path_manip.hpp"
 #include "mamba/util/string.hpp"
 #include "mamba/util/url_manip.hpp"
 
 namespace mamba::util
 {
-    namespace
-    {
-        auto url_is_unreserved_char(char c) -> bool
-        {
-            // https://github.com/curl/curl/blob/67e9e3cb1ea498cb94071dddb7653ab5169734b2/lib/escape.c#L45
-            return util::is_alphanum(c) || (c == '-') || (c == '.') || (c == '_') || (c == '~');
-        }
-
-        auto url_encode_char(char c) -> std::array<char, 3>
-        {
-            // https://github.com/curl/curl/blob/67e9e3cb1ea498cb94071dddb7653ab5169734b2/lib/escape.c#L107
-            static constexpr auto hex = std::array{
-                '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F',
-            };
-            return std::array{
-                '%',
-                hex[static_cast<unsigned char>(c) >> 4],
-                hex[c & 0xf],
-            };
-        }
-
-        auto url_is_hex_char(char c) -> bool
-        {
-            return util::is_digit(c) || (('A' <= c) && (c <= 'F')) || (('a' <= c) && (c <= 'f'));
-        }
-
-        auto url_decode_char(char d10, char d1) -> char
-        {
-            // https://github.com/curl/curl/blob/67e9e3cb1ea498cb94071dddb7653ab5169734b2/lib/escape.c#L147
-            // Offset from char '0', contains '0' padding for incomplete values.
-            static constexpr std::array<unsigned char, 55> hex_offset = {
-                0, 1,  2,  3,  4,  5,  6,  7, 8, 9, 0, 0, 0, 0, 0, 0, /* 0x30 - 0x3f */
-                0, 10, 11, 12, 13, 14, 15, 0, 0, 0, 0, 0, 0, 0, 0, 0, /* 0x40 - 0x4f */
-                0, 0,  0,  0,  0,  0,  0,  0, 0, 0, 0, 0, 0, 0, 0, 0, /* 0x50 - 0x5f */
-                0, 10, 11, 12, 13, 14, 15                             /* 0x60 - 0x66 */
-            };
-            assert('0' <= d10);
-            assert('0' <= d1);
-            unsigned char idx10 = static_cast<unsigned char>(d10 - '0');
-            unsigned char idx1 = static_cast<unsigned char>(d1 - '0');
-            assert(idx10 < hex_offset.size());
-            assert(idx1 < hex_offset.size());
-            return static_cast<char>((hex_offset[idx10] << 4) | hex_offset[idx1]);
-        }
-
-        template <typename Str>
-        auto url_encode_impl(std::string_view url, Str exclude) -> std::string
-        {
-            std::string out = {};
-            out.reserve(url.size());
-            for (char c : url)
-            {
-                if (url_is_unreserved_char(c) || contains(exclude, c))
-                {
-                    out += c;
-                }
-                else
-                {
-                    const auto encoding = url_encode_char(c);
-                    out += std::string_view(encoding.data(), encoding.size());
-                }
-            }
-            return out;
-        }
-    }
-
-    auto url_encode(std::string_view url) -> std::string
-    {
-        return url_encode_impl(url, 'a');  // Already not encoded
-    }
-
-    auto url_encode(std::string_view url, std::string_view exclude) -> std::string
-    {
-        return url_encode_impl(url, exclude);
-    }
-
-    auto url_encode(std::string_view url, char exclude) -> std::string
-    {
-        return url_encode_impl(url, exclude);
-    }
-
-    auto url_decode(std::string_view url) -> std::string
-    {
-        std::string out = {};
-        out.reserve(url.size());
-        const auto end = url.cend();
-        for (auto iter = url.cbegin(); iter < end; ++iter)
-        {
-            if (((iter + 2) < end) && (iter[0] == '%') && url_is_hex_char(iter[1])
-                && url_is_hex_char(iter[2]))
-            {
-                out.push_back(url_decode_char(iter[1], iter[2]));
-                iter += 2;
-            }
-            else
-            {
-                out.push_back(*iter);
-            }
-        }
-        return out;
-    }
-
     void split_platform(
         const std::vector<std::string>& known_platforms,
         const std::string& url,
@@ -211,12 +109,12 @@ namespace mamba::util
                 return concat(
                     file_scheme,
                     path.substr(0, 2),
-                    url_encode(path_to_posix(std::string(path.substr(2))), '/')
+                    encode_percent(path_to_posix(std::string(path.substr(2))), '/')
                 );
             }
-            return util::concat(file_scheme, url_encode(path_to_posix(std::string(path)), '/'));
+            return util::concat(file_scheme, encode_percent(path_to_posix(std::string(path)), '/'));
         }
-        return util::concat(file_scheme, url_encode(path, '/'));
+        return util::concat(file_scheme, encode_percent(path, '/'));
     }
 
     auto abs_path_or_url_to_url(std::string_view path) -> std::string

--- a/libmamba/tests/CMakeLists.txt
+++ b/libmamba/tests/CMakeLists.txt
@@ -25,6 +25,7 @@ set(
     src/util/test_cast.cpp
     src/util/test_compare.cpp
     src/util/test_cryptography.cpp
+    src/util/test_encoding.cpp
     src/util/test_environment.cpp
     src/util/test_flat_bool_expr_tree.cpp
     src/util/test_flat_set.cpp

--- a/libmamba/tests/CMakeLists.txt
+++ b/libmamba/tests/CMakeLists.txt
@@ -24,6 +24,7 @@ set(
     # Utility library
     src/util/test_cast.cpp
     src/util/test_compare.cpp
+    src/util/test_cryptography.cpp
     src/util/test_environment.cpp
     src/util/test_flat_bool_expr_tree.cpp
     src/util/test_flat_set.cpp

--- a/libmamba/tests/src/core/test_cpp.cpp
+++ b/libmamba/tests/src/core/test_cpp.cpp
@@ -25,6 +25,14 @@
 
 namespace mamba
 {
+
+    TEST_CASE("cache_name_from_url")
+    {
+        CHECK_EQ(cache_name_from_url("http://test.com/1234/"), "302f0a61");
+        CHECK_EQ(cache_name_from_url("http://test.com/1234/repodata.json"), "302f0a61");
+        CHECK_EQ(cache_name_from_url("http://test.com/1234/current_repodata.json"), "78a8cce9");
+    }
+
     // TEST(cpp_install, install)
     // {
     //     mambatests::context().output_params.verbosity = 3;

--- a/libmamba/tests/src/core/test_util.cpp
+++ b/libmamba/tests/src/core/test_util.cpp
@@ -110,25 +110,6 @@ namespace mamba
         }
     }
 
-    TEST_SUITE("utils")
-    {
-        TEST_CASE("encode_decode_base64")
-        {
-            for (std::size_t i = 1; i < 20; ++i)
-            {
-                for (std::size_t j = 0; j < 5; ++j)
-                {
-                    std::string r = mamba::generate_random_alphanumeric_string(i);
-                    auto e = encode_base64(r);
-                    CHECK(e);
-                    auto x = decode_base64(e.value());
-                    CHECK(x);
-                    CHECK_EQ(r, x.value());
-                }
-            }
-        }
-    }
-
     TEST_SUITE("fsutils")
     {
         TEST_CASE("is_writable")

--- a/libmamba/tests/src/core/test_validate_common.cpp
+++ b/libmamba/tests/src/core/test_validate_common.cpp
@@ -45,19 +45,23 @@ TEST_SUITE("Validate")
         generate_ed25519_keypair(pk.data(), sk.data());
 
         auto pk_hex = hex_str(pk);
-        auto pk_bytes = ed25519_key_hex_to_bytes(pk_hex);
+        int error = 0;
+        auto pk_bytes = ed25519_key_hex_to_bytes(pk_hex, error);
+        REQUIRE_EQ(error, 0);
         CHECK_EQ(pk_hex, hex_str(pk_bytes));
 
         spdlog::set_level(spdlog::level::debug);
 
         std::array<unsigned char, 5> not_even_key;
         pk_hex = hex_str(not_even_key);
-        pk_bytes = ed25519_key_hex_to_bytes(pk_hex);
+        pk_bytes = ed25519_key_hex_to_bytes(pk_hex, error);
+        REQUIRE_EQ(error, 0);
         CHECK_FALSE(pk_hex == hex_str(pk_bytes));
 
         std::array<unsigned char, 6> wrong_size_key;
         pk_hex = hex_str(wrong_size_key);
-        pk_bytes = ed25519_key_hex_to_bytes(pk_hex);
+        pk_bytes = ed25519_key_hex_to_bytes(pk_hex, error);
+        REQUIRE_EQ(error, 0);
         CHECK_FALSE(pk_hex == hex_str(pk_bytes));
 
         spdlog::set_level(spdlog::level::info);
@@ -71,20 +75,24 @@ TEST_SUITE("Validate")
         std::array<unsigned char, MAMBA_ED25519_SIGSIZE_BYTES> sig;
         sign("Some text.", sk.data(), sig.data());
 
+        int error = 0;
         auto sig_hex = hex_str(sig);
-        auto sig_bytes = ed25519_sig_hex_to_bytes(sig_hex);
+        auto sig_bytes = ed25519_sig_hex_to_bytes(sig_hex, error);
+        REQUIRE_EQ(error, 0);
         CHECK_EQ(sig_hex, hex_str(sig_bytes));
 
         spdlog::set_level(spdlog::level::debug);
 
         std::array<unsigned char, 5> not_even_sig;
         sig_hex = hex_str(not_even_sig);
-        sig_bytes = ed25519_sig_hex_to_bytes(sig_hex);
+        sig_bytes = ed25519_sig_hex_to_bytes(sig_hex, error);
+        REQUIRE_EQ(error, 0);
         CHECK_FALSE(sig_hex == hex_str(sig_bytes));
 
         std::array<unsigned char, 6> wrong_size_sig;
         sig_hex = hex_str(wrong_size_sig);
-        sig_bytes = ed25519_sig_hex_to_bytes(sig_hex);
+        sig_bytes = ed25519_sig_hex_to_bytes(sig_hex, error);
+        REQUIRE_EQ(error, 0);
         CHECK_FALSE(sig_hex == hex_str(sig_bytes));
 
         spdlog::set_level(spdlog::level::info);
@@ -185,8 +193,11 @@ TEST_SUITE("VerifyGPGMsg")
 {
     TEST_CASE_FIXTURE(VerifyGPGMsg, "verify_gpg_hashed_msg_from_bin")
     {
-        auto bin_signature = ed25519_sig_hex_to_bytes(signature);
-        auto bin_pk = ed25519_key_hex_to_bytes(pk);
+        int error = 0;
+        auto bin_signature = ed25519_sig_hex_to_bytes(signature, error);
+        REQUIRE_EQ(error, 0);
+        auto bin_pk = ed25519_key_hex_to_bytes(pk, error);
+        REQUIRE_EQ(error, 0);
 
         CHECK_EQ(verify_gpg_hashed_msg(hash, bin_pk.data(), bin_signature.data()), 1);
     }

--- a/libmamba/tests/src/core/test_validate_v06.cpp
+++ b/libmamba/tests/src/core/test_validate_v06.cpp
@@ -12,6 +12,7 @@
 
 #include "mamba/core/fsutil.hpp"
 #include "mamba/core/validate.hpp"
+#include "mamba/util/encoding.hpp"
 #include "mamba/util/path_manip.hpp"
 #include "mamba/util/string.hpp"
 
@@ -125,7 +126,10 @@ public:
         {
             sign(root_meta.dump(2), secret.second.data(), sig_bin);
 
-            auto sig_hex = ::mamba::util::hex_string(sig_bin, MAMBA_ED25519_SIGSIZE_BYTES);
+            auto sig_hex = util::bytes_to_hex_str(
+                reinterpret_cast<const std::byte*>(sig_bin),
+                reinterpret_cast<const std::byte*>(sig_bin) + MAMBA_ED25519_SIGSIZE_BYTES
+            );
             signatures[secret.first].insert({ "signature", sig_hex });
         }
 
@@ -175,7 +179,10 @@ protected:
         for (int i = 0; i < count; ++i)
         {
             generate_ed25519_keypair(pk, sk.data());
-            auto pk_hex = ::mamba::util::hex_string(pk, MAMBA_ED25519_KEYSIZE_BYTES);
+            auto pk_hex = util::bytes_to_hex_str(
+                reinterpret_cast<const std::byte*>(pk),
+                reinterpret_cast<const std::byte*>(pk) + MAMBA_ED25519_KEYSIZE_BYTES
+            );
 
             role_secrets.insert({ pk_hex, sk });
         }
@@ -772,7 +779,10 @@ protected:
         {
             sign(meta.dump(2), secret.second.data(), sig_bin);
 
-            auto sig_hex = ::mamba::util::hex_string(sig_bin, MAMBA_ED25519_SIGSIZE_BYTES);
+            auto sig_hex = util::bytes_to_hex_str(
+                reinterpret_cast<const std::byte*>(sig_bin),
+                reinterpret_cast<const std::byte*>(sig_bin) + MAMBA_ED25519_SIGSIZE_BYTES
+            );
             signatures[secret.first].insert({ "signature", sig_hex });
         }
 
@@ -1047,7 +1057,10 @@ protected:
         {
             sign(meta.dump(2), secret.second.data(), sig_bin);
 
-            auto sig_hex = ::mamba::util::hex_string(sig_bin, MAMBA_ED25519_SIGSIZE_BYTES);
+            auto sig_hex = util::bytes_to_hex_str(
+                reinterpret_cast<const std::byte*>(sig_bin),
+                reinterpret_cast<const std::byte*>(sig_bin) + MAMBA_ED25519_SIGSIZE_BYTES
+            );
             signatures[secret.first].insert({ "signature", sig_hex });
         }
 
@@ -1095,7 +1108,10 @@ protected:
         {
             sign(meta.dump(2), secret.second.data(), sig_bin);
 
-            auto sig_hex = ::mamba::util::hex_string(sig_bin, MAMBA_ED25519_SIGSIZE_BYTES);
+            auto sig_hex = util::bytes_to_hex_str(
+                reinterpret_cast<const std::byte*>(sig_bin),
+                reinterpret_cast<const std::byte*>(sig_bin) + MAMBA_ED25519_SIGSIZE_BYTES
+            );
             signatures[secret.first].insert({ "signature", sig_hex });
         }
 

--- a/libmamba/tests/src/core/test_validate_v1.cpp
+++ b/libmamba/tests/src/core/test_validate_v1.cpp
@@ -12,7 +12,7 @@
 
 #include "mamba/core/fsutil.hpp"
 #include "mamba/core/validate.hpp"
-#include "mamba/util/string.hpp"
+#include "mamba/util/encoding.hpp"
 
 #include "mambatests.hpp"
 
@@ -114,7 +114,10 @@ public:
         {
             sign(root_meta.dump(), secret.second.data(), sig_bin);
 
-            auto sig_hex = ::mamba::util::hex_string(sig_bin, MAMBA_ED25519_SIGSIZE_BYTES);
+            auto sig_hex = util::bytes_to_hex_str(
+                reinterpret_cast<const std::byte*>(sig_bin),
+                reinterpret_cast<const std::byte*>(sig_bin) + MAMBA_ED25519_SIGSIZE_BYTES
+            );
             signatures.push_back({ secret.first, sig_hex });
         }
 
@@ -142,7 +145,10 @@ protected:
         {
             generate_ed25519_keypair(pk, sk.data());
 
-            auto pk_hex = ::mamba::util::hex_string(pk, MAMBA_ED25519_KEYSIZE_BYTES);
+            auto pk_hex = util::bytes_to_hex_str(
+                reinterpret_cast<const std::byte*>(pk),
+                reinterpret_cast<const std::byte*>(pk) + MAMBA_ED25519_KEYSIZE_BYTES
+            );
             role_secrets.insert({ pk_hex, sk });
         }
         return role_secrets;

--- a/libmamba/tests/src/util/test_cryptography.cpp
+++ b/libmamba/tests/src/util/test_cryptography.cpp
@@ -4,9 +4,8 @@
 //
 // The full license is in the file LICENSE, distributed with this software.
 
-
 #include <array>
-#include <string_view>
+#include <utility>
 
 #include <doctest/doctest.h>
 
@@ -22,35 +21,105 @@ TEST_SUITE("util::cryptography")
 {
     TEST_CASE("Hasher")
     {
+        const auto known_sha256 = std::array<std::pair<std::string, std::string>, 5>{ {
+            {
+                "test",
+                "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08",
+            },
+            {
+                "test",
+                "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08",
+            },
+            {
+                "This is a string !",
+                "4cad2018bf50bdc5c00a0dafdc53e15867c46c8d6cd6dec04302707a5892854e",
+            },
+            {
+                std::string(Sha256Digester::digest_size, 'y'),
+                "65be48e7ef751399d65711c5c053c6cec0c412ea22fae85872c867336b955a46",
+            },
+            {
+                std::string(Sha256Digester::digest_size * 2 + 10, 'z'),
+                "5fb97842061800e4140e9bb07e161a47d327f023a1e4410ea5af2132449a5b0c",
+            },
+        } };
+
+        const auto known_md5 = std::array<std::pair<std::string, std::string>, 5>{ {
+            { "test", "098f6bcd4621d373cade4e832627b4f6" },
+            { "test", "098f6bcd4621d373cade4e832627b4f6" },
+            { "This is a string !", "ffadac0192824b39afda20319ba016b6" },
+            {
+                std::string(Md5Digester::digest_size, 'y'),
+                "358b0ef0cd11424177adb11be4b43269",
+            },
+            {
+                std::string(Md5Digester::digest_size * 2 + 10, 'z'),
+                "43856e090ea42b2862bcf4b49aeda79f",
+            },
+
+        } };
+
+        SUBCASE("Hash string")
+        {
+            SUBCASE("sha256")
+            {
+                auto reused_hasher = Sha256Hasher();
+                for (auto [data, hash] : known_sha256)
+                {
+                    CHECK_EQ(reused_hasher.str_hex_str(data), hash);
+                    auto new_hasher = Sha256Hasher();
+                    CHECK_EQ(new_hasher.str_hex_str(data), hash);
+                }
+            }
+
+            SUBCASE("md5")
+            {
+                auto reused_hasher = Md5Hasher();
+                for (auto [data, hash] : known_md5)
+                {
+                    CHECK_EQ(reused_hasher.str_hex_str(data), hash);
+                    auto new_hasher = Md5Hasher();
+                    CHECK_EQ(new_hasher.str_hex_str(data), hash);
+                }
+            }
+        }
+
         SUBCASE("Hash file")
         {
-            auto tmp = mamba::TemporaryFile();
-            {
-                auto file = std::fstream(tmp.path());
-                REQUIRE(file.good());
-                file << "test";
-                file.close();
-            }
-            auto file = std::ifstream(tmp.path());
-            REQUIRE(file.good());
-
             SUBCASE("sha256")
             {
                 auto hasher = Sha256Hasher();
-                auto hash_hex = hasher.file_hex(file);
-                auto hash_hex_str = std::string_view(hash_hex.data(), hash_hex.size());
-                CHECK_EQ(
-                    hash_hex_str,
-                    "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"
-                );
+                for (auto [data, hash] : known_sha256)
+                {
+                    auto tmp = mamba::TemporaryFile();
+                    {
+                        auto file = std::fstream(tmp.path());
+                        REQUIRE(file.good());
+                        file << data;
+                        file.close();
+                    }
+                    auto file = std::ifstream(tmp.path());
+                    REQUIRE(file.good());
+                    CHECK_EQ(hasher.file_hex_str(file), hash);
+                }
             }
 
             SUBCASE("md5")
             {
                 auto hasher = Md5Hasher();
-                auto hash_hex = hasher.file_hex(file);
-                auto hash_hex_str = std::string_view(hash_hex.data(), hash_hex.size());
-                CHECK_EQ(hash_hex_str, "098f6bcd4621d373cade4e832627b4f6");
+                for (auto [data, hash] : known_md5)
+                {
+                    auto tmp = mamba::TemporaryFile();
+                    {
+                        auto file = std::fstream(tmp.path());
+                        REQUIRE(file.good());
+                        file << data;
+                        file.close();
+                    }
+                    auto file = std::ifstream(tmp.path());
+                    REQUIRE(file.good());
+                    CHECK_EQ(hasher.file_hex_str(file), hash);
+                }
             }
         }
     }

--- a/libmamba/tests/src/util/test_cryptography.cpp
+++ b/libmamba/tests/src/util/test_cryptography.cpp
@@ -1,0 +1,37 @@
+// Copyright (c) 2023, QuantStack and Mamba Contributors
+//
+// Distributed under the terms of the BSD 3-Clause License.
+//
+// The full license is in the file LICENSE, distributed with this software.
+
+
+#include <array>
+#include <string_view>
+
+#include <doctest/doctest.h>
+
+#include "mamba/util/cryptography.hpp"
+
+#include "doctest-printer/array.hpp"
+#include "doctest-printer/optional.hpp"
+
+using namespace mamba::util;
+
+TEST_SUITE("util::cryptography")
+{
+    TEST_CASE("bytes_to_hex")
+    {
+        constexpr auto bytes = std::array{
+            std::byte{ 0x00 }, std::byte{ 0x01 }, std::byte{ 0x03 }, std::byte{ 0x09 },
+            std::byte{ 0x0A }, std::byte{ 0x0D }, std::byte{ 0x0F }, std::byte{ 0xAD },
+            std::byte{ 0x10 }, std::byte{ 0x30 }, std::byte{ 0xA0 }, std::byte{ 0xD0 },
+            std::byte{ 0xF0 }, std::byte{ 0xAD }, std::byte{ 0xA9 }, std::byte{ 0x4E },
+            std::byte{ 0xEF }, std::byte{ 0xFF },
+        };
+
+        auto hex = std::array<char, bytes.size() * 2>{};
+        bytes_to_hex_to(bytes.data(), bytes.data() + bytes.size(), hex.data());
+        const auto hex_str = std::string_view(hex.data(), hex.size());
+        CHECK_EQ(hex_str, "000103090a0d0fad1030a0d0f0ada94eefff");
+    }
+}

--- a/libmamba/tests/src/util/test_cryptography.cpp
+++ b/libmamba/tests/src/util/test_cryptography.cpp
@@ -20,22 +20,6 @@ using namespace mamba::util;
 
 TEST_SUITE("util::cryptography")
 {
-    TEST_CASE("bytes_to_hex")
-    {
-        constexpr auto bytes = std::array{
-            std::byte{ 0x00 }, std::byte{ 0x01 }, std::byte{ 0x03 }, std::byte{ 0x09 },
-            std::byte{ 0x0A }, std::byte{ 0x0D }, std::byte{ 0x0F }, std::byte{ 0xAD },
-            std::byte{ 0x10 }, std::byte{ 0x30 }, std::byte{ 0xA0 }, std::byte{ 0xD0 },
-            std::byte{ 0xF0 }, std::byte{ 0xAD }, std::byte{ 0xA9 }, std::byte{ 0x4E },
-            std::byte{ 0xEF }, std::byte{ 0xFF },
-        };
-
-        auto hex = std::array<char, bytes.size() * 2>{};
-        bytes_to_hex_to(bytes.data(), bytes.data() + bytes.size(), hex.data());
-        const auto hex_str = std::string_view(hex.data(), hex.size());
-        CHECK_EQ(hex_str, "000103090a0d0fad1030a0d0f0ada94eefff");
-    }
-
     TEST_CASE("Hasher")
     {
         SUBCASE("Hash file")

--- a/libmamba/tests/src/util/test_cryptography.cpp
+++ b/libmamba/tests/src/util/test_cryptography.cpp
@@ -93,7 +93,7 @@ TEST_SUITE("util::cryptography")
                 {
                     auto tmp = mamba::TemporaryFile();
                     {
-                        auto file = std::fstream(tmp.path());
+                        auto file = std::fstream(tmp.path().std_path());
                         REQUIRE(file.good());
                         file << data;
                         file.close();
@@ -111,7 +111,7 @@ TEST_SUITE("util::cryptography")
                 {
                     auto tmp = mamba::TemporaryFile();
                     {
-                        auto file = std::fstream(tmp.path());
+                        auto file = std::fstream(tmp.path().std_path());
                         REQUIRE(file.good());
                         file << data;
                         file.close();

--- a/libmamba/tests/src/util/test_cryptography.cpp
+++ b/libmamba/tests/src/util/test_cryptography.cpp
@@ -98,7 +98,7 @@ TEST_SUITE("util::cryptography")
                         file << data;
                         file.close();
                     }
-                    auto file = std::ifstream(tmp.path());
+                    auto file = std::ifstream(tmp.path().std_path());
                     REQUIRE(file.good());
                     CHECK_EQ(hasher.file_hex_str(file), hash);
                 }
@@ -116,7 +116,7 @@ TEST_SUITE("util::cryptography")
                         file << data;
                         file.close();
                     }
-                    auto file = std::ifstream(tmp.path());
+                    auto file = std::ifstream(tmp.path().std_path());
                     REQUIRE(file.good());
                     CHECK_EQ(hasher.file_hex_str(file), hash);
                 }

--- a/libmamba/tests/src/util/test_cryptography.cpp
+++ b/libmamba/tests/src/util/test_cryptography.cpp
@@ -10,6 +10,7 @@
 
 #include <doctest/doctest.h>
 
+#include "mamba/core/util.hpp"
 #include "mamba/util/cryptography.hpp"
 
 #include "doctest-printer/array.hpp"
@@ -33,5 +34,40 @@ TEST_SUITE("util::cryptography")
         bytes_to_hex_to(bytes.data(), bytes.data() + bytes.size(), hex.data());
         const auto hex_str = std::string_view(hex.data(), hex.size());
         CHECK_EQ(hex_str, "000103090a0d0fad1030a0d0f0ada94eefff");
+    }
+
+    TEST_CASE("Hasher")
+    {
+        SUBCASE("Hash file")
+        {
+            auto tmp = mamba::TemporaryFile();
+            {
+                auto file = std::fstream(tmp.path());
+                REQUIRE(file.good());
+                file << "test";
+                file.close();
+            }
+            auto file = std::ifstream(tmp.path());
+            REQUIRE(file.good());
+
+            SUBCASE("sha256")
+            {
+                auto hasher = Sha256Hasher();
+                auto hash_hex = hasher.file_hex(file);
+                auto hash_hex_str = std::string_view(hash_hex.data(), hash_hex.size());
+                CHECK_EQ(
+                    hash_hex_str,
+                    "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"
+                );
+            }
+
+            SUBCASE("md5")
+            {
+                auto hasher = Md5Hasher();
+                auto hash_hex = hasher.file_hex(file);
+                auto hash_hex_str = std::string_view(hash_hex.data(), hash_hex.size());
+                CHECK_EQ(hash_hex_str, "098f6bcd4621d373cade4e832627b4f6");
+            }
+        }
     }
 }

--- a/libmamba/tests/src/util/test_encoding.cpp
+++ b/libmamba/tests/src/util/test_encoding.cpp
@@ -28,10 +28,10 @@ TEST_SUITE("util::encoding")
             std::byte{ 0xEF }, std::byte{ 0xFF },
         };
 
-        auto hex = std::array<char, bytes.size() * 2>{};
-        bytes_to_hex_to(bytes.data(), bytes.data() + bytes.size(), hex.data());
-        const auto hex_str = std::string_view(hex.data(), hex.size());
-        CHECK_EQ(hex_str, "000103090a0d0fad1030a0d0f0ada94eefff");
+        CHECK_EQ(
+            bytes_to_hex_str(bytes.data(), bytes.data() + bytes.size()),
+            "000103090a0d0fad1030a0d0f0ada94eefff"
+        );
     }
 
     TEST_CASE("precent")

--- a/libmamba/tests/src/util/test_encoding.cpp
+++ b/libmamba/tests/src/util/test_encoding.cpp
@@ -34,6 +34,40 @@ TEST_SUITE("util::encoding")
         CHECK_EQ(hex_str, "000103090a0d0fad1030a0d0f0ada94eefff");
     }
 
+    TEST_CASE("precent")
+    {
+        SUBCASE("encode")
+        {
+            CHECK_EQ(encode_percent(""), "");
+            CHECK_EQ(encode_percent("page"), "page");
+            CHECK_EQ(encode_percent(" /word%"), "%20%2Fword%25");
+            CHECK_EQ(encode_percent("user@email.com"), "user%40email.com");
+            CHECK_EQ(
+                encode_percent(R"(#!$&'"(ab23)*+,/:;=?@[])"),
+                "%23%21%24%26%27%22%28ab23%29%2A%2B%2C%2F%3A%3B%3D%3F%40%5B%5D"
+            );
+            // Does NOT parse URL
+            CHECK_EQ(encode_percent("https://foo/"), "https%3A%2F%2Ffoo%2F");
+
+            // Exclude characters
+            CHECK_EQ(encode_percent(" /word%", '/'), "%20/word%25");
+        }
+
+        SUBCASE("decode")
+        {
+            CHECK_EQ(decode_percent(""), "");
+            CHECK_EQ(decode_percent("page"), "page");
+            CHECK_EQ(decode_percent("%20%2Fword%25"), " /word%");
+            CHECK_EQ(decode_percent(" /word%25"), " /word%");
+            CHECK_EQ(decode_percent("user%40email.com"), "user@email.com");
+            CHECK_EQ(decode_percent("https%3A%2F%2Ffoo%2F"), "https://foo/");
+            CHECK_EQ(
+                decode_percent("%23%21%24%26%27%22%28ab23%29%2A%2B%2C%2F%3A%3B%3D%3F%40%5B%5D"),
+                R"(#!$&'"(ab23)*+,/:;=?@[])"
+            );
+        }
+    }
+
     TEST_CASE("base64")
     {
         SUBCASE("encode")

--- a/libmamba/tests/src/util/test_encoding.cpp
+++ b/libmamba/tests/src/util/test_encoding.cpp
@@ -33,4 +33,31 @@ TEST_SUITE("util::encoding")
         const auto hex_str = std::string_view(hex.data(), hex.size());
         CHECK_EQ(hex_str, "000103090a0d0fad1030a0d0f0ada94eefff");
     }
+
+    TEST_CASE("base64")
+    {
+        SUBCASE("encode")
+        {
+            CHECK_EQ(encode_base64("Hello").value(), "SGVsbG8=");
+            CHECK_EQ(encode_base64("Hello World!").value(), "SGVsbG8gV29ybGQh");
+            CHECK_EQ(encode_base64("!@#$%^U&I*O").value(), "IUAjJCVeVSZJKk8=");
+            CHECK_EQ(
+                encode_base64(u8"_私のにほHelloわへたです").value(),
+                "X+engeOBruOBq+OBu0hlbGxv44KP44G444Gf44Gn44GZ"
+            );
+            CHECK_EQ(encode_base64("xyzpass").value(), "eHl6cGFzcw==");
+        }
+
+        SUBCASE("decode")
+        {
+            CHECK_EQ(decode_base64("SGVsbG8=").value(), "Hello");
+            CHECK_EQ(decode_base64("SGVsbG8gV29ybGQh").value(), "Hello World!");
+            CHECK_EQ(decode_base64("IUAjJCVeVSZJKk8=").value(), "!@#$%^U&I*O");
+            CHECK_EQ(
+                decode_base64(u8"X+engeOBruOBq+OBu0hlbGxv44KP44G444Gf44Gn44GZ").value(),
+                "_私のにほHelloわへたです"
+            );
+            CHECK_EQ(decode_base64("eHl6cGFzcw==").value(), "xyzpass");
+        }
+    }
 }

--- a/libmamba/tests/src/util/test_encoding.cpp
+++ b/libmamba/tests/src/util/test_encoding.cpp
@@ -18,20 +18,95 @@ using namespace mamba::util;
 
 TEST_SUITE("util::encoding")
 {
-    TEST_CASE("bytes_to_hex")
+    TEST_CASE("Hexadecimal")
     {
-        constexpr auto bytes = std::array{
-            std::byte{ 0x00 }, std::byte{ 0x01 }, std::byte{ 0x03 }, std::byte{ 0x09 },
-            std::byte{ 0x0A }, std::byte{ 0x0D }, std::byte{ 0x0F }, std::byte{ 0xAD },
-            std::byte{ 0x10 }, std::byte{ 0x30 }, std::byte{ 0xA0 }, std::byte{ 0xD0 },
-            std::byte{ 0xF0 }, std::byte{ 0xAD }, std::byte{ 0xA9 }, std::byte{ 0x4E },
-            std::byte{ 0xEF }, std::byte{ 0xFF },
-        };
+        SUBCASE("nibble_to_hex")
+        {
+            CHECK_EQ(nibble_to_hex(std::byte{ 0x00 }), '0');
+            CHECK_EQ(nibble_to_hex(std::byte{ 0x10 }), '0');  // high ignored
+            CHECK_EQ(nibble_to_hex(std::byte{ 0x01 }), '1');
+            CHECK_EQ(nibble_to_hex(std::byte{ 0x0D }), 'd');
+        }
 
-        CHECK_EQ(
-            bytes_to_hex_str(bytes.data(), bytes.data() + bytes.size()),
-            "000103090a0d0fad1030a0d0f0ada94eefff"
-        );
+        SUBCASE("bytes_to_hex_to")
+        {
+            constexpr auto bytes = std::array{
+                std::byte{ 0x00 }, std::byte{ 0x01 }, std::byte{ 0x03 }, std::byte{ 0x09 },
+                std::byte{ 0x0A }, std::byte{ 0x0D }, std::byte{ 0x0F }, std::byte{ 0xAD },
+                std::byte{ 0x10 }, std::byte{ 0x30 }, std::byte{ 0xA0 }, std::byte{ 0xD0 },
+                std::byte{ 0xF0 }, std::byte{ 0xAD }, std::byte{ 0xA9 }, std::byte{ 0x4E },
+                std::byte{ 0xEF }, std::byte{ 0xFF },
+            };
+
+            CHECK_EQ(
+                bytes_to_hex_str(bytes.data(), bytes.data() + bytes.size()),
+                "000103090a0d0fad1030a0d0f0ada94eefff"
+            );
+        }
+
+        SUBCASE("hex_to_nibble")
+        {
+            CHECK_EQ(hex_to_nibble('0').value(), std::byte{ 0x00 });
+            CHECK_EQ(hex_to_nibble('a').value(), std::byte{ 0x0A });
+            CHECK_EQ(hex_to_nibble('f').value(), std::byte{ 0x0F });
+            CHECK_EQ(hex_to_nibble('B').value(), std::byte{ 0x0B });
+
+            CHECK_FALSE(hex_to_nibble('x').has_value());
+            CHECK_FALSE(hex_to_nibble('*').has_value());
+            CHECK_FALSE(hex_to_nibble('\0').has_value());
+            CHECK_FALSE(hex_to_nibble('~').has_value());
+        }
+
+        SUBCASE("two_hex_to_byte")
+        {
+            CHECK_EQ(two_hex_to_byte('0', '0').value(), std::byte{ 0x00 });
+            CHECK_EQ(two_hex_to_byte('0', '4').value(), std::byte{ 0x04 });
+            CHECK_EQ(two_hex_to_byte('5', '0').value(), std::byte{ 0x50 });
+            CHECK_EQ(two_hex_to_byte('F', 'F').value(), std::byte{ 0xFF });
+            CHECK_EQ(two_hex_to_byte('0', 'A').value(), std::byte{ 0x0A });
+            CHECK_EQ(two_hex_to_byte('b', '8').value(), std::byte{ 0xB8 });
+
+            CHECK_FALSE(two_hex_to_byte('b', 'x').has_value());
+            CHECK_FALSE(two_hex_to_byte('!', 'b').has_value());
+            CHECK_FALSE(two_hex_to_byte(' ', '~').has_value());
+        }
+
+        SUBCASE("hex_to_bytes")
+        {
+            using bytes = std::vector<std::byte>;
+
+            SUBCASE("1234")
+            {
+                auto str = std::string_view("1234");
+                auto b = bytes(str.size() / 2);
+                REQUIRE(hex_to_bytes_to(str, b.data()).has_value());
+                CHECK_EQ(b, bytes{ std::byte{ 0x12 }, std::byte{ 0x34 } });
+            }
+
+            SUBCASE("1f4DaB")
+            {
+                auto str = std::string_view("1f4DaB");
+                auto b = bytes(str.size() / 2);
+                REQUIRE(hex_to_bytes_to(str, b.data()).has_value());
+                CHECK_EQ(b, bytes{ std::byte{ 0x1F }, std::byte{ 0x4D }, std::byte{ 0xAB } });
+            }
+
+            SUBCASE("1f4Da")
+            {
+                // Odd number
+                auto str = std::string_view("1f4Da");
+                auto b = bytes(str.size() / 2);
+                REQUIRE_FALSE(hex_to_bytes_to(str, b.data()).has_value());
+            }
+
+            SUBCASE("1fx4")
+            {
+                // Bad hex
+                auto str = std::string_view("1fx4");
+                auto b = bytes(str.size() / 2);
+                REQUIRE_FALSE(hex_to_bytes_to(str, b.data()).has_value());
+            }
+        }
     }
 
     TEST_CASE("precent")

--- a/libmamba/tests/src/util/test_encoding.cpp
+++ b/libmamba/tests/src/util/test_encoding.cpp
@@ -1,0 +1,36 @@
+// Copyright (c) 2023, QuantStack and Mamba Contributors
+//
+// Distributed under the terms of the BSD 3-Clause License.
+//
+// The full license is in the file LICENSE, distributed with this software.
+
+
+#include <array>
+#include <string_view>
+
+#include <doctest/doctest.h>
+
+#include "mamba/util/encoding.hpp"
+
+#include "doctest-printer/array.hpp"
+
+using namespace mamba::util;
+
+TEST_SUITE("util::encoding")
+{
+    TEST_CASE("bytes_to_hex")
+    {
+        constexpr auto bytes = std::array{
+            std::byte{ 0x00 }, std::byte{ 0x01 }, std::byte{ 0x03 }, std::byte{ 0x09 },
+            std::byte{ 0x0A }, std::byte{ 0x0D }, std::byte{ 0x0F }, std::byte{ 0xAD },
+            std::byte{ 0x10 }, std::byte{ 0x30 }, std::byte{ 0xA0 }, std::byte{ 0xD0 },
+            std::byte{ 0xF0 }, std::byte{ 0xAD }, std::byte{ 0xA9 }, std::byte{ 0x4E },
+            std::byte{ 0xEF }, std::byte{ 0xFF },
+        };
+
+        auto hex = std::array<char, bytes.size() * 2>{};
+        bytes_to_hex_to(bytes.data(), bytes.data() + bytes.size(), hex.data());
+        const auto hex_str = std::string_view(hex.data(), hex.size());
+        CHECK_EQ(hex_str, "000103090a0d0fad1030a0d0f0ada94eefff");
+    }
+}

--- a/libmamba/tests/src/util/test_url_manip.cpp
+++ b/libmamba/tests/src/util/test_url_manip.cpp
@@ -279,11 +279,4 @@ TEST_SUITE("util::url_manip")
         CHECK_FALSE(url_has_scheme("f#gre://"));
         CHECK_FALSE(url_has_scheme(""));
     }
-
-    TEST_CASE("cache_name_from_url")
-    {
-        CHECK_EQ(cache_name_from_url("http://test.com/1234/"), "302f0a61");
-        CHECK_EQ(cache_name_from_url("http://test.com/1234/repodata.json"), "302f0a61");
-        CHECK_EQ(cache_name_from_url("http://test.com/1234/current_repodata.json"), "78a8cce9");
-    }
 }

--- a/libmamba/tests/src/util/test_url_manip.cpp
+++ b/libmamba/tests/src/util/test_url_manip.cpp
@@ -20,34 +20,6 @@ using namespace mamba::util;
 
 TEST_SUITE("util::url_manip")
 {
-    TEST_CASE("encoding")
-    {
-        CHECK_EQ(url_encode(""), "");
-        CHECK_EQ(url_encode("page"), "page");
-        CHECK_EQ(url_encode(" /word%"), "%20%2Fword%25");
-        CHECK_EQ(url_encode("user@email.com"), "user%40email.com");
-        CHECK_EQ(
-            url_encode(R"(#!$&'"(ab23)*+,/:;=?@[])"),
-            "%23%21%24%26%27%22%28ab23%29%2A%2B%2C%2F%3A%3B%3D%3F%40%5B%5D"
-        );
-        // Does NOT parse URL
-        CHECK_EQ(url_encode("https://foo/"), "https%3A%2F%2Ffoo%2F");
-
-        // Exclude characters
-        CHECK_EQ(url_encode(" /word%", '/'), "%20/word%25");
-
-        CHECK_EQ(url_decode(""), "");
-        CHECK_EQ(url_decode("page"), "page");
-        CHECK_EQ(url_decode("%20%2Fword%25"), " /word%");
-        CHECK_EQ(url_decode(" /word%25"), " /word%");
-        CHECK_EQ(url_decode("user%40email.com"), "user@email.com");
-        CHECK_EQ(url_decode("https%3A%2F%2Ffoo%2F"), "https://foo/");
-        CHECK_EQ(
-            url_decode("%23%21%24%26%27%22%28ab23%29%2A%2B%2C%2F%3A%3B%3D%3F%40%5B%5D"),
-            R"(#!$&'"(ab23)*+,/:;=?@[])"
-        );
-    }
-
     TEST_CASE("split_platform")
     {
         std::string platform_found, cleaned_url;

--- a/micromamba/src/constructor.cpp
+++ b/micromamba/src/constructor.cpp
@@ -13,9 +13,9 @@
 #include "mamba/core/match_spec.hpp"
 #include "mamba/core/package_handling.hpp"
 #include "mamba/core/package_info.hpp"
+#include "mamba/core/subdirdata.hpp"
 #include "mamba/core/util.hpp"
 #include "mamba/util/string.hpp"
-#include "mamba/util/url_manip.hpp"
 
 
 using namespace mamba;  // NOLINT(build/namespaces)
@@ -128,10 +128,7 @@ construct(Configuration& config, const fs::u8path& prefix, bool extract_conda_pk
             {
                 channel_url = pkg_info.url.substr(0, pkg_info.url.size() - pkg_info.fn.size());
             }
-            std::string repodata_cache_name = util::concat(
-                util::cache_name_from_url(channel_url),
-                ".json"
-            );
+            std::string repodata_cache_name = util::concat(cache_name_from_url(channel_url), ".json");
             fs::u8path repodata_location = pkgs_dir / "cache" / repodata_cache_name;
 
             nlohmann::json repodata_record;

--- a/micromamba/src/login.cpp
+++ b/micromamba/src/login.cpp
@@ -10,6 +10,7 @@
 
 #include "mamba/core/output.hpp"
 #include "mamba/core/util.hpp"
+#include "mamba/util/encoding.hpp"
 #include "mamba/util/environment.hpp"
 #include "mamba/util/string.hpp"
 #include "mamba/util/url.hpp"
@@ -187,7 +188,7 @@ set_login_command(CLI::App* subcom)
                 {
                     auth_object["type"] = "BasicHTTPAuthentication";
 
-                    auto pass_encoded = mamba::encode_base64(mamba::util::strip(pass));
+                    auto pass_encoded = mamba::util::encode_base64(mamba::util::strip(pass));
                     if (!pass_encoded)
                     {
                         throw pass_encoded.error();


### PR DESCRIPTION
- Add sha256 to cryptography
- Refactor cryptographic hasher
- Use new hasher in validation
- Split util::encoding
- Improve hash tests
