### PR TITLE
Shouldn't we rather deprecate mamba?

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,24 +1,18 @@
 Welcome to Mamba's documentation!
 =================================
 
-Mamba is a fast, robust, and cross-platform package manager.
-
-It runs on Windows, OS X and Linux (ARM64 and PPC64LE included) and is fully compatible with ``conda`` packages and supports most of conda's commands.
+Mamba is a fast, robust, and cross-platform package manager for Conda packages.
 
 The ``mamba-org`` organization hosts multiple Mamba flavors:
 
-- ``mamba``: a Python-based CLI conceived as a *drop-in* replacement for ``conda``, offering higher speed and more reliable environment solutions
-- ``micromamba``: a pure C++-based CLI, self-contained in a single-file executable
-- ``libmamba``: a C++ library exposing low-level and high-level APIs on top of which both ``mamba`` and ``micromamba`` are built
+- Micromamba: a pure C++-based CLI, self-contained in a single-file executable.
+- libmamba: a C++ library exposing low-level and high-level APIs on top of which both Mamba and Micromamba are built.
+- (Mamba: Legacy software; a Python-based CLI conceived as a *drop-in* replacement for Conda, offering higher speed.)
 
-.. note::
-   In this documentation, ``Mamba`` will refer to all flavors while flavor-specific details will mention ``mamba``, ``micromamba`` or ``libmamba``.
-
-.. note::
-    :ref:`micromamba<micromamba>` is especially well fitted for the CI use-case but not limited to that!
+In this documentation, "Mamba" will refer to all flavors while flavor-specific details will mention Mamba, Micromamba, or libmamba.
 
 You can try Mamba now by visiting the installation for
-:ref:`mamba<mamba-install>` or :ref:`micromamba<umamba-install>`
+:ref:`mamba<mamba-install>` or :ref:`micromamba<umamba-install>`.
 
 
 .. toctree::

--- a/docs/source/installation/mamba-installation.rst
+++ b/docs/source/installation/mamba-installation.rst
@@ -4,11 +4,23 @@
 Mamba Installation
 ==================
 
-Fresh install (recommended)
-***************************
+.. warning::
+   With the release of Conda 23.10, **Mamba is deprecated**.
 
-We recommend that you start with the `Miniforge distribution <https://github.com/conda-forge/miniforge>`_ >= `Miniforge3-22.3.1-0`.
-If you need an older version of Mamba, please use the Mambaforge distribution.
+   Please do not create any new installations of Mamba.
+
+   Please use :ref:`Micromamba <umamba-install>` or `Miniforge <https://github.com/conda-forge/miniforge>`_ >= `23.3.1-0` instead.
+
+
+Legacy installation methods (not recommended)
+---------------------------------------------
+
+Mambaforge/Miniforge
+*********************
+
+You can use the `Miniforge distribution <https://github.com/conda-forge/miniforge>`_ >= `Miniforge3-23.3.1-0` to install Mamba.
+If you need an older version of Mamba, please use the Mambaforge distribution instead.
+
 Miniforge comes with the popular ``conda-forge`` channel preconfigured, but you can modify the configuration to use any channel you like.
 
 After successful installation, you can use the mamba commands as described in :ref:`mamba user guide<mamba>`.

--- a/docs/source/installation/micromamba-installation.rst
+++ b/docs/source/installation/micromamba-installation.rst
@@ -5,19 +5,21 @@
 Micromamba Installation
 =======================
 
-``micromamba`` is a fully statically-linked, self-contained, executable.
-This means that the ``base`` environment is completely empty.
-The configuration for ``micromamba`` is slighly different, namely all environments and cache will be
-created by default under the ``MAMBA_ROOT_PREFIX`` environment variable.
-There is also no pre-configured ``.condarc``/``.mambarc`` shipped with micromamba
-(they are however still read if present).
+Micromamba is a fully statically-linked, self-contained, executable written in C++.
+
+Micromamba is not require Conda to be installed on your system; it is entirely self-contained.
+
+The ``base`` environment is completely empty.
+
+The configuration for Micromamba is slighly different from Conda:
+
+- All environments and cache will be created by default under the ``MAMBA_ROOT_PREFIX`` environment variable.
+- There is no pre-configured ``.condarc``/``.mambarc`` shipped with micromamba (they are however still read if present).
 
 .. _umamba-install-automatic-installation:
 
-Operating System package managers
-*********************************
 Homebrew
-^^^^^^^^
+********
 
 On macOS, you can install ``micromamba`` from `Homebrew <https://brew.sh/>`_:
 
@@ -158,24 +160,14 @@ Windows
   micromamba activate yourenv
 
 Nightly builds
-**************
+~~~~~~~~~~~~~~
 
 You can download fully statically linked builds for each commit to ``main`` on GitHub
 (scroll to the bottom of the "Summary" page):
 https://github.com/mamba-org/mamba/actions/workflows/static_build.yml?query=is%3Asuccess
 
