### PR TITLE
Always add `root_prefix/envs` in `envs_dirs`

### DIFF
--- a/libmamba/src/api/configuration.cpp
+++ b/libmamba/src/api/configuration.cpp
@@ -969,7 +969,6 @@ namespace mamba
         {
             // Check that "root_prefix/envs" is already in the dirs,
             // and append if not - to match `conda`
-            // Therefore, there is no need for a fallback value anymore
             fs::u8path default_env_dir = context.prefix_params.root_prefix / "envs";
             if (std::find(dirs.begin(), dirs.end(), default_env_dir) == dirs.end())
             {

--- a/libmamba/tests/src/core/test_configuration.cpp
+++ b/libmamba/tests/src/core/test_configuration.cpp
@@ -538,6 +538,40 @@ namespace mamba
                               - https://repo.mamba.pm/conda-forge)"));
             }
 
+            TEST_CASE_METHOD(Configuration, "envs_dirs")
+            {
+                // Load default config
+                // `envs_dirs` should be set to `root_prefix / envs`
+                config.load();
+
+                const auto& envs_dirs = config.at("envs_dirs").value<std::vector<fs::u8path>>();
+                REQUIRE(envs_dirs.size() == 1);
+                REQUIRE(
+                    envs_dirs[0]
+                    == util::path_concat(
+                        std::string(config.at("root_prefix").value<mamba::fs::u8path>()),
+                        "envs"
+                    )
+                );
+            }
+
+            TEST_CASE_METHOD(Configuration, "envs_dirs_with_additional_rc")
+            {
+                std::string cache1 = util::path_concat(util::user_home_dir(), "foo_envs_dirs");
+                std::string rc1 = "envs_dirs:\n  - " + cache1;
+
+                load_test_config(rc1);
+
+                REQUIRE(
+                    config.dump()
+                    == "envs_dirs:\n  - " + cache1 + "\n  - "
+                           + util::path_concat(
+                               std::string(config.at("root_prefix").value<mamba::fs::u8path>()),
+                               "envs"
+                           )
+                );
+            }
+
             TEST_CASE_METHOD(Configuration, "pkgs_dirs")
             {
                 std::string cache1 = util::path_concat(util::user_home_dir(), "foo");

--- a/libmamba/tests/src/core/test_configuration.cpp
+++ b/libmamba/tests/src/core/test_configuration.cpp
@@ -541,9 +541,9 @@ namespace mamba
             TEST_CASE_METHOD(Configuration, "envs_dirs")
             {
                 // Load default config
-                // `envs_dirs` should be set to `root_prefix / envs`
                 config.load();
 
+                // `envs_dirs` should be set to `root_prefix / envs`
                 const auto& envs_dirs = config.at("envs_dirs").value<std::vector<fs::u8path>>();
                 REQUIRE(envs_dirs.size() == 1);
                 REQUIRE(
@@ -562,6 +562,8 @@ namespace mamba
 
                 load_test_config(rc1);
 
+                // `envs_dirs` should be set to the configured value `cache1`
+                // and `root_prefix / envs`
                 REQUIRE(
                     config.dump()
                     == "envs_dirs:\n  - " + cache1 + "\n  - "

--- a/libmamba/tests/src/core/test_configuration.cpp
+++ b/libmamba/tests/src/core/test_configuration.cpp
@@ -93,6 +93,14 @@ namespace mamba
                 return util::shrink_home(config.valid_sources()[position].string());
             }
 
+            const std::string get_root_prefix_envs_dir()
+            {
+                return util::path_concat(
+                    std::string(config.at("root_prefix").value<mamba::fs::u8path>()),
+                    "envs"
+                );
+            }
+
             std::unique_ptr<TemporaryFile> tempfile_ptr = std::make_unique<TemporaryFile>(
                 "mambarc",
                 ".yaml"
@@ -545,14 +553,9 @@ namespace mamba
 
                 // `envs_dirs` should be set to `root_prefix / envs`
                 const auto& envs_dirs = config.at("envs_dirs").value<std::vector<fs::u8path>>();
+
                 REQUIRE(envs_dirs.size() == 1);
-                REQUIRE(
-                    envs_dirs[0]
-                    == util::path_concat(
-                        std::string(config.at("root_prefix").value<mamba::fs::u8path>()),
-                        "envs"
-                    )
-                );
+                REQUIRE(envs_dirs[0] == get_root_prefix_envs_dir());
             }
 
             TEST_CASE_METHOD(Configuration, "envs_dirs_with_additional_rc")
@@ -566,11 +569,7 @@ namespace mamba
                 // and `root_prefix / envs`
                 REQUIRE(
                     config.dump()
-                    == "envs_dirs:\n  - " + cache1 + "\n  - "
-                           + util::path_concat(
-                               std::string(config.at("root_prefix").value<mamba::fs::u8path>()),
-                               "envs"
-                           )
+                    == "envs_dirs:\n  - " + cache1 + "\n  - " + get_root_prefix_envs_dir()
                 );
             }
 

--- a/micromamba/src/common_options.hpp
+++ b/micromamba/src/common_options.hpp
@@ -41,9 +41,6 @@ void
 load_channel_options(mamba::Context& ctx);
 
 void
-channels_hook(std::vector<std::string>& channels);
-
-void
 override_channels_hook(mamba::Configuration& config, bool& override_channels);
 
 #endif

--- a/micromamba/tests/test_info.py
+++ b/micromamba/tests/test_info.py
@@ -31,6 +31,7 @@ def test_env(tmp_home, tmp_root_prefix, tmp_env_name, tmp_prefix, prefix_selecti
     else:
         infos = helpers.info()
 
+    assert f"envs directories : {tmp_root_prefix / 'envs' }" in infos
     assert f"environment : {tmp_env_name} (active)" in infos
     assert f"env location : {tmp_prefix}" in infos
     assert f"user config files : {tmp_home / '.mambarc' }" in infos
@@ -72,6 +73,7 @@ def test_not_env(tmp_home, tmp_root_prefix, prefix_selection, existing_prefix):
         location = prefix
     print(infos)
 
+    assert f"envs directories : {tmp_root_prefix / 'envs' }" in infos
     assert f"environment : {expected_name}" in infos
     assert f"env location : {location}" in infos
     assert f"user config files : {tmp_home / '.mambarc' }" in infos


### PR DESCRIPTION
Fix #3655 