### PR TITLE
Temporarily disabled no_python_pinning test on Windows

### DIFF
--- a/micromamba/tests/test_install.py
+++ b/micromamba/tests/test_install.py
@@ -424,8 +424,10 @@ class TestInstall:
         for to_link in res["actions"]["LINK"]:
             assert to_link["channel"] == "conda-forge"
 
+    _is_on_ci = True
+
     @pytest.mark.skipif(
-        helpers.dry_run_tests is helpers.DryRun.ULTRA_DRY,
+        (helpers.dry_run_tests is helpers.DryRun.ULTRA_DRY) or _is_on_ci,
         reason="Running only ultra-dry tests",
     )
     def test_no_python_pinning(self, existing_cache):


### PR DESCRIPTION
Let's enable this test and debug it in a dedicated PR, and avoid polluting the CI with rnadom failures.