-Docker images
-*************
-
-The `mambaorg/micromamba <https://hub.docker.com/r/mambaorg/micromamba>`_ docker
-image can be used to run ``micromamba`` without installing it:
-
-.. code-block:: bash
-
-  docker run -it --rm mambaorg/micromamba:latest micromamba info
-
 Build from source
-*****************
+~~~~~~~~~~~~~~~~~
 
 .. note::
 
@@ -213,6 +205,16 @@ The executable can be striped to remove its size:
 
 
 .. _shell_completion:
+
+Docker images
+*************
+
+The `mambaorg/micromamba <https://hub.docker.com/r/mambaorg/micromamba>`_ docker
+image can be used to run ``micromamba`` without installing it:
+
+.. code-block:: bash
+
+  docker run -it --rm mambaorg/micromamba:latest micromamba info
 
 Shell completion
 ****************

--- a/docs/source/installation/micromamba-installation.rst
+++ b/docs/source/installation/micromamba-installation.rst
@@ -9,13 +9,6 @@ Micromamba is a fully statically-linked, self-contained, executable written in C
 
 Micromamba is not require Conda to be installed on your system; it is entirely self-contained.
 
-The ``base`` environment is completely empty.
-
-The configuration for Micromamba is slighly different from Conda:
-
-- All environments and cache will be created by default under the ``MAMBA_ROOT_PREFIX`` environment variable.
-- There is no pre-configured ``.condarc``/``.mambarc`` shipped with micromamba (they are however still read if present).
-
 .. _umamba-install-automatic-installation:
 
 Homebrew

--- a/docs/source/user_guide/concepts.rst
+++ b/docs/source/user_guide/concepts.rst
@@ -52,14 +52,14 @@ The *root prefix* also provide a convenient structure to store *environments* ``
 Base environment
 ================
 
+.. note::
+  This section does not apply to Micromamba.
+
 The *base* environment is the environment located at the *root prefix*.
 
 | This is a legacy *environment* from ``conda`` implementation that is still heavily used.
 | The *base* environment contains the ``conda`` and ``mamba`` installation alongside a Python installation (since ``mamba`` and ``conda`` require Python to run).
 | ``mamba`` and ``conda``, being themselves Python packages, are installed in the *base* environment, making the CLIs available in all *activated* environments *based* on this *base* environment.
-
-.. note::
-  You can't ``create`` the *base* environment because it's already part of the *root prefix* structure. Directly ``install`` in *base* instead.
 
 
 Activation/Deactivation

--- a/docs/source/user_guide/mamba.rst
+++ b/docs/source/user_guide/mamba.rst
@@ -3,6 +3,13 @@
 Mamba User Guide
 ----------------
 
+.. warning::
+   With the release of Conda 23.10, **Mamba is deprecated**.
+
+   Please do not create any new installations of Mamba.
+
+   Please use :ref:`Micromamba <umamba-install>` or `Miniforge <https://github.com/conda-forge/miniforge>`_ >= `23.3.1-0` instead.
+
 ``mamba`` is a CLI tool to manage ``conda`` s environments.
 
 If you already know ``conda``, great, you already know ``mamba``!

--- a/docs/source/user_guide/micromamba.rst
+++ b/docs/source/user_guide/micromamba.rst
@@ -4,116 +4,43 @@
 Micromamba User Guide
 =====================
 
-``micromamba`` is a tiny version of the ``mamba`` package manager.
-It is a statically linked C++ executable with a separate command line interface.
-It does not need a ``base`` environment and does not come with a default version of Python.
+Micromamba is a fully statically-linked, self-contained, executable written in C++.
+
+Micromamba is not require Conda to be installed on your system; it is entirely self-contained.
+
+Thus, ``base`` environment is completely empty and it does not ship Python by default.
+
+The configuration for Micromamba is slighly different from Conda:
+
+- All environments and cache will be created by default under the ``MAMBA_ROOT_PREFIX`` environment variable.
+- There is no pre-configured ``.condarc``/``.mambarc`` shipped with micromamba (they are however still read if present).
 
 
 Quickstarts
 ===========
 
-| ``micromamba`` supports a subset of all ``mamba`` or ``conda`` commands and implements a command line interface from scratch.
-| You can see all implemented commands with ``micromamba --help``:
+Micromamba's CLI interface is similar to Conda's:
 
-.. code::
+Creating environments
+---------------------
 
-  $ micromamba --help
+Use ``micromamba create -f environment.yml`` to create an environment, similar to ``conda env create``.
 
