### PR TITLE
fix: Adapt root prefix' precedence for `envs_dirs`

### DIFF
--- a/libmamba/include/mamba/api/configuration_impl.hpp
+++ b/libmamba/include/mamba/api/configuration_impl.hpp
@@ -83,7 +83,7 @@ namespace mamba
         {
             static std::vector<std::string> default_value(const std::vector<T>& init)
             {
-	      return std::vector<std::string>(std::max<size_t>(1, init.size()), "default");
+                return std::vector<std::string>(std::max<size_t>(1, init.size()), "default");
             };
 
             static void merge(

--- a/libmamba/include/mamba/api/configuration_impl.hpp
+++ b/libmamba/include/mamba/api/configuration_impl.hpp
@@ -83,7 +83,7 @@ namespace mamba
         {
             static std::vector<std::string> default_value(const std::vector<T>& init)
             {
-                return std::vector<std::string>(init.size(), "default");
+	      return std::vector<std::string>(std::max<size_t>(1, init.size()), "default");
             };
 
             static void merge(

--- a/libmamba/src/core/context.cpp
+++ b/libmamba/src/core/context.cpp
@@ -181,7 +181,7 @@ namespace mamba
         prefix_params.root_prefix = detail::get_root_prefix();
         prefix_params.conda_prefix = prefix_params.root_prefix;
 
-        envs_dirs = { prefix_params.root_prefix / "envs" };
+        envs_dirs = { };
         pkgs_dirs = { prefix_params.root_prefix / "pkgs",
                       fs::u8path("~") / ".mamba" / "pkgs"
 #ifdef _WIN32

--- a/libmamba/src/core/context.cpp
+++ b/libmamba/src/core/context.cpp
@@ -181,7 +181,7 @@ namespace mamba
         prefix_params.root_prefix = detail::get_root_prefix();
         prefix_params.conda_prefix = prefix_params.root_prefix;
 
-        envs_dirs = { };
+        envs_dirs = {};
         pkgs_dirs = { prefix_params.root_prefix / "pkgs",
                       fs::u8path("~") / ".mamba" / "pkgs"
 #ifdef _WIN32

--- a/micromamba/tests/test_create.py
+++ b/micromamba/tests/test_create.py
@@ -267,7 +267,7 @@ def test_target_prefix(
     current_target_prefix_fallback,
     similar_non_canonical,
     non_canonical_position,
-    root_prefix_env_exists
+    root_prefix_env_exists,
 ):
     cmd = []
 
@@ -280,7 +280,7 @@ def test_target_prefix(
         root_prefix = Path(os.environ["MAMBA_ROOT_PREFIX"])
 
     if root_prefix_env_exists:
-        os.mkdir((Path(os.environ["MAMBA_ROOT_PREFIX"]) / "envs"))
+        os.mkdir(Path(os.environ["MAMBA_ROOT_PREFIX"]) / "envs")
 
     env_prefix = tmp_path / "myenv"
 

--- a/micromamba/tests/test_create.py
+++ b/micromamba/tests/test_create.py
@@ -253,6 +253,7 @@ def test_env_logging_overhead_regression(tmp_home, tmp_root_prefix, tmp_path):
     "similar_non_canonical,non_canonical_position",
     ((False, None), (True, "append"), (True, "prepend")),
 )
+@pytest.mark.parametrize("root_prefix_env_exists", (False, True))
 def test_target_prefix(
     tmp_home,
     tmp_root_prefix,
@@ -266,6 +267,7 @@ def test_target_prefix(
     current_target_prefix_fallback,
     similar_non_canonical,
     non_canonical_position,
+    root_prefix_env_exists
 ):
     cmd = []
 
@@ -276,6 +278,9 @@ def test_target_prefix(
         cmd += ["-r", root_prefix]
     else:
         root_prefix = Path(os.environ["MAMBA_ROOT_PREFIX"])
+
+    if root_prefix_env_exists:
+        os.mkdir((Path(os.environ["MAMBA_ROOT_PREFIX"]) / "envs"))
 
     env_prefix = tmp_path / "myenv"
 


### PR DESCRIPTION
Adds a new test and fixes #3806.  With this PR it now has the desired behavior:

```
$ mamba create -r /tmp/cliroot --debug -n foo --print-config-only | yq '. | .envs_dirs'
[
  "/tmp/cliroot/envs"
]

$ MAMBA_ROOT_PREFIX=/tmp/envroot mamba create --debug -n foo --print-config-only | yq '. | .envs_dirs'
[
  "/tmp/envroot/envs"
]

$ MAMBA_ROOT_PREFIX=/tmp/envroot mamba create -r /tmp/cliroot --debug -n foo --print-config-only | yq '. | .envs_dirs'
[
  "/tmp/cliroot/envs"
]

$ CONDA_ENVS_DIRS=/tmp/userdirs/envs MAMBA_ROOT_PREFIX=/tmp/envroot mamba create --debug -n foo --print-config-only | yq '. | .envs_dirs'
[
  "/tmp/userdirs/envs",
  "/tmp/envroot/envs"
]
```

One note - in order for this approach to work, I needed to ensure that the minimum vector size for configuration items was 1 so that `--print-config` didn't crash.  (Alternatively I could change the print-config code to ignore a zero-size vector, but this seemed like a more robust approach).



