### PR TITLE
maint: Don't exclude Changelog files from typos-conda

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -52,7 +52,3 @@ repos:
         # In case of ambiguity (multiple possible corrections), `typos` will just report it to the user and move on without applying/writing any changes.
         # cf. https://github.com/crate-ci/typos
         args: [--write-changes]
-
-# pre-commit.ci config reference: https://pre-commit.ci/#configuration
-ci:
-  autoupdate_schedule: monthly

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,7 +49,10 @@ repos:
     rev: 1.28.2
     hooks:
       - id: typos-conda
-        exclude: (CHANGELOG.md)
         # In case of ambiguity (multiple possible corrections), `typos` will just report it to the user and move on without applying/writing any changes.
         # cf. https://github.com/crate-ci/typos
         args: [--write-changes]
+
+# pre-commit.ci config reference: https://pre-commit.ci/#configuration
+ci:
+  autoupdate_schedule: monthly

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,7 +113,7 @@ Bug fixes:
 - [libmamba, libmambapy] maint: Enable -Werror compiler flag for GCC, Clang and AppleClang by @mathbunnyru in https://github.com/mamba-org/mamba/pull/3611
 - [libmamba] Fix build trailing `*` display by @Hind-M in https://github.com/mamba-org/mamba/pull/3619
 - [libmamba] fixed: incorrect erasing of env vars by @Klaim in https://github.com/mamba-org/mamba/pull/3622
-- [libmamba] Prevent pip "rich" ouput by @Klaim in https://github.com/mamba-org/mamba/pull/3607
+- [libmamba] Prevent pip "rich" output by @Klaim in https://github.com/mamba-org/mamba/pull/3607
 - [micromamba, libmamba] maint: Address compiler warnings by @mathbunnyru in https://github.com/mamba-org/mamba/pull/3605
 - [micromamba] fix: Export `'channels'` as part of environments' export by @mathbunnyru in https://github.com/mamba-org/mamba/pull/3587
 - [libmamba] Fix some warnings by @mathbunnyru in https://github.com/mamba-org/mamba/pull/3595
@@ -171,7 +171,7 @@ Bug fixes:
 
 - [libmamba] Fix build trailing `*` display by @Hind-M in https://github.com/mamba-org/mamba/pull/3619
 - [libmamba] fixed: incorrect erasing of env vars by @Klaim in https://github.com/mamba-org/mamba/pull/3622
-- [libmamba] Prevent pip "rich" ouput by @Klaim in https://github.com/mamba-org/mamba/pull/3607
+- [libmamba] Prevent pip "rich" output by @Klaim in https://github.com/mamba-org/mamba/pull/3607
 - [micromamba, libmamba] maint: Address compiler warnings by @mathbunnyru in https://github.com/mamba-org/mamba/pull/3605
 - [micromamba] fix: Export `'channels'` as part of environments' export by @mathbunnyru in https://github.com/mamba-org/mamba/pull/3587
 
@@ -368,7 +368,7 @@ Enhancements:
 - [libmamba, libmambapy] MatchSpec use VersionSpec by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3089
 - [libmamba, libmambapy] GlobSpec by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3094
 - [libmamba] Add BuildNumberSpec by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3098
-- [libmamba] Refactor MatchSpec unlikey data by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3099
+- [libmamba] Refactor MatchSpec unlikely data by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3099
 - [libmamba, micromamba] Remove micromamba shell init -p by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3092
 - [all] Clean PackageInfo interface by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3103
 - [libmamba, libmambapy] NoArchType as standalone enum by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3108
@@ -384,7 +384,7 @@ Enhancements:
 - [libmambapy] Add expected caster to Union by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3135
 - [all] MRepo refactor by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3118
 - [libmamba, libmambapy] No M by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3137
-- [libmamba, micromamba] Explcit transaction duplicate code by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3138
+- [libmamba, micromamba] Explicit transaction duplicate code by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3138
 - [libmamba, libmambapy] Solver improvements by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3140
 - [libmamba] Sort transaction table entries by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3146
 - [all] Solver Request by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3141
@@ -445,7 +445,7 @@ Enhancements:
 - [libmamba, micromamba] Rename env functions by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2954
 - [libmambapy] Modularize libmambapy by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2960
 - [libmamba] Environment map by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2967
-- [libmamba] Add envrionment cleaner test fixtures by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2973
+- [libmamba] Add environment cleaner test fixtures by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2973
 - [all] Update dependencies on OSX by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2976
 - [all] Channel initialization by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2953
 - [libmamba] Add weakening_map by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2981
@@ -459,7 +459,7 @@ Enhancements:
 - [all] Move core/channel > specs/channel by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3000
 - [libmamba, libmambapy] Remove ChannelContext ctor by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3002
 - [libmamba] Improve ChannelContext and Channel by @AntoinePrv in xhttps://github.com/mamba-org/mamba/pull/3003
-- [all] Remove ChanelContext context capture by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3015
+- [all] Remove ChannelContext context capture by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3015
 - [libmamba, libmambapy] Bind Channel by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3001
 - [libmamba, micromamba] Default to hide credentials by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3017
 - [libmamba] Validation QA by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3022
@@ -495,7 +495,7 @@ Bug fixes:
 - [all] Define `etc/profile.d/mamba.sh` and install it by @jjerphan in https://github.com/mamba-org/mamba/pull/3413
 - [micromamba] Add posix to supported shells by @jjerphan in https://github.com/mamba-org/mamba/pull/3412
 - [all] Replaces instances of -p with --root-prefix in documentation by @SylvainCorlay in https://github.com/mamba-org/mamba/pull/3411
-- [libmamba, micromamba] [micromamba] Fix behavior of `env update` (to mimick conda) by @Hind-M in https://github.com/mamba-org/mamba/pull/3396
+- [libmamba, micromamba] [micromamba] Fix behavior of `env update` (to mimic conda) by @Hind-M in https://github.com/mamba-org/mamba/pull/3396
 - [libmamba] Reset the prompt back to default by @cvanelteren in https://github.com/mamba-org/mamba/pull/3392
 - [libmamba] Add missing header by @Hind-M in https://github.com/mamba-org/mamba/pull/3389
 - [libmamba] Restore previous behavior of `MAMBA_ROOT_PREFIX` by @Hind-M in https://github.com/mamba-org/mamba/pull/3365
@@ -508,7 +508,7 @@ Bug fixes:
 - [libmambapy, libmamba] libmambapy: use `Context` explicitly by @Klaim in https://github.com/mamba-org/mamba/pull/3309
 - [micromamba] Fix test_no_python_pinning by @Hind-M in https://github.com/mamba-org/mamba/pull/3319
 - [all] Fix release scripts by @Hind-M in https://github.com/mamba-org/mamba/pull/3306
-- [libmamba] Hotfix to allow Ctrl+C in python scipts by @Klaim in https://github.com/mamba-org/mamba/pull/3285
+- [libmamba] Hotfix to allow Ctrl+C in python scripts by @Klaim in https://github.com/mamba-org/mamba/pull/3285
 - [libmamba] Fix typos in comments by @ryandesign in https://github.com/mamba-org/mamba/pull/3272
 - [all] Fix VersionSpec equal and glob by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3269
 - [libmamba] Fix pin repr in solver error messages by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3268
@@ -520,7 +520,7 @@ Bug fixes:
 - [libmamba] fix(micromamba): anaconda private channels not working by @s22chan in https://github.com/mamba-org/mamba/pull/3220
 - [micromamba] Remove unmaintained and broken pytest-lazy-fixture by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3193
 - [libmamba] Simple logging fix by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3184
