### PR TITLE
maint: Add pre-commit typos back

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -48,3 +48,11 @@ repos:
     rev: v0.6.13
     hooks:
       - id: cmake-format
+  - repo: https://github.com/Quantco/pre-commit-mirrors-typos
+    rev: 1.28.2
+    hooks:
+      - id: typos-conda
+        exclude: (CHANGELOG.md)
+        # In case of ambiguity (multiple possible corrections), `typos` will just report it to the user and move on without applying/writing any changes.
+        # cf. https://github.com/crate-ci/typos
+        args: [ --write-changes ]


### PR DESCRIPTION
I think it was removed accidentally in https://github.com/mamba-org/mamba/pull/3676