### PR TITLE
Warning around manual install and add ref to conda-libmamba

### DIFF
--- a/docs/source/developer_zone/changes-2.0.rst
+++ b/docs/source/developer_zone/changes-2.0.rst
@@ -33,6 +33,7 @@ Micromamba
 Micromamba recieves all new features and its CLI remains mostly unchanged.
 
 Breaking changes include:
+
 - ``micromamba shell init`` root prefix parameter ``--prefix`` (``-p``) was renamed
   ``--root-prefix`` (``-r``).
   Both options were supported in version ``1.5``.
@@ -78,6 +79,7 @@ Libmamba (C++)
 The C++ library ``libmamba`` has received significant changes.
 Due to the low usage of the C++ interface, all changes are not listed here.
 The main changes are:
+
 - Refactoring and testing of a large number of utilities into a ``util::`` namespace,
 - Creation of the ``specs::`` with:
     - Implementations of ``Version`` and ``VersionSpec`` for matching versions,

--- a/docs/source/installation/mamba-installation.rst
+++ b/docs/source/installation/mamba-installation.rst
@@ -48,3 +48,12 @@ images:
 .. code-block:: bash
 
   docker run -it --rm condaforge/miniforge3:latest mamba info
+
+
+Conda libmamba solver
+*********************
+
+For a totally conda-compatible experience with the fast Mamba solver,
+`conda-libmamba-solver <https://github.com/conda/conda-libmamba-solver>`_ now ships by default with
+Conda.
+Just use an up to date version of Conda to enjoy the speed improvememts.

--- a/docs/source/installation/micromamba-installation.rst
+++ b/docs/source/installation/micromamba-installation.rst
@@ -31,6 +31,10 @@ Mamba-org releases
 Automatic install
 ^^^^^^^^^^^^^^^^^
 
+.. hint::
+
+   This is the recommended way to install micromamba.
+
 If you are using macOS, Linux, or Git Bash on Windows there is a simple way of installing ``micromamba``.
 Simply execute the installation script in your preferred shell.
 