-- [libmamba, micromamba] Fix URL enconding in repodata.json by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3076
+- [libmamba, micromamba] Fix URL encoding in repodata.json by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3076
 - [libmamba, micromamba] gracefully handle conflicting names in yaml specs by @jchorl in https://github.com/mamba-org/mamba/pull/3083
 - [libmamba] Fix verbose and strange prefix in Powershell by @pwnfan in https://github.com/mamba-org/mamba/pull/3116
 - [libmamba] handle other deps in multiple env files by @jchorl in https://github.com/mamba-org/mamba/pull/3096
@@ -586,9 +586,9 @@ CI fixes and doc:
 - [micromamba] Improve install instruction by @jonashaag in https://github.com/mamba-org/mamba/pull/2908
 - [libmambapy] Refactor CI and libamambapy tests (on Unix) by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2952
 - [libmambapy] Refactor CI and libamambapy tests (on Win) by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2955
-- [all] Simplify and correct development documention by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2975
+- [all] Simplify and correct development documentation by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2975
 - [all] Add install from source instructions by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2977
-- [all] update readme install link by @artifical-agent in https://github.com/mamba-org/mamba/pull/2980
+- [all] update readme install link by @artificial-agent in https://github.com/mamba-org/mamba/pull/2980
 - [all] Fail fast except on debug runs by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2985
 
 # 2024.09.20
@@ -674,7 +674,7 @@ Enhancements:
 
 Bug fixes:
 
-- [libmamba, micromamba] [micromamba] Fix behavior of `env update` (to mimick conda) by @Hind-M in https://github.com/mamba-org/mamba/pull/3396
+- [libmamba, micromamba] [micromamba] Fix behavior of `env update` (to mimic conda) by @Hind-M in https://github.com/mamba-org/mamba/pull/3396
 - [libmamba] Reset the prompt back to default by @cvanelteren in https://github.com/mamba-org/mamba/pull/3392
 - [libmamba] Add missing header by @Hind-M in https://github.com/mamba-org/mamba/pull/3389
 - [libmamba] Restore previous behavior of `MAMBA_ROOT_PREFIX` by @Hind-M in https://github.com/mamba-org/mamba/pull/3365
@@ -782,7 +782,7 @@ Enhancements:
 
 Bug fixes:
 
-- [libmamba] Hotfix to allow Ctrl+C in python scipts by @Klaim in https://github.com/mamba-org/mamba/pull/3285
+- [libmamba] Hotfix to allow Ctrl+C in python scripts by @Klaim in https://github.com/mamba-org/mamba/pull/3285
 - [libmamba] Fix typos in comments by @ryandesign in https://github.com/mamba-org/mamba/pull/3272
 - [all] Fix VersionSpec equal and glob by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3269
 - [libmamba] Fix pin repr in solver error messages by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3268
@@ -902,7 +902,7 @@ Enhancements:
 - [libmamba, libmambapy] MatchSpec use VersionSpec by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3089
 - [libmamba, libmambapy] GlobSpec by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3094
 - [libmamba] Add BuildNumberSpec by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3098
-- [libmamba] Refactor MatchSpec unlikey data by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3099
+- [libmamba] Refactor MatchSpec unlikely data by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3099
 - [libmamba, micromamba] Remove micromamba shell init -p by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3092
 - [all] Clean PackageInfo interface by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3103
 - [libmamba, libmambapy] NoArchType as standalone enum by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3108
@@ -918,7 +918,7 @@ Enhancements:
 - [libmambapy] Add expected caster to Union by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3135
 - [all] MRepo refactor by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3118
 - [libmamba, libmambapy] No M by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3137
-- [libmamba, micromamba] Explcit transaction duplicate code by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3138
+- [libmamba, micromamba] Explicit transaction duplicate code by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3138
 - [libmamba, libmambapy] Solver improvements by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3140
 - [libmamba] Sort transaction table entries by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3146
 - [all] Solver Request by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3141
@@ -935,7 +935,7 @@ Enhancements:
 
 Bug fixes:
 
-- [libmamba, micromamba] Fix URL enconding in repodata.json by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3076
+- [libmamba, micromamba] Fix URL encoding in repodata.json by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3076
 - [libmamba, micromamba] gracefully handle conflicting names in yaml specs by @jchorl in https://github.com/mamba-org/mamba/pull/3083
 - [libmamba] Fix verbose and strange prefix in Powershell by @pwnfan in https://github.com/mamba-org/mamba/pull/3116
 - [libmamba] handle other deps in multiple env files by @jchorl in https://github.com/mamba-org/mamba/pull/3096
@@ -1018,7 +1018,7 @@ Enhancements:
 - [libmamba, micromamba] Rename env functions by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2954
 - [libmambapy] Modularize libmambapy by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2960
 - [libmamba] Environment map by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2967
-- [libmamba] Add envrionment cleaner test fixtures by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2973
+- [libmamba] Add environment cleaner test fixtures by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2973
 - [all] Update dependencies on OSX by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2976
 - [all] Channel initialization by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2953
 - [libmamba] Add weakening_map by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2981
@@ -1032,7 +1032,7 @@ Enhancements:
 - [all] Move core/channel > specs/channel by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3000
 - [libmamba, libmambapy] Remove ChannelContext ctor by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3002
 - [libmamba] Improve ChannelContext and Channel by @AntoinePrv in xhttps://github.com/mamba-org/mamba/pull/3003
-- [all] Remove ChanelContext context capture by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3015
+- [all] Remove ChannelContext context capture by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3015
 - [libmamba, libmambapy] Bind Channel by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3001
 - [libmamba, micromamba] Default to hide credentials by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3017
 - [libmamba] Validation QA by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3022
@@ -1084,9 +1084,9 @@ CI fixes and doc:
 - [micromamba] Improve install instruction by @jonashaag in https://github.com/mamba-org/mamba/pull/2908
 - [libmambapy] Refactor CI and libamambapy tests (on Unix) by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2952
 - [libmambapy] Refactor CI and libamambapy tests (on Win) by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2955
-- [all] Simplify and correct development documention by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2975
+- [all] Simplify and correct development documentation by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2975
 - [all] Add install from source instructions by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2977
-- [all] update readme install link by @artifical-agent in https://github.com/mamba-org/mamba/pull/2980
+- [all] update readme install link by @artificial-agent in https://github.com/mamba-org/mamba/pull/2980
 - [all] Fail fast except on debug runs by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2985
 
 # 2023.09.05
@@ -1112,12 +1112,12 @@ Bug fixes:
 - [libmamba] Use generic_string for path on Windows unix shells by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2685
 - [libmamba] Fix pins by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2786
 - [libmamba] Various fixes by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2800
-- [micromamba] Fix extra agrument in self-update reinit by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2787
+- [micromamba] Fix extra argument in self-update reinit by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2787
 - [libmamba] Parse subdirs in CLI match specs by @jonashaag in https://github.com/mamba-org/mamba/pull/2799
 
 CI fixes and doc:
 
-- [all] Splitted GHA workflow by @JohanMabille in https://github.com/mamba-org/mamba/pull/2779
+- [all] Split GHA workflow by @JohanMabille in https://github.com/mamba-org/mamba/pull/2779
 - [all] Use Release build mode in Windows CI by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2785
 - [micromamba] Fix wrong command description by @Hind-M in https://github.com/mamba-org/mamba/pull/2804
 
