### PR TITLE
ci: Rerun pytest tests on `main` in case of failures

### DIFF
--- a/.github/workflows/unix_impl.yml
+++ b/.github/workflows/unix_impl.yml
@@ -107,7 +107,10 @@ jobs:
           python -m pip install --no-deps --no-build-isolation ./libmambapy
       - name: Run libmamba Python bindings tests
         run: |
-          python -m pytest libmambapy/tests/ --reruns 3 ${{ runner.debug == 'true' && '-v' || '--exitfirst' }}
+          # Only rerun flaky tests on the `main` branch
+          python -m pytest libmambapy/tests/ \
+              ${{ runner.debug == 'true' && '-v' || '--exitfirst' }} \
+              ${{ github.ref == 'refs/heads/main' && '--reruns 3' || '' }}
 
   mamba_integration_tests_unix:
     name: mamba integration tests

--- a/.github/workflows/unix_impl.yml
+++ b/.github/workflows/unix_impl.yml
@@ -107,7 +107,7 @@ jobs:
           python -m pip install --no-deps --no-build-isolation ./libmambapy
       - name: Run libmamba Python bindings tests
         run: |
-          python -m pytest libmambapy/tests/ ${{ runner.debug == 'true' && '-v' || '--exitfirst' }}
+          python -m pytest libmambapy/tests/ --reruns 3 ${{ runner.debug == 'true' && '-v' || '--exitfirst' }}
 
   mamba_integration_tests_unix:
     name: mamba integration tests

--- a/.github/workflows/unix_impl.yml
+++ b/.github/workflows/unix_impl.yml
@@ -109,7 +109,7 @@ jobs:
         run: |
           # Only rerun flaky tests on the `main` branch
           python -m pytest libmambapy/tests/ \
-              ${{ runner.debug == 'true' && '-v' || '--exitfirst' }} \
+              ${{ runner.debug == 'true' && '-v --capture=tee-sys' || '--exitfirst' }} \
               ${{ github.ref == 'refs/heads/main' && '--reruns 3' || '' }}
 
   mamba_integration_tests_unix:
@@ -165,8 +165,10 @@ jobs:
         run: |
           export TEST_MAMBA_EXE=$(pwd)/build/micromamba/mamba
           unset CONDARC  # Interferes with tests
+          # Only rerun flaky tests on the `main` branch
           python -m pytest micromamba/tests/ \
-            ${{ runner.debug == 'true' && '-v --capture=tee-sys' || '--exitfirst' }}
+              ${{ runner.debug == 'true' && '-v --capture=tee-sys' || '--exitfirst' }} \
+              ${{ github.ref == 'refs/heads/main' && '--reruns 3' || '' }}
 
   verify_pkg_tests:
     name: mamba-content-trust tests

--- a/.github/workflows/windows_impl.yml
+++ b/.github/workflows/windows_impl.yml
@@ -118,7 +118,7 @@ jobs:
         run: |
           # Only rerun flaky tests on the `main` branch
           python -m pytest libmambapy/tests/ \
-              ${{ runner.debug == 'true' && '-v' || '--exitfirst' }} \
+              ${{ runner.debug == 'true' && '-v --capture=tee-sys' || '--exitfirst' }} \
               ${{ github.ref == 'refs/heads/main' && '--reruns 3' || '' }}
 
   mamba_integration_tests_win:
@@ -152,5 +152,7 @@ jobs:
           $env:TEST_MAMBA_EXE = Join-Path -Path $pwd -ChildPath 'local\bin\mamba.exe'
           $env:MAMBA_TEST_SHELL_TYPE='powershell'
           Remove-Item -Path "env:CONDARC"
-          python -m pytest micromamba/tests/ `
-            ${{ runner.debug == 'true' && '-v --capture=tee-sys' || '--exitfirst' }}
+          # Only rerun flaky tests on the `main` branch
+          python -m pytest micromamba/tests/ \
+              ${{ runner.debug == 'true' && '-v --capture=tee-sys' || '--exitfirst' }} \
+              ${{ github.ref == 'refs/heads/main' && '--reruns 3' || '' }}

--- a/.github/workflows/windows_impl.yml
+++ b/.github/workflows/windows_impl.yml
@@ -116,7 +116,10 @@ jobs:
           python -m pip install --no-deps --no-build-isolation ./libmambapy
       - name: Run libmamba Python bindings tests
         run: |
-          python -m pytest libmambapy/tests/ --reruns 3 ${{ runner.debug == 'true' && '-v' || '--exitfirst' }}
+          # Only rerun flaky tests on the `main` branch
+          python -m pytest libmambapy/tests/ \
+              ${{ runner.debug == 'true' && '-v' || '--exitfirst' }} \
+              ${{ github.ref == 'refs/heads/main' && '--reruns 3' || '' }}
 
   mamba_integration_tests_win:
     name: mamba integration tests

--- a/.github/workflows/windows_impl.yml
+++ b/.github/workflows/windows_impl.yml
@@ -116,7 +116,7 @@ jobs:
           python -m pip install --no-deps --no-build-isolation ./libmambapy
       - name: Run libmamba Python bindings tests
         run: |
-          python -m pytest libmambapy/tests/ ${{ runner.debug == 'true' && '-v' || '--exitfirst' }}
+          python -m pytest libmambapy/tests/ --reruns 3 ${{ runner.debug == 'true' && '-v' || '--exitfirst' }}
 
   mamba_integration_tests_win:
     name: mamba integration tests

--- a/dev/environment-dev.yml
+++ b/dev/environment-dev.yml
@@ -31,6 +31,7 @@ dependencies:
   - pytest-asyncio
   - pytest-timeout
   - pytest-xprocess
+  - pytest-rerunfailures
   - memory_profiler
   - requests
   - sel(win): pywin32


### PR DESCRIPTION
Sporadic test failures due to reasons we cannot control (e.g. network) make an entire workflow fail.

This workflow need to be rerun manually, which takes extra time (up to 40 minutes) and distracts from work.

This proposes to automatically rerun test if they fail up to 3 times thanks to [`pytest-rerunfailures`](https://github.com/pytest-dev/pytest-rerunfailures).