### PR TITLE
Splitt `ContextOptions::enable_logging_and_signal_handling` into 2 different options

### DIFF
--- a/libmamba/include/mamba/core/context.hpp
+++ b/libmamba/include/mamba/core/context.hpp
@@ -65,7 +65,8 @@ namespace mamba
 
     struct ContextOptions
     {
-        bool enable_logging_and_signal_handling = false;
+        bool enable_logging = false;
+        bool enable_signal_handling = false;
     };
 
     // Context singleton class
@@ -259,10 +260,6 @@ namespace mamba
         Context(const ContextOptions& options = {});
         ~Context();
 
-        // Enables the provided context to drive the logging system and setup signal handling.
-        // This function must be called only for one Context in the lifetime of the program.
-        static void enable_logging_and_signal_handling(Context& context);
-
     private:
 
         // Used internally
@@ -279,6 +276,16 @@ namespace mamba
         void add_logger(std::shared_ptr<Logger>);
 
         TaskSynchronizer tasksync;
+
+
+
+        // Enables the provided context setup signal handling.
+        // This function must be called only for one Context in the lifetime of the program.
+        void enable_signal_handling();
+
+        // Enables the provided context to drive the logging system.
+        // This function must be called only for one Context in the lifetime of the program.
+        void enable_logging();
     };
 
 

--- a/libmamba/src/core/context.cpp
+++ b/libmamba/src/core/context.cpp
@@ -148,33 +148,36 @@ namespace mamba
         return loggers.front().logger();
     }
 
-    void Context::enable_logging_and_signal_handling(Context& context)
+    void Context::enable_signal_handling()
     {
         if (use_default_signal_handler_val)
         {
             set_default_signal_handler();
         }
+    }
 
-        context.loggers.clear();  // Make sure we work with a known set of loggers, first one is
+    void Context::enable_logging()
+    {
+        loggers.clear();  // Make sure we work with a known set of loggers, first one is
                                   // always the default one.
 
-        context.loggers.emplace_back(
-            std::make_shared<Logger>("libmamba", context.output_params.log_pattern, "\n"),
+        loggers.emplace_back(
+            std::make_shared<Logger>("libmamba", output_params.log_pattern, "\n"),
             logger_kind::default_logger
         );
         MainExecutor::instance().on_close(
-            context.tasksync.synchronized([&context] { context.main_logger()->flush(); })
+            tasksync.synchronized([&] { main_logger()->flush(); })
         );
 
-        context.loggers.emplace_back(
-            std::make_shared<Logger>("libcurl", context.output_params.log_pattern, "")
+        loggers.emplace_back(
+            std::make_shared<Logger>("libcurl", output_params.log_pattern, "")
         );
 
-        context.loggers.emplace_back(
-            std::make_shared<Logger>("libsolv", context.output_params.log_pattern, "")
+        loggers.emplace_back(
+            std::make_shared<Logger>("libsolv", output_params.log_pattern, "")
         );
 
-        spdlog::set_level(convert_log_level(context.output_params.logging_level));
+        spdlog::set_level(convert_log_level(output_params.logging_level));
     }
 
     Context::Context(const ContextOptions& options)
@@ -210,9 +213,14 @@ namespace mamba
         ascii_only = false;
 #endif
 
-        if (options.enable_logging_and_signal_handling)
+        if (options.enable_signal_handling)
         {
-            enable_logging_and_signal_handling(*this);
+            enable_signal_handling();
+        }
+
+        if (options.enable_logging)
+        {
+            enable_logging();
         }
     }
 

--- a/libmamba/tests/include/mambatests.hpp
+++ b/libmamba/tests/include/mambatests.hpp
@@ -33,7 +33,10 @@ namespace mambatests
     {
         // mamba::MainExecutor main_executor; // FIXME: reactivate once the tests are not indirectly
         // using this anymore
-        mamba::Context context{ { /* .enable_logging_and_signal_handling = */ true } };
+        mamba::Context context{ {
+                /* .enable_logging = */ true,
+                /* .enable_signal_handling = */ true
+        } };
         mamba::Console console{ context };
     };
 

--- a/libmambapy/src/libmambapy/bindings/legacy.cpp
+++ b/libmambapy/src/libmambapy/bindings/legacy.cpp
@@ -126,6 +126,8 @@ namespace mambapy
         }
     };
 
+    static constexpr auto default_context_options = mamba::ContextOptions{ true, true };
+
     // MSubdirData objects are movable only, and they need to be moved into
     // a std::vector before we call MSudbirData::download. Since we cannot
     // replicate the move semantics in Python, we encapsulate the creation
@@ -655,21 +657,33 @@ bind_submodule_impl(pybind11::module_ m)
         .def_readwrite("no_progress_bars", &Context::GraphicsParams::no_progress_bars)
         .def_readwrite("palette", &Context::GraphicsParams::palette);
 
+
+
     py::class_<ContextOptions>(m, "ContextOptions")
         .def(
-            py::init([](bool enable_logging_and_signal_handling = true)
-                     { return ContextOptions{ enable_logging_and_signal_handling }; }),
-            py::arg("enable_logging_and_signal_handling") = true
+            py::init(
+                [](bool logging = mambapy::default_context_options.enable_logging,
+                   bool signal_handling = mambapy::default_context_options.enable_signal_handling) {
+                    return ContextOptions{ logging, signal_handling };
+                }
+            ),
+            py::arg("enable_logging") = true,
+            py::arg("enable_signal_handling") = true
         )
         .def_readwrite(
-            "enable_logging_and_signal_handling",
-            &ContextOptions::enable_logging_and_signal_handling
+            "enable_logging",
+            &ContextOptions::enable_logging
+        )
+        .def_readwrite(
+            "enable_signal_handling",
+            &ContextOptions::enable_signal_handling
         );
 
     // The lifetime of the unique Context instance will determine the lifetime of the other
     // singletons.
     using context_ptr = std::unique_ptr<Context, mambapy::destroy_singleton>;
-    auto context_constructor = [](ContextOptions options = {}) -> context_ptr
+    auto context_constructor = [](ContextOptions options = mambapy::default_context_options
+                               ) -> context_ptr
     {
         if (mambapy::current_singletons)
         {
@@ -683,7 +697,7 @@ bind_submodule_impl(pybind11::module_ m)
 
     py::class_<Context, context_ptr> ctx(m, "Context");
 
-    ctx.def(py::init(context_constructor), py::arg("options") = ContextOptions{ true })
+    ctx.def(py::init(context_constructor), py::arg("options") = mambapy::default_context_options)
         .def_static("use_default_signal_handler", &Context::use_default_signal_handler)
         .def_readwrite("graphics_params", &Context::graphics_params)
         .def_readwrite("offline", &Context::offline)

--- a/micromamba/src/main.cpp
+++ b/micromamba/src/main.cpp
@@ -35,7 +35,8 @@ main(int argc, char** argv)
 {
     mamba::MainExecutor scoped_threads;
     mamba::Context ctx{ {
-        /* .enable_logging_and_signal_handling = */ true,
+        /* .enable_logging = */ true,
+        /* .enable_signal_handling = */ true,
     } };
     mamba::Console console{ ctx };
     mamba::Configuration config{ ctx };


### PR DESCRIPTION
This is part of the workarounds necessary for https://github.com/mamba-org/mamba/issues/3271

It also just makes more sense.
