### PR TITLE
windows shell init files use executable name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,4 +92,3 @@ _skbuild/
 
 
 /vcpkg_installed/
-

--- a/.gitignore
+++ b/.gitignore
@@ -89,3 +89,7 @@ installed.json
 tmp/
 test_7.json.state
 _skbuild/
+
+
+/vcpkg_installed/
+

--- a/libmamba/data/activate.bat
+++ b/libmamba/data/activate.bat
@@ -1,5 +1,5 @@
 @REM Copyright (C) 2021 QuantStack
 @REM SPDX-License-Identifier: BSD-3-Clause
 
-@CALL "%~dp0..\condabin\mamba_hook.bat"
+@CALL "%~dp0..\condabin\__MAMBA_HOOK_BAT_NAME__"
 __MAMBA_INSERT_EXE_NAME__ activate %*

--- a/libmamba/data/activate.bat
+++ b/libmamba/data/activate.bat
@@ -1,5 +1,5 @@
 @REM Copyright (C) 2021 QuantStack
 @REM SPDX-License-Identifier: BSD-3-Clause
 
-@CALL "%~dp0..\condabin\__MAMBA_HOOK_BAT_NAME__"
+@CALL "%~dp0..\condabin\__MAMBA_INSERT_HOOK_BAT_NAME__"
 __MAMBA_INSERT_EXE_NAME__ activate %*

--- a/libmamba/data/mamba.bat
+++ b/libmamba/data/mamba.bat
@@ -3,21 +3,21 @@
 
 @REM Replaced by mamba executable with the MAMBA_EXE and MAMBA_ROOT_PREFIX variable pointing
 @REM to the correct locations.
-__MAMBA_INSERT_MAMBA_EXE__
-__MAMBA_INSERT_ROOT_PREFIX__
+__MAMBA_DEFINE_MAMBA_EXE__
+__MAMBA_DEFINE_ROOT_PREFIX__
 
-@IF [%1]==[activate]   "%~dp0__MAMBA_ACTIVATE_BAT_NAME__" %*
-@IF [%1]==[deactivate] "%~dp0__MAMBA_ACTIVATE_BAT_NAME__" %*
+@IF [%1]==[activate]   "%~dp0__MAMBA_INSERT_ACTIVATE_BAT_NAME__" %*
+@IF [%1]==[deactivate] "%~dp0__MAMBA_INSERT_ACTIVATE_BAT_NAME__" %*
 
 @CALL "%MAMBA_EXE%" %*
 
 @IF %errorlevel% NEQ 0 EXIT /B %errorlevel%
 
-@IF [%1]==[install]   "%~dp0__MAMBA_ACTIVATE_BAT_NAME__" reactivate
-@IF [%1]==[update]    "%~dp0__MAMBA_ACTIVATE_BAT_NAME__" reactivate
-@IF [%1]==[upgrade]   "%~dp0__MAMBA_ACTIVATE_BAT_NAME__" reactivate
-@IF [%1]==[remove]    "%~dp0__MAMBA_ACTIVATE_BAT_NAME__" reactivate
-@IF [%1]==[uninstall] "%~dp0__MAMBA_ACTIVATE_BAT_NAME__" reactivate
+@IF [%1]==[install]   "%~dp0__MAMBA_INSERT_ACTIVATE_BAT_NAME__" reactivate
+@IF [%1]==[update]    "%~dp0__MAMBA_INSERT_ACTIVATE_BAT_NAME__" reactivate
+@IF [%1]==[upgrade]   "%~dp0__MAMBA_INSERT_ACTIVATE_BAT_NAME__" reactivate
+@IF [%1]==[remove]    "%~dp0__MAMBA_INSERT_ACTIVATE_BAT_NAME__" reactivate
+@IF [%1]==[uninstall] "%~dp0__MAMBA_INSERT_ACTIVATE_BAT_NAME__" reactivate
 @IF [%1]==[self-update] @CALL DEL /f %MAMBA_EXE%.bkup
 
 @EXIT /B %errorlevel%

--- a/libmamba/data/mamba.bat
+++ b/libmamba/data/mamba.bat
@@ -6,18 +6,18 @@
 __MAMBA_INSERT_MAMBA_EXE__
 __MAMBA_INSERT_ROOT_PREFIX__
 
