### PR TITLE
Update shell_init for nushell

### DIFF
--- a/libmamba/src/core/shell_init.cpp
+++ b/libmamba/src/core/shell_init.cpp
@@ -503,6 +503,7 @@ namespace mamba
       | into record
       | load-env
     )
+    $env.PATH = $env.PATH | split row (char esep)
     # update prompt
     if ($env.CONDA_PROMPT_MODIFIER? != null) {
       $env.PROMPT_COMMAND = {|| $env.CONDA_PROMPT_MODIFIER + (do $env.PROMPT_COMMAND_BK)}


### PR DESCRIPTION
In nushell, PATH variable is a list, not a string. 

Thus, after load-env, must set $env.PATH to a list. Otherwise, all PATH are lost.

Tested on nushell 0.101.0 on mac.