### PR TITLE
fix: remove deprecated PIP_NO_PYTHON_VERSION_WARNING environment vari…

### DIFF
--- a/libmamba/src/core/prefix_data.cpp
+++ b/libmamba/src/core/prefix_data.cpp
@@ -227,7 +227,7 @@ namespace mamba
             { "PYTHONIOENCODING", "utf-8" },
             { "NO_COLOR", "1" },
             { "PIP_NO_COLOR", "1" },
-            { "PIP_NO_PYTHON_VERSION_WARNING", "1" },
+            // Removed due to deprecation: { "PIP_NO_PYTHON_VERSION_WARNING", "1" },
         };
         reproc::options run_options;
         run_options.env.extra = reproc::env{ env };


### PR DESCRIPTION
The PIP_NO_PYTHON_VERSION_WARNING environment variable is deprecated
in Python 3 and no longer has any effect. This flag was originally
used to suppress Python version compatibility warnings from pip.

Since mamba primarily works with Python 3 environments now, this
flag can be safely removed from the environment variables passed
to pip inspect commands.