### PR TITLE
Refactor MatchSpec unlikey data

### DIFF
--- a/libmamba/CMakeLists.txt
+++ b/libmamba/CMakeLists.txt
@@ -272,6 +272,7 @@ set(
     ${LIBMAMBA_INCLUDE_DIR}/mamba/util/flat_set.hpp
     ${LIBMAMBA_INCLUDE_DIR}/mamba/util/functional.hpp
     ${LIBMAMBA_INCLUDE_DIR}/mamba/util/graph.hpp
+    ${LIBMAMBA_INCLUDE_DIR}/mamba/util/heap_optional.hpp
     ${LIBMAMBA_INCLUDE_DIR}/mamba/util/iterator.hpp
     ${LIBMAMBA_INCLUDE_DIR}/mamba/util/json.hpp
     ${LIBMAMBA_INCLUDE_DIR}/mamba/util/os_win.hpp

--- a/libmamba/include/mamba/specs/match_spec.hpp
+++ b/libmamba/include/mamba/specs/match_spec.hpp
@@ -49,6 +49,24 @@ namespace mamba::specs
         [[nodiscard]] auto build_string() const -> const BuildStringSpec&;
         void set_build_string(BuildStringSpec bs);
 
+        [[nodiscard]] auto md5() const -> std::string_view;
+        void set_md5(std::string val);
+
+        [[nodiscard]] auto sha256() const -> std::string_view;
+        void set_sha256(std::string val);
+
+        [[nodiscard]] auto license() const -> std::string_view;
+        void set_license(std::string val);
+
+        [[nodiscard]] auto license_family() const -> std::string_view;
+        void set_license_family(std::string val);
+
+        [[nodiscard]] auto features() const -> std::string_view;
+        void set_features(std::string val);
+
+        [[nodiscard]] auto track_features() const -> std::string_view;
+        void set_track_features(std::string val);
+
         [[nodiscard]] auto optional() const -> bool;
         void set_optional(bool opt);
 
@@ -62,10 +80,6 @@ namespace mamba::specs
         [[nodiscard]] auto is_simple() const -> bool;
 
         [[nodiscard]] auto is_file() const -> bool;
-
-        std::unordered_map<std::string, std::string> brackets;
-
-        std::unordered_map<std::string, std::string> parens;
 
     private:
 
@@ -84,6 +98,8 @@ namespace mamba::specs
         // TODO can put inside channel spec
         std::string m_filename;
         std::string m_url;
+
+        std::unordered_map<std::string, std::string> m_brackets = {};
 
         auto extra() -> ExtraMembers&;
     };

--- a/libmamba/include/mamba/specs/match_spec.hpp
+++ b/libmamba/include/mamba/specs/match_spec.hpp
@@ -27,9 +27,6 @@ namespace mamba::specs
         using NameSpec = GlobSpec;
         using BuildStringSpec = GlobSpec;
 
-        [[nodiscard]] static auto parse_version_and_build(std::string_view s)
-            -> std::tuple<std::string, std::string>;
-
         [[nodiscard]] static auto parse(std::string_view spec) -> MatchSpec;
 
         [[nodiscard]] static auto parse_url(std::string_view spec) -> MatchSpec;

--- a/libmamba/include/mamba/specs/match_spec.hpp
+++ b/libmamba/include/mamba/specs/match_spec.hpp
@@ -10,13 +10,13 @@
 #include <optional>
 #include <string>
 #include <string_view>
-#include <tuple>
 #include <unordered_map>
 
 #include "mamba/specs/build_number_spec.hpp"
 #include "mamba/specs/channel_spec.hpp"
 #include "mamba/specs/glob_spec.hpp"
 #include "mamba/specs/version_spec.hpp"
+#include "mamba/util/heap_optional.hpp"
 
 namespace mamba::specs
 {
@@ -69,16 +69,23 @@ namespace mamba::specs
 
     private:
 
+        struct ExtraMembers
+        {
+            bool optional = false;
+        };
+
         std::optional<ChannelSpec> m_channel;
         VersionSpec m_version;
         NameSpec m_name;
         BuildStringSpec m_build_string;
         std::string m_name_space;
         BuildNumberSpec m_build_number;
+        util::heap_optional<ExtraMembers> m_extra = {};  // unlikely data
         // TODO can put inside channel spec
         std::string m_filename;
         std::string m_url;
-        bool m_optional = false;
+
+        auto extra() -> ExtraMembers&;
     };
 }
 #endif

