### PR TITLE
chore(ci): bump github action versions

### DIFF
--- a/.github/actions/workspace/action.yml
+++ b/.github/actions/workspace/action.yml
@@ -28,13 +28,13 @@ runs:
   steps:
     - name: Create workspace
       if: ${{ inputs.action == 'save' }}
-      uses: actions/cache/save@v3
+      uses: actions/cache/save@v4
       with:
         path: ${{ inputs.path }}
         key: ${{ inputs.key_prefix }}-${{ inputs.key_base }}-${{ inputs.key_suffix }}
     - name: Restore workspace
       if: ${{ inputs.action == 'restore' }}
-      uses: actions/cache/restore@v3
+      uses: actions/cache/restore@v4
       with:
         path: ${{ inputs.path }}
         key: ${{ inputs.key_prefix }}-${{ inputs.key_base }}-${{ inputs.key_suffix }}

--- a/.github/workflows/label_check.yml
+++ b/.github/workflows/label_check.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Check labels
         run: |

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -20,7 +20,7 @@ jobs:
     env:
       PRE_COMMIT_USE_MICROMAMBA: 1
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Install pre-commit
       uses: mamba-org/setup-micromamba@v1
       with:

--- a/.github/workflows/static_build.yml
+++ b/.github/workflows/static_build.yml
@@ -116,7 +116,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Cache vcpkg packages
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           # The installed packages are in %VCPKG_INSTALLATION_ROOT%\installed\x64-windows-static
           # and the info which packages are installed is in %VCPKG_INSTALLATION_ROOT%\installed\vcpkg

--- a/.github/workflows/static_build.yml
+++ b/.github/workflows/static_build.yml
@@ -1,4 +1,5 @@
 name: Micromamba
+
 on:
   push:
     branches:
@@ -13,9 +14,11 @@ on:
       - '**.md'
   merge_group:
     types: [checks_requested]
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
+
 jobs:
   micromamba-static-unix:
     name: "${{ matrix.platform }}-${{ matrix.arch }}"

--- a/.github/workflows/static_build.yml
+++ b/.github/workflows/static_build.yml
@@ -1,5 +1,4 @@
 name: Micromamba
-
 on:
   push:
     branches:
@@ -14,11 +13,9 @@ on:
       - '**.md'
   merge_group:
     types: [checks_requested]
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
-
 jobs:
   micromamba-static-unix:
     name: "${{ matrix.platform }}-${{ matrix.arch }}"
@@ -27,11 +24,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { os: ubuntu-latest, platform: linux, arch: "64" }
-          - { os: ubuntu-latest, platform: linux, arch: aarch64 }
-          - { os: ubuntu-latest, platform: linux, arch: ppc64le }
-          - { os: macos-latest, platform: osx, arch: "64" }
-          - { os: macos-latest, platform: osx, arch: arm64 }
+          - {os: ubuntu-latest, platform: linux, arch: "64"}
+          - {os: ubuntu-latest, platform: linux, arch: aarch64}
+          - {os: ubuntu-latest, platform: linux, arch: ppc64le}
+          - {os: macos-latest, platform: osx, arch: "64"}
+          - {os: macos-latest, platform: osx, arch: arm64}
     steps:
       - name: Checkout micromamba-feedstock
         uses: actions/checkout@v4
@@ -54,7 +51,7 @@ jobs:
         with:
           environment-name: mambabuild
           create-args: python boa
-          post-cleanup: none  # FIXME the cleanup fails on OSX
+          post-cleanup: none # FIXME the cleanup fails on OSX
       - name: Build conda package (Unix native)
         if: ${{ !(matrix.platform == 'linux' && matrix.arch != '64') }}
         shell: bash -l {0}
