### PR TITLE
Options args enhancement

### DIFF
--- a/micromamba/src/activate.cpp
+++ b/micromamba/src/activate.cpp
@@ -54,7 +54,7 @@ set_activate_command(CLI::App* subcom)
     static std::string name = "";
     static bool stack = false;
 
-    subcom->add_option("prefix", name, "The prefix to activate");
+    subcom->add_option("prefix", name, "The prefix to activate")->option_text("PREFIX");
     subcom->add_flag(
         "--stack",
         stack,

--- a/micromamba/src/common_options.cpp
+++ b/micromamba/src/common_options.cpp
@@ -478,5 +478,4 @@ init_install_options(CLI::App* subcom, Configuration& config)
             "Categories of package to install from environment lockfile"
         )
         ->option_text("CAT1 CAT2...");
-    ;
 }

--- a/micromamba/src/common_options.cpp
+++ b/micromamba/src/common_options.cpp
@@ -22,6 +22,7 @@ init_rc_options(CLI::App* subcom, Configuration& config)
             rc_files.get_cli_config<std::vector<fs::u8path>>(),
             rc_files.description()
         )
+        ->option_text("FILE1 FILE2")
         ->group(cli_group);
 
     auto& no_rc = config.at("no_rc");
@@ -108,10 +109,12 @@ init_prefix_options(CLI::App* subcom, Configuration& config)
 
     auto& root = config.at("root_prefix");
     subcom->add_option("-r,--root-prefix", root.get_cli_config<fs::u8path>(), root.description())
+        ->option_text("PATH")
         ->group(cli_group);
 
     auto& prefix = config.at("target_prefix");
     subcom->add_option("-p,--prefix", prefix.get_cli_config<fs::u8path>(), prefix.description())
+        ->option_text("PATH")
         ->group(cli_group);
 
     auto& relocate_prefix = config.at("relocate_prefix");
@@ -121,10 +124,12 @@ init_prefix_options(CLI::App* subcom, Configuration& config)
             relocate_prefix.get_cli_config<fs::u8path>(),
             relocate_prefix.description()
         )
+        ->option_text("PATH")
         ->group(cli_group);
 
     auto& name = config.at("env_name");
     subcom->add_option("-n,--name", name.get_cli_config<std::string>(), name.description())
+        ->option_text("NAME")
         ->group(cli_group);
 }
 
@@ -136,6 +141,7 @@ init_network_options(CLI::App* subcom, Configuration& config)
     auto& ssl_verify = config.at("ssl_verify");
     subcom
         ->add_option("--ssl-verify", ssl_verify.get_cli_config<std::string>(), ssl_verify.description())
+        ->option_text("'<false>' or PATH")
         ->group(cli_group);
 
     auto& ssl_no_revoke = config.at("ssl_no_revoke");
@@ -150,6 +156,7 @@ init_network_options(CLI::App* subcom, Configuration& config)
             cacert_path.get_cli_config<std::string>(),
             cacert_path.description()
         )
+        ->option_text("PATH")
         ->group(cli_group);
 
     auto& local_repodata_ttl = config.at("local_repodata_ttl");
@@ -180,6 +187,7 @@ init_channel_parser(CLI::App* subcom, Configuration& config)
     channels.needs({ "override_channels" });
     subcom
         ->add_option("-c,--channel", channels.get_cli_config<string_list>(), channels.description())
+        ->option_text("CHANNEL")
         ->type_size(1)
         ->allow_extra_args(false);
 
@@ -212,11 +220,13 @@ init_channel_parser(CLI::App* subcom, Configuration& config)
         ->transform(CLI::CheckedTransformer(cp_map, CLI::ignore_case));
 
     auto& channel_alias = config.at("channel_alias");