@@ -48,12 +52,6 @@ On Windows Powershell, use
 
    Invoke-Expression ((Invoke-WebRequest -Uri https://micro.mamba.pm/install.ps1).Content)
 
-.. note::
-
-   The installation instructions executed by this script are available on
-   `mamba-org/micromamba-releases <https://github.com/mamba-org/micromamba-releases>`_.
-   Feel free to have a look and remix the steps as you see fit for a custom installation.
-
 Self updates
 ^^^^^^^^^^^^
 Once installed, ``micromamba`` can be updated with
@@ -67,6 +65,109 @@ A explicit version can be specified with
 .. code-block:: bash
 
    micromamba self-update --version 1.4.6
+
+Manual installation
+^^^^^^^^^^^^^^^^^^^
+
+.. warning::
+
+   This is for advanced users.
+
+.. _umamba-install-posix:
+
+Linux and macOS
+~~~~~~~~~~~~~~~
+
+Download and unzip the executable (from the official conda-forge package):
+
+Ensure that basic utilities are installed. We need ``curl`` and ``tar`` with support for ``bzip2``.
+Also you need a glibc based system like Ubuntu, Fedora or Centos (Alpine Linux does not work natively).
+
+The following magic URL always returns the latest available version of micromamba, and the ``bin/micromamba`` part is automatically extracted using ``tar``.
+
+.. code:: bash
+
+  # Linux Intel (x86_64):
+  curl -Ls https://micro.mamba.pm/api/micromamba/linux-64/latest | tar -xvj bin/micromamba
+  # Linux ARM64:
+  curl -Ls https://micro.mamba.pm/api/micromamba/linux-aarch64/latest | tar -xvj bin/micromamba
+  # Linux Power:
+  curl -Ls https://micro.mamba.pm/api/micromamba/linux-ppc64le/latest | tar -xvj bin/micromamba
+  # macOS Intel (x86_64):
+  curl -Ls https://micro.mamba.pm/api/micromamba/osx-64/latest | tar -xvj bin/micromamba
+  # macOS Silicon/M1 (ARM64):
+  curl -Ls https://micro.mamba.pm/api/micromamba/osx-arm64/latest | tar -xvj bin/micromamba
+
+After extraction is completed, we can use the micromamba binary.
+
+If you want to quickly use micromamba in an ad-hoc usecase, you can run
+
+.. code:: bash
+
+  export MAMBA_ROOT_PREFIX=/some/prefix  # optional, defaults to ~/micromamba
+  eval "$(./bin/micromamba shell hook -s posix)"
+
+This shell hook modifies your shell variables to include the micromamba command.
+
+If you want to persist these changes, you can automatically write them to your ``.bashrc`` (or ``.zshrc``) by running ``./micromamba shell init ...``.
+This also allows you to choose a custom MAMBA_ROOT_ENVIRONMENT, which is where the packages and repodata cache will live.
+
+.. code:: sh
+
+  # Linux/bash:
+  ./bin/micromamba shell init -s bash -p ~/micromamba  # this writes to your .bashrc file
+  # sourcing the bashrc file incorporates the changes into the running session.
+  # better yet, restart your terminal!
+  source ~/.bashrc
+
+  # macOS/zsh:
+  ./micromamba shell init -s zsh -p ~/micromamba
+  source ~/.zshrc
+
+Now you can activate the base environment and install new packages, or create other environments.
+
+.. code:: bash
+
+  micromamba activate  # this activates the base environment
+  micromamba install python=3.6 jupyter -c conda-forge
+  # or
+  micromamba create -n env_name xtensor -c conda-forge
+  micromamba activate env_name
+
+An exclusive `conda-forge <https://conda-forge.org/>`_ setup can be configured with:
+
+.. code-block:: bash
+
+   micromamba config append channels conda-forge
+   micromamba config set channel_priority strict
+
+.. _umamba-install-win:
+
+Windows
+~~~~~~~
+
+| ``micromamba`` also has Windows support! For Windows, we recommend powershell.
+| Below are the commands to get micromamba installed in ``PowerShell``.
+
+.. code-block:: powershell
+
+  Invoke-Webrequest -URI https://micro.mamba.pm/api/micromamba/win-64/latest -OutFile micromamba.tar.bz2
+  tar xf micromamba.tar.bz2
+
+  MOVE -Force Library\bin\micromamba.exe micromamba.exe
+  .\micromamba.exe --help
+
+  # You can use e.g. $HOME\micromambaenv as your base prefix
+  $Env:MAMBA_ROOT_PREFIX="C:\Your\Root\Prefix"
+
+  # Invoke the hook
+  .\micromamba.exe shell hook -s powershell | Out-String | Invoke-Expression
+
+  # ... or initialize the shell
+  .\micromamba.exe shell init -s powershell -p C:\Your\Root\Prefix
+  # and use micromamba directly
+  micromamba create -f ./test/env_win.yaml -y
+  micromamba activate yourenv
 
 
 Nightly builds

--- a/docs/source/installation/micromamba-installation.rst
+++ b/docs/source/installation/micromamba-installation.rst
@@ -28,8 +28,8 @@ On macOS, you can install ``micromamba`` from `Homebrew <https://brew.sh/>`_:
 
 Mamba-org releases
 ******************
-Install script
-^^^^^^^^^^^^^^
+Automatic install
+^^^^^^^^^^^^^^^^^
 
 If you are using macOS, Linux, or Git Bash on Windows there is a simple way of installing ``micromamba``.
 Simply execute the installation script in your preferred shell.
@@ -41,6 +41,18 @@ For Linux, macOS, or Git Bash on Windows install with:
 .. code:: bash
 
    "${SHELL}" <(curl -L micro.mamba.pm/install.sh)
+
+On Windows Powershell, use
+
+.. code :: powershell
+
+   Invoke-Expression ((Invoke-WebRequest -Uri https://micro.mamba.pm/install.ps1).Content)
+
+.. note::
+
+   The installation instructions executed by this script are available on
+   `mamba-org/micromamba-releases <https://github.com/mamba-org/micromamba-releases>`_.
+   Feel free to have a look and remix the steps as you see fit for a custom installation.
 
 Self updates
 ^^^^^^^^^^^^
@@ -56,106 +68,6 @@ A explicit version can be specified with
 
    micromamba self-update --version 1.4.6
 
-.. _umamba-install-manual-installation:
-
-Manual installation
-^^^^^^^^^^^^^^^^^^^
-
-.. _umamba-install-posix:
-
-Linux and macOS
-~~~~~~~~~~~~~~~
-
-Download and unzip the executable (from the official conda-forge package):
-
-Ensure that basic utilities are installed. We need ``curl`` and ``tar`` with support for ``bzip2``.
-Also you need a glibc based system like Ubuntu, Fedora or Centos (Alpine Linux does not work natively).
-
-The following magic URL always returns the latest available version of micromamba, and the ``bin/micromamba`` part is automatically extracted using ``tar``.
-
-.. code:: bash
-
-  # Linux Intel (x86_64):
-  curl -Ls https://micro.mamba.pm/api/micromamba/linux-64/latest | tar -xvj bin/micromamba
-  # Linux ARM64:
-  curl -Ls https://micro.mamba.pm/api/micromamba/linux-aarch64/latest | tar -xvj bin/micromamba
-  # Linux Power:
-  curl -Ls https://micro.mamba.pm/api/micromamba/linux-ppc64le/latest | tar -xvj bin/micromamba
-  # macOS Intel (x86_64):
-  curl -Ls https://micro.mamba.pm/api/micromamba/osx-64/latest | tar -xvj bin/micromamba
-  # macOS Silicon/M1 (ARM64):
-  curl -Ls https://micro.mamba.pm/api/micromamba/osx-arm64/latest | tar -xvj bin/micromamba
-
-After extraction is completed, we can use the micromamba binary.
-
-If you want to quickly use micromamba in an ad-hoc usecase, you can run
-
-.. code:: bash
-
-  export MAMBA_ROOT_PREFIX=/some/prefix  # optional, defaults to ~/micromamba
-  eval "$(./bin/micromamba shell hook -s posix)"
-
-This shell hook modifies your shell variables to include the micromamba command.
-
-If you want to persist these changes, you can automatically write them to your ``.bashrc`` (or ``.zshrc``) by running ``./micromamba shell init ...``.
-This also allows you to choose a custom MAMBA_ROOT_ENVIRONMENT, which is where the packages and repodata cache will live.
-
-.. code:: sh
-
-  # Linux/bash:
-  ./bin/micromamba shell init -s bash -p ~/micromamba  # this writes to your .bashrc file
-  # sourcing the bashrc file incorporates the changes into the running session.
-  # better yet, restart your terminal!
-  source ~/.bashrc
-
-  # macOS/zsh:
-  ./micromamba shell init -s zsh -p ~/micromamba
-  source ~/.zshrc
-
-Now you can activate the base environment and install new packages, or create other environments.
-
-.. code:: bash
-
-  micromamba activate  # this activates the base environment
-  micromamba install python=3.6 jupyter -c conda-forge
-  # or
-  micromamba create -n env_name xtensor -c conda-forge
-  micromamba activate env_name
-
-An exclusive `conda-forge <https://conda-forge.org/>`_ setup can be configured with:
-
-.. code-block:: bash
-
-   micromamba config append channels conda-forge
-   micromamba config set channel_priority strict
-
-.. _umamba-install-win:
-
-Windows
-~~~~~~~
-
-| ``micromamba`` also has Windows support! For Windows, we recommend powershell.
-| Below are the commands to get micromamba installed in ``PowerShell``.
-
-.. code-block:: powershell
-
-  Invoke-Webrequest -URI https://micro.mamba.pm/api/micromamba/win-64/latest -OutFile micromamba.tar.bz2
-  tar xf micromamba.tar.bz2
-
-  MOVE -Force Library\bin\micromamba.exe micromamba.exe
-  .\micromamba.exe --help
-
-  # You can use e.g. $HOME\micromambaenv as your base prefix
-  $Env:MAMBA_ROOT_PREFIX="C:\Your\Root\Prefix"
-
-  # Invoke the hook
-  .\micromamba.exe shell hook -s powershell | Out-String | Invoke-Expression
-
-  # ... or initialize the shell
-  .\micromamba.exe shell init -s powershell -p C:\Your\Root\Prefix
-  # and use micromamba directly
-  micromamba create -f ./test/env_win.yaml -y
-  micromamba activate yourenv
 
 Nightly builds
 **************
@@ -173,6 +85,7 @@ image can be used to run ``micromamba`` without installing it:
 .. code-block:: bash
 
   docker run -it --rm mambaorg/micromamba:latest micromamba info
+
 
 Build from source
 *****************

--- a/docs/source/usage/specs.rst
+++ b/docs/source/usage/specs.rst
@@ -92,7 +92,7 @@ user-friendly string, but that may not be parsed back.
 
 
 UnresolvedChannel
-----------------
+-----------------
 
 A :cpp:type:`UnresolvedChannel <mamba::specs::UnresolvedChannel>` is a lightweight object to represent
 a channel string, as in passed in the CLI or configuration.


### PR DESCRIPTION
The manual installation take a lot of visual space (and distract inexperienced users) while they provide little value.
I cannot imagine someone wanting a manual install that cannot simply go lookup the steps in `install.sh` and adapt as needed, as suggested in the new `:: note:`.