--- a/libmamba/include/mamba/specs/match_spec.hpp
+++ b/libmamba/include/mamba/specs/match_spec.hpp
@@ -10,7 +10,6 @@
 #include <optional>
 #include <string>
 #include <string_view>
-#include <unordered_map>
 
 #include "mamba/specs/build_number_spec.hpp"
 #include "mamba/specs/channel_spec.hpp"
@@ -85,6 +84,12 @@ namespace mamba::specs
 
         struct ExtraMembers
         {
+            std::string md5 = {};
+            std::string sha256 = {};
+            std::string license = {};
+            std::string license_family = {};
+            std::string features = {};
+            std::string track_features = {};
             bool optional = false;
         };
 
@@ -98,8 +103,6 @@ namespace mamba::specs
         // TODO can put inside channel spec
         std::string m_filename;
         std::string m_url;
-
-        std::unordered_map<std::string, std::string> m_brackets = {};
 
         auto extra() -> ExtraMembers&;
     };

--- a/libmamba/include/mamba/util/heap_optional.hpp
+++ b/libmamba/include/mamba/util/heap_optional.hpp
@@ -1,0 +1,239 @@
+// Copyright (c) 2023, QuantStack and Mamba Contributors
+//
+// Distributed under the terms of the BSD 3-Clause License.
+//
+// The full license is in the file LICENSE, distributed with this software.
+
+#ifndef MAMBA_UTIL_HEAP_OPTIONAL_HPP
+#define MAMBA_UTIL_HEAP_OPTIONAL_HPP
+
+#include <memory>
+#include <optional>
+#include <utility>
+
+namespace mamba::util
+{
+    /**
+     * An optional akin to ``std::optional`` but uses heap-allocated storage.
+     *
+     * This is useful for large unlikely data, akin to ``std::unique_ptr`` but also
+     * provides copy semantics.
+     */
+    template <typename T>
+    class heap_optional
+    {
+    public:
+
+        using element_type = T;
+        using const_element_type = const element_type;
+        using reference_type = element_type&;
+        using const_reference_type = const_element_type&;
+        using right_reference_type = element_type&&;
+        using pointer_type = element_type*;
+        using const_pointer_type = element_type*;
+
+        heap_optional() = default;
+        heap_optional(std::nullopt_t);
+        heap_optional(const heap_optional&);
+        heap_optional(heap_optional&&) noexcept = default;
+        explicit heap_optional(element_type&& obj);
+        explicit heap_optional(const element_type& obj);
+
+        auto operator=(const heap_optional&) -> heap_optional&;
+        auto operator=(heap_optional&&) noexcept -> heap_optional& = default;
+
+        [[nodiscard]] auto get() noexcept -> pointer_type;
+        [[nodiscard]] auto get() const noexcept -> const_pointer_type;
+
+        [[nodiscard]] auto operator*() const -> const_reference_type;
+        [[nodiscard]] auto operator*() -> reference_type;
+
+        [[nodiscard]] auto operator->() const noexcept -> const_pointer_type;
+        [[nodiscard]] auto operator->() noexcept -> pointer_type;
+
+        [[nodiscard]] auto has_value() const noexcept -> bool;
+        [[nodiscard]] explicit operator bool() const noexcept;
+
+        [[nodiscard]] auto value() & -> reference_type;
+        [[nodiscard]] auto value() const& -> const_reference_type;
+        [[nodiscard]] auto value() && -> right_reference_type;
+
+        template <typename U>
+        [[nodiscard]] auto value_or(U&& other) const& -> element_type;
+        template <typename U>
+        [[nodiscard]] auto value_or(U&& other) && -> element_type;
+
+        template <typename... Args>
+        auto emplace(Args&&... args) -> reference_type;
+
+        void reset();
+
+    private:
+
+        std::unique_ptr<element_type> m_ptr = nullptr;
+    };
+
+    template <typename T>
+    heap_optional(T&&) -> heap_optional<T>;
+    template <typename T>
+    heap_optional(const T&) -> heap_optional<T>;
+
+    /*************************************
+     *  Implementation of heap_optional  *
+     *************************************/
+
+    template <typename T>
+    heap_optional<T>::heap_optional(std::nullopt_t)
+    {
+    }
+
+    template <typename T>
+    heap_optional<T>::heap_optional(element_type&& obj)
+        : m_ptr(std::make_unique<element_type>(std::move(obj)))
+    {
+    }
+
+    template <typename T>
+    heap_optional<T>::heap_optional(const element_type& obj)
+        : m_ptr(std::make_unique<element_type>(obj))
+    {
+    }
+
+    template <typename T>
+    heap_optional<T>::heap_optional(const heap_optional& other)
+    {
+        if (other.has_value())
+        {
+            m_ptr = std::make_unique<T>(*other);
+        }
+    }
+
+    template <typename T>
+    auto heap_optional<T>::operator=(const heap_optional& other) -> heap_optional&
+    {
+        if (other.has_value())
+        {
+            m_ptr = std::make_unique<T>(*other);
+        }
+        else
+        {
+            m_ptr = nullptr;
+        }
+        return *this;
+    }
+
+    template <typename T>
+    auto heap_optional<T>::get() noexcept -> pointer_type
+    {
+        return m_ptr.get();
+    }
+
+    template <typename T>
+    auto heap_optional<T>::get() const noexcept -> const_pointer_type
+    {
+        return m_ptr.get();
+    }
+
+    template <typename T>
+    auto heap_optional<T>::operator*() const -> const_reference_type
+    {
+        return *m_ptr;
+    }
+
+    template <typename T>
+    auto heap_optional<T>::operator*() -> reference_type
+    {
+        return *m_ptr;
+    }
+
+    template <typename T>
+    auto heap_optional<T>::operator->() const noexcept -> const_pointer_type
+    {
+        return m_ptr.get();
+    }
+
+    template <typename T>
+    auto heap_optional<T>::operator->() noexcept -> pointer_type
+    {
+        return m_ptr.get();
+    }
+
+    template <typename T>
+    auto heap_optional<T>::has_value() const noexcept -> bool
+    {
+        return m_ptr != nullptr;
+    }
+
+    template <typename T>
+    heap_optional<T>::operator bool() const noexcept
+    {
+        return has_value();
+    }
+
+    template <typename T>
+    auto heap_optional<T>::value() & -> reference_type
+    {
+        if (has_value())
+        {
+            return *m_ptr;
+        }
+        throw std::bad_optional_access();
+    }
+
+    template <typename T>
+    auto heap_optional<T>::value() const& -> const_reference_type
+    {
+        if (has_value())
+        {
+            return *m_ptr;
+        }
+        throw std::bad_optional_access();
+    }
+
+    template <typename T>
+    auto heap_optional<T>::value() && -> right_reference_type
+    {
+        if (has_value())
+        {
+            return std::move(*m_ptr);
+        }
+        throw std::bad_optional_access();
+    }
+
+    template <typename T>
+    template <typename U>
+    auto heap_optional<T>::value_or(U&& other) const& -> element_type
+    {
+        if (has_value())
+        {
+            return *m_ptr;
+        }
+        return static_cast<element_type>(std::forward<U>(other));
+    }
+
+    template <typename T>
+    template <typename U>
+    auto heap_optional<T>::value_or(U&& other) && -> element_type
+    {
+        if (has_value())
+        {
+            return std::move(*m_ptr);
+        }
+        return static_cast<element_type>(std::forward<U>(other));
+    }
+
+    template <typename T>
+    template <typename... Args>
+    auto heap_optional<T>::emplace(Args&&... args) -> reference_type
+    {
+        m_ptr = std::make_unique<T>(std::forward<Args>(args)...);
+        return *m_ptr;
+    }
+
+    template <typename T>
+    void heap_optional<T>::reset()
+    {
+        m_ptr = nullptr;
+    }
+}
+#endif

