### PR TITLE
Update mamba.xsh: support xonsh >= 0.18.0

### DIFF
--- a/libmamba/data/mamba.xsh
+++ b/libmamba/data/mamba.xsh
@@ -3,7 +3,14 @@
 # Much of this forked from https://github.com/gforsyth/xonda
 # Copyright (c) 2016, Gil Forsyth, All rights reserved.
 # Original code licensed under BSD-3-Clause.
-from xonsh.lazyasd import lazyobject
+
+try:
+    # xonsh >= 0.18.0
+    from xonsh.lib.lazyasd import lazyobject
+except:
+    # xonsh < 0.18.0
+    from xonsh.lazyasd import lazyobject
+
 from xonsh.completers import completer
 from xonsh.completers.tools import complete_from_sub_proc, contextual_command_completer
 


### PR DESCRIPTION
Added support xonsh >= [0.18.0](https://github.com/xonsh/xonsh/releases/tag/0.18.0)