### PR TITLE
Make Taskfile.dist.yml Windows-compatible

### DIFF
--- a/Taskfile.dist.yml
+++ b/Taskfile.dist.yml
@@ -1,6 +1,8 @@
 version: '3'
 
 vars:
+  # Windows doesn't set the PWD environment variable automatically, but we can
+  # assign it using a dynamic variable since pwd does work in PowerShell
   PWD:
     sh: pwd
   BUILD_DIR: 'build'

--- a/Taskfile.dist.yml
+++ b/Taskfile.dist.yml
@@ -1,6 +1,8 @@
 version: '3'
 
 vars:
+  PWD:
+    sh: pwd
   BUILD_DIR: 'build'
   ENV_DIR: '{{.BUILD_DIR}}/envs'
   DEV_ENV_DIR: '{{.ENV_DIR}}/dev'


### PR DESCRIPTION
PowerShell doesn't set `$env:PWD` automatically, but it can be easily retrieved by making `PWD` a `sh` variable in the Taskfile, which remains POSIX-compliant for other platforms.

If you don't want to modify the Taskfile, then at least a note about this should be made on https://mamba.readthedocs.io/en/latest/developer_zone/dev_environment.html#