### PR TITLE
Removes absolute paths from mamba.bat and  mamba_hook.bat

### DIFF
--- a/libmamba/data/mamba.bat
+++ b/libmamba/data/mamba.bat
@@ -3,8 +3,11 @@
 
 @REM Replaced by mamba executable with the MAMBA_EXE and MAMBA_ROOT_PREFIX variable pointing
 @REM to the correct locations.
-__MAMBA_DEFINE_MAMBA_EXE__
-__MAMBA_DEFINE_ROOT_PREFIX__
+@SET "CURDIR=%CD%"
+@CD /d "%~dp0.."
+@SET "MAMBA_ROOT_PREFIX=%CD%"
+@SET "MAMBA_EXE=%CD%\Library\bin\mamba.exe"
+@CD /d "%CURDIR%"
 
 @IF [%1]==[activate]   "%~dp0__MAMBA_INSERT_ACTIVATE_BAT_NAME__" %*
 @IF [%1]==[deactivate] "%~dp0__MAMBA_INSERT_ACTIVATE_BAT_NAME__" %*

--- a/libmamba/data/mamba_hook.bat
+++ b/libmamba/data/mamba_hook.bat
@@ -9,7 +9,7 @@
 @SET "PATH=%__mambabin_dir%;%PATH%"
 @SET "MAMBA_BAT=%__mambabin_dir%\__MAMBA_INSERT_BAT_NAME__"
 @FOR %%F in ("%__mambabin_dir%") do @SET "__mamba_root=%%~dpF"
-__MAMBA_DEFINE_MAMBA_EXE__
+@SET "MAMBA_EXE=%__mamba_root%Library\bin\mamba.exe"
 @SET __mambabin_dir=
 @SET __mamba_root=
 


### PR DESCRIPTION
Replaces macros expanded to absolute paths with prefix-independent code.
Fixes #3708 