### PR TITLE
build: Support fmt 11

### DIFF
--- a/libmamba/include/mamba/download/mirror.hpp
+++ b/libmamba/include/mamba/download/mirror.hpp
@@ -8,6 +8,7 @@
 #define MAMBA_DOWNLOAD_MIRROR_HPP
 
 #include <functional>
+#include <memory>
 #include <mutex>
 #include <optional>
 #include <string>

--- a/libmamba/include/mamba/fs/filesystem.hpp
+++ b/libmamba/include/mamba/fs/filesystem.hpp
@@ -1371,7 +1371,7 @@ struct fmt::formatter<::mamba::fs::u8path>
     }
 
     template <class FormatContext>
-    auto format(const ::mamba::fs::u8path& path, FormatContext& ctx)
+    auto format(const ::mamba::fs::u8path& path, FormatContext& ctx) const
     {
         return fmt::format_to(ctx.out(), "'{}'", path.string());
     }

--- a/libmamba/include/mamba/specs/build_number_spec.hpp
+++ b/libmamba/include/mamba/specs/build_number_spec.hpp
@@ -154,7 +154,7 @@ struct fmt::formatter<mamba::specs::BuildNumberPredicate>
 {
     auto parse(format_parse_context& ctx) -> decltype(ctx.begin());
 
-    auto format(const ::mamba::specs::BuildNumberPredicate& pred, format_context& ctx)
+    auto format(const ::mamba::specs::BuildNumberPredicate& pred, format_context& ctx) const
         -> decltype(ctx.out());
 };
 
@@ -163,8 +163,8 @@ struct fmt::formatter<mamba::specs::BuildNumberSpec>
 {
     auto parse(format_parse_context& ctx) -> decltype(ctx.begin());
 
-    auto
-    format(const ::mamba::specs::BuildNumberSpec& spec, format_context& ctx) -> decltype(ctx.out());
+    auto format(const ::mamba::specs::BuildNumberSpec& spec, format_context& ctx) const
+        -> decltype(ctx.out());
 };
 
 template <>

--- a/libmamba/include/mamba/specs/chimera_string_spec.hpp
+++ b/libmamba/include/mamba/specs/chimera_string_spec.hpp
@@ -74,8 +74,8 @@ struct fmt::formatter<mamba::specs::ChimeraStringSpec>
 {
     auto parse(format_parse_context& ctx) -> decltype(ctx.begin());
 
-    auto
-    format(const ::mamba::specs::ChimeraStringSpec& spec, format_context& ctx) -> decltype(ctx.out());
+    auto format(const ::mamba::specs::ChimeraStringSpec& spec, format_context& ctx) const
+        -> decltype(ctx.out());
 };
 
 template <>

--- a/libmamba/include/mamba/specs/glob_spec.hpp
+++ b/libmamba/include/mamba/specs/glob_spec.hpp
@@ -65,7 +65,8 @@ struct fmt::formatter<mamba::specs::GlobSpec>
 {
     auto parse(format_parse_context& ctx) -> decltype(ctx.begin());
 
-    auto format(const ::mamba::specs::GlobSpec& spec, format_context& ctx) -> decltype(ctx.out());
+    auto
+    format(const ::mamba::specs::GlobSpec& spec, format_context& ctx) const -> decltype(ctx.out());
 };
 
 template <>

