### PR TITLE
fix: PyPI support for `env update`

### DIFF
--- a/libmamba/CMakeLists.txt
+++ b/libmamba/CMakeLists.txt
@@ -258,6 +258,7 @@ set(
     ${LIBMAMBA_SOURCE_DIR}/api/install.cpp
     ${LIBMAMBA_SOURCE_DIR}/api/list.cpp
     ${LIBMAMBA_SOURCE_DIR}/api/pip_utils.cpp
+    ${LIBMAMBA_SOURCE_DIR}/api/pip_utils.hpp
     ${LIBMAMBA_SOURCE_DIR}/api/remove.cpp
     ${LIBMAMBA_SOURCE_DIR}/api/repoquery.cpp
     ${LIBMAMBA_SOURCE_DIR}/api/shell.cpp

--- a/libmamba/CMakeLists.txt
+++ b/libmamba/CMakeLists.txt
@@ -257,6 +257,7 @@ set(
     ${LIBMAMBA_SOURCE_DIR}/api/info.cpp
     ${LIBMAMBA_SOURCE_DIR}/api/install.cpp
     ${LIBMAMBA_SOURCE_DIR}/api/list.cpp
+    ${LIBMAMBA_SOURCE_DIR}/api/pip_utils.cpp
     ${LIBMAMBA_SOURCE_DIR}/api/remove.cpp
     ${LIBMAMBA_SOURCE_DIR}/api/repoquery.cpp
     ${LIBMAMBA_SOURCE_DIR}/api/shell.cpp

--- a/libmamba/src/api/install.cpp
+++ b/libmamba/src/api/install.cpp
@@ -539,7 +539,7 @@ namespace mamba
                 for (auto other_spec : config.at("others_pkg_mgrs_specs")
                                            .value<std::vector<detail::other_pkg_mgr_spec>>())
                 {
-                    install_for_other_pkgmgr(ctx, other_spec, /* update= */ false);
+                    install_for_other_pkgmgr(ctx, other_spec, pip::Update::No);
                 }
             }
             else
@@ -637,7 +637,7 @@ namespace mamba
 
                 for (auto other_spec : others)
                 {
-                    install_for_other_pkgmgr(ctx, other_spec, /* update= */ false);
+                    install_for_other_pkgmgr(ctx, other_spec, pip::Update::No);
                 }
             }
             else

--- a/libmamba/src/api/pip_utils.cpp
+++ b/libmamba/src/api/pip_utils.cpp
@@ -118,6 +118,12 @@ namespace mamba
         const auto& deps = other_spec.deps;
         const auto& cwd = other_spec.cwd;
 
+        LOG_WARNING << fmt::format(
+            "You are using '{}' as an additional package manager.\nBe aware that packages installed with '{}' are managed independently from 'conda-forge' channel.",
+            pkg_mgr,
+            pkg_mgr
+        );
+
         TemporaryFile specs("mambaf", "", cwd);
         {
             std::ofstream specs_f = open_ofstream(specs.path());

--- a/libmamba/src/api/pip_utils.cpp
+++ b/libmamba/src/api/pip_utils.cpp
@@ -27,21 +27,20 @@ namespace mamba
             bool update
         )
         {
-            const auto get_python_path = [&]
-            { return util::which_in("python", get_path_dirs(target_prefix)).string(); };
+            const auto python = util::which_in("python", get_path_dirs(target_prefix)).string();
 
             const std::unordered_map<std::string, command_args> pip_install_command{
                 { "pip",
-                  { get_python_path(), "-m", "pip", "install", "-r", spec_file, "--no-input" } },
+                  { python, "-m", "pip", "install", "-r", spec_file, "--no-input", "--quiet" } },
                 { "pip --no-deps",
-                  { get_python_path(), "-m", "pip", "install", "--no-deps", "-r", spec_file, "--no-input" } }
+                  { python, "-m", "pip", "install", "--no-deps", "-r", spec_file, "--no-input", "--quiet" } }
             };
 
             const std::unordered_map<std::string, command_args> pip_update_command{
                 { "pip",
-                  { get_python_path(), "-m", "pip", "install", "-U", "-r", spec_file, "--no-input" } },
+                  { python, "-m", "pip", "install", "-U", "-r", spec_file, "--no-input", "--quiet" } },
                 { "pip --no-deps",
-                  { get_python_path(), "-m", "pip", "install", "-U", "--no-deps", "-r", spec_file, "--no-input" } }
+                  { python, "-m", "pip", "install", "-U", "--no-deps", "-r", spec_file, "--no-input", "--quiet" } }
             };
 
             auto found_it = update ? pip_update_command.find(name) : pip_install_command.find(name);

