### PR TITLE
ci: add brew toolchain test

### DIFF
--- a/.github/workflows/brew.yml
+++ b/.github/workflows/brew.yml
@@ -1,0 +1,47 @@
+name: Brew tests impl
+
+on:
+  workflow_call:
+
+jobs:
+  build_linuxbrew:
+    name: Build on linuxbrew
+    runs-on: ubuntu-latest
+    container:
+      image: homebrew/brew:latest
+
+    steps:
+      # v1 required due to permissions error
+      - name: Checkout mamba repository
+        uses: actions/checkout@v1
+
+      - name: Correct the creation permissions
+        run: sudo chown -R linuxbrew .
+
+      - name: Install prerequisites
+        run: brew install fmt libarchive libsolv lz4 openssl@3 reproc simdjson xz yaml-cpp zstd cmake cli11 nlohmann-json spdlog tl-expected curl pkgconfig python bzip2 krb5 zlib
+
+      - name: Configure
+        run: cmake -S. -Bbuild -DBUILD_LIBMAMBA=ON -DBUILD_MAMBA=ON -DBUILD_SHARED=ON -DBUILD_STATIC=OFF
+
+      - name: Build
+        run: cmake --build build -j4
+
+  build_homebrew:
+    name: Build on homebrew
+    runs-on: macos-13
+
+    steps:
+      - name: Checkout mamba repository
+        uses: actions/checkout@v4
+
+      - name: Install prerequisites
+        run: brew install fmt libarchive libsolv lz4 openssl@3 reproc simdjson xz yaml-cpp zstd cmake cli11 nlohmann-json spdlog tl-expected pkgconfig python
+
+      - name: Configure
+        run: >
+          cmake -S. -Bbuild -DBUILD_LIBMAMBA=ON -DBUILD_MAMBA=ON -DBUILD_SHARED=ON -DBUILD_STATIC=OFF
+          -DLibArchive_ROOT=$(brew --prefix libarchive)
+
+      - name: Build
+        run: cmake --build build -j4

--- a/.github/workflows/brew.yml
+++ b/.github/workflows/brew.yml
@@ -1,4 +1,4 @@
-name: Brew tests impl
+name: Homebrew and Linuxbrew toolchains
 
 on:
   workflow_call:
@@ -18,13 +18,13 @@ jobs:
       - name: Correct the creation permissions
         run: sudo chown -R linuxbrew .
 
-      - name: Install prerequisites
+      - name: Install host and build dependencies
         run: brew install fmt libarchive libsolv lz4 openssl@3 reproc simdjson xz yaml-cpp zstd cmake cli11 nlohmann-json spdlog tl-expected curl pkgconfig python bzip2 krb5 zlib
 
-      - name: Configure
+      - name: Configure to build mamba
         run: cmake -S. -Bbuild -DBUILD_LIBMAMBA=ON -DBUILD_MAMBA=ON -DBUILD_SHARED=ON -DBUILD_STATIC=OFF
 
-      - name: Build
+      - name: Build mamba
         run: cmake --build build -j4
 
   build_homebrew:
@@ -35,13 +35,13 @@ jobs:
       - name: Checkout mamba repository
         uses: actions/checkout@v4
 
-      - name: Install prerequisites
+      - name: Install host and build dependencies
         run: brew install fmt libarchive libsolv lz4 openssl@3 reproc simdjson xz yaml-cpp zstd cmake cli11 nlohmann-json spdlog tl-expected pkgconfig python
 
-      - name: Configure
+      - name: Configure to build mamba
         run: >
           cmake -S. -Bbuild -DBUILD_LIBMAMBA=ON -DBUILD_MAMBA=ON -DBUILD_SHARED=ON -DBUILD_STATIC=OFF
           -DLibArchive_ROOT=$(brew --prefix libarchive)
 
-      - name: Build
+      - name: Build mamba
         run: cmake --build build -j4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,5 +44,5 @@ jobs:
       build_type: ${{ matrix.build_type }}
 
   brew_tests:
-    name: Brew
+    name: Homebrew and Linuxbrew toolchains
     uses: ./.github/workflows/brew.yml

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,3 +42,7 @@ jobs:
     with:
       os: ${{ matrix.os }}
       build_type: ${{ matrix.build_type }}
+
+  brew_tests:
+    name: Brew
+    uses: ./.github/workflows/brew.yml


### PR DESCRIPTION
Followup to #3613, adds CI tests for the brew toolchain. These take 4 and 5 minutes, and add the only
CI jobs with AppleClang and GCC <13 (11.4, specifically).

