### PR TITLE
Use QuantStack vcpkg registry for liblzma/xz

### DIFF
--- a/.github/workflows/static_build.yml
+++ b/.github/workflows/static_build.yml
@@ -115,13 +115,13 @@ jobs:
     runs-on: windows-2022
     steps:
       - uses: actions/checkout@v3
-      - name: Cache vcpkg packages
-        uses: actions/cache@v3
-        with:
+        #- name: Cache vcpkg packages
+        #uses: actions/cache@v3
+        #with:
           # The installed packages are in %VCPKG_INSTALLATION_ROOT%\installed\x64-windows-static
           # and the info which packages are installed is in %VCPKG_INSTALLATION_ROOT%\installed\vcpkg
-          path: C:\Users\runneradmin\AppData\Local\vcpkg
-          key: vcpkg-win-64-appdata
+          #path: C:\Users\runneradmin\AppData\Local\vcpkg
+          #key: vcpkg-win-64-appdata
       - name: Install dependencies with vcpkg
         shell: cmd
         # remove libsolv overlay-ports once https://github.com/microsoft/vcpkg/pull/31275 is released

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -9,7 +9,7 @@
       "baseline": "ddbcd3c4e49a04ac10b402c732b6f4ccf4432e65",
       "kind": "git",
       "packages": [
-        "liblzma"
+        "libarchive", "liblzma"
       ],
       "repository": "https://github.com/QuantStack/vcpkg"
     }

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -1,0 +1,17 @@
+{
+  "default-registry": {
+    "baseline": "c5da4bafbd4f47428dea8bdfec96312950dbbf83",
+    "kind": "git",
+    "repository": "https://github.com/microsoft/vcpkg"
+  },
+  "registries": [
+    {
+      "baseline": "ddbcd3c4e49a04ac10b402c732b6f4ccf4432e65",
+      "kind": "git",
+      "packages": [
+        "liblzma"
+      ],
+      "repository": "https://github.com/QuantStack/vcpkg"
+    }
+  ]
+}

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,14 +1,12 @@
 {
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "dependencies": [
+    "liblzma",
     "zstd",
     "curl",
     {
       "name": "winreg",
       "platform": "windows"
-    },
-    {
-      "name": "liblzma"
     },
     {
       "features": [

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -8,6 +8,9 @@
       "platform": "windows"
     },
     {
+      "name": "liblzma"
+    },
+    {
       "features": [
         "bzip2",
         "lz4",


### PR DESCRIPTION
This can be reverted when the [xs issue of vcpkg](https://github.com/microsoft/vcpkg/pull/37957) has been fixed.