-@IF [%1]==[activate]   "%~dp0_mamba_activate" %*
-@IF [%1]==[deactivate] "%~dp0_mamba_activate" %*
+@IF [%1]==[activate]   "%~dp0__MAMBA_ACTIVATE_BAT_NAME__" %*
+@IF [%1]==[deactivate] "%~dp0__MAMBA_ACTIVATE_BAT_NAME__" %*
 
 @CALL "%MAMBA_EXE%" %*
 
 @IF %errorlevel% NEQ 0 EXIT /B %errorlevel%
 
-@IF [%1]==[install]   "%~dp0_mamba_activate" reactivate
-@IF [%1]==[update]    "%~dp0_mamba_activate" reactivate
-@IF [%1]==[upgrade]   "%~dp0_mamba_activate" reactivate
-@IF [%1]==[remove]    "%~dp0_mamba_activate" reactivate
-@IF [%1]==[uninstall] "%~dp0_mamba_activate" reactivate
+@IF [%1]==[install]   "%~dp0__MAMBA_ACTIVATE_BAT_NAME__" reactivate
+@IF [%1]==[update]    "%~dp0__MAMBA_ACTIVATE_BAT_NAME__" reactivate
+@IF [%1]==[upgrade]   "%~dp0__MAMBA_ACTIVATE_BAT_NAME__" reactivate
+@IF [%1]==[remove]    "%~dp0__MAMBA_ACTIVATE_BAT_NAME__" reactivate
+@IF [%1]==[uninstall] "%~dp0__MAMBA_ACTIVATE_BAT_NAME__" reactivate
 @IF [%1]==[self-update] @CALL DEL /f %MAMBA_EXE%.bkup
 
 @EXIT /B %errorlevel%

--- a/libmamba/data/mamba_hook.bat
+++ b/libmamba/data/mamba_hook.bat
@@ -7,9 +7,9 @@
 @FOR %%F in ("%~dp0") do @SET "__mambabin_dir=%%~dpF"
 @SET "__mambabin_dir=%__mambabin_dir:~0,-1%"
 @SET "PATH=%__mambabin_dir%;%PATH%"
-@SET "MAMBA_BAT=%__mambabin_dir%\__MAMBA_BAT_NAME__"
+@SET "MAMBA_BAT=%__mambabin_dir%\__MAMBA_INSERT_BAT_NAME__"
 @FOR %%F in ("%__mambabin_dir%") do @SET "__mamba_root=%%~dpF"
-__MAMBA_INSERT_MAMBA_EXE__
+__MAMBA_DEFINE_MAMBA_EXE__
 @SET __mambabin_dir=
 @SET __mamba_root=
 

--- a/libmamba/data/mamba_hook.bat
+++ b/libmamba/data/mamba_hook.bat
@@ -7,7 +7,7 @@
 @FOR %%F in ("%~dp0") do @SET "__mambabin_dir=%%~dpF"
 @SET "__mambabin_dir=%__mambabin_dir:~0,-1%"
 @SET "PATH=%__mambabin_dir%;%PATH%"
-@SET "MAMBA_BAT=%__mambabin_dir%\mamba.bat"
+@SET "MAMBA_BAT=%__mambabin_dir%\__MAMBA_BAT_NAME__"
 @FOR %%F in ("%__mambabin_dir%") do @SET "__mamba_root=%%~dpF"
 __MAMBA_INSERT_MAMBA_EXE__
 @SET __mambabin_dir=

--- a/libmamba/src/core/shell_init.cpp
+++ b/libmamba/src/core/shell_init.cpp
@@ -776,11 +776,14 @@ namespace mamba
         };
 
         static const auto MARKER_INSERT_EXE_NAME = std::string("__MAMBA_INSERT_EXE_NAME__");
+        static const auto MARKER_MAMBA_BAT_NAME = std::string("__MAMBA_BAT_NAME__");
 
         // mamba.bat
         std::string mamba_bat_contents(data_mamba_bat);
         replace_insert_root_prefix(mamba_bat_contents);
         replace_insert_mamba_exe(mamba_bat_contents);
+        static const auto MARKER_MAMBA_ACTIVATE_BAT_NAME = std::string("__MAMBA_ACTIVATE_BAT_NAME__");
+        util::replace_all(mamba_bat_contents, MARKER_MAMBA_ACTIVATE_BAT_NAME, paths._mamba_activate_bat.stem().string());
         std::ofstream mamba_bat_f = open_ofstream(paths.mamba_bat);
         mamba_bat_f << mamba_bat_contents;
 