--- a/libmamba/src/api/pip_utils.cpp
+++ b/libmamba/src/api/pip_utils.cpp
@@ -31,19 +31,27 @@ namespace mamba
 
             const std::unordered_map<std::string, command_args> pip_install_command{
                 { "pip",
-                  { python, "-m", "pip", "install", "-r", spec_file, "--no-input", "--quiet" } },
+                  { python,
+                    "-m",
+                    "pip",
+                    "install",
+                    (update ? ("-U", "-r") : "-r"),
+                    spec_file,
+                    "--no-input",
+                    "--quiet" } },
                 { "pip --no-deps",
-                  { python, "-m", "pip", "install", "--no-deps", "-r", spec_file, "--no-input", "--quiet" } }
+                  { python,
+                    "-m",
+                    "pip",
+                    "install",
+                    "--no-deps",
+                    (update ? ("-U", "-r") : "-r"),
+                    spec_file,
+                    "--no-input",
+                    "--quiet" } }
             };
 
-            const std::unordered_map<std::string, command_args> pip_update_command{
-                { "pip",
-                  { python, "-m", "pip", "install", "-U", "-r", spec_file, "--no-input", "--quiet" } },
-                { "pip --no-deps",
-                  { python, "-m", "pip", "install", "-U", "--no-deps", "-r", spec_file, "--no-input", "--quiet" } }
-            };
-
-            auto found_it = update ? pip_update_command.find(name) : pip_install_command.find(name);
+            auto found_it = pip_install_command.find(name);
             if (found_it != pip_install_command.end())
             {
                 return found_it->second;

--- a/libmamba/src/api/pip_utils.cpp
+++ b/libmamba/src/api/pip_utils.cpp
@@ -35,7 +35,7 @@ namespace mamba
                     "-m",
                     "pip",
                     "install",
-                    (update ? ("-U", "-r") : "-r"),
+                    (update ? "-U", "-r" : "-r"),
                     spec_file,
                     "--no-input",
                     "--quiet" } },
@@ -45,7 +45,7 @@ namespace mamba
                     "pip",
                     "install",
                     "--no-deps",
-                    (update ? ("-U", "-r") : "-r"),
+                    (update ? "-U", "-r" : "-r"),
                     spec_file,
                     "--no-input",
                     "--quiet" } }

