### PR TITLE
warning as error default to OFF and enabled in CI

### DIFF
--- a/.github/workflows/unix_impl.yml
+++ b/.github/workflows/unix_impl.yml
@@ -40,6 +40,7 @@ jobs:
             --preset mamba-unix-shared-${{ inputs.build_type }}  \
             -D CMAKE_CXX_COMPILER_LAUNCHER=sccache \
             -D CMAKE_C_COMPILER_LAUNCHER=sccache \
+            -D MAMBA_WARNING_AS_ERROR=ON \
             -D BUILD_LIBMAMBAPY=OFF \
             -D ENABLE_MAMBA_ROOT_PREFIX_FALLBACK=OFF
           cmake --build build/ --parallel

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,11 +19,8 @@ option(BUILD_LIBMAMBA_TESTS "Build libmamba C++ tests" OFF)
 option(BUILD_MAMBA "Build mamba" OFF)
 option(BUILD_MICROMAMBA "Build micromamba" OFF)
 option(BUILD_MAMBA_PACKAGE "Build mamba package utility" OFF)
-if(MSVC)
-    option(MAMBA_WARNING_AS_ERROR "Treat compiler warnings as errors" OFF)
-else()
-    option(MAMBA_WARNING_AS_ERROR "Treat compiler warnings as errors" ON)
-endif()
+option(MAMBA_WARNING_AS_ERROR "Treat compiler warnings as errors" OFF)
+
 set(
     MAMBA_LTO
     "Default"

--- a/libmambapy/setup.py
+++ b/libmambapy/setup.py
@@ -33,5 +33,6 @@ skbuild.setup(
     cmake_install_dir="src/libmambapy",  # Must match package_dir layout
     cmake_args=[
         f"-DMAMBA_INSTALL_PYTHON_EXT_LIBDIR={CMAKE_INSTALL_DIR()}/src/libmambapy",
+        f"-DMAMBA_WARNING_AS_ERROR=ON",
     ],
 )


### PR DESCRIPTION
Fixes #3791 

The option MAMBA_WARNING_AS_ERROR has to be explictly set in the micromamba feedstock to catch it in this CI.