### PR TITLE
Restore previous behavior of `MAMBA_ROOT_PREFIX`

### DIFF
--- a/libmamba/src/api/configuration.cpp
+++ b/libmamba/src/api/configuration.cpp
@@ -624,8 +624,8 @@ namespace mamba
             }
 
             if (!fs::exists(prefix / "pkgs")           //
-                || !fs::exists(prefix / "conda-meta")  //
-                || !fs::exists(prefix / "envs"))
+                && !fs::exists(prefix / "conda-meta")  //
+                && !fs::exists(prefix / "envs"))
             {
                 return make_unexpected(
                     fmt::format(R"(Path "{}" is not an existing root prefix.)", prefix.string()),


### PR DESCRIPTION
Fix #3351

The behavior changed within this [commit](https://github.com/mamba-org/mamba/pull/3225/commits/89ce792f5d29aed9afd3db3262cd7e5ddd332bdb).
AFAIC this looks most likely like a mistake made when changing the default mamba root prefix, I don't see any other reasons...