### PR TITLE
Revert "fix: Use `__conda_activate reactivate` instead of `__conda_reactivate` (#3702)"

### DIFF
--- a/mamba/mamba/shell_templates/mamba.sh
+++ b/mamba/mamba/shell_templates/mamba.sh
@@ -17,7 +17,7 @@ mamba() {
             ;;
         install|update|upgrade|remove|uninstall)
             __mamba_exe "$@" || \return
-            __conda_activate reactivate
+            __conda_reactivate
             ;;
         *)
             __mamba_exe "$@"


### PR DESCRIPTION
This reverts commit ce1d936fd6a28bf87fe514d2da03c6daa95fcb61 as it has been addressed in conda thanks to https://github.com/conda/conda/pull/14455.