--- a/libmamba/src/api/pip_utils.cpp
+++ b/libmamba/src/api/pip_utils.cpp
@@ -1,0 +1,167 @@
+#include <fmt/color.h>
+#include <fmt/format.h>
+#include <fmt/ostream.h>
+#include <fmt/ranges.h>
+#include <reproc++/run.hpp>
+#include <reproc/reproc.h>
+
+#include "mamba/api/install.hpp"
+#include "mamba/core/activation.hpp"
+#include "mamba/core/context.hpp"
+#include "mamba/core/util.hpp"
+#include "mamba/fs/filesystem.hpp"
+#include "mamba/util/environment.hpp"
+
+#include "tl/expected.hpp"
+
+#include "pip_utils.hpp"
+
+namespace mamba
+{
+    namespace
+    {
+        tl::expected<command_args, std::runtime_error> get_pip_install_command(
+            const std::string& name,
+            const std::string& target_prefix,
+            const fs::u8path& spec_file,
+            bool update
+        )
+        {
+            const auto get_python_path = [&]
+            { return util::which_in("python", get_path_dirs(target_prefix)).string(); };
+
+            const std::unordered_map<std::string, command_args> pip_install_command{
+                { "pip",
+                  { get_python_path(), "-m", "pip", "install", "-r", spec_file, "--no-input" } },
+                { "pip --no-deps",
+                  { get_python_path(), "-m", "pip", "install", "--no-deps", "-r", spec_file, "--no-input" } }
+            };
+
+            const std::unordered_map<std::string, command_args> pip_update_command{
+                { "pip",
+                  { get_python_path(), "-m", "pip", "install", "-U", "-r", spec_file, "--no-input" } },
+                { "pip --no-deps",
+                  { get_python_path(), "-m", "pip", "install", "-U", "--no-deps", "-r", spec_file, "--no-input" } }
+            };
+
+            auto found_it = update ? pip_update_command.find(name) : pip_install_command.find(name);
+            if (found_it != pip_install_command.end())
+            {
+                return found_it->second;
+            }
+            else
+            {
+                return tl::unexpected(std::runtime_error(fmt::format(
+                    "no {} instruction found for package manager '{}'",
+                    update ? "update" : "install",
+                    name
+                )));
+            }
+        }
+    }
+
+    bool reproc_killed(int status)
+    {
+        return status == REPROC_SIGKILL;
+    }
+
+    bool reproc_terminated(int status)
+    {
+        return status == REPROC_SIGTERM;
+    }
+
+    void assert_reproc_success(const reproc::options& options, int status, std::error_code ec)
+    {
+        bool killed_not_an_err = (options.stop.first.action == reproc::stop::kill)
+                                 || (options.stop.second.action == reproc::stop::kill)
+                                 || (options.stop.third.action == reproc::stop::kill);
+
+        bool terminated_not_an_err = (options.stop.first.action == reproc::stop::terminate)
+                                     || (options.stop.second.action == reproc::stop::terminate)
+                                     || (options.stop.third.action == reproc::stop::terminate);
+
+        if (ec || (!killed_not_an_err && reproc_killed(status))
+            || (!terminated_not_an_err && reproc_terminated(status)))
+        {
+            if (ec)
+            {
+                LOG_ERROR << "Subprocess call failed: " << ec.message();
+            }
+            else if (reproc_killed(status))
+            {
+                LOG_ERROR << "Subprocess call failed (killed)";
+            }
+            else
+            {
+                LOG_ERROR << "Subprocess call failed (terminated)";
+            }
+            throw std::runtime_error("Subprocess call failed. Aborting.");
+        }
+    }
+
+    tl::expected<command_args, std::runtime_error>
+    install_for_other_pkgmgr(const Context& ctx, const detail::other_pkg_mgr_spec& other_spec, bool update)
+    {
+        const auto& pkg_mgr = other_spec.pkg_mgr;
+        const auto& deps = other_spec.deps;
+        const auto& cwd = other_spec.cwd;
+
+        TemporaryFile specs("mambaf", "", cwd);
+        {
+            std::ofstream specs_f = open_ofstream(specs.path());
+            for (auto& d : deps)
+            {
+                specs_f << d.c_str() << '\n';
+            }
+        }
+
+        command_args command = [&]
+        {
+            const auto maybe_command = get_pip_install_command(
+                pkg_mgr,
+                ctx.prefix_params.target_prefix.string(),
+                specs.path(),
+                update
+            );
+            if (maybe_command)
+            {
+                return maybe_command.value();
+            }
+            else
+            {
+                throw maybe_command.error();
+            }
+        }();
+
+        auto [wrapped_command, tmpfile] = prepare_wrapped_call(
+            ctx,
+            ctx.prefix_params.target_prefix,
+            command
+        );
+
+        reproc::options options;
+        options.redirect.parent = true;
+        options.working_directory = cwd.c_str();
+
+        Console::stream() << fmt::format(
+            ctx.graphics_params.palette.external,
+            "\n{} {} packages: {}",
+            update ? "Updating" : "Installing",
+            pkg_mgr,
+            fmt::join(deps, ", ")
+        );
+
+        fmt::print(LOG_INFO, "Calling: {}", fmt::join(command, " "));
+
+        auto [status, ec] = reproc::run(wrapped_command, options);
+        assert_reproc_success(options, status, ec);
+        if (status != 0)
+        {
+            throw std::runtime_error(
+                fmt::format("pip failed to {} packages", update ? "update" : "install")
+            );
+        }
+
+        return command;
+    }
+}

--- a/libmamba/src/api/pip_utils.cpp
+++ b/libmamba/src/api/pip_utils.cpp
@@ -11,8 +11,9 @@
 #include <reproc++/run.hpp>
 #include <reproc/reproc.h>
 
