### PR TITLE
fix: support homebrew/linuxbrew (AppleClang, GCC 11)

### DIFF
--- a/libmamba/CMakeLists.txt
+++ b/libmamba/CMakeLists.txt
@@ -617,6 +617,9 @@ macro(libmamba_create_target target_name linkage output_name)
                 solv::libsolvext
                 solv::cpp
         )
+        # CMake 3.17 provides a LibArchive::LibArchive target that could be used instead of
+        # LIBRARIES/INCLUDE_DIRS
+        target_include_directories(${target_name} PRIVATE "${LibArchive_INCLUDE_DIRS}")
     endif()
 
     if(WIN32)

--- a/libmamba/ext/solv-cpp/CMakeLists.txt
+++ b/libmamba/ext/solv-cpp/CMakeLists.txt
@@ -20,6 +20,7 @@ find_package(Libsolv REQUIRED)
 
 if(BUILD_SHARED)
     set(LIBSOLV_DEPS solv::libsolv solv::libsolvext)
+    set_target_properties(solv-cpp PROPERTIES POSITION_INDEPENDENT_CODE ON)
 else()
     set(LIBSOLV_DEPS solv::libsolv_static solv::libsolvext_static)
 endif()

--- a/libmamba/include/mamba/specs/channel.hpp
+++ b/libmamba/include/mamba/specs/channel.hpp
@@ -22,61 +22,15 @@
 
 namespace mamba::specs
 {
-    class Channel;
-
-    struct ChannelResolveParams
-    {
-        /**
-         * The weakener for @ref ResolveParams::custom_channels.
-         */
-        struct NameWeakener
-        {
-            /**
-             * Return the key unchanged.
-             */
-            [[nodiscard]] auto make_first_key(std::string_view key) const -> std::string_view;
-
-            /**
-             * Remove the last element of the '/'-separated name.
-             */
-            [[nodiscard]] auto weaken_key(std::string_view key) const
-                -> std::optional<std::string_view>;
-        };
-
-        template <typename Key, typename Value>
-        using name_map = util::weakening_map<std::unordered_map<Key, Value>, NameWeakener>;
-
-        using platform_list = util::flat_set<std::string>;
-        using channel_list = std::vector<Channel>;
-        using channel_map = name_map<std::string, Channel>;
-        using multichannel_map = name_map<std::string, channel_list>;
-
-        platform_list platforms = {};
-        CondaURL channel_alias = {};
-        channel_map custom_channels = {};
-        multichannel_map custom_multichannels = {};
-        AuthenticationDataBase authentication_db = {};
-        std::string home_dir = {};
-        std::string current_working_dir = {};
-    };
-
-    struct ChannelResolveParamsView
-    {
-        const ChannelResolveParams::platform_list& platforms = {};
-        const CondaURL& channel_alias = {};
-        const ChannelResolveParams::channel_map& custom_channels = {};
-        const ChannelResolveParams::multichannel_map& custom_multichannels = {};
-        const AuthenticationDataBase& authentication_db = {};
-        std::string_view home_dir = {};
-        std::string_view current_working_dir = {};
-    };
+    struct ChannelResolveParams;
+    struct ChannelResolveParamsView;
 
     class Channel
     {
     public:
 
-        using platform_list = ChannelResolveParams::platform_list;
-        using channel_list = ChannelResolveParams::channel_list;
+        using platform_list = util::flat_set<std::string>;
+        using channel_list = std::vector<Channel>;
 
         [[nodiscard]] static auto resolve(  //
             UnresolvedChannel uc,
@@ -143,6 +97,53 @@ namespace mamba::specs
         std::string m_display_name;
         std::string m_id;
         util::flat_set<std::string> m_platforms;
+    };
+
+    struct ChannelResolveParams
+    {
+        /**
+         * The weakener for @ref ResolveParams::custom_channels.
+         */
+        struct NameWeakener
+        {
+            /**
+             * Return the key unchanged.
+             */
+            [[nodiscard]] auto make_first_key(std::string_view key) const -> std::string_view;
+
+            /**
+             * Remove the last element of the '/'-separated name.
+             */
+            [[nodiscard]] auto weaken_key(std::string_view key) const
+                -> std::optional<std::string_view>;
+        };
+
+        template <typename Key, typename Value>
+        using name_map = util::weakening_map<std::unordered_map<Key, Value>, NameWeakener>;
+
+        using platform_list = util::flat_set<std::string>;
+        using channel_list = std::vector<Channel>;
+        using channel_map = name_map<std::string, Channel>;
+        using multichannel_map = name_map<std::string, channel_list>;
+
+        platform_list platforms = {};
+        CondaURL channel_alias = {};
+        channel_map custom_channels = {};
+        multichannel_map custom_multichannels = {};
+        AuthenticationDataBase authentication_db = {};
+        std::string home_dir = {};
+        std::string current_working_dir = {};
+    };
+
+    struct ChannelResolveParamsView
+    {
+        const ChannelResolveParams::platform_list& platforms = {};
+        const CondaURL& channel_alias = {};
+        const ChannelResolveParams::channel_map& custom_channels = {};
+        const ChannelResolveParams::multichannel_map& custom_multichannels = {};
+        const AuthenticationDataBase& authentication_db = {};
+        std::string_view home_dir = {};
+        std::string_view current_working_dir = {};
     };
 
     /** Tuple-like equality of all observable members */

--- a/libmamba/src/core/transaction.cpp
+++ b/libmamba/src/core/transaction.cpp
@@ -698,7 +698,8 @@ namespace mamba
                  it != extract_tasks.end();
                  ++it)
             {
-                std::packaged_task task{ [=] { return it->run(); } };
+                std::packaged_task<mamba::PackageExtractTask::Result()> task{ [=]
+                                                                              { return it->run(); } };
                 extract_trackers.push_back(task.get_future());
                 MainExecutor::instance().schedule(std::move(task));
             }

--- a/libmamba/src/solver/problems_graph.cpp
+++ b/libmamba/src/solver/problems_graph.cpp
@@ -265,7 +265,7 @@ namespace mamba::solver
         }
 
 // GCC reports dangling reference when using std::invoke with data members
-#if defined(__GNUC__) && !defined(__clang__)
+#if defined(__GNUC__) && !defined(__clang__) && __GNUC__ >= 13
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdangling-reference"
 #endif
@@ -334,7 +334,7 @@ namespace mamba::solver
             }
         }
 
-#if defined(__GNUC__) && !defined(__clang__)
+#if defined(__GNUC__) && !defined(__clang__) && __GNUC__ >= 13
 #pragma GCC diagnostic pop
 #endif
 


### PR DESCRIPTION
This should detect the Linux failure discussed in https://github.com/mamba-org/mamba/issues/3495. Ref #3578.

This contains ~~three~~ ~~four~~ five fixes:

* The deduced template guide is expanded explicitly for AppleClang. There's a note about AppleClang near it, with an expanded template, but this one wasn't expanded. It's required on macOS 13's AppleClang (14+ is fine)
* I've added a missing FPIC when building shared libs. It doesn't link with the linuxbrew setup without this.
* I've reordered the connection code so that the pre-declarations are on references rather than on using statements. GCC 11 seems to choke on the using statements being pre-declared, but references have been supported since medieval times or so. `platform_list`/`channel_list` is expanded explicitly.
* Dependency on LibArchive's header was missing. If CMake 3.17 was the minimum instead of 3.16, this could use the `LibArchive::LibArchive` target instead
* The new warning suppression from #3611 broke GCC < 13 support. Restored (at least to GCC 11).