### PR TITLE
Simple logging fix

### DIFF
--- a/libmamba/CMakeLists.txt
+++ b/libmamba/CMakeLists.txt
@@ -73,7 +73,6 @@ endif()
 
 # TODO: move this into the mamba_create_target macro
 if(BUILD_STATIC)
-    add_definitions("-DSPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_${BUILD_LOG_LEVEL}")
     add_definitions(-DLIBMAMBA_STATIC_DEPS)
 endif()
 
@@ -410,22 +409,31 @@ macro(libmamba_create_target target_name linkage output_name)
     # ======
     add_library(${target_name} ${linkage_upper} ${LIBMAMBA_PUBLIC_HEADERS} ${LIBMAMBA_SOURCES})
 
+    target_include_directories(
+        ${target_name}
+        PUBLIC $<BUILD_INTERFACE:${LIBMAMBA_INCLUDE_DIR}> $<INSTALL_INTERFACE:include>
+        PRIVATE ${LIBMAMBA_SOURCE_DIR}
+    )
+
     # Header only libraries are always linked the same way
     target_link_libraries(${target_name} PUBLIC tl::expected nlohmann_json::nlohmann_json)
+
+    target_compile_features(${target_name} PUBLIC cxx_std_17)
 
     mamba_target_add_compile_warnings(${target_name} WARNING_AS_ERROR ${MAMBA_WARNING_AS_ERROR})
     mamba_target_set_lto(${target_name} MODE ${MAMBA_LTO})
 
+    # For some reasons, using target_compile_definitions does not set the definitions properly
+    add_compile_definitions(
+        SPDLOG_FMT_EXTERNAL "SPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_${BUILD_LOG_LEVEL}"
+    )
+
     if(${linkage_upper} STREQUAL "STATIC")
         message("   -> Statically linking against libmamba (static) dependencies")
-
-        target_compile_definitions(${target_name} PUBLIC SPDLOG_FMT_EXTERNAL)
 
         mamba_target_check_type(yaml-cpp::yaml-cpp STATIC_LIBRARY FATAL_ERROR)
         mamba_target_check_type(reproc STATIC_LIBRARY FATAL_ERROR)
         mamba_target_check_type(reproc++ STATIC_LIBRARY FATAL_ERROR)
-
-        target_compile_definitions(${target_name} PUBLIC SPDLOG_FMT_EXTERNAL)
 
         target_link_libraries(
             ${target_name}
@@ -560,8 +568,6 @@ macro(libmamba_create_target target_name linkage output_name)
         find_package(BZip2 REQUIRED)
         find_package(OpenSSL REQUIRED)
 
-        target_compile_definitions(${target_name} PUBLIC SPDLOG_FMT_EXTERNAL)
-
         target_link_libraries(
             ${target_name}
             PUBLIC
@@ -588,22 +594,14 @@ macro(libmamba_create_target target_name linkage output_name)
         )
     endif()
 
-    target_compile_features(${target_name} PUBLIC cxx_std_17)
-
-    target_include_directories(
-        ${target_name}
-        PUBLIC $<BUILD_INTERFACE:${LIBMAMBA_INCLUDE_DIR}> $<INSTALL_INTERFACE:include>
-    )
-
     if(WIN32)
         find_path(
             WINREG_INCLUDE_DIR
             NAMES WinReg.hpp
             PATH_SUFFIXES winreg
         )
+        target_include_directories(${target_name} PRIVATE ${WINREG_INCLUDE_DIR})
     endif()
-
-    target_include_directories(${target_name} PRIVATE ${LIBMAMBA_SOURCE_DIR} ${WINREG_INCLUDE_DIR})
 
     if(UNIX)
         math(EXPR LIBMAMBA_BINARY_COMPATIBLE "${LIBMAMBA_BINARY_CURRENT} - ${LIBMAMBA_BINARY_AGE}")

--- a/libmamba/include/mamba/core/output.hpp
+++ b/libmamba/include/mamba/core/output.hpp
@@ -124,6 +124,7 @@ namespace mamba
         Console& operator=(Console&&) = delete;
 
         static Console& instance();
+        static bool has_instance();
         static ConsoleStream stream();
         static bool prompt(std::string_view message, char fallback = '_');
         static bool prompt(std::string_view message, char fallback, std::istream& input_stream);

--- a/libmamba/include/mamba/core/output.hpp
+++ b/libmamba/include/mamba/core/output.hpp
@@ -124,7 +124,7 @@ namespace mamba
         Console& operator=(Console&&) = delete;
 
         static Console& instance();
-        static bool has_instance();
+        static bool is_available();
         static ConsoleStream stream();
         static bool prompt(std::string_view message, char fallback = '_');
         static bool prompt(std::string_view message, char fallback, std::istream& input_stream);

--- a/libmamba/src/core/output.cpp
+++ b/libmamba/src/core/output.cpp
@@ -557,7 +557,7 @@ namespace mamba
 
     MessageLogger::~MessageLogger()
     {
-        if (!MessageLoggerData::use_buffer && Console::has_instance())
+        if (!MessageLoggerData::use_buffer && Console::is_available())
         {
             emit(m_stream.str(), m_level);
         }

--- a/libmamba/src/core/output.cpp
+++ b/libmamba/src/core/output.cpp
@@ -557,7 +557,7 @@ namespace mamba
 
     MessageLogger::~MessageLogger()
     {
-        if (!MessageLoggerData::use_buffer)
+        if (!MessageLoggerData::use_buffer && Console::has_instance())
         {
             emit(m_stream.str(), m_level);
         }

--- a/libmamba/src/core/singletons.cpp
+++ b/libmamba/src/core/singletons.cpp
@@ -166,6 +166,11 @@ namespace mamba
         return *main_console;
     }
 
+    bool Console::has_instance()
+    {
+        return main_console != nullptr;
+    }
+
     void Console::set_singleton(Console& console)
     {
         Console* expected = nullptr;

--- a/libmamba/src/core/singletons.cpp
+++ b/libmamba/src/core/singletons.cpp
@@ -166,7 +166,7 @@ namespace mamba
         return *main_console;
     }
 
-    bool Console::has_instance()
+    bool Console::is_available()
     {
         return main_console != nullptr;
     }


### PR DESCRIPTION
Fix logging when libmamba is used as a lib without context.
The proper way would be to set logging sinks that get configured in micromamba or any other client code.

Close #2713
Close #3112