-#include "mamba/api/install.hpp"
-#include "mamba/core/activation.hpp"
+// TODO includes to be removed after moving some functions/structs around
+#include "mamba/api/install.hpp"      // other_pkg_mgr_spec
+#include "mamba/core/activation.hpp"  // get_path_dirs
 #include "mamba/core/context.hpp"
 #include "mamba/core/util.hpp"
 #include "mamba/fs/filesystem.hpp"

--- a/libmamba/src/api/pip_utils.hpp
+++ b/libmamba/src/api/pip_utils.hpp
@@ -1,0 +1,21 @@
+#ifndef MAMBA_PIP_UTILS_HPP
+#define MAMBA_PIP_UTILS_HPP
+
+#include <vector>
+
+// TODO: move elements from `mamba/api/install.hpp` here
+#include "mamba/api/install.hpp"
+#include "mamba/core/context.hpp"
+
+#include "tl/expected.hpp"
+
+namespace mamba
+{
+    using command_args = std::vector<std::string>;
+
+    tl::expected<command_args, std::runtime_error>
+    install_for_other_pkgmgr(const Context& ctx, const detail::other_pkg_mgr_spec& other_spec, bool update);
+
+}
+
+#endif  // MAMBA_PIP_UTILS_HPP

--- a/libmamba/src/api/pip_utils.hpp
+++ b/libmamba/src/api/pip_utils.hpp
@@ -1,3 +1,9 @@
+// Copyright (c) 2024, QuantStack and Mamba Contributors
+//
+// Distributed under the terms of the BSD 3-Clause License.
+//
+// The full license is in the file LICENSE, distributed with this software.
+
 #ifndef MAMBA_PIP_UTILS_HPP
 #define MAMBA_PIP_UTILS_HPP
 