--- a/libmamba/src/api/install.cpp
+++ b/libmamba/src/api/install.cpp
@@ -374,7 +374,7 @@ namespace mamba
                 if (hash != std::string::npos)
                 {
                     p.md5 = u.substr(hash + 1);
-                    ms.brackets["md5"] = u.substr(hash + 1);
+                    ms.set_md5(std::string(u.substr(hash + 1)));
                 }
                 pi_result.push_back(p);
                 ms_result.push_back(ms);

--- a/libmamba/src/core/transaction.cpp
+++ b/libmamba/src/core/transaction.cpp
@@ -85,14 +85,8 @@ namespace mamba
                     }
                 }
                 p.fn = ms.filename();
-                if (ms.brackets.find("md5") != ms.brackets.end())
-                {
-                    p.md5 = ms.brackets.at("md5");
-                }
-                if (ms.brackets.find("sha256") != ms.brackets.end())
-                {
-                    p.sha256 = ms.brackets.at("sha256");
-                }
+                p.md5 = ms.md5();
+                p.sha256 = ms.sha256();
             }
             return out;
         }
@@ -1390,11 +1384,15 @@ namespace mamba
                 std::string_view hash = url.substr(hash_idx + 1);
                 if (util::starts_with(hash, "sha256:"))
                 {
-                    ms.brackets["sha256"] = hash.substr(7);
+                    ms.set_sha256(std::string(hash.substr(7)));
+                }
+                if (util::starts_with(hash, "md5:"))
+                {
+                    ms.set_sha256(std::string(hash.substr(4)));
                 }
                 else
                 {
-                    ms.brackets["md5"] = hash;
+                    ms.set_md5(std::string(hash));
                 }
             }
         }