@@ -1231,7 +1231,7 @@ Enhancements:
 
 - [libmamba] Channels refactoring/cleaning by @Hind-M in https://github.com/mamba-org/mamba/pull/2537
 - [libmamba] Troubleshooting update by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2635
-- [libmamba] Direcly call uname for linux detection by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2624
+- [libmamba] Directly call uname for linux detection by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2624
 
 Bug fixes:
 
@@ -1267,7 +1267,7 @@ Enhancements:
 - [libmamba] Use ObjSolver wrapper in MSolver by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2602
 - [all] Remove banner by @jonashaag in https://github.com/mamba-org/mamba/pull/2298
 - [libmamba, libmambapy] LockFile behavior on file-locking is now almost independent from Context by @Klaim in https://github.com/mamba-org/mamba/pull/2608
-- [micromamba] Add topological sort explict export tests by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2618
+- [micromamba] Add topological sort explicit export tests by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2618
 - [libmamba] Small whitespace fix in error messages by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2623
 
 Bug fixes:
@@ -1285,11 +1285,11 @@ Bug fixes:
 - [libmamba] Handle pip <-> python cycle in topo sort by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2613
 - [libmamba] Fix add missing pip PREREQ_MARKER by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2612
 - [libmamba] Fix lockfiles topological sort by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2616
-- [libmamba] Fix mising SAT message on already installed packages by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2622
+- [libmamba] Fix missing SAT message on already installed packages by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2622
 
 CI fixes and doc:
 
-- [libmamba] Fixe clang-format by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2531
+- [libmamba] Fix clang-format by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2531
 - [micromamba] Use only vcpkg for static windows build by @pavelzw in https://github.com/mamba-org/mamba/pull/2520
 - [all] update the umamba GHA link by @ocefpaf in https://github.com/mamba-org/mamba/pull/2542
 - [all] Extend troubleshooting docs by @jonashaag in https://github.com/mamba-org/mamba/pull/2569
@@ -1404,10 +1404,10 @@ Bug fixes:
 
 Releases: libmamba 1.4.0, libmambapy 1.4.0, mamba 1.4.0, micromamba 1.4.0
 
-Enchancements:
+Enhancements:
 
 - [all] Implemented recursive dependency printout in repoquery by @timostrunk in https://github.com/mamba-org/mamba/pull/2283
-- [libmamba, libmambapy, micromamba] Agressive compilation warnings by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2304
+- [libmamba, libmambapy, micromamba] Aggressive compilation warnings by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2304
 - [all] Fine tune clang-format by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2290
 - [libmamba] Added checked numeric cast by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2315
 - [libmamba, libmambapy] Activated SAT error messages by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2325
@@ -1423,7 +1423,7 @@ Enchancements:
 - [libmamba] Added a heuristic to better handle the (almost) cyclic Python conflicts by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2318
 - [libmamba, libmambapy, mamba] Isolate `PackageInfo` from libsolv from @AntoinePrv in https://github.com/mamba-org/mamba/pull/2340
 - [libmamba] Added `strip_if` functions by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2344
-- [libmamba] Addded conda.rc Options for Existing Remote Settings by @srilman in https://github.com/mamba-org/mamba/pull/2306
+- [libmamba] Added conda.rc Options for Existing Remote Settings by @srilman in https://github.com/mamba-org/mamba/pull/2306
 - [micromamba] Added micromamba server by @wolfv in https://github.com/mamba-org/mamba/pull/2185
 - [libmamba] Hide independent curl code and compression structures in unexposed files by @Hind-M in https://github.com/mamba-org/mamba/pull/2366
 - [libmamba] Added `strip_parts` functions by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2347
@@ -1446,7 +1446,7 @@ CI fixes & docs:
 - [micromamba] Added missing dependency in local recipe by @wolfv in https://github.com/mamba-org/mamba/pull/2334
 - [mamba] `repoquery depends` requires the package to be installed or to specify a channel by @samtygier in https://github.com/mamba-org/mamba/pull/2098
 - [libmamba] Structured test directory layout by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2380
-- [micromamba] Fixed Conda Lock Path by @funtion in https://github.com/mamba-org/mamba/pull/2393
+- [micromamba] Fixed Conda Lock Path by @function in https://github.com/mamba-org/mamba/pull/2393
 
 # 2023.02.09
 
@@ -1532,7 +1532,7 @@ CI fixes & docs:
 - Run conda_nightly once per week by @jonashaag in #2147
 - Update doc by @Hind-M in #2156
 - Use Conda canary in nightly tests by @jonashaag in #2180
-- Expliclity point to libmamba test data independently of cwd by @AntoinePrv in #2158
+- Explicitly point to libmamba test data independently of cwd by @AntoinePrv in #2158
 - Add bug report issue template by @jonashaag in #2182
 - Downgrade curl to fix micromamba on macOS x64 by @wolfv in #2205
 - Use conda-forge micromamba feedstock instead of a fork by @JohanMabille in #2206
@@ -1909,7 +1909,7 @@ Improvements
 - [libmamba] Make max download threads configurable (thanks @adriendelsalle) #1377
 - [micromamba] Only print micromamba version and add library versions to `info` command #1372
 - [micromamba] Implement activate as a micromamba subcommand for better error messages (thanks @maresb) #1360
-- [micromamba] Experimental wass logged twice (thanks @baszalmstra) #1360
+- [micromamba] Experimental was logged twice (thanks @baszalmstra) #1360
 - [mamba] Update to Python 3.10 in the example snippet (thanks @jtpio) #1371
 
 # 2021.12.08
@@ -2101,7 +2101,7 @@ Big changes:
 
 New features
 
-- remove orphaned packages such as dependencies of explicitely installed
+- remove orphaned packages such as dependencies of explicitly installed
   packages (@adriendelsalle) #1040
 - add a diff character before package name in transaction table to improve
   readability without coloration (@adriendelsalle) #1040
@@ -2311,7 +2311,7 @@ General improvements
 # 0.10.0 (Apr 16, 2021)
 
 - [micromamba] allow creation of empty env (without specs) #824 #827
-- [micromamba] automatically create empy `base` env at new root prefix #836
+- [micromamba] automatically create empty `base` env at new root prefix #836
 - [micromamba] add remove all CLI flags `-a,--all` #824
 - [micromamba] add dry-run and ultra-dry-run tests to increase coverage and
   speed-up CI #813 #845
@@ -2337,7 +2337,7 @@ General improvements
 
 # 0.9.2 (Apr 1, 2021)
 
-- [micromamba] fix unc url support (thanks @adament)
+- [micromamba] fix unc url support (thanks @adamant)
 - [micromamba] add --channel-alias as cli option to micromamba (thanks
   @adriendelsalle)
 - [micromamba] fix --no-rc and environment yaml files (thanks @adriendelsalle)
@@ -2360,7 +2360,7 @@ General improvements
   short/long descriptions and groups
 - [micromamba] prevent crashes when no bashrc or zshrc file found (thanks
   @wolfv)
-- add support for UNC file:// urls (thanks @adament)
+- add support for UNC file:// urls (thanks @adamant)
 - add support for use_only_tar_bz2 (thanks @tl-hbk @wolfv)
 - add pinned specs for env update (thanks @wolfv)
 - properly adhere to run_constrains (thanks @wolfv)
@@ -2430,7 +2430,7 @@ General improvements
 - [micromamba] Revert extraction to temporary directory because of invalid
   cross-device links on Linux
 - [micromamba] Clean up partially extracted archives when CTRL+C interruption
-  occured
+  occurred
 
 # 0.7.11 (Feb 2, 2021)
 