-    subcom->add_option(
-        "--channel-alias",
-        channel_alias.get_cli_config<std::string>(),
-        channel_alias.description()
-    );
+    subcom
+        ->add_option(
+            "--channel-alias",
+            channel_alias.get_cli_config<std::string>(),
+            channel_alias.description()
+        )
+        ->option_text("URL");
 
     auto& strict_channel_priority = config.insert(
         Configurable("strict_channel_priority", false)
@@ -342,15 +352,14 @@ init_install_options(CLI::App* subcom, Configuration& config)
     init_channel_parser(subcom, config);
 
     auto& specs = config.at("specs");
-    subcom->add_option(
-        "specs",
-        specs.get_cli_config<string_list>(),
-        "Specs to install into the environment"
-    );
+    subcom
+        ->add_option("specs", specs.get_cli_config<string_list>(), "Specs to install into the environment")
+        ->option_text("SPECS");
 
     auto& file_specs = config.at("file_specs");
     subcom
         ->add_option("-f,--file", file_specs.get_cli_config<string_list>(), file_specs.description())
+        ->option_text("FILE")
         ->type_size(1)
         ->allow_extra_args(false);
 
@@ -437,11 +446,13 @@ init_install_options(CLI::App* subcom, Configuration& config)
     auto& trusted_channels = config.at("trusted_channels");
     // Allowing unlimited number of args (may be modified later if needed using `type_size` and
     // `allow_extra_args`)
-    subcom->add_option(
-        "--trusted-channels",
-        trusted_channels.get_cli_config<string_list>(),
-        trusted_channels.description()
-    );
+    subcom
+        ->add_option(
+            "--trusted-channels",
+            trusted_channels.get_cli_config<string_list>(),
+            trusted_channels.description()
+        )
+        ->option_text("CHANNEL1 CHANNEL2");
 
     auto& repo_parsing = config.at("experimental_repodata_parsing");
     subcom->add_flag(
@@ -451,7 +462,8 @@ init_install_options(CLI::App* subcom, Configuration& config)
     );
 
     auto& platform = config.at("platform");
-    subcom->add_option("--platform", platform.get_cli_config<std::string>(), platform.description());
+    subcom->add_option("--platform", platform.get_cli_config<std::string>(), platform.description())
+        ->option_text("PLATFORM");
 
     auto& no_deps = config.at("no_deps");
     subcom->add_flag("--no-deps", no_deps.get_cli_config<bool>(), no_deps.description());
@@ -459,9 +471,12 @@ init_install_options(CLI::App* subcom, Configuration& config)
     subcom->add_flag("--only-deps", only_deps.get_cli_config<bool>(), only_deps.description());
 
     auto& categories = config.at("categories");
-    subcom->add_option(
-        "--category",
-        categories.get_cli_config<string_list>(),
-        "Categories of package to install from environment lockfile"
-    );
+    subcom
+        ->add_option(
+            "--category",
+            categories.get_cli_config<string_list>(),
+            "Categories of package to install from environment lockfile"
+        )
+        ->option_text("CAT1 CAT2");
+    ;
 }

--- a/micromamba/src/common_options.cpp
+++ b/micromamba/src/common_options.cpp
@@ -22,7 +22,7 @@ init_rc_options(CLI::App* subcom, Configuration& config)
             rc_files.get_cli_config<std::vector<fs::u8path>>(),
             rc_files.description()
         )
-        ->option_text("FILE1 FILE2")
+        ->option_text("FILE1 FILE2...")
         ->group(cli_group);
 
     auto& no_rc = config.at("no_rc");
@@ -452,7 +452,7 @@ init_install_options(CLI::App* subcom, Configuration& config)
             trusted_channels.get_cli_config<string_list>(),
             trusted_channels.description()
         )
-        ->option_text("CHANNEL1 CHANNEL2");
+        ->option_text("CHANNEL1 CHANNEL2...");
 
     auto& repo_parsing = config.at("experimental_repodata_parsing");
     subcom->add_flag(
@@ -477,6 +477,6 @@ init_install_options(CLI::App* subcom, Configuration& config)
             categories.get_cli_config<string_list>(),
             "Categories of package to install from environment lockfile"
         )
-        ->option_text("CAT1 CAT2");
+        ->option_text("CAT1 CAT2...");
     ;
 }

