### PR TITLE
fix: Adapt warnings shown when several channels are used

### DIFF
--- a/libmamba/src/api/channel_loader.cpp
+++ b/libmamba/src/api/channel_loader.cpp
@@ -61,12 +61,15 @@ namespace mamba
             specs::CondaURL& prev_channel_url
         )
         {
+            static bool has_shown_anaconda_channel_warning = false;
             for (const auto& platform : channel.platforms())
             {
                 auto show_warning = ctx.show_anaconda_channel_warnings;
                 auto channel_name = channel.platform_url(platform).host();
-                if (channel_name == "repo.anaconda.com" && show_warning)
+                if (channel_name == "repo.anaconda.com" && show_warning
+                    && !has_shown_anaconda_channel_warning)
                 {
+                    has_shown_anaconda_channel_warning = true;
                     LOG_WARNING << "'" << channel_name
                                 << "', a commercial channel hosted by Anaconda.com, is used.\n";
                     LOG_WARNING << "Please make sure you understand Anaconda Terms of Services.\n";

--- a/libmamba/src/solver/libsolv/unsolvable.cpp
+++ b/libmamba/src/solver/libsolv/unsolvable.cpp
@@ -367,6 +367,8 @@ namespace mamba::solver::libsolv
                 std::optional<std::string>& dep = problem.dep;
                 SolverRuleinfo type = problem.type;
 
+                static bool hint_for_flexible_channel_priority = false;
+
                 switch (type)
                 {
                     case SOLVER_RULE_PKG_CONSTRAINS:
@@ -535,7 +537,27 @@ namespace mamba::solver::libsolv
                     default:
                     {
                         // Many more SolverRuleinfo that have not been encountered.
-                        LOG_WARNING << "Problem type not implemented " << solv::enum_name(type);
+                        if (!hint_for_flexible_channel_priority)
+                        {
+                            hint_for_flexible_channel_priority = true;
+                            LOG_WARNING
+                                << "The specification of the environment does not seem solvable in your current setup.";
+                            LOG_WARNING
+                                << "For instance, packages from different channels might be specified,";
+                            LOG_WARNING
+                                << "whilst your current configuration might not allow their resolution.";
+                            LOG_WARNING << "";
+                            LOG_WARNING << "If it is the case, you need to either:";
+                            LOG_WARNING
+                                << " - adapt the channel ordering (e.g. by reordering the `-c` flags in your command line)";
+                            LOG_WARNING
+                                << " - use the flexible channel priority (e.g. using `--channel-priority flexible` in your command line)";
+                            LOG_WARNING << "";
+                            LOG_WARNING
+                                << "For reference, see this piece of documentation on channel priority:";
+                            LOG_WARNING
+                                << "https://docs.conda.io/projects/conda/en/stable/user-guide/tasks/manage-channels.html#strict-channel-priority";
+                        }
                         break;
                     }
                 }


### PR DESCRIPTION
Fix https://github.com/mamba-org/mamba/issues/2533.
Fix https://github.com/mamba-org/mamba/issues/2810.

Usages of several channels are common, yet users might face problem depending on their configuration (typically when `strict` channel priority is used). This has been reported in several many issues (see [this filter](https://github.com/mamba-org/mamba/issues?q=is%3Aissue+is%3Aopen+SOLVER_RULE_STRICT_REPO_PRIORITY) for an extract).

Currently, an uninformative warning is raised for the user, if this is the case.

This PR proposes to instead give a hint to users.