--- a/libmamba/CHANGELOG.md
+++ b/libmamba/CHANGELOG.md
@@ -94,7 +94,7 @@ Bug fixes:
 - maint: Enable -Werror compiler flag for GCC, Clang and AppleClang by @mathbunnyru in https://github.com/mamba-org/mamba/pull/3611
 - Fix build trailing `*` display by @Hind-M in https://github.com/mamba-org/mamba/pull/3619
 - fixed: incorrect erasing of env vars by @Klaim in https://github.com/mamba-org/mamba/pull/3622
-- Prevent pip "rich" ouput by @Klaim in https://github.com/mamba-org/mamba/pull/3607
+- Prevent pip "rich" output by @Klaim in https://github.com/mamba-org/mamba/pull/3607
 - maint: Address compiler warnings by @mathbunnyru in https://github.com/mamba-org/mamba/pull/3605
 - Fix some warnings by @mathbunnyru in https://github.com/mamba-org/mamba/pull/3595
 - Remove Taskfile from `environment-dev-extra.yml` by @mathbunnyru in https://github.com/mamba-org/mamba/pull/3597
@@ -140,7 +140,7 @@ Bug fixes:
 
 - Fix build trailing `*` display by @Hind-M in https://github.com/mamba-org/mamba/pull/3619
 - fixed: incorrect erasing of env vars by @Klaim in https://github.com/mamba-org/mamba/pull/3622
-- Prevent pip "rich" ouput by @Klaim in https://github.com/mamba-org/mamba/pull/3607
+- Prevent pip "rich" output by @Klaim in https://github.com/mamba-org/mamba/pull/3607
 - maint: Address compiler warnings by @mathbunnyru in https://github.com/mamba-org/mamba/pull/3605
 
 CI fixes and doc:
@@ -312,7 +312,7 @@ Enhancements:
 - MatchSpec use VersionSpec by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3089
 - GlobSpec by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3094
 - Add BuildNumberSpec by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3098
-- Refactor MatchSpec unlikey data by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3099
+- Refactor MatchSpec unlikely data by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3099
 - Remove micromamba shell init -p by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3092
 - Clean PackageInfo interface by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3103
 - NoArchType as standalone enum by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3108
@@ -326,7 +326,7 @@ Enhancements:
 - Move util_random.hpp > util/random.hpp by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3129
 - MRepo refactor by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3118
 - No M by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3137
-- Explcit transaction duplicate code by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3138
+- Explicit transaction duplicate code by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3138
 - Solver improvements by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3140
 - Sort transaction table entries by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3146
 - Solver Request by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3141
@@ -378,7 +378,7 @@ Enhancements:
 - Explicit and smart CMake target by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2935
 - Rename env functions by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2954
 - Environment map by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2967
-- Add envrionment cleaner test fixtures by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2973
+- Add environment cleaner test fixtures by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2973
 - Update dependencies on OSX by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2976
 - Channel initialization by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2953
 - Add weakening_map by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2981
@@ -392,7 +392,7 @@ Enhancements:
 - Move core/channel > specs/channel by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3000
 - Remove ChannelContext ctor by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3002
 - Improve ChannelContext and Channel by @AntoinePrv in xhttps://github.com/mamba-org/mamba/pull/3003
-- Remove ChanelContext context capture by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3015
+- Remove ChannelContext context capture by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3015
 - Bind Channel by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3001
 - Default to hide credentials by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3017
 - Validation QA by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3022
@@ -421,7 +421,7 @@ Bug fixes:
 - fix: Reduce logging system overhead by @jjerphan in https://github.com/mamba-org/mamba/pull/3416
 - Define `etc/profile.d/mamba.sh` and install it by @jjerphan in https://github.com/mamba-org/mamba/pull/3413
 - Replaces instances of -p with --root-prefix in documentation by @SylvainCorlay in https://github.com/mamba-org/mamba/pull/3411
-- [micromamba] Fix behavior of `env update` (to mimick conda) by @Hind-M in https://github.com/mamba-org/mamba/pull/3396
+- [micromamba] Fix behavior of `env update` (to mimic conda) by @Hind-M in https://github.com/mamba-org/mamba/pull/3396
 - Reset the prompt back to default by @cvanelteren in https://github.com/mamba-org/mamba/pull/3392
 - Add missing header by @Hind-M in https://github.com/mamba-org/mamba/pull/3389
 - Restore previous behavior of `MAMBA_ROOT_PREFIX` by @Hind-M in https://github.com/mamba-org/mamba/pull/3365
@@ -431,7 +431,7 @@ Bug fixes:
 - Split `ContextOptions::enable_logging_and_signal_handling` into 2 different options by @Klaim in https://github.com/mamba-org/mamba/pull/3329
 - libmambapy: use `Context` explicitly by @Klaim in https://github.com/mamba-org/mamba/pull/3309
 - Fix release scripts by @Hind-M in https://github.com/mamba-org/mamba/pull/3306
-- Hotfix to allow Ctrl+C in python scipts by @Klaim in https://github.com/mamba-org/mamba/pull/3285
+- Hotfix to allow Ctrl+C in python scripts by @Klaim in https://github.com/mamba-org/mamba/pull/3285
 - Fix typos in comments by @ryandesign in https://github.com/mamba-org/mamba/pull/3272
 - Fix VersionSpec equal and glob by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3269
 - Fix pin repr in solver error messages by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3268
@@ -441,7 +441,7 @@ Bug fixes:
 - Make Taskfile.dist.yml Windows-compatible by @carschandler in https://github.com/mamba-org/mamba/pull/3219
 - fix(micromamba): anaconda private channels not working by @s22chan in https://github.com/mamba-org/mamba/pull/3220
 - Simple logging fix by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3184
-- Fix URL enconding in repodata.json by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3076
+- Fix URL encoding in repodata.json by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3076
 - gracefully handle conflicting names in yaml specs by @jchorl in https://github.com/mamba-org/mamba/pull/3083
 - Fix verbose and strange prefix in Powershell by @pwnfan in https://github.com/mamba-org/mamba/pull/3116
 - handle other deps in multiple env files by @jchorl in https://github.com/mamba-org/mamba/pull/3096
@@ -488,9 +488,9 @@ CI fixes and doc:
 - Warning around manual install and add ref to conda-libmamba by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3119
 - Add MacOS DNS issue logging by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3130
 - Add CI merge groups by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3068
-- Simplify and correct development documention by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2975
+- Simplify and correct development documentation by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2975
 - Add install from source instructions by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2977
-- update readme install link by @artifical-agent in https://github.com/mamba-org/mamba/pull/2980
+- update readme install link by @artificial-agent in https://github.com/mamba-org/mamba/pull/2980
 - Fail fast except on debug runs by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2985
 
 # libmamba 2.0.0rc6 (September 20, 2024)
@@ -561,7 +561,7 @@ Enhancements:
 
 Bug fixes:
 
-- [micromamba] Fix behavior of `env update` (to mimick conda) by @Hind-M in https://github.com/mamba-org/mamba/pull/3396
+- [micromamba] Fix behavior of `env update` (to mimic conda) by @Hind-M in https://github.com/mamba-org/mamba/pull/3396
 - Reset the prompt back to default by @cvanelteren in https://github.com/mamba-org/mamba/pull/3392
 - Add missing header by @Hind-M in https://github.com/mamba-org/mamba/pull/3389
 - Restore previous behavior of `MAMBA_ROOT_PREFIX` by @Hind-M in https://github.com/mamba-org/mamba/pull/3365
@@ -649,7 +649,7 @@ Enhancements:
 
 Bug fixes:
 