--- a/micromamba/src/config.cpp
+++ b/micromamba/src/config.cpp
@@ -106,7 +106,9 @@ void
 init_config_describe_options(CLI::App* subcom, mamba::Configuration& config)
 {
     auto& specs = config.at("specs");
-    subcom->add_option("configs", specs.get_cli_config<std::vector<std::string>>(), "Configuration keys");
+    subcom
+        ->add_option("configs", specs.get_cli_config<std::vector<std::string>>(), "Configuration keys")
+        ->option_text("CONFIG1 CONFIG2");
 
     auto& show_long_descriptions = config.at("show_config_long_descriptions");
     subcom->add_flag(
@@ -352,7 +354,9 @@ set_config_remove_key_command(CLI::App* subcom, mamba::Configuration& config)
     auto& remove_key = config.insert(Configurable("remove_key", std::string(""))
                                          .group("Output, Prompt and Flow Control")
                                          .description("Remove a configuration key and its values"));
-    subcom->add_option("remove_key", remove_key.get_cli_config<std::string>(), remove_key.description());
+    subcom
+        ->add_option("remove_key", remove_key.get_cli_config<std::string>(), remove_key.description())
+        ->option_text("KEY");
 
     subcom->callback(
         [&]()
@@ -413,11 +417,9 @@ set_config_remove_command(CLI::App* subcom, mamba::Configuration& config)
                 "Remove a configuration value from a list key. This removes all instances of the value."
             )
     );
-    subcom->add_option(
-        "remove",
-        remove_vec_map.get_cli_config<string_list>(),
-        remove_vec_map.description()
-    );
+    subcom
+        ->add_option("remove", remove_vec_map.get_cli_config<string_list>(), remove_vec_map.description())
+        ->option_text("VALUE");
 
     subcom->callback(
         [&]
@@ -495,7 +497,9 @@ set_config_set_command(CLI::App* subcom, mamba::Configuration& config)
     auto& set_value = config.insert(Configurable("set_value", std::vector<std::string>({}))
                                         .group("Output, Prompt and Flow Control")
                                         .description("Set configuration value on rc file"));
-    subcom->add_option("set_value", set_value.get_cli_config<string_list>(), set_value.description());
+    subcom
+        ->add_option("set_value", set_value.get_cli_config<string_list>(), set_value.description())
+        ->option_text("VALUE");
 
 
     subcom->callback(
@@ -543,7 +547,9 @@ set_config_get_command(CLI::App* subcom, mamba::Configuration& config)
     auto& get_value = config.insert(Configurable("get_value", std::string(""))
                                         .group("Output, Prompt and Flow Control")
                                         .description("Display configuration value from rc file"));
-    subcom->add_option("get_value", get_value.get_cli_config<std::string>(), get_value.description());
+    subcom
+        ->add_option("get_value", get_value.get_cli_config<std::string>(), get_value.description())
+        ->option_text("VALUE");
 
     subcom->callback(
         [&]

--- a/micromamba/src/config.cpp
+++ b/micromamba/src/config.cpp
@@ -108,7 +108,7 @@ init_config_describe_options(CLI::App* subcom, mamba::Configuration& config)
     auto& specs = config.at("specs");
     subcom
         ->add_option("configs", specs.get_cli_config<std::vector<std::string>>(), "Configuration keys")
-        ->option_text("CONFIG1 CONFIG2");
+        ->option_text("CONFIG1 CONFIG2...");
 
     auto& show_long_descriptions = config.at("show_config_long_descriptions");
     subcom->add_flag(

--- a/micromamba/src/constructor.cpp
+++ b/micromamba/src/constructor.cpp
@@ -24,7 +24,8 @@ init_constructor_parser(CLI::App* subcom, Configuration& config)
                                      .group("cli")
                                      .description("Extract the conda pkgs in <prefix>/pkgs"));
 
-    subcom->add_option("-p,--prefix", prefix.get_cli_config<fs::u8path>(), prefix.description());
+    subcom->add_option("-p,--prefix", prefix.get_cli_config<fs::u8path>(), prefix.description())
+        ->option_text("PATH");
 
     auto& extract_conda_pkgs = config.insert(Configurable("constructor_extract_conda_pkgs", false)
                                                  .group("cli")

--- a/micromamba/src/env.cpp
+++ b/micromamba/src/env.cpp
@@ -403,11 +403,13 @@ set_env_command(CLI::App* com, Configuration& config)
     init_prefix_options(update_subcom, config);
 
     auto& file_specs = config.at("file_specs");
-    update_subcom->add_option(
-        "-f,--file",
-        file_specs.get_cli_config<std::vector<std::string>>(),
-        file_specs.description()
-    );
+    update_subcom
+        ->add_option(
+            "-f,--file",
+            file_specs.get_cli_config<std::vector<std::string>>(),
+            file_specs.description()
+        )
+        ->option_text("FILE");
 
     static bool remove_not_specified = false;
     update_subcom->add_flag(

--- a/micromamba/src/list.cpp
+++ b/micromamba/src/list.cpp
@@ -21,7 +21,8 @@ init_list_parser(CLI::App* subcom, Configuration& config)
     auto& regex = config.insert(Configurable("list_regex", std::string(""))
                                     .group("cli")
                                     .description("List only packages matching a regular expression"));
-    subcom->add_option("regex", regex.get_cli_config<std::string>(), regex.description());
+    subcom->add_option("regex", regex.get_cli_config<std::string>(), regex.description())
+        ->option_text("REGEX");
 
     auto& full_name = config.insert(Configurable("full_name", false)
                                         .group("cli")

--- a/micromamba/src/login.cpp
+++ b/micromamba/src/login.cpp
@@ -55,7 +55,7 @@ void
 set_logout_command(CLI::App* subcom)
 {
     static std::string host;
-    subcom->add_option("host", host, "Host for the account");
+    subcom->add_option("host", host, "Host for the account")->option_text("HOST");
 
     static bool all;
     subcom->add_flag("--all", all, "Log out from all hosts");
@@ -118,19 +118,21 @@ set_login_command(CLI::App* subcom)
     static bool pass_stdin = false;
     static bool token_stdin = false;
     static bool bearer_stdin = false;
-    subcom->add_option("-p,--password", pass, "Password for account");
-    subcom->add_option("-u,--username", user, "User name for the account");
-    subcom->add_option("-t,--token", token, "Token for the account");
-    subcom->add_option("-b,--bearer", bearer, "Bearer token for the account");
+    subcom->add_option("-p,--password", pass, "Password for account")->option_text("PASSWORD");
+    subcom->add_option("-u,--username", user, "User name for the account")->option_text("USERNAME");
+    subcom->add_option("-t,--token", token, "Token for the account")->option_text("TOKEN");
+    subcom->add_option("-b,--bearer", bearer, "Bearer token for the account")->option_text("BEARER");
     subcom->add_flag("--password-stdin", pass_stdin, "Read password from stdin");
     subcom->add_flag("--token-stdin", token_stdin, "Read token from stdin");
     subcom->add_flag("--bearer-stdin", bearer_stdin, "Read bearer token from stdin");
-    subcom->add_option(
-        "host",
-        host,
-        "Host for the account. The scheme (e.g. https://) is ignored\n"
-        "but not the port (optional) nor the channel (optional)."
-    );
+    subcom
+        ->add_option(
+            "host",
+            host,
+            "Host for the account. The scheme (e.g. https://) is ignored\n"
+            "but not the port (optional) nor the channel (optional)."
+        )
+        ->option_text("HOST");
 
     subcom->callback(
         []()

--- a/micromamba/src/package.cpp
+++ b/micromamba/src/package.cpp
@@ -23,8 +23,8 @@ set_package_command(CLI::App* subcom, Configuration& config)
 
     auto extract_subcom = subcom->add_subcommand("extract");
     init_general_options(extract_subcom, config);
-    extract_subcom->add_option("archive", infile, "Archive to extract");
-    extract_subcom->add_option("dest", dest, "Destination folder");
+    extract_subcom->add_option("archive", infile, "Archive to extract")->option_text("ARCHIVE");
+    extract_subcom->add_option("dest", dest, "Destination folder")->option_text("FOLDER");
     extract_subcom->callback(
         [&]
         {
@@ -43,18 +43,23 @@ set_package_command(CLI::App* subcom, Configuration& config)
 
     auto compress_subcom = subcom->add_subcommand("compress");
     init_general_options(compress_subcom, config);
-    compress_subcom->add_option("folder", infile, "Folder to compress");
-    compress_subcom->add_option("dest", dest, "Destination (e.g. myfile-3.1-0.tar.bz2 or .conda)");
-    compress_subcom->add_option(
-        "-c,--compression-level",
-        compression_level,
-        "Compression level from 0-9 (tar.bz2, default is 9), and 1-22 (conda, default is 15)"
-    );
-    compress_subcom->add_option(
-        "--compression-threads",
-        compression_threads,
-        "Compression threads (only relevant for .conda packages, default is 1)"
-    );
+    compress_subcom->add_option("folder", infile, "Folder to compress")->option_text("FOLDER");
+    compress_subcom->add_option("dest", dest, "Destination (e.g. myfile-3.1-0.tar.bz2 or .conda)")
+        ->option_text("DEST");
+    compress_subcom
+        ->add_option(
+            "-c,--compression-level",
+            compression_level,
+            "Compression level from 0-9 (tar.bz2, default is 9), and 1-22 (conda, default is 15)"
+        )
+        ->option_text("COMP_LEVEL");
+    compress_subcom
+        ->add_option(
+            "--compression-threads",
+            compression_threads,
+            "Compression threads (only relevant for .conda packages, default is 1)"
+        )
+        ->option_text("COMP_THREADS");
     compress_subcom->callback(
         [&]()
         {
@@ -84,17 +89,21 @@ set_package_command(CLI::App* subcom, Configuration& config)
 
     auto transmute_subcom = subcom->add_subcommand("transmute");
     init_general_options(transmute_subcom, config);
-    transmute_subcom->add_option("infile", infile, "Folder to compress");
-    transmute_subcom->add_option(
-        "-c,--compression-level",
-        compression_level,
-        "Compression level from 0-9 (tar.bz2, default is 9), and 1-22 (conda, default is 15)"
-    );
-    transmute_subcom->add_option(
-        "--compression-threads",
-        compression_threads,
-        "Compression threads (only relevant for .conda packages, default is 1)"
-    );
+    transmute_subcom->add_option("infile", infile, "Folder to compress")->option_text("FOLDER");
+    transmute_subcom
+        ->add_option(
+            "-c,--compression-level",
+            compression_level,
+            "Compression level from 0-9 (tar.bz2, default is 9), and 1-22 (conda, default is 15)"
+        )
+        ->option_text("COMP_LEVEL");
+    transmute_subcom
+        ->add_option(
+            "--compression-threads",
+            compression_threads,
+            "Compression threads (only relevant for .conda packages, default is 1)"
+        )
+        ->option_text("COMP_THREADS");
     transmute_subcom->callback(
         [&]()
         {

--- a/micromamba/src/remove.cpp
+++ b/micromamba/src/remove.cpp
@@ -20,11 +20,9 @@ set_remove_command(CLI::App* subcom, Configuration& config)
     init_prefix_options(subcom, config);
 
     auto& specs = config.at("specs");
-    subcom->add_option(
-        "specs",
-        specs.get_cli_config<string_list>(),
-        "Specs to remove from the environment"
-    );
+    subcom
+        ->add_option("specs", specs.get_cli_config<string_list>(), "Specs to remove from the environment")
+        ->option_text("SPECS");
 
     static bool remove_all = false, force = false, prune_deps = true;
     subcom->add_flag("-a,--all", remove_all, "Remove all packages in the environment");

--- a/micromamba/src/repoquery.cpp
+++ b/micromamba/src/repoquery.cpp
@@ -39,7 +39,9 @@ namespace
         subcmd->add_option("specs", options.specs, "Specs to search")->required();
 
         auto& platform = config.at("platform");
-        subcmd->add_option("--platform", platform.get_cli_config<std::string>(), platform.description());
+        subcmd
+            ->add_option("--platform", platform.get_cli_config<std::string>(), platform.description())
+            ->option_text("PLATFORM");
     }
 
     template <typename Iter>
@@ -91,7 +93,7 @@ namespace
         init_repoquery_common_options(subcmd, config, options);
 
         static bool remote = false;
-        subcmd->add_flag("--remote", remote, "Use installed prefix instead of remote repositories.");
+        subcmd->add_flag("--remote", remote, "Use remote repositories");
 
         subcmd->callback(
             [&]()
@@ -114,7 +116,7 @@ namespace
                     }
                     if (remote && !channel_passed)
                     {
-                        std::cout << "Try looking in a different channel with '--channel'.\n";
+                        std::cout << "Try looking in a different channel with '-c, --channel'.\n";
                     }
                 }
             }
@@ -136,7 +138,7 @@ namespace
         init_repoquery_common_options(subcmd, config, options);
 
         static bool use_local = false;
-        subcmd->add_flag("--local", use_local, "Use installed prefix instead of remote repositories.");
+        subcmd->add_flag("--local", use_local, "Use installed prefix instead of remote repositories");
 
         subcmd->callback(
             [&]()
@@ -148,7 +150,7 @@ namespace
                 {
                     if (!use_local && !channel_passed)
                     {
-                        std::cout << "Try looking in a different channel with '--channel'.\n";
+                        std::cout << "Try looking in a different channel with '-c, --channel'.\n";
                     }
                 }
             }

--- a/micromamba/src/run.cpp
+++ b/micromamba/src/run.cpp
@@ -95,7 +95,8 @@ set_ps_command(CLI::App* subcom, Context& context)
 
     auto stop_subcom = subcom->add_subcommand("stop");
     static std::string pid_or_name;
-    stop_subcom->add_option("pid_or_name", pid_or_name, "Process ID or process name (label)");
+    stop_subcom->add_option("pid_or_name", pid_or_name, "Process ID or process name (label)")
+        ->option_text("PID or NAME");
     stop_subcom->callback(
         []()
         {
@@ -145,10 +146,13 @@ set_run_command(CLI::App* subcom, Configuration& config)
                                          streams,
                                          "Attach to stdin, stdout and/or stderr. -a \"\" for disabling stream redirection"
                                      )
+                                     ->option_text("STREAM")
                                      ->join(',');
 
     static std::string cwd;
-    subcom->add_option("--cwd", cwd, "Current working directory for command to run in. Defaults to cwd");
+    subcom
+        ->add_option("--cwd", cwd, "Current working directory for command to run in. Defaults to cwd")
+        ->option_text("DIR");
 
     static bool detach = false;
 #ifndef _WIN32
@@ -160,15 +164,18 @@ set_run_command(CLI::App* subcom, Configuration& config)
 
     static std::vector<std::string> env_vars;
     subcom->add_option("-e,--env", env_vars, "Add env vars with -e ENVVAR or -e ENVVAR=VALUE")
+        ->option_text("ENVVAR")
         ->allow_extra_args(false);
 
     static std::string specific_process_name;
 #ifndef _WIN32
-    subcom->add_option(
-        "--label",
-        specific_process_name,
-        "Specifies the name of the process. If not set, a unique name will be generated derived from the executable name if possible."
-    );
+    subcom
+        ->add_option(
+            "--label",
+            specific_process_name,
+            "Specifies the name of the process. If not set, a unique name will be generated derived from the executable name if possible."
+        )
+        ->option_text("NAME");
 #endif
 
     subcom->prefix_command();

--- a/micromamba/src/shell.cpp
+++ b/micromamba/src/shell.cpp
@@ -33,27 +33,32 @@ namespace
             ->add_option("-s,--shell", shell_type.get_cli_config<std::string>(), shell_type.description())
             ->check(CLI::IsMember(std::set<std::string>(
                 { "bash", "posix", "powershell", "cmd.exe", "xonsh", "zsh", "fish", "tcsh", "dash", "nu" }
-            )));
+            )))
+            ->option_text("SHELL");
     }
 
     void init_root_prefix_option(CLI::App* subcmd, Configuration& config)
     {
         auto& root = config.at("root_prefix");
-        subcmd->add_option(
-            "root_prefix,-r,--root-prefix",
-            root.get_cli_config<fs::u8path>(),
-            root.description()
-        );
+        subcmd
+            ->add_option(
+                "root_prefix,-r,--root-prefix",
+                root.get_cli_config<fs::u8path>(),
+                root.description()
+            )
+            ->option_text("PATH");
     }
 
     void init_prefix_options(CLI::App* subcmd, Configuration& config)
     {
         auto& prefix = config.at("target_prefix");
-        auto* prefix_cli = subcmd->add_option(
-            "-p,--prefix",
-            prefix.get_cli_config<fs::u8path>(),
-            prefix.description()
-        );
+        auto* prefix_cli = subcmd
+                               ->add_option(
+                                   "-p,--prefix",
+                                   prefix.get_cli_config<fs::u8path>(),
+                                   prefix.description()
+                               )
+                               ->option_text("PATH");
 
         auto& name = config.at("env_name");
         auto* name_cli = subcmd

--- a/micromamba/src/update.cpp
+++ b/micromamba/src/update.cpp
@@ -229,7 +229,8 @@ set_self_update_command(CLI::App* subcom, Configuration& config)
     init_install_options(subcom, config);
 
     static std::optional<std::string> version;
-    subcom->add_option("--version", version, "Install specific micromamba version");
+    subcom->add_option("--version", version, "Install specific micromamba version")
+        ->option_text("VERSION");
 
     subcom->callback([&] { return update_self(config, version); });
 }


### PR DESCRIPTION
- [x] Fix `--remote` wrong description
- [x] Set default `TEXT` to something more explicit for options using `option_text`.
Note that options using `required()` and `excludes(some_other_option)` are not affected because modifying the `TEXT` option makes the requirement and exclusion descriptions vanish.