### PR TITLE
1.x: Fix repoquery subcommand for Python 3.11/3.12 

### DIFF
--- a/mamba/mamba/mamba.py
+++ b/mamba/mamba/mamba.py
@@ -769,7 +769,7 @@ def do_call(args, parser):
         exit_code = update(args, parser)
     elif relative_mod == ".main_init":
         exit_code = shell_init(args)
-    elif relative_mod in (".main_repoquery", "repoquery"):
+    elif relative_mod in (".main_repoquery", ".repoquery"):
         exit_code = repoquery(args, parser)
     else:
         print(

--- a/mamba/mamba/mamba.py
+++ b/mamba/mamba/mamba.py
@@ -778,7 +778,7 @@ def do_call(args, parser):
             " deactivate are supported through mamba."
         )
 
-        return 0
+        return 1
     return exit_code
 
 


### PR DESCRIPTION
We had a small typo in gh-3036 which caused the `args.func == ".repoquery"` case to not be caught.
For Python versions prior to 3.11 the `args._plugin_subcommand == ".main_repoquery"` case has been handled correctly which is why we didn't see problems with `mamba repoquery` for those versions.

Our tests did not catch this since `mamba` returned a zero exit code in case of not recognized commands.
This PR changes it to return exit code `1` in these cases now.
(N.B.: Cases like `mamba completely-unknown-command` are handled with non-zero exit code by `argparse`.)

Fixes gh-2994 .
Fixes gh-3033 .
