### PR TITLE
Fix x86_64 to use underscore instead of dash

### DIFF
--- a/libmamba/src/core/virtual_packages.cpp
+++ b/libmamba/src/core/virtual_packages.cpp
@@ -174,21 +174,21 @@ namespace mamba
                 && __builtin_cpu_supports("avx512cd") && __builtin_cpu_supports("avx512dq")
                 && __builtin_cpu_supports("avx512vl"))
             {
-                return "x86_64-v4";
+                return "x86_64_v4";
             }
             /* if (__builtin_cpu_supports ("x86-64-v3")) */
             if (__builtin_cpu_supports("avx") && __builtin_cpu_supports("avx2")
                 && __builtin_cpu_supports("bmi") && __builtin_cpu_supports("bmi2")
                 && __builtin_cpu_supports("fma"))
             {
-                return "x86_64-v3";
+                return "x86_64_v3";
             }
             /* if (__builtin_cpu_supports ("x86-64-v2")) */
             if (__builtin_cpu_supports("popcnt") && __builtin_cpu_supports("sse3")
                 && __builtin_cpu_supports("ssse3") && __builtin_cpu_supports("sse4.1")
                 && __builtin_cpu_supports("sse4.2"))
             {
-                return "x86_64-v2";
+                return "x86_64_v2";
             }
 #endif
             return "x86_64";


### PR DESCRIPTION
See https://github.com/mamba-org/mamba/issues/3222#issuecomment-2284324975 .

Fix https://github.com/mamba-org/mamba/issues/3222 also for main/2.* by forward porting https://github.com/mamba-org/mamba/pull/3404 .