### PR TITLE
doc(more_concepts.rst): improve clarity

### DIFF
--- a/docs/source/advanced_usage/more_concepts.rst
+++ b/docs/source/advanced_usage/more_concepts.rst
@@ -132,8 +132,8 @@ This is the most efficient way to link:
 
 There are some limitations to use ``hard-links``:
 
-- all the file systems are not supporting such links
-- those links are not working across file systems/partitions
+- not all file systems support ``hard-links``
+- ``hard-links`` don't work across file systems/partitions
 
 
 .. _soft_link:


### PR DESCRIPTION
`all the file systems are not supporting such links` is most likely meant to mean "not all are" rather "all are not"