-- Hotfix to allow Ctrl+C in python scipts by @Klaim in https://github.com/mamba-org/mamba/pull/3285
+- Hotfix to allow Ctrl+C in python scripts by @Klaim in https://github.com/mamba-org/mamba/pull/3285
 - Fix typos in comments by @ryandesign in https://github.com/mamba-org/mamba/pull/3272
 - Fix VersionSpec equal and glob by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3269
 - Fix pin repr in solver error messages by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3268
@@ -752,7 +752,7 @@ Enhancements:
 - MatchSpec use VersionSpec by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3089
 - GlobSpec by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3094
 - Add BuildNumberSpec by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3098
-- Refactor MatchSpec unlikey data by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3099
+- Refactor MatchSpec unlikely data by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3099
 - Remove micromamba shell init -p by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3092
 - Clean PackageInfo interface by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3103
 - NoArchType as standalone enum by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3108
@@ -766,7 +766,7 @@ Enhancements:
 - Move util_random.hpp > util/random.hpp by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3129
 - MRepo refactor by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3118
 - No M by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3137
-- Explcit transaction duplicate code by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3138
+- Explicit transaction duplicate code by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3138
 - Solver improvements by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3140
 - Sort transaction table entries by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3146
 - Solver Request by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3141
@@ -783,7 +783,7 @@ Enhancements:
 
 Bug fixes:
 
-- Fix URL enconding in repodata.json by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3076
+- Fix URL encoding in repodata.json by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3076
 - gracefully handle conflicting names in yaml specs by @jchorl in https://github.com/mamba-org/mamba/pull/3083
 - Fix verbose and strange prefix in Powershell by @pwnfan in https://github.com/mamba-org/mamba/pull/3116
 - handle other deps in multiple env files by @jchorl in https://github.com/mamba-org/mamba/pull/3096
@@ -846,7 +846,7 @@ Enhancements:
 - Explicit and smart CMake target by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2935
 - Rename env functions by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2954
 - Environment map by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2967
-- Add envrionment cleaner test fixtures by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2973
+- Add environment cleaner test fixtures by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2973
 - Update dependencies on OSX by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2976
 - Channel initialization by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2953
 - Add weakening_map by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2981
@@ -860,7 +860,7 @@ Enhancements:
 - Move core/channel > specs/channel by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3000
 - Remove ChannelContext ctor by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3002
 - Improve ChannelContext and Channel by @AntoinePrv in xhttps://github.com/mamba-org/mamba/pull/3003
-- Remove ChanelContext context capture by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3015
+- Remove ChannelContext context capture by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3015
 - Bind Channel by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3001
 - Default to hide credentials by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3017
 - Validation QA by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3022
@@ -896,9 +896,9 @@ Bug fixes:
 
 CI fixes and doc:
 
-- Simplify and correct development documention by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2975
+- Simplify and correct development documentation by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2975
 - Add install from source instructions by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2977
-- update readme install link by @artifical-agent in https://github.com/mamba-org/mamba/pull/2980
+- update readme install link by @artificial-agent in https://github.com/mamba-org/mamba/pull/2980
 - Fail fast except on debug runs by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2985
 
 # libmamba 2.0.0alpha0 (December 14, 2023)
@@ -943,7 +943,7 @@ Enhancements:
 - Explicit and smart CMake target by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2935
 - Rename env functions by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2954
 - Environment map by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2967
-- Add envrionment cleaner test fixtures by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2973
+- Add environment cleaner test fixtures by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2973
 - Update dependencies on OSX by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2976
 - Channel initialization by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2953
 - Add weakening_map by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2981
@@ -957,7 +957,7 @@ Enhancements:
 - Move core/channel > specs/channel by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3000
 - Remove ChannelContext ctor by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3002
 - Improve ChannelContext and Channel by @AntoinePrv in xhttps://github.com/mamba-org/mamba/pull/3003
-- Remove ChanelContext context capture by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3015
+- Remove ChannelContext context capture by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3015
 - Bind Channel by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3001
 - Default to hide credentials by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3017
 - Validation QA by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3022
@@ -993,9 +993,9 @@ Bug fixes:
 
 CI fixes and doc:
 
-- Simplify and correct development documention by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2975
+- Simplify and correct development documentation by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2975
 - Add install from source instructions by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2977
-- update readme install link by @artifical-agent in https://github.com/mamba-org/mamba/pull/2980
+- update readme install link by @artificial-agent in https://github.com/mamba-org/mamba/pull/2980
 - Fail fast except on debug runs by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2985
 
 # libmamba 1.5.1 (September 05, 2023)
@@ -1020,7 +1020,7 @@ Bug fixes:
 
 CI fixes and doc:
 
-- Splitted GHA workflow by @JohanMabille in https://github.com/mamba-org/mamba/pull/2779
+- Split GHA workflow by @JohanMabille in https://github.com/mamba-org/mamba/pull/2779
 - Use Release build mode in Windows CI by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2785
 
 # libmamba 1.5.0 (August 24, 2023)
@@ -1092,7 +1092,7 @@ Enhancements:
 
 - Channels refactoring/cleaning by @Hind-M in https://github.com/mamba-org/mamba/pull/2537
 - Troubleshooting update by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2635
-- Direcly call uname for linux detection by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2624
+- Directly call uname for linux detection by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2624
 
 Bug fixes:
 
@@ -1133,11 +1133,11 @@ Bug fixes:
 - Handle pip <-> python cycle in topo sort by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2613
 - Fix add missing pip PREREQ_MARKER by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2612
 - Fix lockfiles topological sort by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2616
-- Fix mising SAT message on already installed packages by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2622
+- Fix missing SAT message on already installed packages by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2622
 
 CI fixes and doc:
 
-- Fixe clang-format by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2531
+- Fix clang-format by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2531
 - update the umamba GHA link by @ocefpaf in https://github.com/mamba-org/mamba/pull/2542
 - Extend troubleshooting docs by @jonashaag in https://github.com/mamba-org/mamba/pull/2569
 - Update pre-commit hooks by @jonashaag in https://github.com/mamba-org/mamba/pull/2586
@@ -1232,10 +1232,10 @@ Bug fixes:
 
 # libmamba 1.4.0 (March 22, 2023)
 
-Enchancements:
+Enhancements:
 
 - Implemented recursive dependency printout in repoquery by @timostrunk in https://github.com/mamba-org/mamba/pull/2283
-- Agressive compilation warnings by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2304
+- Aggressive compilation warnings by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2304
 - Fine tune clang-format by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2290
 - Added checked numeric cast by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2315
 - Activated SAT error messages by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2325
@@ -1250,7 +1250,7 @@ Enchancements:
 - Added a heuristic to better handle the (almost) cyclic Python conflicts by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2318
 - Isolate `PackageInfo` from libsolv from @AntoinePrv in https://github.com/mamba-org/mamba/pull/2340
 - Added `strip_if` functions by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2344
-- Addded conda.rc Options for Existing Remote Settings by @srilman in https://github.com/mamba-org/mamba/pull/2306
+- Added conda.rc Options for Existing Remote Settings by @srilman in https://github.com/mamba-org/mamba/pull/2306
 - Hide independent curl code and compression structures in unexposed files by @Hind-M in https://github.com/mamba-org/mamba/pull/2366
 - Added `strip_parts` functions by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2347
 - Added parsing of Conda version by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2373
@@ -1331,7 +1331,7 @@ CI fixes & docs:
 - - Run conda_nightly once per week by @jonashaag in #2147
 - - Update doc by @Hind-M in #2156
 - - Use Conda canary in nightly tests by @jonashaag in #2180
