### PR TITLE
Make xonsh completer only trigger when using micromamba

### DIFF
--- a/libmamba/data/mamba.xsh
+++ b/libmamba/data/mamba.xsh
@@ -95,7 +95,7 @@ aliases['micromamba'] = _micromamba_main
 
 @contextual_command_completer
 def _micromamba_proc_completer(ctx):
-    if not ctx.args:
+    if not ctx.args or ctx.args[0].value != 'micromamba':
         return
 
     return (


### PR DESCRIPTION
Currently, after installing `micromamba` and initializing it with the `xonsh` shell, the completions for `micromamba` will show up upon use of `<TAB>` for other executables, such as `rsync` or `vim`.

This change ensures that `micromamba` completions do *not* appear for cases in which `micromamba` is not the first argument to the context.

See for reference: https://github.com/xonsh/xonsh/issues/5692