--- a/libmamba/include/mamba/specs/match_spec.hpp
+++ b/libmamba/include/mamba/specs/match_spec.hpp
@@ -229,7 +229,8 @@ struct fmt::formatter<::mamba::specs::MatchSpec>
 {
     auto parse(format_parse_context& ctx) -> decltype(ctx.begin());
 
-    auto format(const ::mamba::specs::MatchSpec& spec, format_context& ctx) -> decltype(ctx.out());
+    auto
+    format(const ::mamba::specs::MatchSpec& spec, format_context& ctx) const -> decltype(ctx.out());
 };
 
 /*********************************

--- a/libmamba/include/mamba/specs/regex_spec.hpp
+++ b/libmamba/include/mamba/specs/regex_spec.hpp
@@ -71,7 +71,8 @@ struct fmt::formatter<mamba::specs::RegexSpec>
 {
     auto parse(format_parse_context& ctx) -> decltype(ctx.begin());
 
-    auto format(const ::mamba::specs::RegexSpec& spec, format_context& ctx) -> decltype(ctx.out());
+    auto
+    format(const ::mamba::specs::RegexSpec& spec, format_context& ctx) const -> decltype(ctx.out());
 };
 
 #endif

--- a/libmamba/include/mamba/specs/version.hpp
+++ b/libmamba/include/mamba/specs/version.hpp
@@ -177,8 +177,8 @@ struct fmt::formatter<mamba::specs::VersionPartAtom>
 {
     auto parse(format_parse_context& ctx) -> decltype(ctx.begin());
 
-    auto
-    format(const ::mamba::specs::VersionPartAtom atom, format_context& ctx) -> decltype(ctx.out());
+    auto format(const ::mamba::specs::VersionPartAtom atom, format_context& ctx) const
+        -> decltype(ctx.out());
 };
 
 template <>
@@ -188,7 +188,7 @@ struct fmt::formatter<mamba::specs::Version>
 
     auto parse(format_parse_context& ctx) -> decltype(ctx.begin());
 
-    auto format(const ::mamba::specs::Version v, format_context& ctx) -> decltype(ctx.out());
+    auto format(const ::mamba::specs::Version v, format_context& ctx) const -> decltype(ctx.out());
 };
 
 #endif

--- a/libmamba/include/mamba/specs/version_spec.hpp
+++ b/libmamba/include/mamba/specs/version_spec.hpp
@@ -229,8 +229,8 @@ struct fmt::formatter<mamba::specs::VersionPredicate>
 
     auto parse(format_parse_context& ctx) -> decltype(ctx.begin());
 
-    auto
-    format(const ::mamba::specs::VersionPredicate& pred, format_context& ctx) -> decltype(ctx.out());
+    auto format(const ::mamba::specs::VersionPredicate& pred, format_context& ctx) const
+        -> decltype(ctx.out());
 };
 
 template <>
@@ -243,7 +243,8 @@ struct fmt::formatter<mamba::specs::VersionSpec>
 
     auto parse(format_parse_context& ctx) -> decltype(ctx.begin());
 
-    auto format(const ::mamba::specs::VersionSpec& spec, format_context& ctx) -> decltype(ctx.out());
+    auto
+    format(const ::mamba::specs::VersionSpec& spec, format_context& ctx) const -> decltype(ctx.out());
 };
 
 template <>

--- a/libmamba/src/api/install.cpp
+++ b/libmamba/src/api/install.cpp
@@ -9,6 +9,7 @@
 #include <fmt/color.h>
 #include <fmt/format.h>
 #include <fmt/ostream.h>
+#include <fmt/ranges.h>
 #include <reproc++/run.hpp>
 #include <reproc/reproc.h>
 

--- a/libmamba/src/core/context.cpp
+++ b/libmamba/src/core/context.cpp
@@ -6,8 +6,8 @@
 
 #include <iostream>
 
-#include <fmt/format.h>
 #include <fmt/ostream.h>
+#include <fmt/ranges.h>
 #include <spdlog/pattern_formatter.h>
 #include <spdlog/sinks/stdout_color_sinks.h>
 #include <spdlog/spdlog.h>

--- a/libmamba/src/core/query.cpp
+++ b/libmamba/src/core/query.cpp
@@ -14,6 +14,7 @@
 #include <fmt/color.h>
 #include <fmt/format.h>
 #include <fmt/ostream.h>
+#include <fmt/ranges.h>
 
 #include "mamba/core/context.hpp"
 #include "mamba/core/output.hpp"

--- a/libmamba/src/core/run.cpp
+++ b/libmamba/src/core/run.cpp
@@ -26,6 +26,7 @@ extern "C"
 #include <fmt/color.h>
 #include <fmt/format.h>
 #include <fmt/ostream.h>
+#include <fmt/ranges.h>
 #include <nlohmann/json.hpp>
 #include <reproc++/run.hpp>
 #include <spdlog/spdlog.h>

--- a/libmamba/src/solver/libsolv/unsolvable.cpp
+++ b/libmamba/src/solver/libsolv/unsolvable.cpp
@@ -8,6 +8,7 @@
 #include <string>
 #include <vector>
 
+#include <fmt/ranges.h>
 #include <solv/problems.h>
 #include <solv/solver.h>
 

--- a/libmamba/src/specs/build_number_spec.cpp
+++ b/libmamba/src/specs/build_number_spec.cpp
@@ -113,7 +113,7 @@ auto
 fmt::formatter<mamba::specs::BuildNumberPredicate>::format(
     const ::mamba::specs::BuildNumberPredicate& pred,
     format_context& ctx
-) -> decltype(ctx.out())
+) const -> decltype(ctx.out())
 {
     using BuildNumberPredicate = typename mamba::specs::BuildNumberPredicate;
     using BuildNumber = typename BuildNumberPredicate::BuildNumber;
@@ -268,7 +268,7 @@ auto
 fmt::formatter<mamba::specs::BuildNumberSpec>::format(
     const ::mamba::specs::BuildNumberSpec& spec,
     format_context& ctx
-) -> decltype(ctx.out())
+) const -> decltype(ctx.out())
 {
     return fmt::format_to(ctx.out(), "{}", spec.m_predicate);
 }

--- a/libmamba/src/specs/chimera_string_spec.cpp
+++ b/libmamba/src/specs/chimera_string_spec.cpp
@@ -140,7 +140,7 @@ auto
 fmt::formatter<mamba::specs::ChimeraStringSpec>::format(
     const ::mamba::specs::ChimeraStringSpec& spec,
     format_context& ctx
-) -> decltype(ctx.out())
+) const -> decltype(ctx.out())
 {
     return fmt::format_to(ctx.out(), "{}", spec.str());
 }

--- a/libmamba/src/specs/glob_spec.cpp
+++ b/libmamba/src/specs/glob_spec.cpp
@@ -56,8 +56,10 @@ fmt::formatter<mamba::specs::GlobSpec>::parse(format_parse_context& ctx) -> decl
 }
 
 auto
-fmt::formatter<mamba::specs::GlobSpec>::format(const ::mamba::specs::GlobSpec& spec, format_context& ctx)
-    -> decltype(ctx.out())
+fmt::formatter<mamba::specs::GlobSpec>::format(
+    const ::mamba::specs::GlobSpec& spec,
+    format_context& ctx
+) const -> decltype(ctx.out())
 {
     return fmt::format_to(ctx.out(), "{}", spec.str());
 }

--- a/libmamba/src/specs/match_spec.cpp
+++ b/libmamba/src/specs/match_spec.cpp
@@ -9,6 +9,7 @@
 #include <tuple>
 
 #include <fmt/format.h>
+#include <fmt/ranges.h>
 
 #include "mamba/specs/archive.hpp"
 #include "mamba/specs/match_spec.hpp"
@@ -1069,7 +1070,7 @@ auto
 fmt::formatter<::mamba::specs::MatchSpec>::format(
     const ::mamba::specs::MatchSpec& spec,
     format_context& ctx
-) -> decltype(ctx.out())
+) const -> decltype(ctx.out())
 {
     using MatchSpec = ::mamba::specs::MatchSpec;
 

--- a/libmamba/src/specs/package_info.cpp
+++ b/libmamba/src/specs/package_info.cpp
@@ -11,6 +11,7 @@
 
 #include <fmt/core.h>
 #include <fmt/format.h>
+#include <fmt/ranges.h>
 #include <nlohmann/json.hpp>
 
 #include "mamba/specs/archive.hpp"

--- a/libmamba/src/specs/regex_spec.cpp
+++ b/libmamba/src/specs/regex_spec.cpp
@@ -102,7 +102,7 @@ auto
 fmt::formatter<mamba::specs::RegexSpec>::format(
     const ::mamba::specs::RegexSpec& spec,
     format_context& ctx
-) -> decltype(ctx.out())
+) const -> decltype(ctx.out())
 {
     return fmt::format_to(ctx.out(), "{}", spec.str());
 }

--- a/libmamba/src/specs/unresolved_channel.cpp
+++ b/libmamba/src/specs/unresolved_channel.cpp
@@ -13,6 +13,7 @@
 #include <utility>
 
 #include <fmt/format.h>
+#include <fmt/ranges.h>
 
 #include "mamba/fs/filesystem.hpp"
 #include "mamba/specs/archive.hpp"

--- a/libmamba/src/specs/version.cpp
+++ b/libmamba/src/specs/version.cpp
@@ -191,7 +191,7 @@ auto
 fmt::formatter<mamba::specs::VersionPartAtom>::format(
     const ::mamba::specs::VersionPartAtom atom,
     format_context& ctx
-) -> decltype(ctx.out())
+) const -> decltype(ctx.out())
 {
     return fmt::format_to(ctx.out(), "{}{}", atom.numeral(), atom.literal());
 }
@@ -792,7 +792,7 @@ fmt::formatter<mamba::specs::Version>::parse(format_parse_context& ctx) -> declt
 
 auto
 fmt::formatter<mamba::specs::Version>::format(const ::mamba::specs::Version v, format_context& ctx)
-    -> decltype(ctx.out())
+    const -> decltype(ctx.out())
 {
     auto out = ctx.out();
     if (v.epoch() != 0)

--- a/libmamba/src/specs/version_spec.cpp
+++ b/libmamba/src/specs/version_spec.cpp
@@ -195,7 +195,7 @@ auto
 fmt::formatter<mamba::specs::VersionPredicate>::format(
     const ::mamba::specs::VersionPredicate& pred,
     format_context& ctx
-) -> decltype(ctx.out())
+) const -> decltype(ctx.out())
 {
     using VersionPredicate = typename mamba::specs::VersionPredicate;
     using VersionSpec = typename mamba::specs::VersionSpec;
@@ -589,7 +589,7 @@ auto
 fmt::formatter<mamba::specs::VersionSpec>::format(
     const ::mamba::specs::VersionSpec& spec,
     format_context& ctx
-) -> decltype(ctx.out())
+) const -> decltype(ctx.out())
 {
     using VersionSpec = typename mamba::specs::VersionSpec;
 

--- a/libmamba/src/util/os_win.cpp
+++ b/libmamba/src/util/os_win.cpp
@@ -10,6 +10,7 @@
 #include <string>
 
 #include <fmt/format.h>
+#include <fmt/ranges.h>
 #include <reproc++/run.hpp>
 
 #include "mamba/util/environment.hpp"

--- a/micromamba/src/run.cpp
+++ b/micromamba/src/run.cpp
@@ -10,6 +10,7 @@
 
 #include <fmt/color.h>
 #include <fmt/format.h>
+#include <fmt/ranges.h>
 #include <nlohmann/json.hpp>
 #include <reproc++/run.hpp>
 #include <spdlog/spdlog.h>


### PR DESCRIPTION
Required changes for `fmt 11`:
 - `fmt::join` is now declared and defined in `fmt/ranges.h` (see https://github.com/fmtlib/fmt/commit/50565f9853926501bd1c9bda07c6a98f4d940691)
 - `fmt::format` has to respect its argument's `const`-qualification
 
Other changes are required as include paths might have change slightly.