-- - Expliclity point to libmamba test data independently of cwd by @AntoinePrv in #2158
+- - Explicitly point to libmamba test data independently of cwd by @AntoinePrv in #2158
 - - Add bug report issue template by @jonashaag in #2182
 - - Downgrade curl to fix micromamba on macOS x64 by @wolfv in #2205
 - - Use conda-forge micromamba feedstock instead of a fork by @JohanMabille in #2206
@@ -1715,7 +1715,7 @@ Big changes:
 
 New features
 
-- remove orphaned packages such as dependencies of explicitely installed
+- remove orphaned packages such as dependencies of explicitly installed
   packages (@adriendelsalle) #1040
 - add a diff character before package name in transaction table to improve
   readability without coloration (@adriendelsalle) #1040
@@ -1925,7 +1925,7 @@ General improvements
 # 0.10.0 (Apr 16, 2021)
 
 - [micromamba] allow creation of empty env (without specs) #824 #827
-- [micromamba] automatically create empy `base` env at new root prefix #836
+- [micromamba] automatically create empty `base` env at new root prefix #836
 - [micromamba] add remove all CLI flags `-a,--all` #824
 - [micromamba] add dry-run and ultra-dry-run tests to increase coverage and
   speed-up CI #813 #845
@@ -1951,7 +1951,7 @@ General improvements
 
 # 0.9.2 (Apr 1, 2021)
 
-- [micromamba] fix unc url support (thanks @adament)
+- [micromamba] fix unc url support (thanks @adamant)
 - [micromamba] add --channel-alias as cli option to micromamba (thanks
   @adriendelsalle)
 - [micromamba] fix --no-rc and environment yaml files (thanks @adriendelsalle)
@@ -1974,7 +1974,7 @@ General improvements
   short/long descriptions and groups
 - [micromamba] prevent crashes when no bashrc or zshrc file found (thanks
   @wolfv)
-- add support for UNC file:// urls (thanks @adament)
+- add support for UNC file:// urls (thanks @adamant)
 - add support for use_only_tar_bz2 (thanks @tl-hbk @wolfv)
 - add pinned specs for env update (thanks @wolfv)
 - properly adhere to run_constrains (thanks @wolfv)
@@ -2044,7 +2044,7 @@ General improvements
 - [micromamba] Revert extraction to temporary directory because of invalid
   cross-device links on Linux
 - [micromamba] Clean up partially extracted archives when CTRL+C interruption
-  occured
+  occurred
 
 # 0.7.11 (Feb 2, 2021)
 

--- a/libmambapy/CHANGELOG.md
+++ b/libmambapy/CHANGELOG.md
@@ -212,7 +212,7 @@ Enhancements:
 - Migrate Channel::make_channel to resolve multi channels by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2986
 - Move core/channel > specs/channel by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3000
 - Remove ChannelContext ctor by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3002
-- Remove ChanelContext context capture by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3015
+- Remove ChannelContext context capture by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3015
 - Bind Channel by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3001
 - Bind ChannelContext by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3034
 - Split validate.[ch]pp by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3041
@@ -268,9 +268,9 @@ CI fixes and doc:
 - Add CI merge groups by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3068
 - Refactor CI and libamambapy tests (on Unix) by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2952
 - Refactor CI and libamambapy tests (on Win) by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2955
-- Simplify and correct development documention by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2975
+- Simplify and correct development documentation by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2975
 - Add install from source instructions by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2977
-- update readme install link by @artifical-agent in https://github.com/mamba-org/mamba/pull/2980
+- update readme install link by @artificial-agent in https://github.com/mamba-org/mamba/pull/2980
 - Fail fast except on debug runs by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2985
 
 # libmambapy 2.0.0rc6 (September 20, 2024)
@@ -508,7 +508,7 @@ Enhancements:
 - Migrate Channel::make_channel to resolve multi channels by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2986
 - Move core/channel > specs/channel by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3000
 - Remove ChannelContext ctor by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3002
-- Remove ChanelContext context capture by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3015
+- Remove ChannelContext context capture by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3015
 - Bind Channel by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3001
 - Bind ChannelContext by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3034
 - MatchSpec small improvements by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3043
@@ -526,9 +526,9 @@ CI fixes and doc:
 
 - Refactor CI and libamambapy tests (on Unix) by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2952
 - Refactor CI and libamambapy tests (on Win) by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2955
-- Simplify and correct development documention by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2975
+- Simplify and correct development documentation by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2975
 - Add install from source instructions by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2977
-- update readme install link by @artifical-agent in https://github.com/mamba-org/mamba/pull/2980
+- update readme install link by @artificial-agent in https://github.com/mamba-org/mamba/pull/2980
 - Fail fast except on debug runs by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2985
 
 # libmambapy 2.0.0alpha0 (December 14, 2023)
@@ -552,7 +552,7 @@ Enhancements:
 - Migrate Channel::make_channel to resolve multi channels by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2986
 - Move core/channel > specs/channel by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3000
 - Remove ChannelContext ctor by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3002
-- Remove ChanelContext context capture by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3015
+- Remove ChannelContext context capture by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3015
 - Bind Channel by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3001
 - Bind ChannelContext by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3034
 - MatchSpec small improvements by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3043
@@ -570,9 +570,9 @@ CI fixes and doc:
 
 - Refactor CI and libamambapy tests (on Unix) by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2952
 - Refactor CI and libamambapy tests (on Win) by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2955
-- Simplify and correct development documention by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2975
+- Simplify and correct development documentation by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2975
 - Add install from source instructions by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2977
-- update readme install link by @artifical-agent in https://github.com/mamba-org/mamba/pull/2980
+- update readme install link by @artificial-agent in https://github.com/mamba-org/mamba/pull/2980
 - Fail fast except on debug runs by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2985
 
 # libmambapy 1.5.1 (September 05, 2023)
@@ -583,7 +583,7 @@ Enhancements:
 
 CI fixes and doc:
 
-- Splitted GHA workflow by @JohanMabille in https://github.com/mamba-org/mamba/pull/2779
+- Split GHA workflow by @JohanMabille in https://github.com/mamba-org/mamba/pull/2779
 - Use Release build mode in Windows CI by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2785
 
 # libmambapy 1.5.0 (August 24, 2023)
@@ -676,10 +676,10 @@ CI fixes and doc:
 
 # libmambapy 1.4.0 (March 22, 2023)
 
-Enchancements:
+Enhancements:
 
 - Implemented recursive dependency printout in repoquery by @timostrunk in https://github.com/mamba-org/mamba/pull/2283
-- Agressive compilation warnings by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2304
+- Aggressive compilation warnings by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2304
 - Fine tune clang-format by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2290
 - Activated SAT error messages by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2325
 - Removed redundant `DependencyInfo` by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2314
@@ -726,7 +726,7 @@ CI fixes & docs:
 - - Run conda_nightly once per week by @jonashaag in #2147
 - - Update doc by @Hind-M in #2156
 - - Use Conda canary in nightly tests by @jonashaag in #2180
-- - Expliclity point to libmamba test data independently of cwd by @AntoinePrv in #2158
+- - Explicitly point to libmamba test data independently of cwd by @AntoinePrv in #2158
 - - Add bug report issue template by @jonashaag in #2182
 - - Downgrade curl to fix micromamba on macOS x64 by @wolfv in #2205
 - - Use conda-forge micromamba feedstock instead of a fork by @JohanMabille in #2206
