### PR TITLE
Make more classes hashable and comparable

### DIFF
--- a/libmamba/include/mamba/specs/build_number_spec.hpp
+++ b/libmamba/include/mamba/specs/build_number_spec.hpp
@@ -125,7 +125,7 @@ namespace mamba::specs
          */
         [[nodiscard]] auto contains(BuildNumber point) const -> bool;
 
-        // TODO: only use the `= default` implementation of `operator==` when we will use C++20.
+        // TODO(C++20): replace by the `= default` implementation of `operator==`
         [[nodiscard]] auto operator==(const BuildNumberSpec& other) const -> bool
         {
             return m_predicate == other.m_predicate;

--- a/libmamba/include/mamba/specs/build_number_spec.hpp
+++ b/libmamba/include/mamba/specs/build_number_spec.hpp
@@ -15,6 +15,7 @@
 #include <fmt/format.h>
 
 #include "mamba/specs/error.hpp"
+#include "mamba/util/tuple_hash.hpp"
 
 namespace mamba::specs
 {
@@ -124,6 +125,16 @@ namespace mamba::specs
          */
         [[nodiscard]] auto contains(BuildNumber point) const -> bool;
 
+        [[nodiscard]] auto operator==(const BuildNumberSpec& other) const -> bool
+        {
+            return m_predicate == other.m_predicate;
+        }
+
+        [[nodiscard]] auto operator!=(const BuildNumberSpec& other) const -> bool
+        {
+            return !(*this == other);
+        }
+
     private:
 
         BuildNumberPredicate m_predicate;
@@ -153,6 +164,18 @@ struct fmt::formatter<mamba::specs::BuildNumberSpec>
 
     auto
     format(const ::mamba::specs::BuildNumberSpec& spec, format_context& ctx) -> decltype(ctx.out());
+};
+
+template <>
+struct std::hash<mamba::specs::BuildNumberSpec>
+{
+    auto operator()(const mamba::specs::BuildNumberSpec& spec) const -> std::size_t
+    {
+        auto seed = std::size_t{ 0 };
+        seed = mamba::util::hash_combine_val(seed, spec.str());
+
+        return seed;
+    }
 };
 
 #endif

--- a/libmamba/include/mamba/specs/build_number_spec.hpp
+++ b/libmamba/include/mamba/specs/build_number_spec.hpp
@@ -125,6 +125,7 @@ namespace mamba::specs
          */
         [[nodiscard]] auto contains(BuildNumber point) const -> bool;
 
+        // TODO: only use the `= default` implementation of `operator==` when we will use C++20.
         [[nodiscard]] auto operator==(const BuildNumberSpec& other) const -> bool
         {
             return m_predicate == other.m_predicate;
@@ -171,10 +172,7 @@ struct std::hash<mamba::specs::BuildNumberSpec>
 {
     auto operator()(const mamba::specs::BuildNumberSpec& spec) const -> std::size_t
     {
-        auto seed = std::size_t{ 0 };
-        seed = mamba::util::hash_combine_val(seed, spec.str());
-
-        return seed;
+        return mamba::util::hash_vals(spec.str());
     }
 };
 

--- a/libmamba/include/mamba/specs/chimera_string_spec.hpp
+++ b/libmamba/include/mamba/specs/chimera_string_spec.hpp
@@ -52,6 +52,7 @@ namespace mamba::specs
 
         [[nodiscard]] auto str() const -> const std::string&;
 
+        // TODO: only use the `= default` implementation of `operator==` when we will use C++20.
         [[nodiscard]] auto operator==(const ChimeraStringSpec& other) const -> bool
         {
             return m_spec == other.m_spec;
@@ -82,9 +83,7 @@ struct std::hash<mamba::specs::ChimeraStringSpec>
 {
     auto operator()(const mamba::specs::ChimeraStringSpec& spec) const -> std::size_t
     {
-        auto seed = std::size_t(0);
-        seed = mamba::util::hash_combine_val(seed, spec.str());
-        return seed;
+        return mamba::util::hash_vals(spec.str());
     }
 };
 

--- a/libmamba/include/mamba/specs/chimera_string_spec.hpp
+++ b/libmamba/include/mamba/specs/chimera_string_spec.hpp
@@ -52,7 +52,7 @@ namespace mamba::specs
 
         [[nodiscard]] auto str() const -> const std::string&;
 
-        // TODO: only use the `= default` implementation of `operator==` when we will use C++20.
+        // TODO(C++20): replace by the `= default` implementation of `operator==`
         [[nodiscard]] auto operator==(const ChimeraStringSpec& other) const -> bool
         {
             return m_spec == other.m_spec;

--- a/libmamba/include/mamba/specs/chimera_string_spec.hpp
+++ b/libmamba/include/mamba/specs/chimera_string_spec.hpp
@@ -15,6 +15,7 @@
 #include "mamba/specs/error.hpp"
 #include "mamba/specs/glob_spec.hpp"
 #include "mamba/specs/regex_spec.hpp"
+#include "mamba/util/tuple_hash.hpp"
 
 namespace mamba::specs
 {
@@ -51,6 +52,16 @@ namespace mamba::specs
 
         [[nodiscard]] auto str() const -> const std::string&;
 
+        [[nodiscard]] auto operator==(const ChimeraStringSpec& other) const -> bool
+        {
+            return m_spec == other.m_spec;
+        }
+
+        [[nodiscard]] auto operator!=(const ChimeraStringSpec& other) const -> bool
+        {
+            return !(*this == other);
+        }
+
     private:
 
         Chimera m_spec;
@@ -64,6 +75,17 @@ struct fmt::formatter<mamba::specs::ChimeraStringSpec>
 
     auto
     format(const ::mamba::specs::ChimeraStringSpec& spec, format_context& ctx) -> decltype(ctx.out());
+};
+
+template <>
+struct std::hash<mamba::specs::ChimeraStringSpec>
+{
+    auto operator()(const mamba::specs::ChimeraStringSpec& spec) const -> std::size_t
+    {
+        auto seed = std::size_t(0);
+        seed = mamba::util::hash_combine_val(seed, spec.str());
+        return seed;
+    }
 };
 
 #endif

--- a/libmamba/include/mamba/specs/glob_spec.hpp
+++ b/libmamba/include/mamba/specs/glob_spec.hpp
@@ -43,6 +43,7 @@ namespace mamba::specs
 
         [[nodiscard]] auto str() const -> const std::string&;
 
+        // TODO: only use the `= default` implementation of `operator==` when we will use C++20.
         [[nodiscard]] auto operator==(const GlobSpec& other) const -> bool
         {
             return m_pattern == other.m_pattern;

--- a/libmamba/include/mamba/specs/glob_spec.hpp
+++ b/libmamba/include/mamba/specs/glob_spec.hpp
@@ -43,6 +43,16 @@ namespace mamba::specs
 
         [[nodiscard]] auto str() const -> const std::string&;
 
+        [[nodiscard]] auto operator==(const GlobSpec& other) const -> bool
+        {
+            return m_pattern == other.m_pattern;
+        }
+
+        [[nodiscard]] auto operator!=(const GlobSpec& other) const -> bool
+        {
+            return !(*this == other);
+        }
+
     private:
 
         std::string m_pattern = std::string(free_pattern);
@@ -55,6 +65,15 @@ struct fmt::formatter<mamba::specs::GlobSpec>
     auto parse(format_parse_context& ctx) -> decltype(ctx.begin());
 
     auto format(const ::mamba::specs::GlobSpec& spec, format_context& ctx) -> decltype(ctx.out());
+};
+
+template <>
+struct std::hash<mamba::specs::GlobSpec>
+{
+    auto operator()(const mamba::specs::GlobSpec& spec) const -> std::size_t
+    {
+        return std::hash<std::string>{}(spec.str());
+    }
 };
 
 #endif

--- a/libmamba/include/mamba/specs/glob_spec.hpp
+++ b/libmamba/include/mamba/specs/glob_spec.hpp
@@ -43,7 +43,7 @@ namespace mamba::specs
 
         [[nodiscard]] auto str() const -> const std::string&;
 
-        // TODO: only use the `= default` implementation of `operator==` when we will use C++20.
+        // TODO(C++20): replace by the `= default` implementation of `operator==`
         [[nodiscard]] auto operator==(const GlobSpec& other) const -> bool
         {
             return m_pattern == other.m_pattern;

--- a/libmamba/include/mamba/specs/match_spec.hpp
+++ b/libmamba/include/mamba/specs/match_spec.hpp
@@ -136,7 +136,7 @@ namespace mamba::specs
          */
         [[nodiscard]] auto contains_except_channel(const PackageInfo& pkg) const -> bool;
 
-        // TODO: only use the `= default` implementation of `operator==` when we will use C++20.
+        // TODO(C++20): replace by the `= default` implementation of `operator==`
         [[nodiscard]] auto operator==(const MatchSpec& other) const -> bool
         {
             return m_channel == other.m_channel               //
@@ -174,7 +174,7 @@ namespace mamba::specs
             string_set track_features = {};
             bool optional = false;
 
-            // TODO: only use the `= default` implementation of `operator==` when we will use C++20.
+            // TODO(C++20): replace by the `= default` implementation of `operator==`
             [[nodiscard]] auto operator==(const ExtraMembers& other) const -> bool
             {
                 return filename == other.filename                 //

--- a/libmamba/include/mamba/specs/match_spec.hpp
+++ b/libmamba/include/mamba/specs/match_spec.hpp
@@ -136,7 +136,8 @@ namespace mamba::specs
          */
         [[nodiscard]] auto contains_except_channel(const PackageInfo& pkg) const -> bool;
 
-        auto operator==(const MatchSpec& other) const -> bool
+        // TODO: only use the `= default` implementation of `operator==` when we will use C++20.
+        [[nodiscard]] auto operator==(const MatchSpec& other) const -> bool
         {
             return m_channel == other.m_channel && m_version == other.m_version
                    && m_name == other.m_name && m_build_string == other.m_build_string
@@ -144,14 +145,14 @@ namespace mamba::specs
                    && m_extra == other.m_extra;
         }
 
-        auto operator!=(const MatchSpec& other) const -> bool
+        [[nodiscard]] auto operator!=(const MatchSpec& other) const -> bool
         {
             return !(*this == other);
         }
 
-        auto extra_members_hash(std::size_t seed) const -> std::size_t
+        auto extra_members_hash() const -> std::size_t
         {
-            return mamba::util::hash_combine_val(seed, m_extra);
+            return mamba::util::hash_vals(m_extra);
         }
 
     private:
@@ -170,6 +171,7 @@ namespace mamba::specs
             string_set track_features = {};
             bool optional = false;
 
+            // TODO: only use the `= default` implementation of `operator==` when we will use C++20.
             [[nodiscard]] auto operator==(const ExtraMembers& other) const -> bool
             {
                 return filename == other.filename && subdirs == other.subdirs && md5 == other.md5
@@ -296,15 +298,15 @@ struct std::hash<mamba::specs::MatchSpec>
 {
     auto operator()(const mamba::specs::MatchSpec& spec) const -> std::size_t
     {
-        auto seed = std::size_t(0);
-        seed = mamba::util::hash_combine_val(seed, spec.channel());
-        seed = mamba::util::hash_combine_val(seed, spec.version());
-        seed = mamba::util::hash_combine_val(seed, spec.name());
-        seed = mamba::util::hash_combine_val(seed, spec.build_string());
-        seed = mamba::util::hash_combine_val(seed, spec.name_space());
-        seed = mamba::util::hash_combine_val(seed, spec.build_number());
-        seed = spec.extra_members_hash(seed);
-        return seed;
+        return mamba::util::hash_vals(
+            spec.channel(),
+            spec.version(),
+            spec.name(),
+            spec.build_string(),
+            spec.name_space(),
+            spec.build_number(),
+            spec.extra_members_hash()
+        );
     }
 };
 
@@ -313,17 +315,17 @@ struct std::hash<mamba::specs::MatchSpec::ExtraMembers>
 {
     auto operator()(const mamba::specs::MatchSpec::ExtraMembers& extra) const -> std::size_t
     {
-        auto seed = std::size_t(0);
-        seed = mamba::util::hash_combine_val(seed, extra.filename);
-        seed = mamba::util::hash_combine_val(seed, extra.subdirs);
-        seed = mamba::util::hash_combine_val(seed, extra.md5);
-        seed = mamba::util::hash_combine_val(seed, extra.sha256);
-        seed = mamba::util::hash_combine_val(seed, extra.license);
-        seed = mamba::util::hash_combine_val(seed, extra.license_family);
-        seed = mamba::util::hash_combine_val(seed, extra.features);
-        seed = mamba::util::hash_combine_val(seed, extra.track_features);
-        seed = mamba::util::hash_combine_val(seed, extra.optional);
-        return seed;
+        return mamba::util::hash_vals(
+            extra.filename,
+            extra.subdirs,
+            extra.md5,
+            extra.sha256,
+            extra.license,
+            extra.license_family,
+            extra.features,
+            extra.track_features,
+            extra.optional
+        );
     }
 };
 

--- a/libmamba/include/mamba/specs/match_spec.hpp
+++ b/libmamba/include/mamba/specs/match_spec.hpp
@@ -139,9 +139,12 @@ namespace mamba::specs
         // TODO: only use the `= default` implementation of `operator==` when we will use C++20.
         [[nodiscard]] auto operator==(const MatchSpec& other) const -> bool
         {
-            return m_channel == other.m_channel && m_version == other.m_version
-                   && m_name == other.m_name && m_build_string == other.m_build_string
-                   && m_name_space == other.m_name_space && m_build_number == other.m_build_number
+            return m_channel == other.m_channel               //
+                   && m_version == other.m_version            //
+                   && m_name == other.m_name                  //
+                   && m_build_string == other.m_build_string  //
+                   && m_name_space == other.m_name_space      //
+                   && m_build_number == other.m_build_number  //
                    && m_extra == other.m_extra;
         }
 
@@ -174,10 +177,15 @@ namespace mamba::specs
             // TODO: only use the `= default` implementation of `operator==` when we will use C++20.
             [[nodiscard]] auto operator==(const ExtraMembers& other) const -> bool
             {
-                return filename == other.filename && subdirs == other.subdirs && md5 == other.md5
-                       && sha256 == other.sha256 && license == other.license
-                       && license_family == other.license_family && features == other.features
-                       && track_features == other.track_features && optional == other.optional;
+                return filename == other.filename                 //
+                       && subdirs == other.subdirs                //
+                       && md5 == other.md5                        //
+                       && sha256 == other.sha256                  //
+                       && license == other.license                //
+                       && license_family == other.license_family  //
+                       && features == other.features              //
+                       && track_features == other.track_features  //
+                       && optional == other.optional;
             }
 
             [[nodiscard]] auto operator!=(const ExtraMembers& other) const -> bool

--- a/libmamba/include/mamba/specs/package_info.hpp
+++ b/libmamba/include/mamba/specs/package_info.hpp
@@ -15,6 +15,7 @@
 
 #include "mamba/specs/error.hpp"
 #include "mamba/specs/platform.hpp"
+#include "mamba/util/tuple_hash.hpp"
 
 namespace mamba::specs
 {
@@ -81,4 +82,47 @@ namespace mamba::specs
 
     void from_json(const nlohmann::json& j, PackageInfo& pkg);
 }
+
+template <>
+struct std::hash<mamba::specs::PackageInfo>
+{
+    auto operator()(const mamba::specs::PackageInfo& pkg) const -> std::size_t
+    {
+        auto seed = std::size_t(0);
+        seed = mamba::util::hash_combine_val(seed, pkg.name);
+        seed = mamba::util::hash_combine_val(seed, pkg.version);
+        seed = mamba::util::hash_combine_val(seed, pkg.build_string);
+        seed = mamba::util::hash_combine_val(seed, pkg.build_number);
+        seed = mamba::util::hash_combine_val(seed, pkg.channel);
+        seed = mamba::util::hash_combine_val(seed, pkg.package_url);
+        seed = mamba::util::hash_combine_val(seed, pkg.platform);
+        seed = mamba::util::hash_combine_val(seed, pkg.filename);
+        seed = mamba::util::hash_combine_val(seed, pkg.license);
+        seed = mamba::util::hash_combine_val(seed, pkg.md5);
+        seed = mamba::util::hash_combine_val(seed, pkg.sha256);
+        seed = mamba::util::hash_combine_val(seed, pkg.signatures);
+        seed = mamba::util::hash_combine_val_range(
+            seed,
+            pkg.track_features.begin(),
+            pkg.track_features.end()
+        );
+        seed = mamba::util::hash_combine_val_range(
+            seed,
+            pkg.dependencies.begin(),
+            pkg.dependencies.end()
+        );
+        seed = mamba::util::hash_combine_val_range(seed, pkg.constrains.begin(), pkg.constrains.end());
+        seed = mamba::util::hash_combine_val_range(
+            seed,
+            pkg.defaulted_keys.begin(),
+            pkg.defaulted_keys.end()
+        );
+        seed = mamba::util::hash_combine_val(seed, pkg.noarch);
+        seed = mamba::util::hash_combine_val(seed, pkg.size);
+        seed = mamba::util::hash_combine_val(seed, pkg.timestamp);
+        seed = mamba::util::hash_combine_val(seed, pkg.package_type);
+        return seed;
+    }
+};
+
 #endif

--- a/libmamba/include/mamba/specs/package_info.hpp
+++ b/libmamba/include/mamba/specs/package_info.hpp
@@ -89,18 +89,21 @@ struct std::hash<mamba::specs::PackageInfo>
     auto operator()(const mamba::specs::PackageInfo& pkg) const -> std::size_t
     {
         auto seed = std::size_t(0);
-        seed = mamba::util::hash_combine_val(seed, pkg.name);
-        seed = mamba::util::hash_combine_val(seed, pkg.version);
-        seed = mamba::util::hash_combine_val(seed, pkg.build_string);
-        seed = mamba::util::hash_combine_val(seed, pkg.build_number);
-        seed = mamba::util::hash_combine_val(seed, pkg.channel);
-        seed = mamba::util::hash_combine_val(seed, pkg.package_url);
-        seed = mamba::util::hash_combine_val(seed, pkg.platform);
-        seed = mamba::util::hash_combine_val(seed, pkg.filename);
-        seed = mamba::util::hash_combine_val(seed, pkg.license);
-        seed = mamba::util::hash_combine_val(seed, pkg.md5);
-        seed = mamba::util::hash_combine_val(seed, pkg.sha256);
-        seed = mamba::util::hash_combine_val(seed, pkg.signatures);
+        seed = mamba::util::hash_vals(
+            seed,
+            pkg.name,
+            pkg.version,
+            pkg.build_string,
+            pkg.build_number,
+            pkg.channel,
+            pkg.package_url,
+            pkg.platform,
+            pkg.filename,
+            pkg.license,
+            pkg.md5,
+            pkg.sha256,
+            pkg.signatures
+        );
         seed = mamba::util::hash_combine_val_range(
             seed,
             pkg.track_features.begin(),
@@ -117,10 +120,7 @@ struct std::hash<mamba::specs::PackageInfo>
             pkg.defaulted_keys.begin(),
             pkg.defaulted_keys.end()
         );
-        seed = mamba::util::hash_combine_val(seed, pkg.noarch);
-        seed = mamba::util::hash_combine_val(seed, pkg.size);
-        seed = mamba::util::hash_combine_val(seed, pkg.timestamp);
-        seed = mamba::util::hash_combine_val(seed, pkg.package_type);
+        seed = mamba::util::hash_vals(seed, pkg.noarch, pkg.size, pkg.timestamp, pkg.package_type);
         return seed;
     }
 };

--- a/libmamba/include/mamba/specs/regex_spec.hpp
+++ b/libmamba/include/mamba/specs/regex_spec.hpp
@@ -47,11 +47,11 @@ namespace mamba::specs
 
         [[nodiscard]] auto str() const -> const std::string&;
 
+        // TODO: only use the `= default` implementation of `operator==` when we will use C++20.
         [[nodiscard]] auto operator==(const RegexSpec& other) const -> bool
         {
-            return (
-                m_raw_pattern == other.m_raw_pattern && m_pattern.flags() == other.m_pattern.flags()
-            );
+            return m_raw_pattern == other.m_raw_pattern
+                   && m_pattern.flags() == other.m_pattern.flags();
         }
 
         [[nodiscard]] auto operator!=(const RegexSpec& other) const -> bool

--- a/libmamba/include/mamba/specs/regex_spec.hpp
+++ b/libmamba/include/mamba/specs/regex_spec.hpp
@@ -47,6 +47,18 @@ namespace mamba::specs
 
         [[nodiscard]] auto str() const -> const std::string&;
 
+        [[nodiscard]] auto operator==(const RegexSpec& other) const -> bool
+        {
+            return (
+                m_raw_pattern == other.m_raw_pattern && m_pattern.flags() == other.m_pattern.flags()
+            );
+        }
+
+        [[nodiscard]] auto operator!=(const RegexSpec& other) const -> bool
+        {
+            return !(*this == other);
+        }
+
     private:
 
         std::regex m_pattern;

--- a/libmamba/include/mamba/specs/regex_spec.hpp
+++ b/libmamba/include/mamba/specs/regex_spec.hpp
@@ -47,7 +47,7 @@ namespace mamba::specs
 
         [[nodiscard]] auto str() const -> const std::string&;
 
-        // TODO: only use the `= default` implementation of `operator==` when we will use C++20.
+        // TODO(C++20): replace by the `= default` implementation of `operator==`
         [[nodiscard]] auto operator==(const RegexSpec& other) const -> bool
         {
             return m_raw_pattern == other.m_raw_pattern

--- a/libmamba/include/mamba/specs/unresolved_channel.hpp
+++ b/libmamba/include/mamba/specs/unresolved_channel.hpp
@@ -154,11 +154,7 @@ struct std::hash<mamba::specs::UnresolvedChannel>
 {
     auto operator()(const mamba::specs::UnresolvedChannel& uc) const -> std::size_t
     {
-        auto seed = std::size_t{ 0 };
-        seed = mamba::util::hash_combine_val(seed, uc.location());
-        seed = mamba::util::hash_combine_val(seed, uc.platform_filters());
-        seed = mamba::util::hash_combine_val(seed, static_cast<int>(uc.type()));
-        return seed;
+        return mamba::util::hash_vals(uc.location(), uc.platform_filters(), static_cast<int>(uc.type()));
     }
 };
 

--- a/libmamba/include/mamba/specs/unresolved_channel.hpp
+++ b/libmamba/include/mamba/specs/unresolved_channel.hpp
@@ -114,7 +114,8 @@ namespace mamba::specs
 
         [[nodiscard]] auto operator==(const UnresolvedChannel& other) const -> bool
         {
-            return m_location == other.m_location && m_platform_filters == other.m_platform_filters
+            return m_location == other.m_location                     //
+                   && m_platform_filters == other.m_platform_filters  //
                    && m_type == other.m_type;
         }
 

--- a/libmamba/include/mamba/specs/unresolved_channel.hpp
+++ b/libmamba/include/mamba/specs/unresolved_channel.hpp
@@ -17,6 +17,7 @@
 #include "mamba/specs/error.hpp"
 #include "mamba/specs/platform.hpp"
 #include "mamba/util/flat_set.hpp"
+#include "mamba/util/tuple_hash.hpp"
 
 namespace mamba::specs
 {
@@ -111,6 +112,17 @@ namespace mamba::specs
 
         [[nodiscard]] auto str() const -> std::string;
 
+        [[nodiscard]] auto operator==(const UnresolvedChannel& other) const -> bool
+        {
+            return m_location == other.m_location && m_platform_filters == other.m_platform_filters
+                   && m_type == other.m_type;
+        }
+
+        [[nodiscard]] auto operator!=(const UnresolvedChannel& other) const -> bool
+        {
+            return !(*this == other);
+        }
+
     private:
 
         std::string m_location = std::string(unknown_channel);
@@ -135,6 +147,19 @@ struct fmt::formatter<mamba::specs::UnresolvedChannel>
     }
 
     auto format(const UnresolvedChannel& uc, format_context& ctx) const -> format_context::iterator;
+};
+
+template <>
+struct std::hash<mamba::specs::UnresolvedChannel>
+{
+    auto operator()(const mamba::specs::UnresolvedChannel& uc) const -> std::size_t
+    {
+        auto seed = std::size_t{ 0 };
+        seed = mamba::util::hash_combine_val(seed, uc.location());
+        seed = mamba::util::hash_combine_val(seed, uc.platform_filters());
+        seed = mamba::util::hash_combine_val(seed, static_cast<int>(uc.type()));
+        return seed;
+    }
 };
 
 #endif

--- a/libmamba/include/mamba/specs/version_spec.hpp
+++ b/libmamba/include/mamba/specs/version_spec.hpp
@@ -17,6 +17,7 @@
 #include "mamba/specs/error.hpp"
 #include "mamba/specs/version.hpp"
 #include "mamba/util/flat_bool_expr_tree.hpp"
+#include "mamba/util/tuple_hash.hpp"
 
 namespace mamba::specs
 {
@@ -195,6 +196,16 @@ namespace mamba::specs
          */
         [[nodiscard]] auto expression_size() const -> std::size_t;
 
+        [[nodiscard]] auto operator==(const VersionSpec& other) const -> bool
+        {
+            return m_tree == other.m_tree;
+        }
+
+        [[nodiscard]] auto operator!=(const VersionSpec& other) const -> bool
+        {
+            return !(*this == other);
+        }
+
     private:
 
         tree_type m_tree;
@@ -234,4 +245,27 @@ struct fmt::formatter<mamba::specs::VersionSpec>
 
     auto format(const ::mamba::specs::VersionSpec& spec, format_context& ctx) -> decltype(ctx.out());
 };
+
+template <>
+struct std::hash<mamba::specs::VersionPredicate>
+{
+    auto operator()(const mamba::specs::VersionPredicate& pred) const -> std::size_t
+    {
+        auto seed = std::size_t{ 0 };
+        seed = mamba::util::hash_combine_val(seed, pred.str());
+        return seed;
+    }
+};
+
+template <>
+struct std::hash<mamba::specs::VersionSpec>
+{
+    auto operator()(const mamba::specs::VersionSpec& spec) const -> std::size_t
+    {
+        auto seed = std::size_t{ 0 };
+        seed = mamba::util::hash_combine_val(seed, spec.str());
+        return seed;
+    }
+};
+
 #endif

--- a/libmamba/include/mamba/specs/version_spec.hpp
+++ b/libmamba/include/mamba/specs/version_spec.hpp
@@ -251,9 +251,7 @@ struct std::hash<mamba::specs::VersionPredicate>
 {
     auto operator()(const mamba::specs::VersionPredicate& pred) const -> std::size_t
     {
-        auto seed = std::size_t{ 0 };
-        seed = mamba::util::hash_combine_val(seed, pred.str());
-        return seed;
+        return mamba::util::hash_vals(pred.str());
     }
 };
 
@@ -262,9 +260,7 @@ struct std::hash<mamba::specs::VersionSpec>
 {
     auto operator()(const mamba::specs::VersionSpec& spec) const -> std::size_t
     {
-        auto seed = std::size_t{ 0 };
-        seed = mamba::util::hash_combine_val(seed, spec.str());
-        return seed;
+        return mamba::util::hash_vals(spec.str());
     }
 };
 

--- a/libmamba/include/mamba/util/flat_binary_tree.hpp
+++ b/libmamba/include/mamba/util/flat_binary_tree.hpp
@@ -42,7 +42,8 @@ namespace mamba::util
             // TODO: only use the `= default` implementation of `operator==` when we will use C++20.
             [[nodiscard]] auto operator==(const branch_node& other) const -> bool
             {
-                return data == other.data && left_child == other.left_child
+                return data == other.data                 //
+                       && left_child == other.left_child  //
                        && right_child == other.right_child;
             }
 

--- a/libmamba/include/mamba/util/flat_binary_tree.hpp
+++ b/libmamba/include/mamba/util/flat_binary_tree.hpp
@@ -39,7 +39,7 @@ namespace mamba::util
             std::size_t left_child = 0;
             std::size_t right_child = 0;
 
-            // TODO: only use the `= default` implementation of `operator==` when we will use C++20.
+            // TODO(C++20): replace by the `= default` implementation of `operator==`
             [[nodiscard]] auto operator==(const branch_node& other) const -> bool
             {
                 return data == other.data                 //
@@ -103,7 +103,7 @@ namespace mamba::util
         [[nodiscard]] auto right(idx_type idx) const -> idx_type;
         [[nodiscard]] auto root() const -> idx_type;
 
-        // TODO: only use the `= default` implementation of `operator==` when we will use C++20.
+        // TODO(C++20): replace by the `= default` implementation of `operator==`
         [[nodiscard]] auto operator==(const flat_binary_tree& other) const -> bool
         {
             return m_nodes == other.m_nodes && m_root == other.m_root;

--- a/libmamba/include/mamba/util/flat_binary_tree.hpp
+++ b/libmamba/include/mamba/util/flat_binary_tree.hpp
@@ -38,6 +38,17 @@ namespace mamba::util
             branch_type data;
             std::size_t left_child = 0;
             std::size_t right_child = 0;
+
+            [[nodiscard]] auto operator==(const branch_node& other) const -> bool
+            {
+                return data == other.data && left_child == other.left_child
+                       && right_child == other.right_child;
+            }
+
+            [[nodiscard]] auto operator!=(const branch_node& other) const -> bool
+            {
+                return !(*this == other);
+            }
         };
 
         using leaf_node = leaf_type;
@@ -89,6 +100,16 @@ namespace mamba::util
         [[nodiscard]] auto left(idx_type idx) const -> idx_type;
         [[nodiscard]] auto right(idx_type idx) const -> idx_type;
         [[nodiscard]] auto root() const -> idx_type;
+
+        [[nodiscard]] auto operator==(const flat_binary_tree& other) const -> bool
+        {
+            return m_nodes == other.m_nodes && m_root == other.m_root;
+        }
+
+        [[nodiscard]] auto operator!=(const flat_binary_tree& other) const -> bool
+        {
+            return !(*this == other);
+        }
 
         template <typename Visitor>
         void dfs_raw(Visitor&& visitor, idx_type start) const;

--- a/libmamba/include/mamba/util/flat_binary_tree.hpp
+++ b/libmamba/include/mamba/util/flat_binary_tree.hpp
@@ -39,6 +39,7 @@ namespace mamba::util
             std::size_t left_child = 0;
             std::size_t right_child = 0;
 
+            // TODO: only use the `= default` implementation of `operator==` when we will use C++20.
             [[nodiscard]] auto operator==(const branch_node& other) const -> bool
             {
                 return data == other.data && left_child == other.left_child
@@ -101,6 +102,7 @@ namespace mamba::util
         [[nodiscard]] auto right(idx_type idx) const -> idx_type;
         [[nodiscard]] auto root() const -> idx_type;
 
+        // TODO: only use the `= default` implementation of `operator==` when we will use C++20.
         [[nodiscard]] auto operator==(const flat_binary_tree& other) const -> bool
         {
             return m_nodes == other.m_nodes && m_root == other.m_root;

--- a/libmamba/include/mamba/util/flat_bool_expr_tree.hpp
+++ b/libmamba/include/mamba/util/flat_bool_expr_tree.hpp
@@ -173,7 +173,7 @@ namespace mamba::util
         template <typename UnaryFunc>
         void infix_for_each(UnaryFunc&& func) const;
 
-        // TODO: only use the `= default` implementation of `operator==` when we will use C++20.
+        // TODO(C++20): replace by the `= default` implementation of `operator==`
         [[nodiscard]] auto operator==(const self_type& other) const -> bool
         {
             return m_tree == other.m_tree;

--- a/libmamba/include/mamba/util/flat_bool_expr_tree.hpp
+++ b/libmamba/include/mamba/util/flat_bool_expr_tree.hpp
@@ -173,6 +173,16 @@ namespace mamba::util
         template <typename UnaryFunc>
         void infix_for_each(UnaryFunc&& func) const;
 
+        [[nodiscard]] auto operator==(const self_type& other) const -> bool
+        {
+            return m_tree == other.m_tree;
+        }
+
+        [[nodiscard]] auto operator!=(const self_type& other) const -> bool
+        {
+            return !(*this == other);
+        }
+
     private:
 
         using idx_type = typename tree_type::idx_type;

--- a/libmamba/include/mamba/util/flat_bool_expr_tree.hpp
+++ b/libmamba/include/mamba/util/flat_bool_expr_tree.hpp
@@ -173,6 +173,7 @@ namespace mamba::util
         template <typename UnaryFunc>
         void infix_for_each(UnaryFunc&& func) const;
 
+        // TODO: only use the `= default` implementation of `operator==` when we will use C++20.
         [[nodiscard]] auto operator==(const self_type& other) const -> bool
         {
             return m_tree == other.m_tree;

--- a/libmamba/include/mamba/util/flat_set.hpp
+++ b/libmamba/include/mamba/util/flat_set.hpp
@@ -12,6 +12,8 @@
 #include <utility>
 #include <vector>
 
+#include "mamba/util/tuple_hash.hpp"
+
 namespace mamba::util
 {
 
@@ -557,4 +559,19 @@ namespace mamba::util
         return out;
     }
 }
+
+template <typename Key, typename Compare, typename Allocator>
+struct std::hash<mamba::util::flat_set<Key, Compare, Allocator>>
+{
+    auto operator()(const mamba::util::flat_set<Key, Compare, Allocator>& set) const -> std::size_t
+    {
+        auto seed = std::size_t{ 0 };
+        for (const auto& key : set)
+        {
+            seed = mamba::util::hash_combine_val(seed, key);
+        }
+        return seed;
+    }
+};
+
 #endif

--- a/libmamba/include/mamba/util/flat_set.hpp
+++ b/libmamba/include/mamba/util/flat_set.hpp
@@ -565,12 +565,7 @@ struct std::hash<mamba::util::flat_set<Key, Compare, Allocator>>
 {
     auto operator()(const mamba::util::flat_set<Key, Compare, Allocator>& set) const -> std::size_t
     {
-        auto seed = std::size_t{ 0 };
-        for (const auto& key : set)
-        {
-            seed = mamba::util::hash_combine_val(seed, key);
-        }
-        return seed;
+        return mamba::util::hash_vals(set);
     }
 };
 

--- a/libmamba/include/mamba/util/heap_optional.hpp
+++ b/libmamba/include/mamba/util/heap_optional.hpp
@@ -68,6 +68,20 @@ namespace mamba::util
 
         void reset();
 
+        [[nodiscard]] auto operator==(const heap_optional& other) const -> bool
+        {
+            if (has_value() && other.has_value())
+            {
+                return *m_ptr == *other;
+            }
+            return !has_value() && !other.has_value();
+        }
+
+        [[nodiscard]] auto operator!=(const heap_optional& other) const -> bool
+        {
+            return !(*this == other);
+        }
+
     private:
 
         std::unique_ptr<element_type> m_ptr = nullptr;
@@ -236,4 +250,18 @@ namespace mamba::util
         m_ptr = nullptr;
     }
 }
+
+template <typename T>
+struct std::hash<mamba::util::heap_optional<T>>
+{
+    std::size_t operator()(const mamba::util::heap_optional<T>& opt) const
+    {
+        if (opt.has_value())
+        {
+            return std::hash<T>{}(*opt);
+        }
+        return 0;
+    }
+};
+
 #endif


### PR DESCRIPTION
This allows using instances of `MatchSpec` and `PackageInfo` in mappings such as `std::unordered_map`.