### PR TITLE
1.x: Run tests for conda=24.1

### DIFF
--- a/mamba/environment-dev.yml
+++ b/mamba/environment-dev.yml
@@ -25,7 +25,7 @@ dependencies:
   - pytest >=7.3
   - pyyaml
   - boltons
-  - conda >=23.11.0
+  - conda >=24.1.0
   - conda-content-trust
   - cryptography<40.0  # Or breaks conda-content-trust
   - pip:

--- a/mamba/setup.py
+++ b/mamba/setup.py
@@ -45,7 +45,7 @@ setup(
         "conda>=4.14.0",
         "libmambapy",
     ],
-    extras_require={"test": ["pytest", "pytest-lazy-fixture"]},
+    extras_require={"test": ["pytest"]},
     data_files=data_files,
     include_package_data=True,
     zip_safe=False,

--- a/micromamba/environment-dev.yml
+++ b/micromamba/environment-dev.yml
@@ -19,7 +19,6 @@ dependencies:
   - cli11 >=2.2
   - pytest >=7.3.0
   - pytest-asyncio
-  - pytest-lazy-fixture
   - pytest-xprocess
   - conda-package-handling
   - pyyaml

--- a/micromamba/tests/test_pkg_cache.py
+++ b/micromamba/tests/test_pkg_cache.py
@@ -255,10 +255,13 @@ def same_repodata_json_solv(cache: Path):
 
 
 class TestMultiplePkgCaches:
-    @pytest.mark.parametrize(
-        "cache", (pytest.lazy_fixture(("tmp_cache", "tmp_cache_alt")))
-    )
-    def test_different_caches(self, tmp_home, tmp_root_prefix, cache):
+    @pytest.mark.parametrize("which_cache", ["tmp_cache", "tmp_cache_alt"])
+    def test_different_caches(
+        self, tmp_home, tmp_root_prefix, tmp_cache, tmp_cache_alt, which_cache
+    ):
+        # Test parametrization
+        cache = {"tmp_cache": tmp_cache, "tmp_cache_alt": tmp_cache_alt}[which_cache]
+
         os.environ["CONDA_PKGS_DIRS"] = f"{cache}"
         env_name = "some_env"
         res = helpers.create("-n", env_name, "xtensor", "-v", "--json", no_dry_run=True)


### PR DESCRIPTION
Just seeing whether `mamba=1`'s test suite passes with `conda=24.1`.

If it does, could we tag the current `1.x` with `1.5.7` and rebuild on https://github.com/conda-forge/mamba-feedstock with the test and dependency update from https://github.com/conda-forge/mamba-feedstock/pull/208 (excluding its last commit, of course)?