@@ -955,7 +955,7 @@ Big changes:
 
 New features
 
-- remove orphaned packages such as dependencies of explicitely installed
+- remove orphaned packages such as dependencies of explicitly installed
   packages (@adriendelsalle) #1040
 - add a diff character before package name in transaction table to improve
   readability without coloration (@adriendelsalle) #1040
@@ -1165,7 +1165,7 @@ General improvements
 # 0.10.0 (Apr 16, 2021)
 
 - [micromamba] allow creation of empty env (without specs) #824 #827
-- [micromamba] automatically create empy `base` env at new root prefix #836
+- [micromamba] automatically create empty `base` env at new root prefix #836
 - [micromamba] add remove all CLI flags `-a,--all` #824
 - [micromamba] add dry-run and ultra-dry-run tests to increase coverage and
   speed-up CI #813 #845
@@ -1191,7 +1191,7 @@ General improvements
 
 # 0.9.2 (Apr 1, 2021)
 
-- [micromamba] fix unc url support (thanks @adament)
+- [micromamba] fix unc url support (thanks @adamant)
 - [micromamba] add --channel-alias as cli option to micromamba (thanks
   @adriendelsalle)
 - [micromamba] fix --no-rc and environment yaml files (thanks @adriendelsalle)
@@ -1214,7 +1214,7 @@ General improvements
   short/long descriptions and groups
 - [micromamba] prevent crashes when no bashrc or zshrc file found (thanks
   @wolfv)
-- add support for UNC file:// urls (thanks @adament)
+- add support for UNC file:// urls (thanks @adamant)
 - add support for use_only_tar_bz2 (thanks @tl-hbk @wolfv)
 - add pinned specs for env update (thanks @wolfv)
 - properly adhere to run_constrains (thanks @wolfv)
@@ -1284,7 +1284,7 @@ General improvements
 - [micromamba] Revert extraction to temporary directory because of invalid
   cross-device links on Linux
 - [micromamba] Clean up partially extracted archives when CTRL+C interruption
-  occured
+  occurred
 
 # 0.7.11 (Feb 2, 2021)
 

--- a/micromamba/CHANGELOG.md
+++ b/micromamba/CHANGELOG.md
@@ -240,7 +240,7 @@ Enhancements:
 - Move util_random.hpp > util/random.hpp by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3129
 - Refactor test_remove.py to use fixture by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3131
 - MRepo refactor by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3118
-- Explcit transaction duplicate code by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3138
+- Explicit transaction duplicate code by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3138
 - Solver Request by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3141
 - Split Solver and Unsolvable by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3156
 - Solver sort deps by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3163
@@ -276,7 +276,7 @@ Enhancements:
 - Refactor env::which by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2997
 - Migrate Channel::make_channel to resolve multi channels by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2986
 - Move core/channel > specs/channel by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3000
-- Remove ChanelContext context capture by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3015
+- Remove ChannelContext context capture by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3015
 - Default to hide credentials by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3017
 - Refactor (some) OpenSSL functions by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3024
 - Default to conda-forge channel by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3035
@@ -299,7 +299,7 @@ Bug fixes:
 - Define `etc/profile.d/mamba.sh` and install it by @jjerphan in https://github.com/mamba-org/mamba/pull/3413
 - Add posix to supported shells by @jjerphan in https://github.com/mamba-org/mamba/pull/3412
 - Replaces instances of -p with --root-prefix in documentation by @SylvainCorlay in https://github.com/mamba-org/mamba/pull/3411
-- [micromamba] Fix behavior of `env update` (to mimick conda) by @Hind-M in https://github.com/mamba-org/mamba/pull/3396
+- [micromamba] Fix behavior of `env update` (to mimic conda) by @Hind-M in https://github.com/mamba-org/mamba/pull/3396
 - Attempt to fix `test_proxy_install` by @Hind-M in https://github.com/mamba-org/mamba/pull/3324
 - Fix `test_no_python_pinning` by @Hind-M in https://github.com/mamba-org/mamba/pull/3321
 - Split `ContextOptions::enable_logging_and_signal_handling` into 2 different options by @Klaim in https://github.com/mamba-org/mamba/pull/3329
@@ -310,7 +310,7 @@ Bug fixes:
 - Mamba 2.0 name fixes by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3225
 - Make Taskfile.dist.yml Windows-compatible by @carschandler in https://github.com/mamba-org/mamba/pull/3219
 - Remove unmaintained and broken pytest-lazy-fixture by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3193
-- Fix URL enconding in repodata.json by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3076
+- Fix URL encoding in repodata.json by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3076
 - gracefully handle conflicting names in yaml specs by @jchorl in https://github.com/mamba-org/mamba/pull/3083
 - add manually given .tar.bz2 / .conda packages to solver pool by @0xbe7a in https://github.com/mamba-org/mamba/pull/3164
 - Fix linking on Windows when Scripts folder is missing by @dalcinl in https://github.com/mamba-org/mamba/pull/2825
@@ -354,9 +354,9 @@ CI fixes and doc:
 - Mark Anaconda channels as unsupported by @jonashaag in https://github.com/mamba-org/mamba/pull/2904
 - Fix nodefaults in documentation by @jonashaag in https://github.com/mamba-org/mamba/pull/2809
 - Improve install instruction by @jonashaag in https://github.com/mamba-org/mamba/pull/2908
-- Simplify and correct development documention by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2975
+- Simplify and correct development documentation by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2975
 - Add install from source instructions by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2977
-- update readme install link by @artifical-agent in https://github.com/mamba-org/mamba/pull/2980
+- update readme install link by @artificial-agent in https://github.com/mamba-org/mamba/pull/2980
 - Fail fast except on debug runs by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2985
 
 # micromamba 2.0.0rc6 (September 20, 2024)
@@ -422,7 +422,7 @@ Enhancements:
 
 Bug fixes:
 
-- [micromamba] Fix behavior of `env update` (to mimick conda) by @Hind-M in https://github.com/mamba-org/mamba/pull/3396
+- [micromamba] Fix behavior of `env update` (to mimic conda) by @Hind-M in https://github.com/mamba-org/mamba/pull/3396
 
 CI fixes and doc:
 
@@ -562,14 +562,14 @@ Enhancements:
 - Move util_random.hpp > util/random.hpp by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3129
 - Refactor test_remove.py to use fixture by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3131
 - MRepo refactor by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3118
-- Explcit transaction duplicate code by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3138
+- Explicit transaction duplicate code by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3138
 - Solver Request by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3141
 - Split Solver and Unsolvable by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3156
 - Solver sort deps by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3163
 
 Bug fixes:
 
-- Fix URL enconding in repodata.json by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3076
+- Fix URL encoding in repodata.json by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3076
 - gracefully handle conflicting names in yaml specs by @jchorl in https://github.com/mamba-org/mamba/pull/3083
 - add manually given .tar.bz2 / .conda packages to solver pool by @0xbe7a in https://github.com/mamba-org/mamba/pull/3164
 
@@ -625,7 +625,7 @@ Enhancements:
 - Refactor env::which by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2997
 - Migrate Channel::make_channel to resolve multi channels by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2986
 - Move core/channel > specs/channel by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3000
-- Remove ChanelContext context capture by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3015
+- Remove ChannelContext context capture by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3015
 - Default to hide credentials by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3017
 - Refactor (some) OpenSSL functions by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3024
 - Default to conda-forge channel by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3035
