### PR TITLE
Fix release scripts

### DIFF
--- a/releaser.py
+++ b/releaser.py
@@ -126,7 +126,7 @@ def main():
             release_start = idx + 1
             break
 
-    brackets_re = re.compile(r"\[(.*)\]")
+    brackets_re = re.compile(r"\[(.*?)\]")
 
     # section with groups, heading + items
     sections = []


### PR DESCRIPTION
- Fix requested files limit (100) by using `grapghql` command allowing pagination
- Only write in file when PRs list is not empty in each category
- Fix regex expression to only capture characters between two square brackets without including the brackets themselves