### PR TITLE
[win-64] Add constraint on fmt

### DIFF
--- a/.github/workflows/static_build.yml
+++ b/.github/workflows/static_build.yml
@@ -136,13 +136,15 @@ jobs:
         with:
           environment-name: mambabuild
           init-shell: bash cmd.exe
+          # Constraint on fmt is due to an issue with 11.0.2 (to be fixed in next version)
+          # cf. https://github.com/fmtlib/fmt/issues/4091
           create-args: >-
             cli11>=2.2,<3
             cpp-expected
             nlohmann_json
             simdjson-static>=3.3.0
             spdlog
-            fmt
+            fmt<=11.0.1
             yaml-cpp-static>=0.8.0
             libsolv-static>=0.7.24
             reproc-cpp-static>=14.2.4.post0


### PR DESCRIPTION
Add constraint on `fmt` due to an [issue](https://github.com/fmtlib/fmt/issues/4091) with `fmt 11.0.2`.
The fix is merged into master and would be available in the next version.
(Constraint to be removed when next release is out).