@@ -651,9 +651,9 @@ CI fixes and doc:
 - Mark Anaconda channels as unsupported by @jonashaag in https://github.com/mamba-org/mamba/pull/2904
 - Fix nodefaults in documentation by @jonashaag in https://github.com/mamba-org/mamba/pull/2809
 - Improve install instruction by @jonashaag in https://github.com/mamba-org/mamba/pull/2908
-- Simplify and correct development documention by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2975
+- Simplify and correct development documentation by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2975
 - Add install from source instructions by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2977
-- update readme install link by @artifical-agent in https://github.com/mamba-org/mamba/pull/2980
+- update readme install link by @artificial-agent in https://github.com/mamba-org/mamba/pull/2980
 - Fail fast except on debug runs by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2985
 
 # micromamba 2.0.0alpha0 (December 14, 2023)
@@ -692,7 +692,7 @@ Enhancements:
 - Refactor env::which by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2997
 - Migrate Channel::make_channel to resolve multi channels by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2986
 - Move core/channel > specs/channel by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3000
-- Remove ChanelContext context capture by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3015
+- Remove ChannelContext context capture by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3015
 - Default to hide credentials by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3017
 - Refactor (some) OpenSSL functions by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3024
 - Default to conda-forge channel by @AntoinePrv in https://github.com/mamba-org/mamba/pull/3035
@@ -718,9 +718,9 @@ CI fixes and doc:
 - Mark Anaconda channels as unsupported by @jonashaag in https://github.com/mamba-org/mamba/pull/2904
 - Fix nodefaults in documentation by @jonashaag in https://github.com/mamba-org/mamba/pull/2809
 - Improve install instruction by @jonashaag in https://github.com/mamba-org/mamba/pull/2908
-- Simplify and correct development documention by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2975
+- Simplify and correct development documentation by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2975
 - Add install from source instructions by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2977
-- update readme install link by @artifical-agent in https://github.com/mamba-org/mamba/pull/2980
+- update readme install link by @artificial-agent in https://github.com/mamba-org/mamba/pull/2980
 - Fail fast except on debug runs by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2985
 
 # micromamba 1.5.1 (September 05, 2023)
@@ -736,11 +736,11 @@ Enhancements:
 
 Bug fixes:
 
-- Fix extra agrument in self-update reinit by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2787
+- Fix extra argument in self-update reinit by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2787
 
 CI fixes and doc:
 
-- Splitted GHA workflow by @JohanMabille in https://github.com/mamba-org/mamba/pull/2779
+- Split GHA workflow by @JohanMabille in https://github.com/mamba-org/mamba/pull/2779
 - Use Release build mode in Windows CI by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2785
 - Fix wrong command description by @Hind-M in https://github.com/mamba-org/mamba/pull/2804
 
@@ -807,7 +807,7 @@ Enhancements:
 - Common CMake presets by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2532
 - No singleton: configuration by @Klaim in https://github.com/mamba-org/mamba/pull/2541
 - Remove banner by @jonashaag in https://github.com/mamba-org/mamba/pull/2298
-- Add topological sort explict export tests by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2618
+- Add topological sort explicit export tests by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2618
 
 Bug fixes:
 
@@ -870,10 +870,10 @@ Enhancements:
 
 # micromamba 1.4.0 (March 22, 2023)
 
-Enchancements:
+Enhancements:
 
 - Implemented recursive dependency printout in repoquery by @timostrunk in https://github.com/mamba-org/mamba/pull/2283
-- Agressive compilation warnings by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2304
+- Aggressive compilation warnings by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2304
 - Fine tune clang-format by @AntoinePrv in https://github.com/mamba-org/mamba/pull/2290
 - Only full shared or full static builds by @JohanMabille in https://github.com/mamba-org/mamba/pull/2342
 - Fixed repoquery commands working with installed packages only by @Hind-M in https://github.com/mamba-org/mamba/pull/2330
@@ -886,7 +886,7 @@ Bug fixes:
 CI fixes & docs:
 
 - Added missing dependency in local recipe by @wolfv in https://github.com/mamba-org/mamba/pull/2334
-- Fixed Conda Lock Path by @funtion in https://github.com/mamba-org/mamba/pull/2393
+- Fixed Conda Lock Path by @function in https://github.com/mamba-org/mamba/pull/2393
 
 # micromamba 1.3.1 (February 09, 2023)
 
@@ -955,7 +955,7 @@ CI fixes & docs:
 - - Run conda_nightly once per week by @jonashaag in #2147
 - - Update doc by @Hind-M in #2156
 - - Use Conda canary in nightly tests by @jonashaag in #2180
-- - Expliclity point to libmamba test data independently of cwd by @AntoinePrv in #2158
+- - Explicitly point to libmamba test data independently of cwd by @AntoinePrv in #2158
 - - Add bug report issue template by @jonashaag in #2182
 - - Downgrade curl to fix micromamba on macOS x64 by @wolfv in #2205
 - - Use conda-forge micromamba feedstock instead of a fork by @JohanMabille in #2206
@@ -1203,7 +1203,7 @@ Improvements
 
 - Only print micromamba version and add library versions to `info` command #1372
 - Implement activate as a micromamba subcommand for better error messages (thanks @maresb) #1360
-- Experimental wass logged twice (thanks @baszalmstra) #1360
+- Experimental was logged twice (thanks @baszalmstra) #1360
 - Store platform when creating env with `--platform=...` (thanks @adriendelsalle) #1381
 
 # micromamba 0.19.1 (December 08, 2021)
@@ -1353,7 +1353,7 @@ Big changes:
 
 New features
 
-- remove orphaned packages such as dependencies of explicitely installed
+- remove orphaned packages such as dependencies of explicitly installed
   packages (@adriendelsalle) #1040
 - add a diff character before package name in transaction table to improve
   readability without coloration (@adriendelsalle) #1040
@@ -1563,7 +1563,7 @@ General improvements
 # 0.10.0 (Apr 16, 2021)
 
 - [micromamba] allow creation of empty env (without specs) #824 #827
-- [micromamba] automatically create empy `base` env at new root prefix #836
+- [micromamba] automatically create empty `base` env at new root prefix #836
 - [micromamba] add remove all CLI flags `-a,--all` #824
 - [micromamba] add dry-run and ultra-dry-run tests to increase coverage and
   speed-up CI #813 #845
@@ -1589,7 +1589,7 @@ General improvements
 
 # 0.9.2 (Apr 1, 2021)
 
-- [micromamba] fix unc url support (thanks @adament)
+- [micromamba] fix unc url support (thanks @adamant)
 - [micromamba] add --channel-alias as cli option to micromamba (thanks
   @adriendelsalle)
 - [micromamba] fix --no-rc and environment yaml files (thanks @adriendelsalle)
@@ -1612,7 +1612,7 @@ General improvements
   short/long descriptions and groups
 - [micromamba] prevent crashes when no bashrc or zshrc file found (thanks
   @wolfv)
-- add support for UNC file:// urls (thanks @adament)
+- add support for UNC file:// urls (thanks @adamant)
 - add support for use_only_tar_bz2 (thanks @tl-hbk @wolfv)
 - add pinned specs for env update (thanks @wolfv)
 - properly adhere to run_constrains (thanks @wolfv)
@@ -1682,7 +1682,7 @@ General improvements
 - [micromamba] Revert extraction to temporary directory because of invalid
   cross-device links on Linux
 - [micromamba] Clean up partially extracted archives when CTRL+C interruption
-  occured
+  occurred
 
 # 0.7.11 (Feb 2, 2021)
 


### PR DESCRIPTION
We already change these files during `prettier` run, so it won't harm to fix typos in changelog files