### PR TITLE
Fix compilation with -Werror=unused-result

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -48,11 +48,3 @@ repos:
     rev: v0.6.13
     hooks:
       - id: cmake-format
-  - repo: https://github.com/Quantco/pre-commit-mirrors-typos
-    rev: 1.27.3
-    hooks:
-      - id: typos-conda
-        exclude: (CHANGELOG.md)
-        # In case of ambiguity (multiple possible corrections), `typos` will just report it to the user and move on without applying/writing any changes.
-        # cf. https://github.com/crate-ci/typos
-        args: [ --write-changes ]

--- a/micromamba/src/constructor.cpp
+++ b/micromamba/src/constructor.cpp
@@ -196,18 +196,19 @@ void
 read_binary_from_stdin_and_write_to_file(fs::u8path& filename)
 {
     std::ofstream out_stream = open_ofstream(filename, std::ofstream::binary);
+    FILE* stdin_bin;
     // Need to reopen stdin as binary
-    std::freopen(nullptr, "rb", stdin);
-    if (std::ferror(stdin))
+    stdin_bin = std::freopen(nullptr, "rb", stdin);
+    if (std::ferror(stdin_bin))
     {
         throw std::runtime_error("Re-opening stdin as binary failed.");
     }
     std::size_t len;
     std::array<char, 1024> buffer;
 
-    while ((len = std::fread(buffer.data(), sizeof(char), buffer.size(), stdin)) > 0)
+    while ((len = std::fread(buffer.data(), sizeof(char), buffer.size(), stdin_bin)) > 0)
     {
-        if (std::ferror(stdin) && !std::feof(stdin))
+        if (std::ferror(stdin_bin) && !std::feof(stdin_bin))
         {
             throw std::runtime_error("Reading from stdin failed.");
         }


### PR DESCRIPTION
Compile-tested only.


~ $ /usr/local/bin/c++ -DFMT_SHARED -DSPDLOG_FMT_EXTERNAL -I/home/build/libmamba/include -isystem /usr/share -fPIC -O3 -DNDEBUG -std=gnu++17 -Wall -Wextra -Wshado w -Wnon-virtual-dtor -Wold-style-cast -Wcast-align -Wunused -Woverloaded-virtual -Wpedantic -Wconversion -Wsign-conversion -Wnull-dereference -Wdouble-promotion - Wformat=2 -Wunreachable-code -Wuninitialized -Werror -Wmisleading-indentation -Wduplicated-cond -Wduplicated-branches -Wlogical-op -Wuseless-cast -MD -MT micromam ba/CMakeFiles/micromamba.dir/src/constructor.cpp.o -MF micromamba/CMakeFiles/micromamba.dir/src/constructor.cpp.o.d -o micromamba/CMakeFiles/micromamba.dir/src/co nstructor.cpp.o -c /home/build/micromamba/src/constructor.cpp /home/build/micromamba/src/constructor.cpp: In function 'void read_binary_from_stdin_and_write_to_file(mamba::fs::u8path&)': /home/build/micromamba/src/constructor.cpp:200:17: error: ignoring return value of 'FILE* freopen(const char*, const char*, FILE*)' declared with attribute 'warn_unused_result' [-Werror=unused-result]
  200 |     std::freopen(nullptr, "rb", stdin);
      |     ~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~
