### PR TITLE
handle other deps in multiple env files

### DIFF
--- a/libmamba/src/api/install.cpp
+++ b/libmamba/src/api/install.cpp
@@ -909,7 +909,20 @@ namespace mamba
                         specs.set_cli_value(updated_specs);
                     }
 
-                    others_pkg_mgrs_specs.set_value(parse_result.others_pkg_mgrs_specs);
+                    if (parse_result.others_pkg_mgrs_specs.size() != 0)
+                    {
+                        std::vector<mamba::detail::other_pkg_mgr_spec> updated_specs;
+                        if (others_pkg_mgrs_specs.cli_configured())
+                        {
+                            updated_specs = others_pkg_mgrs_specs.cli_value<
+                                std::vector<mamba::detail::other_pkg_mgr_spec>>();
+                        }
+                        for (auto& s : parse_result.others_pkg_mgrs_specs)
+                        {
+                            updated_specs.push_back(s);
+                        }
+                        others_pkg_mgrs_specs.set_cli_value(updated_specs);
+                    }
                 }
                 else
                 {


### PR DESCRIPTION
Subtle bug I caught with ordering of specs.

For external deps, i.e. pip, last-write-wins.

Instead we do the same thing as normal specs.

I attempted to write a test for this:
```
+    def test_multiple_spec_files_other_deps(self, existing_cache):
+        cmd = []
+
+        env_file_1 = Path(TestInstall.prefix, "env_1.yml")
+        env_file_1.write_text('dependencies: ["xtensor", {"pip": ["pipdep1"]}]')
+
+        env_file_2 = Path(TestInstall.prefix, "env_2.yml")
+        env_file_2.write_text('dependencies: ["xsimd", {"pip": ["pipdep2"]}]')
+
+        cmd += ["-f", str(env_file_1), "-f", str(env_file_2)]
+
+        res = helpers.install(*cmd, "--print-config-only")
```

Unfortunately, the proc config dump in the test doesn't include other package manager specs, and I couldn't chase down why. I assume because it's a struct and the yaml dumper doesn't know how to dump that struct? Anyway, here is the dumped config:
```
{'root_prefix': '/root/tmprootE6Q0C3XJ49',                                                                                                        
 'create_base': True,                                                                                                                             
 'target_prefix': '/root/tmprootE6Q0C3XJ49/envs/BAYELLYX12',                                                                                      
 'relocate_prefix': '',                                                                                                                           
 'use_target_prefix_fallback': True,                                                                                                              
 'target_prefix_checks': 18,                                                                                                                      
 'env_name': '',                                                                                                                                  
 'envs_dirs': ['/root/tmprootE6Q0C3XJ49/envs'],                                                                                                   
 'pkgs_dirs': ['/root/cacheCQYNJ9OPX8'],                                                                                                          
 'platform': 'linux-64',                                                                                                                          
 'spec_file_env_name': '',                                                                                                                        
 'specs': ['xtensor', 'pip', 'xsimd'],                                                                                                            
 'others_pkg_mgrs_specs': [],
...
```

I tested manually and it fixed the issue.