### PR TITLE
maint: Clarify `env` subcommand documentation in help menu (cont'd)

### DIFF
--- a/docs/source/user_guide/micromamba.rst
+++ b/docs/source/user_guide/micromamba.rst
@@ -32,7 +32,7 @@ Quickstarts
     config                      Configuration of micromamba
     info                        Information about micromamba
     constructor                 Commands to support using micromamba in constructor
-    env                         See `mamba/micromamba env --help`.
+    env                         See `mamba/micromamba env --help`
     activate                    Activate an environment
     run                         Run an executable in an environment
     ps                          Show, inspect or kill running processes

--- a/libmamba/data/mamba.fish
+++ b/libmamba/data/mamba.fish
@@ -143,7 +143,7 @@ __fish_mamba_complete_subcmds '__fish_mamba_has_command' '
   config                      Configuration of micromamba
   info                        Information about micromamba
   constructor                 Commands to support using micromamba in constructor
-  env                         Access information about environments
+  env                         See `mamba/micromamba env --help`
   activate                    Activate an environment
   run                         Run an executable in an environment
   ps                          Show, inspect or kill running processes

--- a/micromamba/src/umamba.cpp
+++ b/micromamba/src/umamba.cpp
@@ -87,7 +87,7 @@ set_umamba_command(CLI::App* com, mamba::Configuration& config)
     );
     set_constructor_command(constructor_subcom, config);
 
-    CLI::App* env_subcom = com->add_subcommand("env", "Access information about environments");
+    CLI::App* env_subcom = com->add_subcommand("env", "See `mamba/micromamba env --help`");
     set_env_command(env_subcom, config);
 
     CLI::App* activate_subcom = com->add_subcommand("activate", "Activate an environment");


### PR DESCRIPTION
Fixes https://github.com/mamba-org/mamba/issues/3538.
Continues https://github.com/mamba-org/mamba/pull/3502/.