### PR TITLE
fix: Use `__conda_activate reactivate` instead of `__conda_reactivate`

### DIFF
--- a/mamba/mamba/shell_templates/mamba.sh
+++ b/mamba/mamba/shell_templates/mamba.sh
@@ -17,7 +17,7 @@ mamba() {
             ;;
         install|update|upgrade|remove|uninstall)
             __mamba_exe "$@" || \return
-            __conda_reactivate
+            __conda_activate reactivate
             ;;
         *)
             __mamba_exe "$@"


### PR DESCRIPTION
The work in https://github.com/mamba-org/mamba/pull/3643 was deleted

this is really hurting users at conda-forge (myself included) https://github.com/conda-forge/miniforge/issues/700#issuecomment-2554272743