### PR TITLE
Fix display of env activation message and co

### DIFF
--- a/libmamba/include/mamba/core/transaction.hpp
+++ b/libmamba/include/mamba/core/transaction.hpp
@@ -107,6 +107,9 @@ namespace mamba
         MultiPackageCache& package_caches,
         std::vector<detail::other_pkg_mgr_spec>& other_specs
     );
+
+    // NOTE: This can be moved to somewhere else if more appropriate
+    void print_activation_message(const Context& ctx);
 }  // namespace mamba
 
 #endif  // MAMBA_TRANSACTION_HPP

--- a/libmamba/include/mamba/core/transaction.hpp
+++ b/libmamba/include/mamba/core/transaction.hpp
@@ -109,6 +109,7 @@ namespace mamba
     );
 
     // NOTE: This can be moved to somewhere else if more appropriate
+    // See: https://github.com/mamba-org/mamba/issues/2288
     void print_activation_message(const Context& ctx);
 }  // namespace mamba
 

--- a/libmamba/src/api/install.cpp
+++ b/libmamba/src/api/install.cpp
@@ -537,6 +537,12 @@ namespace mamba
 
                 trans.execute(ctx, channel_context, prefix_data);
 
+                // Print activation message only if the environment is freshly created
+                if (create_env)
+                {
+                    print_activation_message(ctx);
+                }
+
                 if (!ctx.dry_run)
                 {
                     for (auto other_spec : config.at("others_pkg_mgrs_specs")
@@ -640,6 +646,12 @@ namespace mamba
                 }
 
                 transaction.execute(ctx, channel_context, prefix_data);
+
+                // Print activation message only if the environment is freshly created
+                if (create_env)
+                {
+                    print_activation_message(ctx);
+                }
 
                 for (auto other_spec : others)
                 {

--- a/libmamba/src/core/transaction.cpp
+++ b/libmamba/src/core/transaction.cpp
@@ -41,6 +41,32 @@ namespace mamba
 {
     namespace nl = nlohmann;
 
+    void print_activation_message(const Context& ctx)
+    {
+        // Check that the target prefix is not active before printing the activation message
+        if (util::get_env("CONDA_PREFIX") != ctx.prefix_params.target_prefix)
+        {
+            // Get the name of the executable used directly from the command.
+            const auto executable = get_self_exe_path().stem().string();
+
+            // Get the name of the environment
+            const auto environment = env_name(ctx);
+
+            Console::stream() << "\nTo activate this environment, use:\n\n"
+                                 "    "
+                              << executable << " activate " << environment
+                              << "\n\n"
+                                 "Or to execute a single command in this environment, use:\n\n"
+                                 "    "
+                              << executable
+                              << " run "
+                              // Use -n or -p depending on if the env_name is a full prefix or just
+                              // a name.
+                              << (environment == ctx.prefix_params.target_prefix ? "-p " : "-n ")
+                              << environment << " mycommand\n";
+        }
+    }
+
     namespace
     {
         bool need_pkg_download(const specs::PackageInfo& pkg_info, MultiPackageCache& caches)
@@ -438,33 +464,7 @@ namespace mamba
         LOG_INFO << "Waiting for pyc compilation to finish";
         m_transaction_context.wait_for_pyc_compilation();
 
-        // Get the name of the executable used directly from the command.
-        const auto executable = get_self_exe_path().stem().string();
-
-        // Get the name of the environment
-        const auto environment = env_name(ctx);
-
-        // Check if the target prefix is active
-        if (util::get_env("CONDA_PREFIX") == ctx.prefix_params.target_prefix)
-        {
-            Console::stream() << "\nTransaction finished\n";
-        }
-        else
-        {
-            Console::stream() << "\nTransaction finished\n\n"
-                                 "To activate this environment, use:\n\n"
-                                 "    "
-                              << executable << " activate " << environment
-                              << "\n\n"
-                                 "Or to execute a single command in this environment, use:\n\n"
-                                 "    "
-                              << executable
-                              << " run "
-                              // Use -n or -p depending on if the env_name is a full prefix or just
-                              // a name.
-                              << (environment == ctx.prefix_params.target_prefix ? "-p " : "-n ")
-                              << environment << " mycommand\n";
-        }
+        Console::stream() << "\nTransaction finished\n";
 
         prefix.history().add_entry(m_history_entry);
         return true;

--- a/micromamba/tests/test_create.py
+++ b/micromamba/tests/test_create.py
@@ -545,6 +545,12 @@ def test_classic_specs(tmp_home, tmp_root_prefix, tmp_path, outside_root_prefix)
         assert cached_file.exists()
 
 
+def test_create_check_logs(tmp_home, tmp_root_prefix):
+    env_name = "env-create-check-logs"
+    res = helpers.create("-n", env_name, "xtensor")
+    assert "To activate this environment, use:" in res
+
+
 @pytest.mark.skipif(
     helpers.dry_run_tests is helpers.DryRun.ULTRA_DRY,
     reason="Running only ultra-dry tests",

--- a/micromamba/tests/test_create.py
+++ b/micromamba/tests/test_create.py
@@ -545,10 +545,17 @@ def test_classic_specs(tmp_home, tmp_root_prefix, tmp_path, outside_root_prefix)
         assert cached_file.exists()
 
 
-def test_create_check_logs(tmp_home, tmp_root_prefix):
+@pytest.mark.parametrize("output_flag", ["", "--json", "--quiet"])
+def test_create_check_logs(tmp_home, tmp_root_prefix, output_flag):
     env_name = "env-create-check-logs"
-    res = helpers.create("-n", env_name, "xtensor")
-    assert "To activate this environment, use:" in res
+    res = helpers.create("-n", env_name, "xtensor", output_flag)
+
+    if output_flag == "--json":
+        assert res["success"]
+    elif output_flag == "--quiet":
+        assert res == ""
+    else:
+        assert "To activate this environment, use:" in res
 
 
 @pytest.mark.skipif(

--- a/micromamba/tests/test_env.py
+++ b/micromamba/tests/test_env.py
@@ -164,7 +164,9 @@ def test_env_remove(tmp_home, tmp_root_prefix):
         assert str(env_fp) in lines
 
     # Unregister / remove env_name
-    helpers.run_env("remove", "-n", env_name, "-y")
+    res = helpers.run_env("remove", "-n", env_name, "-y")
+    assert "To activate this environment, use:" not in res
+
     env_json = helpers.run_env("list", "--json")
     assert str(env_fp) not in env_json["envs"]
     assert not env_fp.exists()

--- a/micromamba/tests/test_install.py
+++ b/micromamba/tests/test_install.py
@@ -665,11 +665,18 @@ def test_install_check_dirs(tmp_home, tmp_root_prefix):
         assert os.path.isdir(env_prefix / "lib" / "python3.8" / "site-packages")
 
 
-def test_install_check_logs(tmp_home, tmp_root_prefix):
+@pytest.mark.parametrize("output_flag", ["", "--json", "--quiet"])
+def test_install_check_logs(tmp_home, tmp_root_prefix, output_flag):
     env_name = "env-install-check-logs"
     helpers.create("-n", env_name)
-    res = helpers.install("-n", env_name, "xtensor")
-    assert "To activate this environment, use:" not in res
+    res = helpers.install("-n", env_name, "xtensor", output_flag)
+
+    if output_flag == "--json":
+        assert res["success"]
+    elif output_flag == "--quiet":
+        assert res == ""
+    else:
+        assert "To activate this environment, use:" not in res
 
 
 def test_install_local_package(tmp_home, tmp_root_prefix):

--- a/micromamba/tests/test_install.py
+++ b/micromamba/tests/test_install.py
@@ -665,6 +665,13 @@ def test_install_check_dirs(tmp_home, tmp_root_prefix):
         assert os.path.isdir(env_prefix / "lib" / "python3.8" / "site-packages")
 
 
+def test_install_check_logs(tmp_home, tmp_root_prefix):
+    env_name = "env-install-check-logs"
+    helpers.create("-n", env_name)
+    res = helpers.install("-n", env_name, "xtensor")
+    assert "To activate this environment, use:" not in res
+
+
 def test_install_local_package(tmp_home, tmp_root_prefix):
     env_name = "myenv"
     tmp_root_prefix / "envs" / env_name

--- a/micromamba/tests/test_remove.py
+++ b/micromamba/tests/test_remove.py
@@ -36,6 +36,13 @@ def test_remove(tmp_home, tmp_root_prefix, env_selector, tmp_xtensor_env, tmp_en
 
 
 @pytest.mark.parametrize("shared_pkgs_dirs", [True], indirect=True)
+def test_remove_check_logs(tmp_home, tmp_root_prefix, tmp_xtensor_env, tmp_env_name):
+    helpers.install("xtensor-python", "-n", tmp_env_name, no_dry_run=True)
+    res = helpers.remove("xtensor", "-n", tmp_env_name)
+    assert "To activate this environment, use:" not in res
+
+
+@pytest.mark.parametrize("shared_pkgs_dirs", [True], indirect=True)
 @pytest.mark.skipif(sys.platform == "win32", reason="This test is currently failing on Windows")
 def test_remove_orphaned(tmp_home, tmp_root_prefix, tmp_xtensor_env, tmp_env_name):
     env_pkgs = [p["name"] for p in helpers.umamba_list("-p", tmp_xtensor_env, "--json")]

--- a/micromamba/tests/test_remove.py
+++ b/micromamba/tests/test_remove.py
@@ -36,10 +36,17 @@ def test_remove(tmp_home, tmp_root_prefix, env_selector, tmp_xtensor_env, tmp_en
 
 
 @pytest.mark.parametrize("shared_pkgs_dirs", [True], indirect=True)
-def test_remove_check_logs(tmp_home, tmp_root_prefix, tmp_xtensor_env, tmp_env_name):
+@pytest.mark.parametrize("output_flag", ["", "--json", "--quiet"])
+def test_remove_check_logs(tmp_home, tmp_root_prefix, tmp_xtensor_env, tmp_env_name, output_flag):
     helpers.install("xtensor-python", "-n", tmp_env_name, no_dry_run=True)
-    res = helpers.remove("xtensor", "-n", tmp_env_name)
-    assert "To activate this environment, use:" not in res
+    res = helpers.remove("xtensor", "-n", tmp_env_name, output_flag)
+
+    if output_flag == "--json":
+        assert res["success"]
+    elif output_flag == "--quiet":
+        assert res == ""
+    else:
+        assert "To activate this environment, use:" not in res
 
 
 @pytest.mark.parametrize("shared_pkgs_dirs", [True], indirect=True)

--- a/micromamba/tests/test_update.py
+++ b/micromamba/tests/test_update.py
@@ -205,9 +205,16 @@ class TestUpdate:
         for to_link in res["actions"]["LINK"]:
             assert to_link["channel"] == "conda-forge"
 
-    def test_update_check_logs(self, env_created):
-        res = helpers.update("-n", TestUpdate.env_name, "xtensor=0.24.5")
-        assert "To activate this environment, use:" not in res
+    @pytest.mark.parametrize("output_flag", ["", "--json", "--quiet"])
+    def test_update_check_logs(self, env_created, output_flag):
+        res = helpers.update("-n", TestUpdate.env_name, "xtensor=0.24.5", output_flag)
+
+        if output_flag == "--json":
+            assert res["success"]
+        elif output_flag == "--quiet":
+            assert res == ""
+        else:
+            assert "To activate this environment, use:" not in res
 
 
 class TestUpdateConfig:

--- a/micromamba/tests/test_update.py
+++ b/micromamba/tests/test_update.py
@@ -205,6 +205,10 @@ class TestUpdate:
         for to_link in res["actions"]["LINK"]:
             assert to_link["channel"] == "conda-forge"
 
+    def test_update_check_logs(self, env_created):
+        res = helpers.update("-n", TestUpdate.env_name, "xtensor=0.24.5")
+        assert "To activate this environment, use:" not in res
+
 
 class TestUpdateConfig:
     current_root_prefix = os.environ["MAMBA_ROOT_PREFIX"]


### PR DESCRIPTION
- [x] Fix #3712 
- [x] Only print activation message when the environment is created (to mimic `conda`).