### PR TITLE
test: Adapt test_explicit_export_topologically_sorted

### DIFF
--- a/micromamba/tests/test_env.py
+++ b/micromamba/tests/test_env.py
@@ -184,7 +184,6 @@ def test_explicit_export_topologically_sorted(tmp_home, tmp_prefix):
     indices = {
         "libzlib": 0,
         "python": 0,
-        "wheel": 0,
         "pip": 0,
         "jupyterlab": 0,
     }
@@ -194,6 +193,5 @@ def test_explicit_export_topologically_sorted(tmp_home, tmp_prefix):
                 indices[pkg] = i
 
     assert indices["libzlib"] < indices["python"]
-    assert indices["python"] < indices["wheel"]
-    assert indices["wheel"] < indices["pip"]
+    assert indices["python"] < indices["pip"]
     assert indices["python"] < indices["jupyterlab"]


### PR DESCRIPTION
Fixes #3376.

As of pip 24.1.2 distribution on conda-forge, [pip does not depend on wheel at runtime anymore](https://github.com/conda-forge/pip-feedstock/pull/121/files#diff-f3725a55bf339595bf865fec73bda8ac99f283b0810c205442021f29c06eea9aR21-R25
).

Hence wheel index being 0 causing the bug.

Let's omit it entirely.