### PR TITLE
Hotfix to allow Ctrl+C in python scipts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,4 @@ __cache__/
 installed.json
 tmp/
 test_7.json.state
+_skbuild/

--- a/libmamba/include/mamba/core/thread_utils.hpp
+++ b/libmamba/include/mamba/core/thread_utils.hpp
@@ -31,6 +31,7 @@ namespace mamba
 #endif
 
     void set_default_signal_handler();
+    void restore_system_signal_handler();
     bool is_sig_interrupted() noexcept;
     void set_sig_interrupted() noexcept;
 

--- a/libmamba/src/core/context.cpp
+++ b/libmamba/src/core/context.cpp
@@ -76,7 +76,7 @@ namespace mamba
     void Context::use_default_signal_handler(bool val)
     {
         use_default_signal_handler_val = val;
-        if(use_default_signal_handler_val)
+        if (use_default_signal_handler_val)
         {
             set_default_signal_handler();
         }

--- a/libmamba/src/core/context.cpp
+++ b/libmamba/src/core/context.cpp
@@ -76,6 +76,14 @@ namespace mamba
     void Context::use_default_signal_handler(bool val)
     {
         use_default_signal_handler_val = val;
+        if(use_default_signal_handler_val)
+        {
+            set_default_signal_handler();
+        }
+        else
+        {
+            restore_system_signal_handler();
+        }
     }
 
     void Context::enable_logging_and_signal_handling(Context& context)

--- a/libmamba/src/core/thread_utils.cpp
+++ b/libmamba/src/core/thread_utils.cpp
@@ -95,6 +95,10 @@ namespace mamba
         std::signal(SIGINT, [](int /*signum*/) { set_sig_interrupted(); });
     }
 #endif
+    void restore_system_signal_handler()
+    {
+        std::signal(SIGINT, SIG_DFL);
+    }
 
     bool is_sig_interrupted() noexcept
     {


### PR DESCRIPTION
Partial fix for #3271 , in particular this makes the script in that issue work.

While there are major issues with the signal handling implementation in libmamba (and the fact that ideally it should be a cancelling system with async high-level functions being cancellable, and then scripts/executables decide how to trigger that cancelling), this only helps if `Context.use_default_signal_handler(False)` (or the equivalent in C++) is used.
That function had no effect before this PR because the boolean it sets was only taken into account at the construction of the `Context` instance, which necessarilly must happen before the function can be called. To make it effective I (with the help of @Hind-M ) just made sure that the meaning of the variable is re-applied when the function is set. This might break some usage once called, not sure.
We discussed with @Hind-M and @JohanMabille a future long-term solution for this but it will not come soon so this is the quickest hotfix for now.