### PR TITLE
docs: Document that mamba 2 only supports trailing globs in version strings

### DIFF
--- a/docs/source/developer_zone/changes-2.0.rst
+++ b/docs/source/developer_zone/changes-2.0.rst
@@ -19,7 +19,7 @@ Mamba (executable)
 has been entirely replaced by the dynamically linked version of ``micromamba``,
 a statically-linked ELF based on ``libmamba``.
 
-Hence ``mamba``` now has the exact same user interface and experience as ``micromamba``.
+Hence ``mamba`` now has the exact same user interface and experience as ``micromamba``.
 
 .. warning::
 
@@ -40,6 +40,9 @@ Breaking changes include:
 - A new config ``order_solver_request`` (default true) can be used to order the dependencies passed
   to the solver, getting order independent solutions.
 - Support for complex match specs such as ``pkg[md5=0000000000000]`` and ``pkg[build='^\d*$']``.
+- Dropped support for leading and internal globs in version strings (via
+  redesigned ``VersionSpec``, which no longer handles version strings as a
+  regex). Only trailing globs continue to be supported.
 
 .. TODO OCI and mirrors
 
@@ -86,6 +89,9 @@ Changes include:
   - The redesign of ``MatchSpec``.
     The module also includes a platform enumeration, an implementation of ordered ``Version``,
     and a ``VersionSpec`` to match versions.
+    **Breaking change:** ``VersionSpec`` dropped support for leading and
+    internal globs in version strings because they are no longer handled as a
+    regex. Only trailing globs continue to be supported.
   - ``PackageInfo`` has been moved to this submodule.
     Some attributes have been given a more explicit name ``fn`` > ``filename``,
     ``url`` > ``package_url``.
@@ -127,6 +133,10 @@ The main changes are:
   - A refactoring of a purely functional ``Channel`` class,
   - Implementation of a ``UnresolvedChannel`` to describe unresolved ``Channels``,
   - A refactored and complete implementation of ``MatchSpec`` using the components above.
+  - **Breaking change:** ``VersionSpec`` dropped support for leading and
+    internal globs in version strings because they are no longer handled as a
+    regex. Only trailing globs continue to be supported. This affects version
+    strings in both the command-line interface and recipe requirements.
 
 - A cleanup of ``ChannelContext`` to be a light proxy and parameter holder wrapping the
   ``specs::Channel``.

--- a/docs/source/developer_zone/changes-2.0.rst
+++ b/docs/source/developer_zone/changes-2.0.rst
@@ -40,9 +40,9 @@ Breaking changes include:
 - A new config ``order_solver_request`` (default true) can be used to order the dependencies passed
   to the solver, getting order independent solutions.
 - Support for complex match specs such as ``pkg[md5=0000000000000]`` and ``pkg[build='^\d*$']``.
-- Dropped support for leading and internal globs in version strings (via
-  redesigned ``VersionSpec``, which no longer handles version strings as a
-  regex). Only trailing globs continue to be supported.
+- **Temporary regression:** Lost support for leading and internal globs in
+  version strings (via redesigned ``VersionSpec``, which no longer handles
+  version strings as a regex). Only trailing globs are supported at the moment.
 
 .. TODO OCI and mirrors
 
@@ -89,9 +89,9 @@ Changes include:
   - The redesign of ``MatchSpec``.
     The module also includes a platform enumeration, an implementation of ordered ``Version``,
     and a ``VersionSpec`` to match versions.
-    **Breaking change:** ``VersionSpec`` dropped support for leading and
-    internal globs in version strings because they are no longer handled as a
-    regex. Only trailing globs continue to be supported.
+    **Breaking change (temporary regression):** ``VersionSpec`` lost support for
+    leading and internal globs in version strings because they are no longer
+    handled as a regex. Only trailing globs are supported at the moment.
   - ``PackageInfo`` has been moved to this submodule.
     Some attributes have been given a more explicit name ``fn`` > ``filename``,
     ``url`` > ``package_url``.
@@ -133,10 +133,11 @@ The main changes are:
   - A refactoring of a purely functional ``Channel`` class,
   - Implementation of a ``UnresolvedChannel`` to describe unresolved ``Channels``,
   - A refactored and complete implementation of ``MatchSpec`` using the components above.
-  - **Breaking change:** ``VersionSpec`` dropped support for leading and
-    internal globs in version strings because they are no longer handled as a
-    regex. Only trailing globs continue to be supported. This affects version
-    strings in both the command-line interface and recipe requirements.
+  - **Breaking change (temporary regression):** ``VersionSpec`` lost support for
+    leading and internal globs in version strings because they are no longer
+    handled as a regex. Only trailing globs are supported at the moment. This
+    affects version strings in both the command-line interface and recipe
+    requirements.
 
 - A cleanup of ``ChannelContext`` to be a light proxy and parameter holder wrapping the
   ``specs::Channel``.


### PR DESCRIPTION
Mamba 1 supported leading and internal globs in version strings (eg `*.0.0` and `0.*.0` respectively). Mamba 2 only supports trailing globs. This PR documents this breaking change.

xref: https://github.com/mamba-org/mamba/issues/3601#issuecomment-2515447329

Here is a demonstration using libmambapy 2.0.5:

```python
import libmambapy

