### PR TITLE
fix: Handle space in `mamba` and `micromamba` executable absolute paths 

### DIFF
--- a/libmamba/data/mamba.bat
+++ b/libmamba/data/mamba.bat
@@ -9,7 +9,7 @@ __MAMBA_INSERT_ROOT_PREFIX__
 @IF [%1]==[activate]   "%~dp0_mamba_activate" %*
 @IF [%1]==[deactivate] "%~dp0_mamba_activate" %*
 
-@CALL %MAMBA_EXE% %*
+@CALL "%MAMBA_EXE%" %*
 
 @IF %errorlevel% NEQ 0 EXIT /B %errorlevel%
 


### PR DESCRIPTION
version: micromamba-2.0.2-0.tar.bz2

on windows cmd,
it will fail by `'C:\Program' is not recognized as an internal or external command, operable program or batch file.` when `micromamba.exe` is located at eg `C:\Program Files`. 

this PR fixed it.