### PR TITLE
Passed url_path to request_generators

### DIFF
--- a/libmamba/include/mamba/download/mirror.hpp
+++ b/libmamba/include/mamba/download/mirror.hpp
@@ -69,7 +69,7 @@ namespace mamba::download
         Mirror& operator=(Mirror&&) = delete;
 
         const MirrorID& id() const;
-        request_generator_list get_request_generators() const;
+        request_generator_list get_request_generators(const std::string& url_path) const;
 
         std::size_t max_retries() const;
         std::size_t successful_transfers() const;
@@ -88,7 +88,7 @@ namespace mamba::download
 
     private:
 
-        virtual request_generator_list get_request_generators_impl() const = 0;
+        virtual request_generator_list get_request_generators_impl(const std::string&) const = 0;
 
         MirrorID m_id;
         size_t m_max_retries;

--- a/libmamba/src/download/downloader.cpp
+++ b/libmamba/src/download/downloader.cpp
@@ -563,9 +563,9 @@ namespace mamba::download
      * LAST_REQUEST_FAILED:
      *     - m_retries == p_mirror->max_retries ? => SEQUENCE_FAILED
      */
-    MirrorAttempt::MirrorAttempt(Mirror& mirror)
+    MirrorAttempt::MirrorAttempt(Mirror& mirror, const std::string& url_path)
         : p_mirror(&mirror)
-        , m_request_generators(p_mirror->get_request_generators())
+        , m_request_generators(p_mirror->get_request_generators(url_path))
     {
     }
 
@@ -862,7 +862,7 @@ namespace mamba::download
         if (mirror != nullptr)
         {
             m_tried_mirrors.insert(mirror->id());
-            m_mirror_attempt = MirrorAttempt(*mirror);
+            m_mirror_attempt = MirrorAttempt(*mirror, p_initial_request->url_path);
         }
         else
         {

--- a/libmamba/src/download/downloader_impl.hpp
+++ b/libmamba/src/download/downloader_impl.hpp
@@ -119,7 +119,7 @@ namespace mamba::download
         using on_failure_callback = DownloadAttempt::on_failure_callback;
 
         MirrorAttempt() = default;
-        explicit MirrorAttempt(Mirror& mirror);
+        MirrorAttempt(Mirror& mirror, const std::string& url_path);
 
         void prepare_request(const Request& initial_request);
         auto prepare_attempt(

--- a/libmamba/src/download/mirror.cpp
+++ b/libmamba/src/download/mirror.cpp
@@ -60,9 +60,9 @@ namespace mamba::download
         return m_id;
     }
 
-    auto Mirror::get_request_generators() const -> request_generator_list
+    auto Mirror::get_request_generators(const std::string& url_path) const -> request_generator_list
     {
-        return get_request_generators_impl();
+        return get_request_generators_impl(url_path);
     }
 
     std::size_t Mirror::max_retries() const

--- a/libmamba/src/download/mirror_impl.cpp
+++ b/libmamba/src/download/mirror_impl.cpp
@@ -30,7 +30,8 @@ namespace mamba::download
         return PASSTHROUGH_MIRROR_ID;
     }
 
-    auto PassThroughMirror::get_request_generators_impl() const -> request_generator_list
+    auto PassThroughMirror::get_request_generators_impl(const std::string&) const
+        -> request_generator_list
     {
         return { [](const Request& dl_request, const Content*)
                  { return MirrorRequest(dl_request, dl_request.url_path); } };
@@ -51,7 +52,7 @@ namespace mamba::download
         return MirrorID(std::move(url));
     }
 
-    auto HTTPMirror::get_request_generators_impl() const -> request_generator_list
+    auto HTTPMirror::get_request_generators_impl(const std::string&) const -> request_generator_list
     {
         return { [url = m_url](const Request& dl_request, const Content*)
                  { return MirrorRequest(dl_request, util::url_concat(url, dl_request.url_path)); } };

--- a/libmamba/src/download/mirror_impl.hpp
+++ b/libmamba/src/download/mirror_impl.hpp
@@ -25,7 +25,7 @@ namespace mamba::download
     private:
 
         using request_generator_list = Mirror::request_generator_list;
-        request_generator_list get_request_generators_impl() const override;
+        request_generator_list get_request_generators_impl(const std::string&) const override;
     };
 
     class HTTPMirror : public Mirror
@@ -39,7 +39,7 @@ namespace mamba::download
     private:
 
         using request_generator_list = Mirror::request_generator_list;
-        request_generator_list get_request_generators_impl() const override;
+        request_generator_list get_request_generators_impl(const std::string&) const override;
 
         std::string m_url;
     };


### PR DESCRIPTION
This will be required by OCI mirrrors, and allows to release mamba without the OCI mirrors while ensuring API stability.