### PR TITLE
build: Remove another uninitialized variable in curl handler

### DIFF
--- a/libmamba/src/download/curl.cpp
+++ b/libmamba/src/download/curl.cpp
@@ -250,6 +250,7 @@ namespace mamba::download
     {
         rhs.m_handle = nullptr;
         rhs.p_headers = nullptr;
+        std::fill(m_errorbuffer.begin(), m_errorbuffer.end(), '\0');
         std::swap(m_errorbuffer, rhs.m_errorbuffer);
         set_opt(CURLOPT_ERRORBUFFER, m_errorbuffer.data());
     }


### PR DESCRIPTION
Similar to commit 4c5c1d74308a47b2d6de858b4b90c9fb529863b4. Compile-tested only.