### PR TITLE
1.x: retain add_channel_specific_matchspec between create_whatprovides calls

### DIFF
--- a/libmamba/src/core/pool.cpp
+++ b/libmamba/src/core/pool.cpp
@@ -211,10 +211,7 @@ namespace mamba
                 bool already_added = false;
                 pool.for_each_whatprovides(
                     maybe_id.value(),
-                    [&](solv::ObjSolvableViewConst s)
-                    {
-                        already_added = true;
-                    }
+                    [&](solv::ObjSolvableViewConst s) { already_added = true; }
                 );
                 if (already_added)
                 {

--- a/libmamba/src/core/pool.cpp
+++ b/libmamba/src/core/pool.cpp
@@ -204,10 +204,23 @@ namespace mamba
             // Poor man's ms repr to match waht the user provided
             std::string const repr = fmt::format("{}::{}", ms.channel, ms.conda_build_form());
 
-            // Already added, return that id
-            if (const auto maybe_id = pool.find_string(repr))
+            const auto maybe_id = pool.find_string(repr);
+            if (maybe_id)
             {
-                return maybe_id.value();
+                // Channel specific matchspec already added to libsolv string cache
+                bool already_added = false;
+                pool.for_each_whatprovides(
+                    maybe_id.value(),
+                    [&](solv::ObjSolvableViewConst s)
+                    {
+                        already_added = true;
+                    }
+                );
+                if (already_added)
+                {
+                    // whatprovides already added and still present in pool
+                    return maybe_id.value();
+                }
             }
 
             // conda_build_form does **NOT** contain the channel info
@@ -253,7 +266,7 @@ namespace mamba
                 }
             );
 
-            solv::StringId const repr_id = pool.add_string(repr);
+            solv::StringId const repr_id = maybe_id ? maybe_id.value() : pool.add_string(repr);
             // FRAGILE This get deleted when calling ``pool_createwhatprovides`` so care
             // must be taken to do it before
             // TODO investigate namespace providers


### PR DESCRIPTION
https://github.com/conda/conda-libmamba-solver/issues/447

`conda-libmamba-solver` reuses the same pool between solve attempts but creates a new solver each attempt.  The solver initialization calls `create_whatprovides` and wipes the whatprovides relationships added for the channel specific matchspecs.  

The problem with this is that the channel specific match spec is still present in the pool's string cache so later `add_jobs` calls just return the id for the channel specific match spec without readding the wiped whatprovides