### PR TITLE
ci: Unpin libcxx <18

### DIFF
--- a/.github/workflows/unix_impl.yml
+++ b/.github/workflows/unix_impl.yml
@@ -28,12 +28,6 @@ jobs:
           environment-file: ./dev/environment-dev.yml
           environment-name: build_env
           cache-environment: true
-      - name: Use libcxx <18 (see conda-forge/libcxx-feedstock#162)
-        # TODO: remove this step once the issue is fixed
-        # See: https://github.com/conda-forge/libcxx-feedstock/issues/162
-        if: startsWith(inputs.os, 'macos')
-        run: |
-          micromamba install -n build_env -c conda-forge "libcxx<18"
       - uses: hendrikmuhs/ccache-action@main
         with:
           variant: sccache


### PR DESCRIPTION
Since https://github.com/conda-forge/libcxx-feedstock/issues/162 has been resolved.