### PR TITLE
fix: Support globs in `MatchSpec` build strings

### DIFF
--- a/libmamba/include/mamba/specs/regex_spec.hpp
+++ b/libmamba/include/mamba/specs/regex_spec.hpp
@@ -31,7 +31,7 @@ namespace mamba::specs
         [[nodiscard]] static auto parse(std::string pattern) -> expected_parse_t<RegexSpec>;
 
         RegexSpec();
-        RegexSpec(std::regex pattern, std::string raw_pattern);
+        RegexSpec(std::string raw_pattern);
 
         [[nodiscard]] auto contains(std::string_view str) const -> bool;
 

--- a/libmamba/include/mamba/specs/regex_spec.hpp
+++ b/libmamba/include/mamba/specs/regex_spec.hpp
@@ -61,8 +61,8 @@ namespace mamba::specs
 
     private:
 
-        std::regex m_pattern;
         std::string m_raw_pattern;
+        std::regex m_pattern;
     };
 }
 

--- a/libmamba/include/mamba/specs/regex_spec.hpp
+++ b/libmamba/include/mamba/specs/regex_spec.hpp
@@ -31,7 +31,7 @@ namespace mamba::specs
         [[nodiscard]] static auto parse(std::string pattern) -> expected_parse_t<RegexSpec>;
 
         RegexSpec();
-        RegexSpec(std::string raw_pattern);
+        explicit RegexSpec(std::string raw_pattern);
 
         [[nodiscard]] auto contains(std::string_view str) const -> bool;
 

--- a/libmamba/src/specs/regex_spec.cpp
+++ b/libmamba/src/specs/regex_spec.cpp
@@ -44,6 +44,18 @@ namespace mamba::specs
 
     RegexSpec::RegexSpec(std::string raw_pattern)
     {
+        // If the string is wrapped in `^` and `$`, `conda.model.MatchSpec` considers it a regex.
+        // See:
+        // https://github.com/conda/conda/blob/52b6393d6331e8aa36b2e23ab65766a980f381d2/conda/models/match_spec.py#L134-L139.
+        // See:
+        // https://github.com/conda/conda/blob/52b6393d6331e8aa36b2e23ab65766a980f381d2/conda/models/match_spec.py#L889-L894
+        if (util::starts_with(raw_pattern, pattern_start) && util::ends_with(raw_pattern, pattern_end))
+        {
+            m_raw_pattern = raw_pattern;
+            m_pattern = std::regex(m_raw_pattern);
+            return;
+        }
+
         // Construct ss from raw_pattern, in particular make sure to replace all `*` by `.*`
         // in the pattern if they are not preceded by a `.`.
         // We force regex to start with `^` and end with `$` to simplify the multiple

--- a/libmamba/src/specs/regex_spec.cpp
+++ b/libmamba/src/specs/regex_spec.cpp
@@ -6,7 +6,6 @@
 
 #include <algorithm>
 #include <cassert>
-#include <iostream>
 #include <sstream>
 
 #include <fmt/format.h>
@@ -30,7 +29,7 @@ namespace mamba::specs
         // Parse error need to be handled by ``tl::expected`` to be managed down the road.
         try
         {
-            return { std::move(pattern) };
+            return RegexSpec{ std::move(pattern) };
         }
         catch (const std::regex_error& e)
         {

--- a/libmamba/tests/src/specs/test_match_spec.cpp
+++ b/libmamba/tests/src/specs/test_match_spec.cpp
@@ -981,6 +981,25 @@ namespace
                 /* .track_features =*/{ "openssl", "mkl" },
             }));
         }
+
+        SECTION("pytorch=2.3.1=py3.10_cuda11.8*")
+        {
+            // Check that it contains `pytorch=2.3.1=py3.10_cuda11.8_cudnn8.7.0_0`
+
+            const auto ms = "pytorch=2.3.1=py3.10_cuda11.8*"_ms;
+
+            REQUIRE(ms.contains_except_channel(Pkg{
+                /* .name= */ "pytorch",
+                /* .version= */ "2.3.1"_v,
+                /* .build_string= */ "py3.10_cuda11.8_cudnn8.7.0_0",
+                /* .build_number= */ 0,
+                /* .md5= */ "lemd5",
+                /* .sha256= */ "somesha256",
+                /* .license= */ "GPL",
+                /* .platform= */ "linux-64",
+                /* .track_features =*/{},
+            }));
+        }
     }
 
     TEST_CASE("MatchSpec comparability and hashability")

--- a/libmamba/tests/src/specs/test_regex_spec.cpp
+++ b/libmamba/tests/src/specs/test_regex_spec.cpp
@@ -81,9 +81,19 @@ namespace
         REQUIRE(hash_fn(spec1) != hash_fn(spec3));
     }
 
-    TEST_CASE("RegexSpec ^py3.10_cuda11.8*$")
+    TEST_CASE("RegexSpec py3.10_cuda11.8*")
     {
-        auto spec = RegexSpec::parse("^py3.10_cuda11.8*$").value();
+        auto spec = RegexSpec::parse("py3.10_cuda11.8*").value();
         REQUIRE(spec.contains("py3.10_cuda11.8_cudnn8.7.0_0"));
     }