--- a/libmamba/src/specs/match_spec.cpp
+++ b/libmamba/src/specs/match_spec.cpp
@@ -155,7 +155,7 @@ namespace mamba::specs
             extract_kv(parens_str, out.parens);
             if (parens_str.find("optional") != parens_str.npos)
             {
-                out.m_optional = true;
+                out.extra().optional = true;
             }
             spec_str.erase(
                 static_cast<std::size_t>(match.position(1)),
@@ -351,12 +351,12 @@ namespace mamba::specs
 
     auto MatchSpec::optional() const -> bool
     {
-        return m_optional;
+        return m_extra.has_value() && m_extra->optional;
     }
 
     void MatchSpec::set_optional(bool opt)
     {
-        m_optional = opt;
+        extra().optional = opt;
     }
 
     void MatchSpec::set_build_string(BuildStringSpec bs)
@@ -509,5 +509,14 @@ namespace mamba::specs
     auto MatchSpec::is_file() const -> bool
     {
         return (!m_filename.empty()) || (!m_url.empty());
+    }
+
+    auto MatchSpec::extra() -> ExtraMembers&
+    {
+        if (!m_extra.has_value())
+        {
+            m_extra.emplace();
+        }
+        return *m_extra;
     }
 }

--- a/libmamba/src/specs/match_spec.cpp
+++ b/libmamba/src/specs/match_spec.cpp
@@ -139,7 +139,7 @@ namespace mamba::specs
         {
             auto brackets_str = match[1].str();
             brackets_str = brackets_str.substr(1, brackets_str.size() - 2);
-            extract_kv(brackets_str, out.brackets);
+            extract_kv(brackets_str, out.m_brackets);
             spec_str.erase(
                 static_cast<std::size_t>(match.position(1)),
                 static_cast<std::size_t>(match.length(1))
@@ -152,7 +152,7 @@ namespace mamba::specs
         {
             auto parens_str = match[1].str();
             parens_str = parens_str.substr(1, parens_str.size() - 2);
-            extract_kv(parens_str, out.parens);
+            extract_kv(parens_str, out.m_brackets);
             if (parens_str.find("optional") != parens_str.npos)
             {
                 out.extra().optional = true;
@@ -231,7 +231,7 @@ namespace mamba::specs
         // TODO think about using a hash function here, (and elsewhere), like:
         // https://hbfs.wordpress.com/2017/01/10/strings-in-c-switchcase-statements/
 
-        for (auto& [k, v] : out.brackets)
+        for (auto& [k, v] : out.m_brackets)
         {
             if (k == "build_number")
             {
@@ -347,6 +347,90 @@ namespace mamba::specs
     auto MatchSpec::build_string() const -> const BuildStringSpec&
     {
         return m_build_string;
+    }
+
+    auto MatchSpec::md5() const -> std::string_view
+    {
+        if (auto it = m_brackets.find("md5"); it != m_brackets.cend())
+        {
+            return it->second;
+        }
+        return "";
+    }
+
+    void MatchSpec::set_md5(std::string val)
+    {
+        m_brackets["md5"] = std::move(val);
+    }
+
+    auto MatchSpec::sha256() const -> std::string_view
+    {
+        if (auto it = m_brackets.find("sha256"); it != m_brackets.cend())
+        {
+            return it->second;
+        }
+        return "";
+    }
+
+    void MatchSpec::set_sha256(std::string val)
+    {
+        m_brackets["sha256"] = std::move(val);
+    }
+
+    auto MatchSpec::license() const -> std::string_view
+    {
+        if (auto it = m_brackets.find("license"); it != m_brackets.cend())
+        {
+            return it->second;
+        }
+        return "";
+    }
+
+    void MatchSpec::set_license(std::string val)
+    {
+        m_brackets["license"] = std::move(val);
+    }
+
+    auto MatchSpec::license_family() const -> std::string_view
+    {
+        if (auto it = m_brackets.find("license_family"); it != m_brackets.cend())
+        {
+            return it->second;
+        }
+        return "";
+    }
+
+    void MatchSpec::set_license_family(std::string val)
+    {
+        m_brackets["license_family"] = std::move(val);
+    }
+
+    auto MatchSpec::features() const -> std::string_view
+    {
+        if (auto it = m_brackets.find("features"); it != m_brackets.cend())
+        {
+            return it->second;
+        }
+        return "";
+    }
+
+    void MatchSpec::set_features(std::string val)
+    {
+        m_brackets["features"] = std::move(val);
+    }
+
+    auto MatchSpec::track_features() const -> std::string_view
+    {
+        if (auto it = m_brackets.find("track_features"); it != m_brackets.cend())
+        {
+            return it->second;
+        }
+        return "";
+    }
+
+    void MatchSpec::set_track_features(std::string val)
+    {
+        m_brackets["track_features"] = std::move(val);
     }
 
     auto MatchSpec::optional() const -> bool
@@ -469,16 +553,16 @@ namespace mamba::specs
         }
         for (const auto& key : check)
         {
-            if (brackets.find(key) != brackets.end())
+            if (m_brackets.find(key) != m_brackets.end())
             {
-                if (brackets.at(key).find_first_of("= ,") != std::string::npos)
+                if (m_brackets.at(key).find_first_of("= ,") != std::string::npos)
                 {
                     // need quoting
-                    formatted_brackets.push_back(util::concat(key, "='", brackets.at(key), "'"));
+                    formatted_brackets.push_back(util::concat(key, "='", m_brackets.at(key), "'"));
                 }
                 else
                 {
-                    formatted_brackets.push_back(util::concat(key, "=", brackets.at(key)));
+                    formatted_brackets.push_back(util::concat(key, "=", m_brackets.at(key)));
                 }
             }
         }

--- a/libmamba/tests/CMakeLists.txt
+++ b/libmamba/tests/CMakeLists.txt
@@ -30,6 +30,7 @@ set(
     src/util/test_flat_bool_expr_tree.cpp
     src/util/test_flat_set.cpp
     src/util/test_graph.cpp
+    src/util/test_heap_optional.cpp
     src/util/test_iterator.cpp
     src/util/test_os_win.cpp
     src/util/test_path_manip.cpp

--- a/libmamba/tests/src/specs/test_match_spec.cpp
+++ b/libmamba/tests/src/specs/test_match_spec.cpp
@@ -18,51 +18,6 @@ TEST_SUITE("specs::match_spec")
 {
     using PlatformSet = typename util::flat_set<std::string>;
 
-    TEST_CASE("parse_version_build")
-    {
-        std::string v, b;
-        // >>> _parse_version_plus_build("=1.2.3 0")
-        // ('=1.2.3', '0')
-        // >>> _parse_version_plus_build("1.2.3=0")
-        // ('1.2.3', '0')
-        // >>> _parse_version_plus_build(">=1.0 , < 2.0 py34_0")
-        // ('>=1.0,<2.0', 'py34_0')
-        // >>> _parse_version_plus_build(">=1.0 , < 2.0 =py34_0")
-        // ('>=1.0,<2.0', 'py34_0')
-        // >>> _parse_version_plus_build("=1.2.3 ")
-        // ('=1.2.3', None)
-        // >>> _parse_version_plus_build(">1.8,<2|==1.7")
-        // ('>1.8,<2|==1.7', None)
-        // >>> _parse_version_plus_build("* openblas_0")
-        // ('*', 'openblas_0')
-        // >>> _parse_version_plus_build("* *")
-        // ('*', '*')
-        std::tie(v, b) = MatchSpec::parse_version_and_build("=1.2.3 0");
-        CHECK_EQ(v, "=1.2.3");
-        CHECK_EQ(b, "0");
-        std::tie(v, b) = MatchSpec::parse_version_and_build("=1.2.3=0");
-        CHECK_EQ(v, "=1.2.3");
-        CHECK_EQ(b, "0");
-        std::tie(v, b) = MatchSpec::parse_version_and_build(">=1.0 , < 2.0 py34_0");
-        CHECK_EQ(v, ">=1.0,<2.0");
-        CHECK_EQ(b, "py34_0");
-        std::tie(v, b) = MatchSpec::parse_version_and_build(">=1.0 , < 2.0 =py34_0");
-        CHECK_EQ(v, ">=1.0,<2.0");
-        CHECK_EQ(b, "py34_0");
-        std::tie(v, b) = MatchSpec::parse_version_and_build("=1.2.3 ");
-        CHECK_EQ(v, "=1.2.3");
-        CHECK_EQ(b, "");
-        std::tie(v, b) = MatchSpec::parse_version_and_build(">1.8,<2|==1.7");
-        CHECK_EQ(v, ">1.8,<2|==1.7");
-        CHECK_EQ(b, "");
-        std::tie(v, b) = MatchSpec::parse_version_and_build("* openblas_0");
-        CHECK_EQ(v, "*");
-        CHECK_EQ(b, "openblas_0");
-        std::tie(v, b) = MatchSpec::parse_version_and_build("* *");
-        CHECK_EQ(v, "*");
-        CHECK_EQ(b, "*");
-    }
-
     TEST_CASE("parse")
     {
         {

--- a/libmamba/tests/src/specs/test_match_spec.cpp
+++ b/libmamba/tests/src/specs/test_match_spec.cpp
@@ -49,10 +49,8 @@ TEST_SUITE("specs::match_spec")
         }
         {
             auto ms = MatchSpec::parse("numpy[version='1.7|1.8']");
-            // TODO!
-            // CHECK_EQ(ms.version, "1.7|1.8");
             CHECK_EQ(ms.name().str(), "numpy");
-            CHECK_EQ(ms.brackets["version"], "1.7|1.8");
+            CHECK_EQ(ms.version().str(), "==1.7|==1.8");
             CHECK_EQ(ms.str(), "numpy[version='==1.7|==1.8']");
         }
         {
@@ -70,20 +68,17 @@ TEST_SUITE("specs::match_spec")
             CHECK_EQ(ms.name().str(), "foo");
             REQUIRE(ms.channel().has_value());
             CHECK_EQ(ms.channel()->location(), "conda-forge");
-            CHECK_EQ(ms.brackets["build"], "3");
-            CHECK_EQ(ms.parens["target"], "blarg");
+            CHECK_EQ(ms.build_string().str(), "3");
             CHECK_EQ(ms.optional(), true);
         }
         {
             auto ms = MatchSpec::parse("python[build_number=3]");
             CHECK_EQ(ms.name().str(), "python");
-            CHECK_EQ(ms.brackets["build_number"], "3");
             CHECK_EQ(ms.build_number().str(), "=3");
         }
         {
             auto ms = MatchSpec::parse("python[build_number='<=3']");
             CHECK_EQ(ms.name().str(), "python");
-            CHECK_EQ(ms.brackets["build_number"], "<=3");
             CHECK_EQ(ms.build_number().str(), "<=3");
         }
         {
@@ -146,10 +141,6 @@ TEST_SUITE("specs::match_spec")
                 "xtensor[url=file:///home/wolfv/Downloads/xtensor-0.21.4-hc9558a2_0.tar.bz2]"
             );
             CHECK_EQ(ms.name().str(), "xtensor");
-            CHECK_EQ(
-                ms.brackets["url"],
-                "file:///home/wolfv/Downloads/xtensor-0.21.4-hc9558a2_0.tar.bz2"
-            );
             CHECK_EQ(ms.url(), "file:///home/wolfv/Downloads/xtensor-0.21.4-hc9558a2_0.tar.bz2");
         }
         {

--- a/libmamba/tests/src/specs/test_match_spec.cpp
+++ b/libmamba/tests/src/specs/test_match_spec.cpp
@@ -152,14 +152,14 @@ TEST_SUITE("specs::match_spec")
             auto ms = MatchSpec::parse("foo=1.0=2[md5=123123123, license=BSD-3, fn='test 123.tar.bz2']"
             );
             CHECK_EQ(ms.conda_build_form(), "foo 1.0.* 2");
-            CHECK_EQ(ms.str(), "foo=1.0=2[md5=123123123,license=BSD-3,fn='test 123.tar.bz2']");
+            CHECK_EQ(ms.str(), R"ms(foo=1.0=2[fn="test 123.tar.bz2",md5=123123123,license=BSD-3])ms");
         }
         {
             auto ms = MatchSpec::parse(
                 "foo=1.0=2[md5=123123123, license=BSD-3, fn='test 123.tar.bz2', url='abcdef']"
             );
             CHECK_EQ(ms.conda_build_form(), "foo 1.0.* 2");
-            CHECK_EQ(ms.str(), "foo=1.0=2[url=abcdef,md5=123123123,license=BSD-3]");
+            CHECK_EQ(ms.str(), R"ms(foo=1.0=2[url=abcdef,md5=123123123,license=BSD-3])ms");
         }
         {
             auto ms = MatchSpec::parse("libblas=*=*mkl");

--- a/libmamba/tests/src/util/test_heap_optional.cpp
+++ b/libmamba/tests/src/util/test_heap_optional.cpp
@@ -1,0 +1,148 @@
+// Copyright (c) 2023, QuantStack and Mamba Contributors
+//
+// Distributed under the terms of the BSD 3-Clause License.
+//
+// The full license is in the file LICENSE, distributed with this software.
+
+#include <doctest/doctest.h>
+
+#include "mamba/util/heap_optional.hpp"
+
+using namespace mamba::util;
+
+TEST_SUITE("util::heap_optional")
+{
+    TEST_CASE("heap_optional")
+    {
+        SUBCASE("Without value")
+        {
+            auto opt = heap_optional<int>();
+            CHECK_FALSE(opt.has_value());
+            CHECK_FALSE(opt);
+            CHECK_EQ(opt.get(), nullptr);
+
+            SUBCASE("Emplace data")
+            {
+                opt.emplace(3);
+                CHECK(opt.has_value());
+                CHECK(opt);
+                REQUIRE_NE(opt.get(), nullptr);
+                CHECK_EQ(*opt, 3);
+            }
+
+            SUBCASE("Reset")
+            {
+                opt.reset();
+                CHECK_FALSE(opt.has_value());
+                CHECK_FALSE(opt);
+                CHECK_EQ(opt.get(), nullptr);
+            }
+
+            SUBCASE("Value")
+            {
+                // Silence [[nodiscard]] warnings
+                auto lref = [](heap_optional<int>& o) { return o.value(); };
+                CHECK_THROWS_AS(lref(opt), std::bad_optional_access);
+                auto clref = [](const heap_optional<int>& o) { return o.value(); };
+                CHECK_THROWS_AS(clref(opt), std::bad_optional_access);
+                auto rref = [](heap_optional<int>& o) { return std::move(o).value(); };
+                CHECK_THROWS_AS(rref(opt), std::bad_optional_access);
+            }
+
+            SUBCASE("Value Or")
+            {
+                CHECK_EQ(opt.value_or(42), 42);
+                CHECK_EQ(const_cast<const heap_optional<int>&>(opt).value_or(42), 42);
+                CHECK_EQ(std::move(opt).value_or(42), 42);
+            }
+        }
+
+        SUBCASE("With copy and move value")
+        {
+            auto opt = heap_optional(std::string("hello"));
+            using Opt = heap_optional<std::string>;
+            static_assert(std::is_same_v<decltype(opt), Opt>);
+
+            CHECK(opt.has_value());
+            CHECK(opt);
+            REQUIRE_NE(opt.get(), nullptr);
+            CHECK_EQ(*opt, "hello");
+            CHECK_EQ(opt->size(), 5);
+
+            SUBCASE("Emplace data")
+            {
+                opt.emplace("bonjour");
+                CHECK(opt.has_value());
+                CHECK(opt);
+                REQUIRE_NE(opt.get(), nullptr);
+                CHECK_EQ(*opt, "bonjour");
+                CHECK_EQ(opt->size(), 7);
+            }
+
+            SUBCASE("Reset")
+            {
+                opt.reset();
+                CHECK_FALSE(opt.has_value());
+                CHECK_FALSE(opt);
+                CHECK_EQ(opt.get(), nullptr);
+            }
+
+            SUBCASE("Value")
+            {
+                CHECK_EQ(opt.value(), "hello");
+                CHECK_EQ(const_cast<const Opt&>(opt).value(), "hello");
+                CHECK_EQ(std::move(opt).value(), "hello");
+            }
+
+            SUBCASE("Value Or")
+            {
+                CHECK_EQ(opt.value_or("world"), "hello");
+                CHECK_EQ(const_cast<const Opt&>(opt).value_or("world"), "hello");
+                CHECK_EQ(std::move(opt).value_or("world"), "hello");
+            }
+        }
+
+        SUBCASE("With move only value")
+        {
+            auto opt = heap_optional(std::make_unique<int>(3));
+            using Opt = heap_optional<std::unique_ptr<int>>;
+            static_assert(std::is_same_v<decltype(opt), Opt>);
+
+            CHECK(opt.has_value());
+            CHECK(opt);
+            REQUIRE_NE(opt.get(), nullptr);
+            CHECK_EQ(**opt, 3);
+            CHECK_EQ(*(opt->get()), 3);
+
+            SUBCASE("Emplace data")
+            {
+                opt.emplace(std::make_unique<int>(5));
+                CHECK(opt.has_value());
+                CHECK(opt);
+                REQUIRE_NE(opt.get(), nullptr);
+                CHECK_EQ(**opt, 5);
+                CHECK_EQ(*(opt->get()), 5);
+            }
+
+            SUBCASE("Reset")
+            {
+                opt.reset();
+                CHECK_FALSE(opt.has_value());
+                CHECK_FALSE(opt);
+                CHECK_EQ(opt.get(), nullptr);
+            }
+
+            SUBCASE("Value")
+            {
+                CHECK_EQ(*(opt.value()), 3);
+                CHECK_EQ(*(const_cast<const Opt&>(opt).value()), 3);
+                CHECK_EQ(*(std::move(opt).value()), 3);
+            }
+
+            SUBCASE("Value Or")
+            {
+                CHECK_EQ(*(std::move(opt).value_or(std::make_unique<int>(5))), 3);
+            }
+        }
+    }
+}

--- a/libmamba/tests/src/util/test_os_win.cpp
+++ b/libmamba/tests/src/util/test_os_win.cpp
@@ -14,9 +14,9 @@
 
 using namespace mamba::util;
 
-TEST_SUITE("uti::os_win")
+TEST_SUITE("util::os_win")
 {
-    TEST_CASE("")
+    TEST_CASE("utf8")
     {
         const std::wstring text_utf16 = L"Hello, I am Joël. 私のにほんごわへたです";
         const std::string text_utf8 = u8"Hello, I am Joël. 私のにほんごわへたです";


### PR DESCRIPTION
- Add BuildNumberSpec
- Fix test case name
- use BuildNumberSpec in MatchSpec
- Fix BuildNumberSpec
- Hide MatchSpec implementation detail
- Add heap_optional
- Refactor MatchSpec unlikely members
