### PR TITLE
Unpin cryptography, python, and add make to environment-dev.yml

### DIFF
--- a/dev/environment-dev.yml
+++ b/dev/environment-dev.yml
@@ -6,6 +6,7 @@ dependencies:
   - cmake >=3.16
   - pkg-config  # Used by some CMake dependencies
   - ninja
+  - make  # not always present
   # libmamba dependencies
   - cpp-expected
   - fmt
@@ -34,7 +35,7 @@ dependencies:
   - sel(win): menuinst
   - conda-content-trust
   - conda-package-handling
-  - cryptography<40.0  # Or breaks conda-content-trust
+  - cryptography
   - securesystemslib
   # libmambapy build dependencies
   - scikit-build


### PR DESCRIPTION
I'm using this in some Docker containers as part of my devcontainer config, and they don't include `make`. Also, cryptography<40 is not needed anymore (see https://github.com/conda/conda-content-trust/pull/57).

I also unpinned `python` so you can use it on any solvable Python environment without overriding to 3.9.

`mitmproxy` and `doctest` are not available on linux-aarch64, so that fails, but the selector syntax only allows OS-level names, not architectures, so I can't omit those.