@@ -793,6 +796,8 @@ namespace mamba
         replace_insert_root_prefix(activate_bat_contents);
         replace_insert_mamba_exe(activate_bat_contents);
         util::replace_all(activate_bat_contents, MARKER_INSERT_EXE_NAME, run_info().this_exe_name);
+        static const auto MARKER_MAMBA_HOOK_BAT_NAME = std::string("__MAMBA_HOOK_BAT_NAME__");
+        util::replace_all(activate_bat_contents, MARKER_MAMBA_HOOK_BAT_NAME, paths.mamba_hook_bat.stem().string());
         std::ofstream condabin_activate_bat_f = open_ofstream(paths.condabin_activate_bat);
         condabin_activate_bat_f << activate_bat_contents;
 
@@ -804,6 +809,7 @@ namespace mamba
         std::string hook_content = data_mamba_hook_bat;
         replace_insert_mamba_exe(hook_content);
         util::replace_all(hook_content, MARKER_INSERT_EXE_NAME, run_info().this_exe_path.string());
+        util::replace_all(hook_content, MARKER_MAMBA_BAT_NAME, paths.mamba_bat.stem().string());
 
         std::ofstream mamba_hook_bat_f = open_ofstream(paths.mamba_hook_bat);
         mamba_hook_bat_f << hook_content;

--- a/libmamba/src/core/shell_init.cpp
+++ b/libmamba/src/core/shell_init.cpp
@@ -100,9 +100,7 @@ namespace mamba
         return "";
     }
 
-#ifdef _WIN32
-
-    namespace
+    namespace // Windows-specific but must be available for cli on all platforms
     {
         struct RunInfo // FIXME: find a better name
         {
@@ -164,6 +162,8 @@ namespace mamba
 
     }
 
+
+#ifdef _WIN32
 
     std::wstring get_autorun_registry_key(const std::wstring& reg_path)
     {

--- a/libmamba/src/core/shell_init.cpp
+++ b/libmamba/src/core/shell_init.cpp
@@ -144,7 +144,7 @@ namespace mamba
 
             }
 
-            auto every_generated_files_paths() const -> std::initializer_list<fs::u8path>
+            auto every_generated_files_paths() const -> std::vector<fs::u8path>
             {
                 return { mamba_bat,
                          _mamba_activate_bat,
@@ -154,7 +154,7 @@ namespace mamba
                 };
             }
 
-            auto every_generated_directories_paths() const -> std::initializer_list<fs::u8path>
+            auto every_generated_directories_paths() const -> std::vector<fs::u8path>
             {
                 return { condabin, scripts };
             }
@@ -754,6 +754,11 @@ namespace mamba
             // Maybe the prefix isn't writable. No big deal, just keep going.
             std::error_code maybe_error [[maybe_unused]];
             fs::create_directories(directory, maybe_error);
+            if (maybe_error)
+            {
+                LOG_ERROR << "Failed to create directory '" << directory.string() << "' : "
+                          << maybe_error.message();
+            }
         }
 
 

--- a/libmamba/src/core/shell_init.cpp
+++ b/libmamba/src/core/shell_init.cpp
@@ -100,20 +100,19 @@ namespace mamba
         return "";
     }
 
-    namespace // Windows-specific but must be available for cli on all platforms
+    namespace  // Windows-specific but must be available for cli on all platforms
     {
-        struct RunInfo // FIXME: find a better name
+        struct RunInfo  // FIXME: find a better name
         {
             fs::u8path this_exe_path = get_self_exe_path();
             fs::u8path this_exe_name_path = this_exe_path.stem();
             std::string this_exe_name = this_exe_name_path;
             std::wregex regex_mamba_cmd_hook{ L"(\"[^\"]*?" + this_exe_name_path.wstring()
-                                            + L"[-_] hook\\.bat\")",  // TODO: replace by fmt?
-                                              std::regex_constants::icase
-            };
+                                                  + L"[-_] hook\\.bat\")",  // TODO: replace by fmt?
+                                              std::regex_constants::icase };
         };
 