+
+    TEST_CASE("RegexSpec * semantic")
+    {
+        auto spec = RegexSpec::parse("py3.*").value();
+
+        REQUIRE(spec.contains("py3."));
+        REQUIRE(spec.contains("py3.10"));
+        REQUIRE(spec.contains("py3.10_cuda11.8_cudnn8.7.0_0"));
+    }
+
 }

--- a/libmamba/tests/src/specs/test_regex_spec.cpp
+++ b/libmamba/tests/src/specs/test_regex_spec.cpp
@@ -80,4 +80,10 @@ namespace
         REQUIRE(hash_fn(spec1) == hash_fn(spec2));
         REQUIRE(hash_fn(spec1) != hash_fn(spec3));
     }
+
+    TEST_CASE("RegexSpec ^py3.10_cuda11.8*$")
+    {
+        auto spec = RegexSpec::parse("^py3.10_cuda11.8*$").value();
+        REQUIRE(spec.contains("py3.10_cuda11.8_cudnn8.7.0_0"));
+    }
 }

--- a/micromamba/tests/test_create.py
+++ b/micromamba/tests/test_create.py
@@ -1638,3 +1638,42 @@ def test_ca_certificates(tmp_path):
     )
 
     assert root_prefix_ca_certificates_used or fall_back_certificates_used
+
+def test_glob_in_build_string(tmp_path):
+    # Non-regression test for https://github.com/mamba-org/mamba/issues/3699
+    env_prefix = tmp_path / "test_glob_in_build_string"
+
+    pytorch_match_spec = "pytorch=2.3.1=py3.10_cuda11.8*"
+
+    # Export CONDA_OVERRIDE_GLIBC=2.17 to force the solver to use the glibc 2.17 package
+    try:
+        os.environ["CONDA_OVERRIDE_GLIBC"] = "2.17"
+
+        # Should run without error
+        out = helpers.create(
+            "-p",
+            env_prefix,
+            pytorch_match_spec,
+            "-c",
+            "pytorch",
+            "-c",
+            "nvidia/label/cuda-11.8.0",
+            "-c",
+            "nvidia",
+            "-c",
+            "conda-forge",
+            "--platform",
+            "linux-64",
+            "--dry-run",
+            "--json",
+        )
+    finally:
+        os.environ.pop("CONDA_OVERRIDE_GLIBC", None)
+
+    # Check that a build of pytorch 2.3.1 with `py3.10_cuda11.8_cudnn8.7.0_0` as a build string is found
+    assert any(
+        package["name"] == "pytorch"
+        and package["version"] == "2.3.1"
+        and package["build_string"] == "py3.10_cuda11.8_cudnn8.7.0_0"
+        for package in out["actions"]["FETCH"]
+    )

--- a/micromamba/tests/test_create.py
+++ b/micromamba/tests/test_create.py
@@ -1639,36 +1639,34 @@ def test_ca_certificates(tmp_path):
 
     assert root_prefix_ca_certificates_used or fall_back_certificates_used
 
-def test_glob_in_build_string(tmp_path):
+
+def test_glob_in_build_string(monkeypatch, tmp_path):
     # Non-regression test for https://github.com/mamba-org/mamba/issues/3699
     env_prefix = tmp_path / "test_glob_in_build_string"
 
     pytorch_match_spec = "pytorch=2.3.1=py3.10_cuda11.8*"
 
     # Export CONDA_OVERRIDE_GLIBC=2.17 to force the solver to use the glibc 2.17 package
-    try:
-        os.environ["CONDA_OVERRIDE_GLIBC"] = "2.17"
+    monkeypatch.setenv("CONDA_OVERRIDE_GLIBC", "2.17")
 
-        # Should run without error
-        out = helpers.create(
-            "-p",
-            env_prefix,
-            pytorch_match_spec,
-            "-c",
-            "pytorch",
-            "-c",
-            "nvidia/label/cuda-11.8.0",
-            "-c",
-            "nvidia",
-            "-c",
-            "conda-forge",
-            "--platform",
-            "linux-64",
-            "--dry-run",
-            "--json",
-        )
-    finally:
-        os.environ.pop("CONDA_OVERRIDE_GLIBC", None)
+    # Should run without error
+    out = helpers.create(
+        "-p",
+        env_prefix,
+        pytorch_match_spec,
+        "-c",
+        "pytorch",
+        "-c",
+        "nvidia/label/cuda-11.8.0",
+        "-c",
+        "nvidia",
+        "-c",
+        "conda-forge",
+        "--platform",
+        "linux-64",
+        "--dry-run",
+        "--json",
+    )
 
     # Check that a build of pytorch 2.3.1 with `py3.10_cuda11.8_cudnn8.7.0_0` as a build string is found
     assert any(


### PR DESCRIPTION
Fix #3699.