@@ -98,18 +95,17 @@ jobs:
         if: failure()
         run: tar -czf ${{ github.workspace }}/micromamba-conda-build-failed-${{ matrix.platform }}-${{ matrix.arch }}.tar.gz $MAMBA_ROOT_PREFIX/envs/mambabuild/conda-bld/micromamba_*
       - name: Upload conda build artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: micromamba-conda-build-failed-${{ matrix.platform }}-${{ matrix.arch }}
           path: ${{ github.workspace }}/micromamba-conda-build-failed-${{ matrix.platform }}-${{ matrix.arch }}.tar.gz
           retention-days: 7
       - name: Upload micromamba
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: micromamba-${{ matrix.platform }}-${{ matrix.arch }}
           path: ${{ github.workspace }}/artifacts/micromamba
-
   micromamba-static-win:
     name: "win-64"
     runs-on: windows-2022
@@ -138,15 +134,7 @@ jobs:
           environment-name: mambabuild
           init-shell: bash cmd.exe
           create-args: >-
-            cli11>=2.2,<3
-            cpp-expected
-            nlohmann_json
-            simdjson-static>=3.3.0
-            spdlog
-            fmt
-            yaml-cpp-static>=0.8.0
-            libsolv-static>=0.7.24
-            reproc-cpp-static>=14.2.4.post0
+            cli11>=2.2,<3 cpp-expected nlohmann_json simdjson-static>=3.3.0 spdlog fmt yaml-cpp-static>=0.8.0 libsolv-static>=0.7.24 reproc-cpp-static>=14.2.4.post0
       - name: build micromamba
         shell: cmd /C call {0}
         # Using D_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR is a workaround to fix CI failure on win-64
@@ -180,13 +168,13 @@ jobs:
         if: failure()
         run: tar -czf ${{ github.workspace }}/micromamba-build-failed-win-64.tar.gz ${{ github.workspace }}/build/
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: micromamba-build-failed-win-64
           path: ${{ github.workspace }}/micromamba-build-failed-win-64.tar.gz
           retention-days: 7
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: micromamba-win-64
           path: ${{ github.workspace }}/build/micromamba/micromamba.exe

--- a/.github/workflows/static_build.yml
+++ b/.github/workflows/static_build.yml
@@ -34,12 +34,12 @@ jobs:
           - { os: macos-latest, platform: osx, arch: arm64 }
     steps:
       - name: Checkout micromamba-feedstock
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: conda-forge/micromamba-feedstock
           path: micromamba-feedstock
       - name: Checkout mamba branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: mamba
       - name: Clear mamba git directory and link source
@@ -114,7 +114,7 @@ jobs:
     name: "win-64"
     runs-on: windows-2022
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Cache vcpkg packages
         uses: actions/cache@v3
         with:

--- a/.github/workflows/static_build.yml
+++ b/.github/workflows/static_build.yml
@@ -134,7 +134,15 @@ jobs:
           environment-name: mambabuild
           init-shell: bash cmd.exe
           create-args: >-
-            cli11>=2.2,<3 cpp-expected nlohmann_json simdjson-static>=3.3.0 spdlog fmt yaml-cpp-static>=0.8.0 libsolv-static>=0.7.24 reproc-cpp-static>=14.2.4.post0
+            cli11>=2.2,<3
+            cpp-expected
+            nlohmann_json
+            simdjson-static>=3.3.0
+            spdlog
+            fmt
+            yaml-cpp-static>=0.8.0
+            libsolv-static>=0.7.24
+            reproc-cpp-static>=14.2.4.post0
       - name: build micromamba
         shell: cmd /C call {0}
         # Using D_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR is a workaround to fix CI failure on win-64


### PR DESCRIPTION
- **chore(ci): bump actions/checkout to v4**
- **chore(ci): bump actions/cache to v4**
- **chore(ci): bump upload-artifact to v4**

Fixes lints in Github actions such as this:

<img width="1473" alt="Brave Browser 2024-07-17 12 03 17" src="https://github.com/user-attachments/assets/cd631ddd-a408-48ad-8d5f-52d0e1a96865">