-        const RunInfo& run_info() // FIXME: find a better name
+        const RunInfo& run_info()  // FIXME: find a better name
         {
             static const RunInfo info;
             return info;
@@ -139,7 +138,6 @@ namespace mamba
                 , scripts_activate_bat(scripts / "activate.bat")
                 , mamba_hook_bat(condabin / "mamba_hook.bat")
             {
-
             }
 
             auto every_generated_files_paths() const -> std::vector<fs::u8path>
@@ -148,15 +146,13 @@ namespace mamba
                          _mamba_activate_bat,
                          condabin_activate_bat,
                          scripts_activate_bat,
-                         mamba_hook_bat
-                };
+                         mamba_hook_bat };
             }
 
             auto every_generated_directories_paths() const -> std::vector<fs::u8path>
             {
                 return { condabin, scripts };
             }
-
         };
 
 
@@ -760,8 +756,8 @@ namespace mamba
             fs::create_directories(directory, maybe_error);
             if (maybe_error)
             {
-                LOG_ERROR << "Failed to create directory '" << directory.string() << "' : "
-                          << maybe_error.message();
+                LOG_ERROR << "Failed to create directory '" << directory.string()
+                          << "' : " << maybe_error.message();
             }
         }
 
@@ -791,7 +787,9 @@ namespace mamba
         std::string mamba_bat_contents(data_mamba_bat);
         replace_insert_root_prefix(mamba_bat_contents);
         replace_insert_mamba_exe(mamba_bat_contents);
