### PR TITLE
docs: Specify `CMAKE_INSTALL_PREFIX`

### DIFF
--- a/docs/source/installation/micromamba-installation.rst
+++ b/docs/source/installation/micromamba-installation.rst
@@ -212,6 +212,7 @@ Use CMake from this environment to drive the build:
    cmake -B build/ \
        -G Ninja \
        ${CMAKE_ARGS} \
+       -D CMAKE_INSTALL_PREFIX="${CONDA_PREFIX}" \
        -D CMAKE_BUILD_TYPE="Release" \
        -D BUILD_LIBMAMBA=ON \
        -D BUILD_STATIC=ON \


### PR DESCRIPTION
This allows building `mamba` and `micromamba` correctly on many systems.