### PR TITLE
Fix `channel` and `base_url` in `list` cmd

### DIFF
--- a/docs/source/developer_zone/changes-2.0.rst
+++ b/docs/source/developer_zone/changes-2.0.rst
@@ -185,5 +185,5 @@ Listing packages in the created ``pandoc_from_oci`` environment:
   $ micromamba list -n pandoc_from_oci
 
   Name    Version  Build       Channel
-  ───────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-  pandoc  3.2      ha770c72_0  https://pkg-containers.githubusercontent.com/ghcr1/blobs/pandoc-3.2-ha770c72_0.conda
+  ─────────────────────────────────────────────────────────────────────────────────────
+  pandoc  3.2      ha770c72_0  https://pkg-containers.githubusercontent.com/ghcr1/blobs

--- a/libmamba/src/api/list.cpp
+++ b/libmamba/src/api/list.cpp
@@ -51,7 +51,21 @@ namespace mamba
             }
         }
 
-        void list_packages(const Context& ctx, std::string regex, ChannelContext& channel_context, list_options options)
+        std::string strip_from_filename_and_platform(
+            const std::string& full_str,
+            const std::string& filename,
+            const std::string& platform
+        )
+        {
+            return rstrip(rstrip(rstrip(rstrip(full_str, filename), "/"), platform), "/");
+        }
+
+        void list_packages(
+            const Context& ctx,
+            std::string regex,
+            ChannelContext& channel_context,
+            list_options options
+        )
         {
             auto sprefix_data = PrefixData::create(ctx.prefix_params.target_prefix, channel_context);
             if (!sprefix_data)
@@ -87,27 +101,17 @@ namespace mamba
                     {
                         auto channels = channel_context.make_channel(pkg_info.package_url);
                         assert(channels.size() == 1);  // A URL can only resolve to one channel
-                        obj["base_url"] = rstrip(
-                            rstrip(
-                                rstrip(
-                                    rstrip(
-                                        channels.front().url().str(specs::CondaURL::Credentials::Remove),
-                                        pkg_info.filename
-                                    ),
-                                    "/"
-                                ),
-                                pkg_info.platform
-                            ),
-                            "/"
+                        obj["base_url"] = strip_from_filename_and_platform(
+                            channels.front().url().str(specs::CondaURL::Credentials::Remove),
+                            pkg_info.filename,
+                            pkg_info.platform
                         );
                         obj["build_number"] = pkg_info.build_number;
                         obj["build_string"] = pkg_info.build_string;
-                        obj["channel"] = rstrip(
-                            rstrip(
-                                rstrip(rstrip(channels.front().display_name(), pkg_info.filename), "/"),
-                                pkg_info.platform
-                            ),
-                            "/"
+                        obj["channel"] = strip_from_filename_and_platform(
+                            channels.front().display_name(),
+                            pkg_info.filename,
+                            pkg_info.platform
                         );
                         obj["dist_name"] = pkg_info.str();
                         obj["name"] = pkg_info.name;
@@ -144,15 +148,10 @@ namespace mamba
                     {
                         auto channels = channel_context.make_channel(package.second.channel);
                         assert(channels.size() == 1);  // A URL can only resolve to one channel
-                        formatted_pkgs.channel = rstrip(
-                            rstrip(
-                                rstrip(
-                                    rstrip(channels.front().display_name(), package.second.filename),
-                                    "/"
-                                ),
-                                package.second.platform
-                            ),
-                            "/"
+                        formatted_pkgs.channel = strip_from_filename_and_platform(
+                            channels.front().display_name(),
+                            package.second.filename,
+                            package.second.platform
                         );
                     }
                     packages.push_back(formatted_pkgs);

--- a/libmamba/src/api/list.cpp
+++ b/libmamba/src/api/list.cpp
@@ -12,6 +12,7 @@
 #include "mamba/core/channel_context.hpp"
 #include "mamba/core/context.hpp"
 #include "mamba/core/prefix_data.hpp"
+#include "mamba/util/string.hpp"
 
 namespace mamba
 {
@@ -34,12 +35,23 @@ namespace mamba
             return a.name < b.name;
         }
 
-        void list_packages(
-            const Context& ctx,
-            std::string regex,
-            ChannelContext& channel_context,
-            list_options options
-        )
+        // This is more or less an implementation of `util::rstrip` specific to this use case
+        // (for printing purposes), but using `std::string` instead of `std::string_view`
+        // `util::rstrip` is not used here because it leads to an UB,
+        // `using non owned/tracked strings from Channel (& co) and PackageInfo
+        std::string rstrip(const std::string& full_str, const std::string& sub_str)
+        {
+            if (util::ends_with(full_str, sub_str))
+            {
+                return full_str.substr(0, full_str.length() - sub_str.length());
+            }
+            else
+            {
+                return full_str;
+            }
+        }
+
+        void list_packages(const Context& ctx, std::string regex, ChannelContext& channel_context, list_options options)
         {
             auto sprefix_data = PrefixData::create(ctx.prefix_params.target_prefix, channel_context);
             if (!sprefix_data)
@@ -73,17 +85,30 @@ namespace mamba
 
                     if (regex.empty() || std::regex_search(pkg_info.name, spec_pat))
                     {
-                        auto display_channels = channel_context.make_channel(pkg_info.channel);
-                        auto url_channels = channel_context.make_channel(pkg_info.package_url);
-                        assert(display_channels.size() == 1);  // A URL can only resolve to one
-                                                               // channel
-                        assert(url_channels.size() == 1);  // A URL can only resolve to one channel
-                        obj["base_url"] = url_channels.front().url().str(
-                            specs::CondaURL::Credentials::Remove
+                        auto channels = channel_context.make_channel(pkg_info.package_url);
+                        assert(channels.size() == 1);  // A URL can only resolve to one channel
+                        obj["base_url"] = rstrip(
+                            rstrip(
+                                rstrip(
+                                    rstrip(
+                                        channels.front().url().str(specs::CondaURL::Credentials::Remove),
+                                        pkg_info.filename
+                                    ),
+                                    "/"
+                                ),
+                                pkg_info.platform
+                            ),
+                            "/"
                         );
                         obj["build_number"] = pkg_info.build_number;
                         obj["build_string"] = pkg_info.build_string;
-                        obj["channel"] = display_channels.front().display_name();
+                        obj["channel"] = rstrip(
+                            rstrip(
+                                rstrip(rstrip(channels.front().display_name(), pkg_info.filename), "/"),
+                                pkg_info.platform
+                            ),
+                            "/"
+                        );
                         obj["dist_name"] = pkg_info.str();
                         obj["name"] = pkg_info.name;
                         obj["platform"] = pkg_info.platform;
@@ -119,7 +144,16 @@ namespace mamba
                     {
                         auto channels = channel_context.make_channel(package.second.channel);
                         assert(channels.size() == 1);  // A URL can only resolve to one channel
-                        formatted_pkgs.channel = channels.front().display_name();
+                        formatted_pkgs.channel = rstrip(
+                            rstrip(
+                                rstrip(
+                                    rstrip(channels.front().display_name(), package.second.filename),
+                                    "/"
+                                ),
+                                package.second.platform
+                            ),
+                            "/"
+                        );
                     }
                     packages.push_back(formatted_pkgs);
                 }

--- a/micromamba/tests/test_create.py
+++ b/micromamba/tests/test_create.py
@@ -1231,9 +1231,8 @@ def test_create_from_oci_mirrored_channels(tmp_home, tmp_root_prefix, tmp_path, 
     assert pkg["name"] == "pandoc"
     if spec == "pandoc=3.1.13":
         assert pkg["version"] == "3.1.13"
-    assert pkg["base_url"].startswith(
-        "https://pkg-containers.githubusercontent.com/ghcr1/blobs/pandoc"
-    )
+    assert pkg["base_url"] == "https://pkg-containers.githubusercontent.com/ghcr1/blobs"
+    assert pkg["channel"] == "https://pkg-containers.githubusercontent.com/ghcr1/blobs"
 
 
 @pytest.mark.parametrize("shared_pkgs_dirs", [True], indirect=True)
@@ -1261,16 +1260,14 @@ def test_create_from_oci_mirrored_channels_with_deps(tmp_home, tmp_root_prefix, 
     assert len(packages) > 2
     assert any(
         package["name"] == "xtensor"
-        and package["base_url"].startswith(
-            "https://pkg-containers.githubusercontent.com/ghcr1/blobs/xtensor"
-        )
+        and package["base_url"] == "https://pkg-containers.githubusercontent.com/ghcr1/blobs"
+        and package["channel"] == "https://pkg-containers.githubusercontent.com/ghcr1/blobs"
         for package in packages
     )
     assert any(
         package["name"] == "xtl"
-        and package["base_url"].startswith(
-            "https://pkg-containers.githubusercontent.com/ghcr1/blobs/xtl"
-        )
+        and package["base_url"] == "https://pkg-containers.githubusercontent.com/ghcr1/blobs"
+        and package["channel"] == "https://pkg-containers.githubusercontent.com/ghcr1/blobs"
         for package in packages
     )
 
@@ -1304,9 +1301,8 @@ def test_create_from_oci_mirrored_channels_pkg_name_mapping(
     assert len(packages) == 1
     pkg = packages[0]
     assert pkg["name"] == "_go_select"
-    assert pkg["base_url"].startswith(
-        "https://pkg-containers.githubusercontent.com/ghcr1/blobs/_go_select"
-    )
+    assert pkg["base_url"] == "https://pkg-containers.githubusercontent.com/ghcr1/blobs"
+    assert pkg["channel"] == "https://pkg-containers.githubusercontent.com/ghcr1/blobs"
 
 
 @pytest.mark.parametrize("shared_pkgs_dirs", [True], indirect=True)

--- a/micromamba/tests/test_list.py
+++ b/micromamba/tests/test_list.py
@@ -21,6 +21,10 @@ def test_list(tmp_home, tmp_root_prefix, tmp_env_name, tmp_xtensor_env, env_sele
     names = [i["name"] for i in res]
     assert "xtensor" in names
     assert "xtl" in names
+    assert all(
+        i["channel"] == "conda-forge" and i["base_url"] == "https://conda.anaconda.org/conda-forge"
+        for i in res
+    )
 
 
 @pytest.mark.parametrize("quiet_flag", ["", "-q", "--quiet"])


### PR DESCRIPTION
Fix #3480

The channel name used in `1.x` was dropped during the "Great refactoring" (under the assumption, IIUC, that it's the same as `canonical_name`,  which was not always true...) and now that info is stored/computed nowhere.
Since this is only used in the `list` command, it's handled this way for now...