-        static const auto MARKER_MAMBA_INSERT_ACTIVATE_BAT_NAME = std::string("__MAMBA_INSERT_ACTIVATE_BAT_NAME__");
+        static const auto MARKER_MAMBA_INSERT_ACTIVATE_BAT_NAME = std::string(
+            "__MAMBA_INSERT_ACTIVATE_BAT_NAME__"
+        );
         util::replace_all(
             mamba_bat_contents,
             MARKER_MAMBA_INSERT_ACTIVATE_BAT_NAME,
@@ -809,7 +807,9 @@ namespace mamba
         replace_insert_root_prefix(activate_bat_contents);
         replace_insert_mamba_exe(activate_bat_contents);
         util::replace_all(activate_bat_contents, MARKER_INSERT_EXE_NAME, run_info().this_exe_name);
-        static const auto MARKER_MAMBA_INSERT_HOOK_BAT_NAME = std::string("__MAMBA_INSERT_HOOK_BAT_NAME__");
+        static const auto MARKER_MAMBA_INSERT_HOOK_BAT_NAME = std::string(
+            "__MAMBA_INSERT_HOOK_BAT_NAME__"
+        );
         util::replace_all(
             activate_bat_contents,
             MARKER_MAMBA_INSERT_HOOK_BAT_NAME,

--- a/libmamba/src/core/shell_init.cpp
+++ b/libmamba/src/core/shell_init.cpp
@@ -139,7 +139,7 @@ namespace mamba
                 , _mamba_activate_bat(condabin / ("_" + run_info().this_exe_name + "_activate.bat"))
                 , condabin_activate_bat(condabin / "activate.bat")
                 , scripts_activate_bat(scripts / "activate.bat")
-                , mamba_hook_bat(condabin / (run_info().this_exe_name + "_hook.bat"))
+                , mamba_hook_bat(condabin / "mamba_hook.bat")
             {
 
             }
@@ -761,7 +761,7 @@ namespace mamba
         {
             return util::replace_all(
                 text,
-                std::string("__MAMBA_INSERT_ROOT_PREFIX__"),
+                std::string("__MAMBA_DEFINE_ROOT_PREFIX__"),
                 "@SET \"MAMBA_ROOT_PREFIX=" + root_prefix.string() + "\""
             );
         };
@@ -770,20 +770,24 @@ namespace mamba
         {
             return util::replace_all(
                 text,
-                std::string("__MAMBA_INSERT_MAMBA_EXE__"),
+                std::string("__MAMBA_DEFINE_MAMBA_EXE__"),
                 "@SET \"MAMBA_EXE=" + run_info().this_exe_path.string() + "\""
             );
         };
 
         static const auto MARKER_INSERT_EXE_NAME = std::string("__MAMBA_INSERT_EXE_NAME__");
-        static const auto MARKER_MAMBA_BAT_NAME = std::string("__MAMBA_BAT_NAME__");
+        static const auto MARKER_INSERT_MAMBA_BAT_NAME = std::string("__MAMBA_INSERT_BAT_NAME__");
 
         // mamba.bat
         std::string mamba_bat_contents(data_mamba_bat);
         replace_insert_root_prefix(mamba_bat_contents);
         replace_insert_mamba_exe(mamba_bat_contents);
-        static const auto MARKER_MAMBA_ACTIVATE_BAT_NAME = std::string("__MAMBA_ACTIVATE_BAT_NAME__");
-        util::replace_all(mamba_bat_contents, MARKER_MAMBA_ACTIVATE_BAT_NAME, paths._mamba_activate_bat.stem().string());
+        static const auto MARKER_MAMBA_INSERT_ACTIVATE_BAT_NAME = std::string("__MAMBA_INSERT_ACTIVATE_BAT_NAME__");
+        util::replace_all(
+            mamba_bat_contents,
+            MARKER_MAMBA_INSERT_ACTIVATE_BAT_NAME,
+            paths._mamba_activate_bat.stem().string()
+        );
         std::ofstream mamba_bat_f = open_ofstream(paths.mamba_bat);
         mamba_bat_f << mamba_bat_contents;
 
@@ -796,8 +800,12 @@ namespace mamba
         replace_insert_root_prefix(activate_bat_contents);
         replace_insert_mamba_exe(activate_bat_contents);
         util::replace_all(activate_bat_contents, MARKER_INSERT_EXE_NAME, run_info().this_exe_name);
-        static const auto MARKER_MAMBA_HOOK_BAT_NAME = std::string("__MAMBA_HOOK_BAT_NAME__");
-        util::replace_all(activate_bat_contents, MARKER_MAMBA_HOOK_BAT_NAME, paths.mamba_hook_bat.stem().string());
+        static const auto MARKER_MAMBA_INSERT_HOOK_BAT_NAME = std::string("__MAMBA_INSERT_HOOK_BAT_NAME__");
+        util::replace_all(
+            activate_bat_contents,
+            MARKER_MAMBA_INSERT_HOOK_BAT_NAME,
+            paths.mamba_hook_bat.filename().string()
+        );
         std::ofstream condabin_activate_bat_f = open_ofstream(paths.condabin_activate_bat);
         condabin_activate_bat_f << activate_bat_contents;
 
@@ -808,8 +816,12 @@ namespace mamba
         // mamba_hook.bat
         std::string hook_content = data_mamba_hook_bat;
         replace_insert_mamba_exe(hook_content);
-        util::replace_all(hook_content, MARKER_INSERT_EXE_NAME, run_info().this_exe_path.string());
-        util::replace_all(hook_content, MARKER_MAMBA_BAT_NAME, paths.mamba_bat.stem().string());
+        util::replace_all(hook_content, MARKER_INSERT_EXE_NAME, run_info().this_exe_name);
+        util::replace_all(
+            hook_content,
+            MARKER_INSERT_MAMBA_BAT_NAME,
+            paths.mamba_bat.filename().string()
+        );
 
         std::ofstream mamba_hook_bat_f = open_ofstream(paths.mamba_hook_bat);
         mamba_hook_bat_f << hook_content;

--- a/libmamba/src/core/shell_init.cpp
+++ b/libmamba/src/core/shell_init.cpp
@@ -756,7 +756,7 @@ namespace mamba
             fs::create_directories(directory, maybe_error);
         }
 
-        // mamba.bat
+
         const auto replace_insert_root_prefix = [&](auto& text)
         {
             return util::replace_all(
@@ -777,6 +777,7 @@ namespace mamba
 
         static const auto MARKER_INSERT_EXE_NAME = std::string("__MAMBA_INSERT_EXE_NAME__");
 
+        // mamba.bat
         std::string mamba_bat_contents(data_mamba_bat);
         replace_insert_root_prefix(mamba_bat_contents);
         replace_insert_mamba_exe(mamba_bat_contents);

--- a/libmamba/src/core/shell_init.cpp
+++ b/libmamba/src/core/shell_init.cpp
@@ -199,9 +199,9 @@ namespace mamba
 
     std::wstring get_hook_string(const fs::u8path& conda_prefix)
     {
-        const ShellInitPathsWindowsCmd paths{ conda_prefix }; // FIXME: too expensive
-
-        return fmt::format(L"{:?}", paths.mamba_hook_bat.wstring());
+        const ShellInitPathsWindowsCmd paths{ conda_prefix };
+        auto hook_path = fs::canonical(paths.mamba_hook_bat).std_path();
+        return fmt::format(LR"("{}")", hook_path.make_preferred().wstring());
     }
 
     void
@@ -225,7 +225,11 @@ namespace mamba
         {
             if (!new_value.empty())
             {
-                new_value += L" & " + hook_string;
+                if (new_value.find(hook_string) == std::wstring::npos)
+                {
+                    new_value += L" & " + hook_string;
+                }
+                // else the hook path already exists in the string
             }
             else
             {

--- a/libmamba/src/core/shell_init.cpp
+++ b/libmamba/src/core/shell_init.cpp
@@ -102,17 +102,14 @@ namespace mamba
 
     namespace  // Windows-specific but must be available for cli on all platforms
     {
-        struct RunInfo  // FIXME: find a better name
+        struct RunInfo
         {
             fs::u8path this_exe_path = get_self_exe_path();
             fs::u8path this_exe_name_path = this_exe_path.stem();
             std::string this_exe_name = this_exe_name_path;
-            std::wregex regex_mamba_cmd_hook{ L"(\"[^\"]*?" + this_exe_name_path.wstring()
-                                                  + L"[-_] hook\\.bat\")",  // TODO: replace by fmt?
-                                              std::regex_constants::icase };
         };
 
-        const RunInfo& run_info()  // FIXME: find a better name
+        const RunInfo& run_info()
         {
             static const RunInfo info;
             return info;
@@ -160,6 +157,9 @@ namespace mamba
 
 
 #ifdef _WIN32
+
+    static const std::wregex
+        MAMBA_CMDEXE_HOOK_REGEX(L"(\"[^\"]*?mamba[-_]hook\\.bat\")", std::regex_constants::icase);
 
     std::wstring get_autorun_registry_key(const std::wstring& reg_path)
     {
@@ -210,7 +210,7 @@ namespace mamba
         std::wstring replace_str(L"__CONDA_REPLACE_ME_123__");
         std::wstring replaced_value = std::regex_replace(
             prev_value,
-            run_info().regex_mamba_cmd_hook,
+            MAMBA_CMDEXE_HOOK_REGEX,
             replace_str,
             std::regex_constants::format_first_only
         );
@@ -1410,7 +1410,7 @@ namespace mamba
 #ifdef _WIN32
         // cmd.exe
         const std::wstring reg = get_autorun_registry_key(L"Software\\Microsoft\\Command Processor");
-        if (std::regex_match(reg, run_info().regex_mamba_cmd_hook))
+        if (std::regex_match(reg, MAMBA_CMDEXE_HOOK_REGEX))
         {
             result.push_back("cmd.exe");
         }

--- a/libmamba/src/core/util_os.cpp
+++ b/libmamba/src/core/util_os.cpp
@@ -140,10 +140,13 @@ namespace mamba
         // Needs to be set system-wide & can only be run as admin ...
 
         const auto win_ver = util::windows_version();
-        LOG_DEBUG << fmt::format("Windows version : {}", win_ver ? win_ver.value() : win_ver.error().message);
+        LOG_DEBUG << fmt::format(
+            "Windows version : {}",
+            win_ver ? win_ver.value() : win_ver.error().message
+        );
 
         static constexpr auto error_message_wrong_version = "Not setting long path registry key;"
-            "Windows version must be at least 10 with the fall 2016 \"Anniversary update\" or newer.";
+                                                            "Windows version must be at least 10 with the fall 2016 \"Anniversary update\" or newer.";
 
         if (!win_ver.has_value())
         {

--- a/libmamba/src/core/util_os.cpp
+++ b/libmamba/src/core/util_os.cpp
@@ -50,9 +50,8 @@ namespace mamba
     fs::u8path get_self_exe_path()
     {
 #ifdef _WIN32
-        DWORD size;
         std::wstring buffer(MAX_PATH, '\0');
-        size = GetModuleFileNameW(NULL, (wchar_t*) buffer.c_str(), (DWORD) buffer.size());
+        DWORD size = GetModuleFileNameW(NULL, (wchar_t*) buffer.c_str(), (DWORD) buffer.size());
         if (size == 0)
         {
             throw std::runtime_error("Could find location of the micromamba executable!");

--- a/libmamba/src/core/util_os.cpp
+++ b/libmamba/src/core/util_os.cpp
@@ -139,19 +139,25 @@ namespace mamba
     {
         // Needs to be set system-wide & can only be run as admin ...
 
-        auto win_ver = util::windows_version();
+        const auto win_ver = util::windows_version();
+        LOG_DEBUG << fmt::format("Windows version : {}", win_ver ? win_ver.value() : win_ver.error().message);
+
+        static constexpr auto error_message_wrong_version = "Not setting long path registry key;"
+            "Windows version must be at least 10 with the fall 2016 \"Anniversary update\" or newer.";
+
         if (!win_ver.has_value())
         {
-            LOG_WARNING << "Not setting long path registry key; Windows version must be at least 10 "
-                           "with the fall 2016 \"Anniversary update\" or newer.";
+            LOG_WARNING << "failed to acquire Windows version - " << error_message_wrong_version;
             return false;
         }
+
+
         auto split_out = util::split(win_ver.value(), ".");
         if (!(split_out.size() >= 3 && std::stoull(split_out[0]) >= 10
               && std::stoull(split_out[2]) >= 14352))
         {
-            LOG_WARNING << "Not setting long path registry key; Windows version must be at least 10 "
-                           "with the fall 2016 \"Anniversary update\" or newer.";
+            LOG_WARNING << "Windows version found:" << win_ver.value() << " - "
+                        << error_message_wrong_version;
             return false;
         }
 
@@ -164,7 +170,8 @@ namespace mamba
         }
         catch (const winreg::RegException& /*e*/)
         {
-            LOG_INFO << "No LongPathsEnabled key detected.";
+            LOG_INFO << "No LongPathsEnabled key detected. (Windows version = " << win_ver.value()
+                     << ")";
             return false;
         }
 
@@ -173,8 +180,9 @@ namespace mamba
             auto out = Console::stream();
             fmt::print(
                 out,
-                "{}",
-                fmt::styled("Windows long-path support already enabled.", palette.ignored)
+                "{} (Windows version = {})",
+                fmt::styled("Windows long-path support already enabled.", palette.ignored),
+                win_ver.value()
             );
             return true;
         }

--- a/libmamba/src/util/os_win.cpp
+++ b/libmamba/src/util/os_win.cpp
@@ -218,7 +218,11 @@ namespace mamba::util
         // from python
         static const auto ver_output_regex = std::regex(R"((?:([\w ]+) ([\w.]+) .*\[.* ([\d.]+)\]))");
 
-        if (auto rmatch = std::smatch(); std::regex_match(out, rmatch, ver_output_regex))
+        // The output of the command could contain multiple unrelated lines, so we need to check
+        // every lines, which is why we need to search in a loop until reaching the end of the output.
+        std::smatch rmatch;
+        auto start_it = out.cbegin();
+        while (std::regex_search(start_it, out.cend(), rmatch, ver_output_regex))
         {
             std::string full_version = rmatch[3];
             auto version_elems = util::split(full_version, ".");

--- a/libmamba/src/util/os_win.cpp
+++ b/libmamba/src/util/os_win.cpp
@@ -219,7 +219,8 @@ namespace mamba::util
         static const auto ver_output_regex = std::regex(R"((?:([\w ]+) ([\w.]+) .*\[.* ([\d.]+)\]))");
 
         // The output of the command could contain multiple unrelated lines, so we need to check
-        // every lines, which is why we need to search in a loop until reaching the end of the output.
+        // every lines, which is why we need to search in a loop until reaching the end of the
+        // output.
         std::smatch rmatch;
         auto start_it = out.cbegin();
         while (std::regex_search(start_it, out.cend(), rmatch, ver_output_regex))


### PR DESCRIPTION
- shell-init: Windows bat paths are factorized and depend on exe name (`micromamba` or `mamba`) except for `mamba_hook.bat` which for now needs to keep that name whatever the exe name;
- Fixed windows version detection: When more than one line of output appears at the start of cmd (because of AUTORUN), we parsed only the first line which failed the version detection. This version simply search every line instead of just the first one.
    It also clarifies through more precise logs the exact reason why enabling long-paths actually failed.
- Improved error output for clarity on failure to create shell-init files (.bat) or directories.