### PR TITLE
 fix: Correctly populate lists of `MatchSpec` in `MTransaction`'s history

### DIFF
--- a/libmamba/src/core/transaction.cpp
+++ b/libmamba/src/core/transaction.cpp
@@ -177,30 +177,32 @@ namespace mamba
             [](const auto& pkg) { return explicit_spec(pkg); }
         );
 
+        m_history_entry.update.reserve(pkgs_to_install.size());
+        for (auto& pkg : pkgs_to_install)
+        {
+            m_history_entry.update.push_back(explicit_spec(pkg).str());
+        }
+        m_history_entry.remove.reserve(pkgs_to_remove.size());
+        for (auto& pkg : pkgs_to_remove)
+        {
+            m_history_entry.remove.push_back(explicit_spec(pkg).str());
+        }
+
         m_solution.actions.reserve(pkgs_to_install.size() + pkgs_to_remove.size());
+
         std::transform(
             std::move_iterator(pkgs_to_install.begin()),
             std::move_iterator(pkgs_to_install.end()),
             std::back_insert_iterator(m_solution.actions),
             [](specs::PackageInfo&& pkg) { return solver::Solution::Install{ std::move(pkg) }; }
         );
+
         std::transform(
             std::move_iterator(pkgs_to_remove.begin()),
             std::move_iterator(pkgs_to_remove.end()),
             std::back_insert_iterator(m_solution.actions),
             [](specs::PackageInfo&& pkg) { return solver::Solution::Remove{ std::move(pkg) }; }
         );
-
-        m_history_entry.remove.reserve(pkgs_to_remove.size());
-        for (auto& pkg : pkgs_to_remove)
-        {
-            m_history_entry.remove.push_back(explicit_spec(pkg).str());
-        }
-        m_history_entry.update.reserve(pkgs_to_install.size());
-        for (auto& pkg : pkgs_to_install)
-        {
-            m_history_entry.update.push_back(explicit_spec(pkg).str());
-        }
 
         // if no action required, don't even start logging them
         if (!empty())

--- a/micromamba/tests/test_create.py
+++ b/micromamba/tests/test_create.py
@@ -1521,4 +1521,4 @@ https://conda.anaconda.org/conda-forge/noarch/pip-24.3.1-pyh145f28c_2.conda#7660
 
     out = helpers.create("-p", env_prefix, "-f", env_spec_file, "--dry-run")
 
-    assert update_specs_list in out
+    assert update_specs_list in out.replace("\r", "")

--- a/micromamba/tests/test_create.py
+++ b/micromamba/tests/test_create.py
@@ -1495,3 +1495,30 @@ def test_create_with_empty_lines_and_comments(tmp_path, env_spec):
         pytest.fail(
             f"test_create_with_empty_lines_and_comments exceeded memory limit of {memory_limit} MB (used {max_memory:.2f} MB)"
         )
+
+
+def test_update_spec_list(tmp_path):
+    env_prefix = tmp_path / "env-invalid_spec"
+
+    env_spec = """
+# This file may be used to create an environment using:
+# $ conda create --name <env> --file <this file>
+# platform: linux-64
+@EXPLICIT
+https://conda.anaconda.org/conda-forge/noarch/pip-24.3.1-pyh145f28c_2.conda#76601b0ccfe1fe13a21a5f8813cb38de
+"""
+
+    env_spec_file = tmp_path / "env_spec.txt"
+
+    update_specs_list = """
+  Updating specs:
+
+   - pip==24.3.1=pyh145f28c_2
+"""
+
+    with open(env_spec_file, "w") as f:
+        f.write(env_spec)
+
+    out = helpers.create("-p", env_prefix, "-f", env_spec_file, "--dry-run")
+
+    assert update_specs_list in out


### PR DESCRIPTION
Fix https://github.com/mamba-org/mamba/issues/3713.