### PR TITLE
feat: allow underscores anywhere in token

### DIFF
--- a/libmamba/src/core/util.cpp
+++ b/libmamba/src/core/util.cpp
@@ -1603,7 +1603,7 @@ namespace mamba
     {
         // usernames on anaconda.org can have a underscore, which influences the
         // first two characters
-        inline const std::regex token_regex{ "/t/([a-zA-Z0-9-_]{0,2}[a-zA-Z0-9-]*)" };
+        inline const std::regex token_regex{ "/t/([a-zA-Z0-9-_]*)" };
         inline const std::regex http_basicauth_regex{ "(://|^)([^\\s]+):([^\\s]+)@" };
     }
 


### PR DESCRIPTION
The token format on anaconda is `wo-1234-asdf-123123` (UUID4 style). The first two letters are derived from the user name (e.g. wolfv in my case).

On prefix.dev, we use something like `pfx_1234asdf123123...`. We are now changing this to use `-` as well (to maximize compatibility). I think `_` is still better because it allows tokens to be easier selected e.g. in a browser / text-editor.

LMK what you think! :)