-  Subcommands:
-    shell                       Generate shell init scripts
-    create                      Create new environment
-    install                     Install packages in active environment
-    update                      Update packages in active environment
-    repoquery                   Find and analyze packages in active environment or channels
-    remove                      Remove packages from active environment
-    list                        List packages in active environment
-    package                     Extract a package or bundle files into an archive
-    clean                       Clean package cache
-    config                      Configuration of micromamba
-    info                        Information about micromamba
-    constructor                 Commands to support using micromamba in constructor
-    env                         List environments
-    activate                    Activate an environment
-    run                         Run an executable in an environment
-    ps                          Show, inspect or kill running processes
-    auth                        Login or logout of a given host
-    search                      Find packages in active environment or channels
+You can also start with an empty environment and add new packages later (see below): ``micromamba create -n myenv``.
+
+Activating environments
+-----------------------
+
+Use ``micromamba activate -n myenv`` or ``micromamba activate -p /path/to/myenv`` to :ref:`activate <activation>` an environment.
+
+Installing packages
+-------------------
+
+Use ``micromamba install mypackage`` to install a new package to the activated environment, or ``micromamba install -n myenv mypackage`` to install a new package to any other environment.
 
 
-To activate an environment just call ``micromamba activate /path/to/env`` or, when it's a named environment in your :ref:`root prefix<root-prefix>`, then you can also use ``micromamba activate myenv``.
-
-``micromamba`` expects to find the *root prefix* set by ``$MAMBA_ROOT_PREFIX`` environment variable. You can also provide it using CLI option ``-r,--root-prefix``.
-
- | Named environments then live in ``$MAMBA_ROOT_PREFIX/envs/``.
-
-For more details, please read about :ref:`configuration<configuration>`.
-
-After :ref:`activation<activation>`, you can run ``install`` to add new packages to the environment.
-
-.. code::
-
-  $ micromamba install xtensor -c conda-forge
-
-
-Using ``create``, you can also create environments:
-
-.. code::
-
-  $ micromamba create -n xtensor_env xtensor xsimd -c conda-forge
-                                             __
-            __  ______ ___  ____ _____ ___  / /_  ____ _
-           / / / / __ `__ \/ __ `/ __ `__ \/ __ \/ __ `/
-          / /_/ / / / / / / /_/ / / / / / / /_/ / /_/ /
-         / .___/_/ /_/ /_/\__,_/_/ /_/ /_/_.___/\__,_/
-        /_/
-
-  conda-forge/noarch       [====================] (00m:01s) Done
-  conda-forge/linux-64     [====================] (00m:04s) Done
-
-  Transaction
-
-    Prefix: /home/wolfv/miniconda3/envs/xtensor_env
-
-    Updating specs:
-
-    - xtensor
-    - xsimd
-
-
-    Package        Version  Build        Channel                    Size
-  ────────────────────────────────────────────────────────────────────────
-    Install:
-  ────────────────────────────────────────────────────────────────────────
-
-    _libgcc_mutex      0.1  conda_forge  conda-forge/linux-64     Cached
-    _openmp_mutex      4.5  1_gnu        conda-forge/linux-64     Cached
-    libgcc-ng        9.3.0  h5dbcf3e_17  conda-forge/linux-64     Cached
-    libgomp          9.3.0  h5dbcf3e_17  conda-forge/linux-64     Cached
-    libstdcxx-ng     9.3.0  h2ae2ef3_17  conda-forge/linux-64     Cached
-    xsimd            7.4.9  hc9558a2_0   conda-forge/linux-64     102 KB
-    xtensor         0.21.9  h0efe328_0   conda-forge/linux-64     183 KB
-    xtl             0.6.21  h0efe328_0   conda-forge/linux-64     Cached
-
-    Summary:
-
-    Install: 8 packages
-
-    Total download: 285 KB
-
-  ────────────────────────────────────────────────────────────────────────
-
-  Confirm changes: [Y/n] ...
-
-
-After the installation is finished, the environment can be :ref:`activated<activation>` with:
-
-.. code::
-
-  $ micromamba activate xtensor_env
-
-
-Specification files
-===================
+Environment specification files
+===============================
 
 The ``create`` syntax also allows you to use specification or environment files (also called *spec files*) to easily re-create environments.
 

--- a/docs/source/user_guide/micromamba.rst
+++ b/docs/source/user_guide/micromamba.rst
@@ -6,9 +6,9 @@ Micromamba User Guide
 
 Micromamba is a fully statically-linked, self-contained, executable written in C++.
 
-Micromamba is not require Conda to be installed on your system; it is entirely self-contained.
+Micromamba does not require Conda to be installed on your system; it is entirely self-contained.
 
-Thus, ``base`` environment is completely empty and it does not ship Python by default.
+Thus, its ``base`` environment is completely empty and it does not ship Python by default.
 
 The configuration for Micromamba is slighly different from Conda:
 


### PR DESCRIPTION
Maybe controversial change? I'd like to propose that we're not recommending new Mamba installations anymore. Will help keep the support volume down.

How do we trigger a RTD build?