--- a/libmamba/src/api/pip_utils.hpp
+++ b/libmamba/src/api/pip_utils.hpp
@@ -13,6 +13,7 @@ namespace mamba
 {
     using command_args = std::vector<std::string>;
 
+    // TODO: make it `command_from_other_pkgmgr` with a enum for Install / Update / etc.
     tl::expected<command_args, std::runtime_error>
     install_for_other_pkgmgr(const Context& ctx, const detail::other_pkg_mgr_spec& other_spec, bool update);
 

--- a/libmamba/src/api/pip_utils.hpp
+++ b/libmamba/src/api/pip_utils.hpp
@@ -17,11 +17,22 @@
 
 namespace mamba
 {
+    namespace pip
+    {
+        enum class Update : bool
+        {
+            No = false,
+            Yes = true,
+        };
+    }
+
     using command_args = std::vector<std::string>;
 
-    // TODO: make it `command_from_other_pkgmgr` with a enum for Install / Update / etc.
-    tl::expected<command_args, std::runtime_error>
-    install_for_other_pkgmgr(const Context& ctx, const detail::other_pkg_mgr_spec& other_spec, bool update);
+    tl::expected<command_args, std::runtime_error> install_for_other_pkgmgr(
+        const Context& ctx,
+        const detail::other_pkg_mgr_spec& other_spec,
+        pip::Update update
+    );
 
 }
 

--- a/libmamba/src/api/pip_utils.hpp
+++ b/libmamba/src/api/pip_utils.hpp
@@ -7,16 +7,21 @@
 #ifndef MAMBA_PIP_UTILS_HPP
 #define MAMBA_PIP_UTILS_HPP
 
+#include <stdexcept>
+#include <string>
 #include <vector>
-
-// TODO: move elements from `mamba/api/install.hpp` here
-#include "mamba/api/install.hpp"
-#include "mamba/core/context.hpp"
 
 #include "tl/expected.hpp"
 
 namespace mamba
 {
+    class Context;
+
+    namespace detail
+    {
+        struct other_pkg_mgr_spec;
+    }
+
     namespace pip
     {
         enum class Update : bool

--- a/libmamba/src/api/update.cpp
+++ b/libmamba/src/api/update.cpp
@@ -4,6 +4,7 @@
 //
 // The full license is in the file LICENSE, distributed with this software.
 
+
 #include "mamba/api/channel_loader.hpp"
 #include "mamba/api/configuration.hpp"
 #include "mamba/api/update.hpp"

--- a/libmamba/src/api/update.cpp
+++ b/libmamba/src/api/update.cpp
@@ -239,7 +239,7 @@ namespace mamba
         for (auto other_spec :
              config.at("others_pkg_mgrs_specs").value<std::vector<detail::other_pkg_mgr_spec>>())
         {
-            install_for_other_pkgmgr(ctx, other_spec, /* update= */ true);
+            install_for_other_pkgmgr(ctx, other_spec, pip::Update::Yes);
         }
     }
 }

--- a/libmamba/src/api/update.cpp
+++ b/libmamba/src/api/update.cpp
@@ -4,10 +4,17 @@
 //
 // The full license is in the file LICENSE, distributed with this software.
 
+#include <fmt/color.h>
+#include <fmt/format.h>
+#include <fmt/ostream.h>
+#include <fmt/ranges.h>
+#include <reproc++/run.hpp>
+#include <reproc/reproc.h>
 
 #include "mamba/api/channel_loader.hpp"
 #include "mamba/api/configuration.hpp"
 #include "mamba/api/update.hpp"
+#include "mamba/core/activation.hpp"
 #include "mamba/core/channel_context.hpp"
 #include "mamba/core/context.hpp"
 #include "mamba/core/package_database_loader.hpp"
@@ -22,6 +29,134 @@ namespace mamba
 {
     namespace
     {
+        using command_args = std::vector<std::string>;
+
+        tl::expected<command_args, std::runtime_error> get_other_pkg_mgr_update_instructions(
+            const std::string& name,
+            const std::string& target_prefix,
+            const fs::u8path& spec_file
+        )
+        {
+            const auto get_python_path = [&]
+            { return util::which_in("python", get_path_dirs(target_prefix)).string(); };
+
+            const std::unordered_map<std::string, command_args> other_pkg_mgr_update_instructions{
+                { "pip",
+                  { get_python_path(), "-m", "pip", "install", "-U", "-r", spec_file, "--no-input" } },
+                { "pip --no-deps",
+                  { get_python_path(), "-m", "pip", "install", "-U", "--no-deps", "-r", spec_file, "--no-input" } }
+            };
+
+            auto found_it = other_pkg_mgr_update_instructions.find(name);
+            if (found_it != other_pkg_mgr_update_instructions.end())
+            {
+                return found_it->second;
+            }
+            else
+            {
+                return tl::unexpected(std::runtime_error(
+                    fmt::format("no update instruction found for package manager '{}'", name)
+                ));
+            }
+        }
+
+        bool reproc_killed(int status)
+        {
+            return status == REPROC_SIGKILL;
+        }
+
+        bool reproc_terminated(int status)
+        {
+            return status == REPROC_SIGTERM;
+        }
+
+        void assert_reproc_success(const reproc::options& options, int status, std::error_code ec)
+        {
+            bool killed_not_an_err = (options.stop.first.action == reproc::stop::kill)
+                                     || (options.stop.second.action == reproc::stop::kill)
+                                     || (options.stop.third.action == reproc::stop::kill);
+
+            bool terminated_not_an_err = (options.stop.first.action == reproc::stop::terminate)
+                                         || (options.stop.second.action == reproc::stop::terminate)
+                                         || (options.stop.third.action == reproc::stop::terminate);
+
+            if (ec || (!killed_not_an_err && reproc_killed(status))
+                || (!terminated_not_an_err && reproc_terminated(status)))
+            {
+                if (ec)
+                {
+                    LOG_ERROR << "Subprocess call failed: " << ec.message();
+                }
+                else if (reproc_killed(status))
+                {
+                    LOG_ERROR << "Subprocess call failed (killed)";
+                }
+                else
+                {
+                    LOG_ERROR << "Subprocess call failed (terminated)";
+                }
+                throw std::runtime_error("Subprocess call failed. Aborting.");
+            }
+        }
+
+        auto update_for_other_pkgmgr(const Context& ctx, const detail::other_pkg_mgr_spec& other_spec)
+        {
+            const auto& pkg_mgr = other_spec.pkg_mgr;
+            const auto& deps = other_spec.deps;
+            const auto& cwd = other_spec.cwd;
+
+            TemporaryFile specs("mambaf", "", cwd);
+            {
+                std::ofstream specs_f = open_ofstream(specs.path());
+                for (auto& d : deps)
+                {
+                    specs_f << d.c_str() << '\n';
+                }
+            }
+
+            command_args update_instructions = [&]
+            {
+                const auto maybe_instructions = get_other_pkg_mgr_update_instructions(
+                    pkg_mgr,
+                    ctx.prefix_params.target_prefix.string(),
+                    specs.path()
+                );
+                if (maybe_instructions)
+                {
+                    return maybe_instructions.value();
+                }
+                else
+                {
+                    throw maybe_instructions.error();
+                }
+            }();
+
+            auto [wrapped_command, tmpfile] = prepare_wrapped_call(
+                ctx,
+                ctx.prefix_params.target_prefix,
+                update_instructions
+            );
+
+            reproc::options options;
+            options.redirect.parent = true;
+            options.working_directory = cwd.c_str();
+
+            Console::stream() << fmt::format(
+                ctx.graphics_params.palette.external,
+                "\nUpdating {} packages: {}",
+                pkg_mgr,
+                fmt::join(deps, ", ")
+            );
+            fmt::print(LOG_INFO, "Calling: {}", fmt::join(update_instructions, " "));
+
+            auto [status, ec] = reproc::run(wrapped_command, options);
+            assert_reproc_success(options, status, ec);
+            if (status != 0)
+            {
+                throw std::runtime_error("pip failed to update packages");
+            }
+        }
+
         auto create_update_request(
             PrefixData& prefix_data,
             std::vector<std::string> specs,
@@ -232,5 +367,10 @@ namespace mamba
         };
 
         execute_transaction(transaction);
+        for (auto other_spec :
+             config.at("others_pkg_mgrs_specs").value<std::vector<detail::other_pkg_mgr_spec>>())
+        {
+            update_for_other_pkgmgr(ctx, other_spec);
+        }
     }
 }

--- a/micromamba/tests/env-pypi-pkg-test.yaml
+++ b/micromamba/tests/env-pypi-pkg-test.yaml
@@ -1,0 +1,4 @@
+dependencies:
+  - pip
+  - pip:
+      - pypi-pkg-test

--- a/micromamba/tests/env-pypi-pkg-test.yaml
+++ b/micromamba/tests/env-pypi-pkg-test.yaml
@@ -1,4 +1,4 @@
 dependencies:
   - pip
   - pip:
-      - pypi-pkg-test
+    - pypi-pkg-test

--- a/micromamba/tests/test_create.py
+++ b/micromamba/tests/test_create.py
@@ -162,55 +162,6 @@ def test_env_logging_overhead_regression(tmp_home, tmp_root_prefix, tmp_path):
 
 
 @pytest.mark.parametrize("shared_pkgs_dirs", [True], indirect=True)
-def test_env_create_pypi(tmp_home, tmp_root_prefix, tmp_path):
-    env_prefix = tmp_path / "myenv"
-
-    create_spec_file = tmp_path / "env-pypi-pkg-test.yaml"
-
-    shutil.copyfile(__this_dir__ / "env-pypi-pkg-test.yaml", create_spec_file)
-
-    res = helpers.create("-p", env_prefix, "-f", create_spec_file, "-y", "--json")
-    assert res["success"]
-
-    # Check that pypi-pkg-test is installed using pip for now
-    # See: https://github.com/mamba-org/mamba/issues/2059
-    pip_list_output = helpers.umamba_run("-p", env_prefix, "pip", "list", "--format=json")
-    pip_packages_list = yaml.safe_load(pip_list_output)
-    assert any(pkg["name"] == "pypi-pkg-test" for pkg in pip_packages_list)
-
-
-@pytest.mark.parametrize("shared_pkgs_dirs", [True], indirect=True)
-def test_env_create_update_pypi(tmp_home, tmp_root_prefix, tmp_path):
-    env_prefix = tmp_path / "myenv"
-
-    create_spec_file = tmp_path / "env-requires-pip-install.yaml"
-    update_spec_file = tmp_path / "env-pypi-pkg-test.yaml"
-
-    shutil.copyfile(__this_dir__ / "env-requires-pip-install.yaml", create_spec_file)
-    shutil.copyfile(__this_dir__ / "env-pypi-pkg-test.yaml", update_spec_file)
-
-    res = helpers.create("-p", env_prefix, "-f", create_spec_file, "-y", "--json")
-    assert res["success"]
-
-    # Check that pypi-pkg-test is not installed before the update
-    pip_list_output = helpers.umamba_run("-p", env_prefix, "pip", "list", "--format=json")
-    pip_packages_list = yaml.safe_load(pip_list_output)
-    assert all(pkg["name"] != "pypi-pkg-test" for pkg in pip_packages_list)
-
-    umamba_packages_list = helpers.umamba_list("-p", env_prefix, "--json")
-    assert all(pkg["name"] != "pypi-pkg-test" for pkg in umamba_packages_list)
-
-    res = helpers.update("-p", env_prefix, "-f", update_spec_file, "-y", "--json")
-    assert res["success"]
-
-    # Check that pypi-pkg-test (that is part of the update environment) is installed after the update
-    # See: https://github.com/mamba-org/mamba/issues/2059
-    pip_list_output = helpers.umamba_run("-p", env_prefix, "pip", "list", "--format=json")
-    packages_list = yaml.safe_load(pip_list_output)
-    assert any(pkg["name"] == "pypi-pkg-test" for pkg in packages_list)
-
-
-@pytest.mark.parametrize("shared_pkgs_dirs", [True], indirect=True)
 @pytest.mark.parametrize("root_prefix_type", (None, "env_var", "cli"))
 @pytest.mark.parametrize("target_is_root", (False, True))
 @pytest.mark.parametrize("cli_prefix", (False, True))

--- a/micromamba/tests/test_env.py
+++ b/micromamba/tests/test_env.py
@@ -284,10 +284,16 @@ def test_env_update_conda_forge_with_pypi(tmp_home, tmp_root_prefix, tmp_path):
     res = helpers.run_env("update", "-p", env_prefix, "-f", env_file_yml, "-y", "--json")
     assert res["success"]
 
-    # TODO
-    # numpy=1.24.2 from conda-forge is supposed to be uninstalled here (as done in conda)
-    # packages = helpers.umamba_list("-p", env_prefix, "--json")
-    # assert all(pkg["name"] != "numpy" for pkg in packages)
+    # Note that conda's behavior is different:
+    # numpy 1.24.2 is uninstalled to be replaced with 1.24.3 from PyPI
+    # (micro)mamba keeps both
+    packages = helpers.umamba_list("-p", env_prefix, "--json")
+    assert any(
+        pkg["name"] == "numpy"
+        and pkg["version"] == "1.24.2"
+        and pkg["channel"].startswith("conda-forge")
+        for pkg in packages
+    )
 
     ## Check pip packages using pip list for now
     ## See: https://github.com/mamba-org/mamba/issues/2059
@@ -340,12 +346,16 @@ def test_env_update_pypi_with_conda_forge(tmp_home, tmp_root_prefix, tmp_path):
     res = helpers.run_env("update", "-p", env_prefix, "-f", env_file_yml, "-y", "--json")
     assert res["success"]
 
-    # TODO
-    # numpy from conda-forge is not supposed to be installed
-    # packages = helpers.umamba_list("-p", env_prefix, "--json")
-    # assert all(
-    # package["name"] != "numpy" for package in packages
-    # )
+    # Note that conda's behavior is different:
+    # numpy 2.0.0 is not installed and numpy 1.26.4 from PyPI is kept
+    # (micro)mamba keeps both
+    packages = helpers.umamba_list("-p", env_prefix, "--json")
+    assert any(
+        pkg["name"] == "numpy"
+        and pkg["version"] == "2.0.0"
+        and pkg["channel"].startswith("conda-forge")
+        for pkg in packages
+    )
 
     ## Check pip packages using pip list for now
     ## See: https://github.com/mamba-org/mamba/issues/2059


### PR DESCRIPTION
Completes #1455.

This factors the logic of the call to `pip` for the install and update path.

Note that previously the output of `pip install` was redirected up to the `libmambapy` helpers' outputs, breaking JSON outputs when `--json` is specify. The logging level aren't managing the standard output of subprocess for now, and doing this properly probably should  be done in another PR. For now, we simply call `pip` in quiet mode.