### PR TITLE
restore use_default_signal_handler flag for libmambapy

### DIFF
--- a/libmamba/include/mamba/core/context.hpp
+++ b/libmamba/include/mamba/core/context.hpp
@@ -63,6 +63,8 @@ namespace mamba
     {
     public:
 
+        static void use_default_signal_handler(bool val);
+
         struct RemoteFetchParams
         {
             // ssl_verify can be either an empty string (regular SSL verification),

--- a/libmamba/src/core/context.cpp
+++ b/libmamba/src/core/context.cpp
@@ -68,9 +68,22 @@ namespace mamba
         return static_cast<spdlog::level::level_enum>(l);
     }
 
+    namespace
+    {
+        std::atomic<bool> use_default_signal_handler_val{ true };
+    }
+
+    void Context::use_default_signal_handler(bool val)
+    {
+        use_default_signal_handler_val = val;
+    }
+
     void Context::enable_logging_and_signal_handling(Context& context)
     {
-        set_default_signal_handler();
+        if (use_default_signal_handler_val)
+        {
+            set_default_signal_handler();
+        }
 
         context.logger = std::make_shared<Logger>("libmamba", context.output_params.log_pattern, "\n");
         MainExecutor::instance().on_close(

--- a/libmambapy/src/libmambapy/bindings/legacy.cpp
+++ b/libmambapy/src/libmambapy/bindings/legacy.cpp
@@ -726,6 +726,7 @@ bind_submodule_impl(pybind11::module_ m)
                 );
             }
         ))
+        .def_static("use_default_signal_handler", &Context::use_default_signal_handler)
         .def_readwrite("offline", &Context::offline)
         .def_readwrite("local_repodata_ttl", &Context::local_repodata_ttl)
         .def_readwrite("use_index_cache", &Context::use_index_cache)


### PR DESCRIPTION
This was present in the 1.5.x libmambapy but was probably lost in the mamba refactor. It allows CTRL-C to work in Python, instead of being disabled as a side effect of merely importing libmambapy.

Fix https://github.com/mamba-org/mamba/issues/3019