### PR TITLE
Fix `__conda_reactivate` command not found error

### DIFF
--- a/mamba/mamba/shell_templates/mamba.sh
+++ b/mamba/mamba/shell_templates/mamba.sh
@@ -17,7 +17,7 @@ mamba() {
             ;;
         install|update|upgrade|remove|uninstall)
             __mamba_exe "$@" || \return
-            __conda_reactivate
+            __conda_activate reactivate
             ;;
         *)
             __mamba_exe "$@"


### PR DESCRIPTION
This fix is for 1.x. `__conda_reactivate` was removed from conda in conda/conda#14277; now `__conda_activate reactivate` should be used instead.

Fixes #3637.
