### PR TITLE
fix: Skip misformatted configuration files

### DIFF
--- a/libmamba/src/api/configuration.cpp
+++ b/libmamba/src/api/configuration.cpp
@@ -2082,6 +2082,14 @@ namespace mamba
             strStream << inFile.rdbuf();
             std::string s = strStream.str();
             config = YAML::Load(expandvars(s));
+            if (config.IsScalar())
+            {
+                LOG_WARNING << fmt::format(
+                    "The configuration file at {} is misformatted or corrupted. Skipping file.",
+                    file.string()
+                );
+                return YAML::Node();
+            }
         }
         catch (const std::exception& ex)
         {

--- a/libmamba/tests/src/core/test_configuration.cpp
+++ b/libmamba/tests/src/core/test_configuration.cpp
@@ -901,6 +901,15 @@ namespace mamba
                 env::unset("MAMBA_CHANNEL_PRIORITY");
             }
 
+            TEST_CASE_FIXTURE(Configuration, "skip_misformatted_config_file")
+            {
+                std::string rc = "invalid_scalar_value";
+                load_test_config(rc);
+                CHECK_EQ(config.sources().size(), 1);
+                CHECK_EQ(config.valid_sources().size(), 0);
+                CHECK_EQ(config.dump(), "");
+            }
+
             TEST_CASE_FIXTURE(Configuration, "pinned_packages")
             {
                 std::string rc1 = unindent(R"(


### PR DESCRIPTION
Apply the same fix on `main` for `1.x` branch https://github.com/mamba-org/mamba/pull/3580