### PR TITLE
Fixed restoring the previous signal handler for example in python case (Windows only for now)

### DIFF
--- a/libmamba/include/mamba/core/thread_utils.hpp
+++ b/libmamba/include/mamba/core/thread_utils.hpp
@@ -23,7 +23,7 @@ namespace mamba
      ***********************/
 
 
-    using signal_handler_t = void(*)(int);
+    using signal_handler_t = void (*)(int);
 
 #ifndef _WIN32
     void set_signal_handler(const std::function<void(sigset_t)>& handler);

--- a/libmamba/include/mamba/core/thread_utils.hpp
+++ b/libmamba/include/mamba/core/thread_utils.hpp
@@ -22,6 +22,9 @@ namespace mamba
      * thread interruption *
      ***********************/
 
+
+    using signal_handler_t = void(*)(int);
+
 #ifndef _WIN32
     void set_signal_handler(const std::function<void(sigset_t)>& handler);
 
@@ -31,10 +34,10 @@ namespace mamba
 #endif
 
     void set_default_signal_handler();
-    void restore_system_signal_handler();
+    void restore_previous_signal_handler();
+    signal_handler_t previous_signal_handler();
     bool is_sig_interrupted() noexcept;
     void set_sig_interrupted() noexcept;
-
 
     void interruption_point();
 

--- a/libmamba/src/core/context.cpp
+++ b/libmamba/src/core/context.cpp
@@ -134,7 +134,7 @@ namespace mamba
         }
         else
         {
-            restore_system_signal_handler();
+            restore_previous_signal_handler();
         }
     }
 

--- a/libmamba/src/core/thread_utils.cpp
+++ b/libmamba/src/core/thread_utils.cpp
@@ -89,7 +89,8 @@ namespace mamba
 
     void set_default_signal_handler()
     {
-        previous_handler = set_signal_handler(default_signal_handler);
+        previous_handler = std::signal(SIGINT, [](int) {});
+        set_signal_handler(default_signal_handler);
     }
 #else
     void set_default_signal_handler()


### PR DESCRIPTION
Should fix #3271 partially.