### PR TITLE
Allow leading lowercase letter in version

### DIFF
--- a/libmamba/src/specs/version_spec.cpp
+++ b/libmamba/src/specs/version_spec.cpp
@@ -423,7 +423,13 @@ namespace mamba::specs
                     .transform([](specs::Version&& ver)
                                { return VersionPredicate::make_starts_with(std::move(ver)); });
             }
-            if (util::is_digit(str.front()))  // All versions must start with a digit
+            // All versions must start with either a digit or a lowercase letter
+            // The version regex should comply with r"^[\*\.\+!_0-9a-z]+$"
+            // cf. https://github.com/conda/conda/blob/main/conda/models/version.py#L33
+            // Note that we don't apply this condition when the version is given with an operator
+            // In that case, string literals are converted to lowercase in `version.cpp` through
+            // `Version::parse`
+            if (util::is_digit(str.front()) || util::is_lower(str.front()))
             {
                 // Glob suffix does  change meaning for 1.3.* and 1.3*
                 if (util::ends_with(str, VersionSpec::glob_suffix_token))

--- a/libmamba/tests/src/specs/test_match_spec.cpp
+++ b/libmamba/tests/src/specs/test_match_spec.cpp
@@ -82,6 +82,43 @@ TEST_SUITE("specs::match_spec")
             CHECK(ms.version().is_explicitly_free());
         }
 
+        SUBCASE("disperse=v0.9.24")
+        {
+            auto ms = MatchSpec::parse("disperse=v0.9.24").value();
+            CHECK_EQ(ms.name().str(), "disperse");
+            CHECK_EQ(ms.version().str(), "=0v0.9.24");
+            CHECK(ms.build_string().is_explicitly_free());
+            CHECK(ms.build_number().is_explicitly_free());
+            CHECK_EQ(ms.str(), "disperse=0v0.9.24");
+        }
+
+        SUBCASE("disperse v0.9.24")
+        {
+            auto ms = MatchSpec::parse("disperse v0.9.24").value();
+            CHECK_EQ(ms.name().str(), "disperse");
+            CHECK_EQ(ms.version().str(), "==0v0.9.24");
+            CHECK(ms.build_string().is_explicitly_free());
+            CHECK(ms.build_number().is_explicitly_free());
+            CHECK_EQ(ms.str(), "disperse==0v0.9.24");
+        }
+
+        SUBCASE("foo V0.9.24")
+        {
+            auto ms = MatchSpec::parse("foo V0.9.24");
+            CHECK_FALSE(ms.has_value());
+            CHECK_EQ(std::string(ms.error().what()), "Found invalid version predicate in \"V0.9.24\"");
+        }
+
+        SUBCASE("foo=V0.9.24")
+        {
+            auto ms = MatchSpec::parse("foo=V0.9.24").value();
+            CHECK_EQ(ms.name().str(), "foo");
+            CHECK_EQ(ms.version().str(), "=0v0.9.24");
+            CHECK(ms.build_string().is_explicitly_free());
+            CHECK(ms.build_number().is_explicitly_free());
+            CHECK_EQ(ms.str(), "foo=0v0.9.24");
+        }
+
         SUBCASE("numpy 1.7*")
         {
             auto ms = MatchSpec::parse("numpy 1.7*").value();


### PR DESCRIPTION
Fix #3353 

`VersionSpec::parse` was recently added in mamba and never used in 1.x. Therefore the former condition of necessarily having a leading digit in versions seems to be wrong.
According to [conda codebase](https://github.com/conda/conda/blob/main/conda/models/version.py#L33), the version regex should match `r"^[\*\.\+!_0-9a-z]+$"`, meaning that digits and lowercase letters are both allowed.