### PR TITLE
fixed: incorrect erasing of env vars

### DIFF
--- a/libmamba/src/core/activation.cpp
+++ b/libmamba/src/core/activation.cpp
@@ -554,10 +554,13 @@ namespace mamba
         auto conda_environment_env_vars = get_environment_vars(prefix);
 
         // TODO check with conda if that's really what's supposed to happen ...
-        std::remove_if(
-            conda_environment_env_vars.begin(),
-            conda_environment_env_vars.end(),
-            [](auto& el) { return el.second == CONDA_ENV_VARS_UNSET_VAR; }
+        conda_environment_env_vars.erase(
+            std::remove_if(
+                conda_environment_env_vars.begin(),
+                conda_environment_env_vars.end(),
+                [](auto& el) { return el.second == CONDA_ENV_VARS_UNSET_VAR; }
+            ),
+            conda_environment_env_vars.end()
         );
 
         std::vector<std::string> clobbering_env_vars;

--- a/libmamba/src/core/activation.cpp
+++ b/libmamba/src/core/activation.cpp
@@ -554,6 +554,7 @@ namespace mamba
         auto conda_environment_env_vars = get_environment_vars(prefix);
 
         // TODO check with conda if that's really what's supposed to happen ...
+        // TODO: C++20 replace by `std::erase_if`
         conda_environment_env_vars.erase(
             std::remove_if(
                 conda_environment_env_vars.begin(),


### PR DESCRIPTION
The expectaction of this change is that the intent was to remove elements (env vars values) from that vector, in which case an `erase` was missing as `remove_if` will not remove elements, just move them around and report where the new range ends (c++20's `std::erase_if` would have done the job more properly here - or replacing the container by a flat_map).