### PR TITLE
fix(micromamba): anaconda private channels not working

### DIFF
--- a/libmamba/src/core/context.cpp
+++ b/libmamba/src/core/context.cpp
@@ -229,10 +229,10 @@ namespace mamba
                     // anaconda client writes out a token for https://api.anaconda.org...
                     // but we need the token for https://conda.anaconda.org
                     // conda does the same
-                    std::size_t api_pos = token_url.find("://api.");
+                    std::size_t api_pos = token_url.find("https://api.");
                     if (api_pos != std::string::npos)
                     {
-                        token_url.replace(api_pos, 7, "://conda.");
+                        token_url.replace(api_pos, 12, "conda.");
                     }
 
                     // cut ".token" ending


### PR DESCRIPTION
Similar to https://github.com/mamba-org/boa/pull/81, the search key and db is slightly out of sync.

In this case, the keys are the (weakened) urls without the scheme.

The anaconda tokens are stored with the scheme, so they are ignored.

https://github.com/mamba-org/mamba/blob/fd42d8dd8ee8cf756b8d0d600663622ac425d392/libmamba/src/specs/channel.cpp#L295-L300