### PR TITLE
fix `activate.bat` fail on windows 

### DIFF
--- a/libmamba/src/core/shell_init.cpp
+++ b/libmamba/src/core/shell_init.cpp
@@ -734,7 +734,7 @@ namespace mamba
         util::replace_all(
             activate_bat_contents,
             std::string("__MAMBA_INSERT_EXE_NAME__"),
-            exe_name.string()
+            "mamba"
         );
         std::ofstream condabin_activate_bat_f = open_ofstream(
             root_prefix / "condabin" / "activate.bat"


### PR DESCRIPTION
version: micromamba-2.0.2-0.tar.bz2

curently run `activate` or `activate.bat` will end result with:
```
>> activate
>> micromamba activate
'micromamba' is not recognized as an internal or external command,
operable program or batch file.
```

the reason is DOSKEY "cannot run a macro from a command that you didn't type in manually" confirmed in docs and other sources eg https://stackoverflow.com/questions/71229141/windows-bat-file-using-start-cmd-k-with-doskey-not-work

this PR fixed it.