libmambapy.version.version_info
## ('2', '0', '5')

import libmambapy.specs as specs

specs.VersionSpec.parse("0.0.*")
specs.VersionSpec.parse("0.*.0")
specs.VersionSpec.parse("*.0.0")
## Traceback (most recent call last):
##   File "<stdin>", line 1, in <module>
## libmambapy.bindings.specs.ParseError: Found invalid version predicate in "*.0.0"

# Trailing glob works as expected
specs.VersionSpec.parse("0.0.*").contains(specs.Version.parse("0.0.1"))
## True
specs.VersionSpec.parse("0.0.*").contains(specs.Version.parse("1.0.0"))
## False

# Internal glob accepted but does not work
specs.VersionSpec.parse("0.*.0").contains(specs.Version.parse("0.1.0"))
## False
specs.VersionSpec.parse("0.*.0").contains(specs.Version.parse("1.0.0"))
## False
```

Here is a comparison of micromamba 2.0.5 versus 1.5.12:

```sh
docker run --rm -it ubuntu:24.10 bash
apt-get update
apt-get install --yes curl
"${SHELL}" <(curl -L micro.mamba.pm/install.sh)
## Micromamba binary folder? [~/.local/bin]
## Init shell (bash)? [Y/n] Y
## Configure conda-forge? [Y/n] Y
## Prefix location? [~/micromamba]
source ~/.bashrc
micromamba --version
## 2.0.5

micromamba --dry-run create -p test python=3.10.*
## + python               3.10.16  he725a3c_1_cpython  conda-forge      25MB
micromamba --dry-run create -p test python=3.*.16
## error    libmamba Could not solve for environment specs
##     The following package could not be installed
##     └─ python =3.0*.16 * does not exist (perhaps a typo or a missing channel).
## critical libmamba Could not solve for environment specs
micromamba --dry-run create -p test python=*.10.16
## error    libmamba Could not solve for environment specs
##     The following package could not be installed
##     └─ python =0*.10.16 * does not exist (perhaps a typo or a missing channel).
## critical libmamba Could not solve for environment specs

micromamba self-update --version 1.5
## Installing micromamba version: 1.5.12 (currently installed 2.0.5)
micromamba --version
## 1.5.12

micromamba --dry-run create -p test python=3.10.*
## + python               3.10.16  he725a3c_1_cpython  conda-forge      25MB
micromamba --dry-run create -p test python=3.*.16
## + python               3.10.16  he725a3c_1_cpython  conda-forge      25MB
micromamba --dry-run create -p test python=*.10.16
## + python               3.10.16  he725a3c_1_cpython  conda-forge      25MB
```