### PR TITLE
doc: add github links to documentation

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -2,6 +2,8 @@
 Contributing
 ==============
 
+The mamba repository is hosted at https://github.com/mamba-org/mamba.
+
 When contributing to this repository, it is always a good idea to first
 discuss the change you wish to make via issue, email, or any other method with
 the owners of this repository before making a change.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -61,6 +61,10 @@ html_theme = "sphinx_book_theme"
 html_logo = "_static/logo.png"
 html_title = "documentation"
 
+html_theme_options = {
+    "repository_url": "https://github.com/mamba-org/mamba",
+    "use_repository_button": True,
+}
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,


### PR DESCRIPTION
I've tried to find the github repository from the documentation, but it seems that it's not linked.

This PR adds links

- as a button in the theme
- at the top of https://mamba.readthedocs.io/en/latest/developer_zone/contributing.html