### PR TITLE
fix: Wrap `MAMBA_EXE` around double quotes in run shell script

### DIFF
--- a/libmamba/src/core/util.cpp
+++ b/libmamba/src/core/util.cpp
@@ -1510,7 +1510,7 @@ namespace mamba
         {
             // Micromamba hook
             out << "export MAMBA_EXE=" << std::quoted(get_self_exe_path().string(), '\'') << "\n";
-            hook_quoted << "$MAMBA_EXE 'shell' 'hook' '-s' 'bash' '-r' "
+            hook_quoted << "\"$MAMBA_EXE\" 'shell' 'hook' '-s' 'bash' '-r' "
                         << std::quoted(root_prefix.string(), '\'');
         }
         if (options.debug_wrapper_scripts)


### PR DESCRIPTION
## Description

This PR addresses an issue where the `$MAMBA_EXE` variable in `mamba run` and `micromamba run` shell scripts were not properly quoted, causing failures when the executable path contains spaces characters.

## Linked Issue

Closes #3057