### PR TITLE
Disabled failing test

### DIFF
--- a/micromamba/tests/test_remove.py
+++ b/micromamba/tests/test_remove.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import platform
 import shutil
 import subprocess
@@ -65,6 +66,7 @@ class TestRemove:
             assert p["name"] in env_pkgs
         assert res["actions"]["PREFIX"] == TestRemove.prefix
 
+    @pytest.mark.skipif(sys.platform == "win32", reason="This test is currently failing on Windows")
     def test_remove_orphaned(self, env_created):
         env_pkgs = [p["name"] for p in helpers.umamba_list("-p", TestRemove.prefix, "--json")]
         helpers.install("xframe", "-n", TestRemove.env_name, no_dry_run=True)


### PR DESCRIPTION
Context: `test_remove_orphaned` is now failing on Windows with the dynamic build of micromamba, while it was passing last week. The main difference that seems related in the build environment is a patch update of libsolv; pinning the version that had the test passing doe snot solve the problem, see #3061 for the failure.