### PR TITLE
ci: test on macOS 13 (Intel)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,7 +23,7 @@ jobs:
     name: Unix
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, macos-13]
         build_type: [release, debug]
       fail-fast: false
     uses: ./.github/workflows/unix_impl.yml


### PR DESCRIPTION
macOS 13 is a target for homebrew, and still an important target for GHA, as it's the last Intel build they provide. I think on macOS 13 there will be a missing deduction guide error, but will have to see.