### PR TITLE
maint: Address compiler warnings

### DIFF
--- a/libmamba/include/mamba/util/parsers.hpp
+++ b/libmamba/include/mamba/util/parsers.hpp
@@ -280,8 +280,8 @@ namespace mamba::util
             std::size_t pos = N;
             for (std::size_t i = 0; i < N; ++i)
             {
-                const auto found = static_cast<std::size_t>(arr[i] == val);
-                pos = found * i + (1 - found) * pos;
+                const bool found = arr[i] == val;
+                pos = found ? i : pos;
             }
             return pos;
         }

--- a/libmamba/include/mamba/util/parsers.hpp
+++ b/libmamba/include/mamba/util/parsers.hpp
@@ -277,11 +277,11 @@ namespace mamba::util
         template <typename T, std::size_t N>
         constexpr auto find(const std::array<T, N>& arr, const T& val) -> std::size_t
         {
-            auto pos = std::size_t(N);
+            std::size_t pos = N;
             for (std::size_t i = 0; i < N; ++i)
             {
-                const bool found = arr[i] == val;
-                pos = static_cast<int>(found) * i + (1 - static_cast<int>(found)) * pos;
+                const auto found = static_cast<std::size_t>(arr[i] == val);
+                pos = found * i + (1 - found) * pos;
             }
             return pos;
         }

--- a/libmamba/src/core/prefix_data.cpp
+++ b/libmamba/src/core/prefix_data.cpp
@@ -261,11 +261,11 @@ namespace mamba
         {
             j = nlohmann::json::parse(out);
         }
-        catch (const std::exception& ec)
+        catch (const std::exception& exc)
         {
             const auto message = fmt::format(
                 "failed to parse python command output:\n  error: {}\n  command ran: {}\n  env options:{}\n-> output:\n{}\n\n-> error output:{}",
-                ec.what(),
+                exc.what(),
                 fmt::join(args, " "),
                 fmt::join(env, " "),
                 out,

--- a/libmamba/src/core/progress_bar_impl.cpp
+++ b/libmamba/src/core/progress_bar_impl.cpp
@@ -1395,7 +1395,7 @@ namespace mamba
     {
         if (!m_is_spinner)
         {
-            auto seed = static_cast<unsigned int>(
+            auto seed = static_cast<typename std::default_random_engine::result_type>(
                 std::chrono::system_clock::now().time_since_epoch().count()
             );
             std::default_random_engine generator(seed);

--- a/libmamba/src/core/progress_bar_impl.cpp
+++ b/libmamba/src/core/progress_bar_impl.cpp
@@ -1395,7 +1395,7 @@ namespace mamba
     {
         if (!m_is_spinner)
         {
-            auto seed = static_cast<std::size_t>(
+            auto seed = static_cast<unsigned int>(
                 std::chrono::system_clock::now().time_since_epoch().count()
             );
             std::default_random_engine generator(seed);

--- a/libmamba/tests/src/validation/test_update_framework_v0_6.cpp
+++ b/libmamba/tests/src/validation/test_update_framework_v0_6.cpp
@@ -4,6 +4,11 @@
 //
 // The full license is in the file LICENSE, distributed with this software.
 
+// There are several `CHECK_THROWS_AS` expressions in this file.
+// Sometimes they call a method marked as `[[nodiscard]]`.
+// This causes compiler warnnings.
+// This doctest flag is designed specifically to prevent this warning from happening.
+// https://github.com/doctest/doctest/blob/master/doc/markdown/configuration.md#doctest_config_void_cast_expressions
 #define DOCTEST_CONFIG_VOID_CAST_EXPRESSIONS
 
 #include <map>

--- a/libmamba/tests/src/validation/test_update_framework_v0_6.cpp
+++ b/libmamba/tests/src/validation/test_update_framework_v0_6.cpp
@@ -4,6 +4,8 @@
 //
 // The full license is in the file LICENSE, distributed with this software.
 
+#define DOCTEST_CONFIG_VOID_CAST_EXPRESSIONS
+
 #include <map>
 
 #include <doctest/doctest.h>
@@ -249,7 +251,7 @@ TEST_SUITE("validation::v0_6::RootImpl")
         out_file.close();
 
         // "2.sv1.root.json" is not compatible spec version (spec version N)
-        CHECK_THROWS_AS(v0_6::RootImpl root(p), role_file_error);
+        CHECK_THROWS_AS(v0_6::RootImpl{ p }, role_file_error);
     }
 
     TEST_CASE_FIXTURE(RootImplT_v0_6, "update_from_path")

--- a/micromamba/src/constructor.cpp
+++ b/micromamba/src/constructor.cpp
@@ -211,7 +211,7 @@ read_binary_from_stdin_and_write_to_file(fs::u8path& filename)
         {
             throw std::runtime_error("Reading from stdin failed.");
         }
-        out_stream.write(buffer.data(), len);
+        out_stream.write(buffer.data(), static_cast<std::streamsize>(len));
     }
     out_stream.close();
 }


### PR DESCRIPTION
I fixed most of the compiler warnings (on my machine).
I think it's nice being able to build cleanly.

And we may want to enable `-Werror` in the future (but there is still some work to be done to make it possible).