### PR TITLE
[win-64] Remove workaround

### DIFF
--- a/.github/workflows/static_build.yml
+++ b/.github/workflows/static_build.yml
@@ -148,9 +148,6 @@ jobs:
             reproc-cpp-static>=14.2.4.post0
       - name: build micromamba
         shell: cmd /C call {0}
-        # Using D_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR is a workaround to fix CI failure on win-64
-        # after updating runners to 20240603.1 image
-        # (cf. https://github.com/actions/runner-images/issues/10004#issuecomment-2153445161)
         run: |
           set CMAKE_PREFIX_PATH=.\vcpkg_installed\x64-windows-static-md;%CONDA_PREFIX%\Library
           cmake -S . ^
@@ -158,7 +155,6 @@ jobs:
             -D CMAKE_CXX_COMPILER_LAUNCHER=sccache ^
             -D CMAKE_C_COMPILER_LAUNCHER=sccache ^
             -D CMAKE_MSVC_RUNTIME_LIBRARY="MultiThreadedDLL" ^
-            -D CMAKE_CXX_FLAGS=" /D_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR" ^
             -D CMAKE_BUILD_TYPE="Release" ^
             -D BUILD_LIBMAMBA=ON ^
             -D BUILD_STATIC=ON ^


### PR DESCRIPTION
Removing the workaround as the [issue](https://github.com/actions/runner-images/issues/10004) is now fixed.