### PR TITLE
Support `pip --no-deps` in spec files

### DIFF
--- a/libmamba/src/api/install.cpp
+++ b/libmamba/src/api/install.cpp
@@ -281,12 +281,12 @@ namespace mamba
                                 }
                             }
                         }
-                        else if (key == "pip")
+                        else if (key == "pip" || key == "pip --no-deps")
                         {
                             const auto yaml_parent_path = fs::absolute(yaml_file).parent_path().string(
                             );
                             result.others_pkg_mgrs_specs.push_back({
-                                "pip",
+                                key,
                                 map_el.second.as<std::vector<std::string>>(),
                                 yaml_parent_path,
                             });

--- a/micromamba/tests/test_install.py
+++ b/micromamba/tests/test_install.py
@@ -109,6 +109,25 @@ class TestInstall:
         assert res["env_name"] == ""
         assert res["specs"] == specs
 
+    def test_spec_pip_nodeps(self, existing_cache):
+        spec_file = os.path.join(TestInstall.root_prefix, "spec.yml")
+
+        file_content = [
+            "dependencies:",
+            "  - xtensor >0.20",
+            "  - pip --no-deps:",
+            "    - pandas",
+        ]
+
+        with open(spec_file, "w") as f:
+            f.write("\n".join(file_content))
+
+        res = helpers.install("-f", spec_file, "--print-config-only")
+
+        TestInstall.config_tests(res)
+        assert res["env_name"] == ""
+        assert "pip" in res["specs"]
+
     @pytest.mark.parametrize("root_prefix", (None, "env_var", "cli"))
     @pytest.mark.parametrize("target_is_root", (False, True))
     @pytest.mark.parametrize("cli_prefix", (False, True))


### PR DESCRIPTION
`pip --no-deps` seems to be a supported third-party package manager. However, with a spec file, there's no way to specify it. The rest of the plumbing is already in-place.

Quick tweak to support specifying it in spec files.

Testing is tough because the response doesn't contain the third-party packages to be installed. I did check though that `pip` was accurately picked up.