### PR TITLE
maint: Rename `Database` arguments

### DIFF
--- a/libmamba/include/mamba/api/channel_loader.hpp
+++ b/libmamba/include/mamba/api/channel_loader.hpp
@@ -30,7 +30,7 @@ namespace mamba
     auto load_channels(
         Context& ctx,
         ChannelContext& channel_context,
-        solver::libsolv::Database& pool,
+        solver::libsolv::Database& database,
         MultiPackageCache& package_caches
     ) -> expected_t<void, mamba_aggregated_error>;
 

--- a/libmamba/include/mamba/api/repoquery.hpp
+++ b/libmamba/include/mamba/api/repoquery.hpp
@@ -23,7 +23,7 @@ namespace mamba
     };
 
     [[nodiscard]] auto make_repoquery(
-        solver::libsolv::Database& pool,
+        solver::libsolv::Database& database,
         QueryType type,
         QueryResultFormat format,
         const std::vector<std::string>& queries,

--- a/libmamba/include/mamba/core/package_database_loader.hpp
+++ b/libmamba/include/mamba/core/package_database_loader.hpp
@@ -22,17 +22,17 @@ namespace mamba
         class Database;
     }
 
-    void add_spdlog_logger_to_database(solver::libsolv::Database& db);
+    void add_spdlog_logger_to_database(solver::libsolv::Database& database);
 
     auto load_subdir_in_database(  //
         const Context& ctx,
-        solver::libsolv::Database& db,
+        solver::libsolv::Database& database,
         const SubdirData& subdir
     ) -> expected_t<solver::libsolv::RepoInfo>;
 
     auto load_installed_packages_in_database(
         const Context& ctx,
-        solver::libsolv::Database& db,
+        solver::libsolv::Database& database,
         const PrefixData& prefix
     ) -> solver::libsolv::RepoInfo;
 }

--- a/libmamba/include/mamba/core/query.hpp
+++ b/libmamba/include/mamba/core/query.hpp
@@ -94,12 +94,14 @@ namespace mamba
 
         using Database = solver::libsolv::Database;
 
-        [[nodiscard]] static auto find(Database& db, const std::vector<std::string>& queries)
+        [[nodiscard]] static auto find(Database& database, const std::vector<std::string>& queries)
             -> QueryResult;
 
-        [[nodiscard]] static auto whoneeds(Database& db, std::string query, bool tree) -> QueryResult;
+        [[nodiscard]] static auto whoneeds(Database& database, std::string query, bool tree)
+            -> QueryResult;
 
-        [[nodiscard]] static auto depends(Database& db, std::string query, bool tree) -> QueryResult;
+        [[nodiscard]] static auto depends(Database& database, std::string query, bool tree)
+            -> QueryResult;
     };
 
     /********************

--- a/libmamba/include/mamba/core/transaction.hpp
+++ b/libmamba/include/mamba/core/transaction.hpp
@@ -37,7 +37,7 @@ namespace mamba
 
         MTransaction(
             const Context& ctx,
-            solver::libsolv::Database& db,
+            solver::libsolv::Database& database,
             std::vector<specs::PackageInfo> pkgs_to_remove,
             std::vector<specs::PackageInfo> pkgs_to_install,
             MultiPackageCache& caches
@@ -45,7 +45,7 @@ namespace mamba
 
         MTransaction(
             const Context& ctx,
-            solver::libsolv::Database& db,
+            solver::libsolv::Database& database,
             const solver::Request& request,
             solver::Solution solution,
             MultiPackageCache& caches
@@ -54,7 +54,7 @@ namespace mamba
         // Only use if the packages have been solved previously already.
         MTransaction(
             const Context& ctx,
-            solver::libsolv::Database& db,
+            solver::libsolv::Database& database,
             std::vector<specs::PackageInfo> packages,
             MultiPackageCache& caches
         );
@@ -93,7 +93,7 @@ namespace mamba
 
     MTransaction create_explicit_transaction_from_urls(
         const Context& ctx,
-        solver::libsolv::Database& db,
+        solver::libsolv::Database& database,
         const std::vector<std::string>& urls,
         MultiPackageCache& package_caches,
         std::vector<detail::other_pkg_mgr_spec>& other_specs
@@ -101,7 +101,7 @@ namespace mamba
 
     MTransaction create_explicit_transaction_from_lockfile(
         const Context& ctx,
-        solver::libsolv::Database& db,
+        solver::libsolv::Database& database,
         const fs::u8path& env_lockfile_path,
         const std::vector<std::string>& categories,
         MultiPackageCache& package_caches,

--- a/libmamba/include/mamba/solver/libsolv/database.hpp
+++ b/libmamba/include/mamba/solver/libsolv/database.hpp
@@ -133,8 +133,8 @@ namespace mamba::solver::libsolv
          */
         class Impl
         {
-            [[nodiscard]] static auto get(Database& pool) -> solv::ObjPool&;
-            [[nodiscard]] static auto get(const Database& pool) -> const solv::ObjPool&;
+            [[nodiscard]] static auto get(Database& database) -> solv::ObjPool&;
+            [[nodiscard]] static auto get(const Database& database) -> const solv::ObjPool&;
 
             friend class Solver;
             friend class UnSolvable;

--- a/libmamba/include/mamba/solver/libsolv/solver.hpp
+++ b/libmamba/include/mamba/solver/libsolv/solver.hpp
@@ -22,12 +22,12 @@ namespace mamba::solver::libsolv
 
         using Outcome = std::variant<Solution, UnSolvable>;
 
-        [[nodiscard]] auto solve(Database& pool, Request&& request) -> expected_t<Outcome>;
-        [[nodiscard]] auto solve(Database& pool, const Request& request) -> expected_t<Outcome>;
+        [[nodiscard]] auto solve(Database& database, Request&& request) -> expected_t<Outcome>;
+        [[nodiscard]] auto solve(Database& database, const Request& request) -> expected_t<Outcome>;
 
     private:
 
-        auto solve_impl(Database& pool, const Request& request) -> expected_t<Outcome>;
+        auto solve_impl(Database& database, const Request& request) -> expected_t<Outcome>;
     };
 }
 #endif

--- a/libmamba/include/mamba/solver/libsolv/unsolvable.hpp
+++ b/libmamba/include/mamba/solver/libsolv/unsolvable.hpp
@@ -39,22 +39,23 @@ namespace mamba::solver::libsolv
 
         auto operator=(UnSolvable&&) -> UnSolvable&;
 
-        [[nodiscard]] auto problems(Database& pool) const -> std::vector<std::string>;
+        [[nodiscard]] auto problems(Database& database) const -> std::vector<std::string>;
 
-        [[nodiscard]] auto problems_to_str(Database& pool) const -> std::string;
+        [[nodiscard]] auto problems_to_str(Database& database) const -> std::string;
 
-        [[nodiscard]] auto all_problems_to_str(Database& pool) const -> std::string;
+        [[nodiscard]] auto all_problems_to_str(Database& database) const -> std::string;
 
-        [[nodiscard]] auto problems_graph(const Database& pool) const -> ProblemsGraph;
+        [[nodiscard]] auto problems_graph(const Database& database) const -> ProblemsGraph;
 
         auto explain_problems_to(  //
-            Database& pool,
+            Database& database,
             std::ostream& out,
             const ProblemsMessageFormat& format
         ) const -> std::ostream&;
 
         [[nodiscard]] auto
-        explain_problems(Database& pool, const ProblemsMessageFormat& format) const -> std::string;
+        explain_problems(Database& database, const ProblemsMessageFormat& format) const
+            -> std::string;
 
     private:
 

--- a/libmamba/src/api/create.cpp
+++ b/libmamba/src/api/create.cpp
@@ -36,6 +36,7 @@ namespace mamba
         auto channel_context = ChannelContext::make_conda_compatible(ctx);
 
         bool remove_prefix_on_failure = false;
+        bool create_env = true;
 
         if (!ctx.dry_run)
         {
@@ -105,7 +106,7 @@ namespace mamba
                 channel_context,
                 lockfile_path,
                 config.at("categories").value<std::vector<std::string>>(),
-                true,
+                create_env,
                 remove_prefix_on_failure
             );
         }
@@ -113,11 +114,24 @@ namespace mamba
         {
             if (use_explicit)
             {
-                install_explicit_specs(ctx, channel_context, create_specs, true, remove_prefix_on_failure);
+                install_explicit_specs(
+                    ctx,
+                    channel_context,
+                    create_specs,
+                    create_env,
+                    remove_prefix_on_failure
+                );
             }
             else
             {
-                install_specs(ctx, channel_context, config, create_specs, true, remove_prefix_on_failure);
+                install_specs(
+                    ctx,
+                    channel_context,
+                    config,
+                    create_specs,
+                    create_env,
+                    remove_prefix_on_failure
+                );
             }
         }
     }

--- a/libmamba/src/api/repoquery.cpp
+++ b/libmamba/src/api/repoquery.cpp
@@ -82,7 +82,7 @@ namespace mamba
     }
 
     auto make_repoquery(
-        solver::libsolv::Database& db,
+        solver::libsolv::Database& database,
         QueryType type,
         QueryResultFormat format,
         const std::vector<std::string>& queries,
@@ -93,7 +93,7 @@ namespace mamba
     {
         if (type == QueryType::Search)
         {
-            auto res = Query::find(db, queries);
+            auto res = Query::find(database, queries);
             switch (format)
             {
                 case QueryResultFormat::Json:
@@ -114,7 +114,7 @@ namespace mamba
                 throw std::invalid_argument("Only one query supported for 'depends'.");
             }
             auto res = Query::depends(
-                db,
+                database,
                 queries.front(),
                 /* tree= */ format == QueryResultFormat::Tree
                     || format == QueryResultFormat::RecursiveTable
@@ -141,7 +141,7 @@ namespace mamba
                 throw std::invalid_argument("Only one query supported for 'whoneeds'.");
             }
             auto res = Query::whoneeds(
-                db,
+                database,
                 queries.front(),
                 /* tree= */ format == QueryResultFormat::Tree
                     || format == QueryResultFormat::RecursiveTable

--- a/libmamba/src/core/query.cpp
+++ b/libmamba/src/core/query.cpp
@@ -75,11 +75,11 @@ namespace mamba
             }
         };
 
-        auto database_latest_package(solver::libsolv::Database& db, specs::MatchSpec spec)
+        auto database_latest_package(solver::libsolv::Database& database, specs::MatchSpec spec)
             -> std::optional<specs::PackageInfo>
         {
             auto out = std::optional<specs::PackageInfo>();
-            db.for_each_package_matching(
+            database.for_each_package_matching(
                 spec,
                 [&](auto pkg)
                 {
@@ -99,7 +99,7 @@ namespace mamba
             using DepGraph = typename QueryResult::dependency_graph;
             using node_id = typename QueryResult::dependency_graph::node_id;
 
-            PoolWalker(solver::libsolv::Database& db);
+            PoolWalker(solver::libsolv::Database& database);
 
             void walk(specs::PackageInfo pkg, std::size_t max_depth);
             void walk(specs::PackageInfo pkg);
@@ -122,8 +122,8 @@ namespace mamba
             void reverse_walk_impl(node_id id);
         };
 
-        PoolWalker::PoolWalker(solver::libsolv::Database& db)
-            : m_database(db)
+        PoolWalker::PoolWalker(solver::libsolv::Database& database)
+            : m_database(database)
         {
         }
 
@@ -219,7 +219,7 @@ namespace mamba
         }
     }
 
-    auto Query::find(Database& db, const std::vector<std::string>& queries) -> QueryResult
+    auto Query::find(Database& database, const std::vector<std::string>& queries) -> QueryResult
     {
         QueryResult::dependency_graph g;
         for (const auto& query : queries)
@@ -227,7 +227,7 @@ namespace mamba
             const auto ms = specs::MatchSpec::parse(query)
                                 .or_else([](specs::ParseError&& err) { throw std::move(err); })
                                 .value();
-            db.for_each_package_matching(
+            database.for_each_package_matching(
                 ms,
                 [&](specs::PackageInfo&& pkg) { g.add_node(std::move(pkg)); }
             );
@@ -240,16 +240,16 @@ namespace mamba
         };
     }
 
-    auto Query::whoneeds(Database& db, std::string query, bool tree) -> QueryResult
+    auto Query::whoneeds(Database& database, std::string query, bool tree) -> QueryResult
     {
         const auto ms = specs::MatchSpec::parse(query)
                             .or_else([](specs::ParseError&& err) { throw std::move(err); })
                             .value();
         if (tree)
         {
-            if (auto pkg = database_latest_package(db, ms))
+            if (auto pkg = database_latest_package(database, ms))
             {
-                auto walker = PoolWalker(db);
+                auto walker = PoolWalker(database);
                 walker.reverse_walk(std::move(pkg).value());
                 return { QueryType::WhoNeeds, std::move(query), std::move(walker).graph() };
             }
@@ -257,7 +257,7 @@ namespace mamba
         else
         {
             QueryResult::dependency_graph g;
-            db.for_each_package_depending_on(
+            database.for_each_package_depending_on(
                 ms,
                 [&](specs::PackageInfo&& pkg) { g.add_node(std::move(pkg)); }
             );
@@ -266,14 +266,14 @@ namespace mamba
         return { QueryType::WhoNeeds, std::move(query), QueryResult::dependency_graph() };
     }
 
-    auto Query::depends(Database& db, std::string query, bool tree) -> QueryResult
+    auto Query::depends(Database& database, std::string query, bool tree) -> QueryResult
     {
         const auto ms = specs::MatchSpec::parse(query)
                             .or_else([](specs::ParseError&& err) { throw std::move(err); })
                             .value();
-        if (auto pkg = database_latest_package(db, ms))
+        if (auto pkg = database_latest_package(database, ms))
         {
-            auto walker = PoolWalker(db);
+            auto walker = PoolWalker(database);
             if (tree)
             {
                 walker.walk(std::move(pkg).value());

--- a/libmamba/src/solver/libsolv/database.cpp
+++ b/libmamba/src/solver/libsolv/database.cpp
@@ -72,14 +72,14 @@ namespace mamba::solver::libsolv
         return m_data->pool;
     }
 
-    auto Database::Impl::get(Database& pool) -> solv::ObjPool&
+    auto Database::Impl::get(Database& database) -> solv::ObjPool&
     {
-        return pool.pool();
+        return database.pool();
     }
 
-    auto Database::Impl::get(const Database& pool) -> const solv::ObjPool&
+    auto Database::Impl::get(const Database& database) -> const solv::ObjPool&
     {
-        return pool.pool();
+        return database.pool();
     }
 
     auto Database::channel_params() const -> const specs::ChannelResolveParams&

--- a/libmamba/src/solver/libsolv/unsolvable.cpp
+++ b/libmamba/src/solver/libsolv/unsolvable.cpp
@@ -42,9 +42,9 @@ namespace mamba::solver::libsolv
         return *m_solver;
     }
 
-    auto UnSolvable::problems(Database& db) const -> std::vector<std::string>
+    auto UnSolvable::problems(Database& database) const -> std::vector<std::string>
     {
-        auto& pool = Database::Impl::get(db);
+        auto& pool = Database::Impl::get(database);
         std::vector<std::string> problems;
         solver().for_each_problem_id([&](solv::ProblemId pb)
                                      { problems.emplace_back(solver().problem_to_string(pool, pb)); }
@@ -52,9 +52,9 @@ namespace mamba::solver::libsolv
         return problems;
     }
 
-    auto UnSolvable::problems_to_str(Database& db) const -> std::string
+    auto UnSolvable::problems_to_str(Database& database) const -> std::string
     {
-        auto& pool = Database::Impl::get(db);
+        auto& pool = Database::Impl::get(database);
         std::stringstream problems;
         problems << "Encountered problems while solving:\n";
         solver().for_each_problem_id(
@@ -64,9 +64,9 @@ namespace mamba::solver::libsolv
         return problems.str();
     }
 
-    auto UnSolvable::all_problems_to_str(Database& db) const -> std::string
+    auto UnSolvable::all_problems_to_str(Database& database) const -> std::string
     {
-        auto& pool = Database::Impl::get(db);
+        auto& pool = Database::Impl::get(database);
         std::stringstream problems;
         solver().for_each_problem_id(
             [&](solv::ProblemId pb)
@@ -565,32 +565,32 @@ namespace mamba::solver::libsolv
         }
     }
 
-    auto UnSolvable::problems_graph(const Database& pool) const -> ProblemsGraph
+    auto UnSolvable::problems_graph(const Database& database) const -> ProblemsGraph
     {
         assert(m_solver != nullptr);
-        return ProblemsGraphCreator(Database::Impl::get(pool), *m_solver).problem_graph();
+        return ProblemsGraphCreator(Database::Impl::get(database), *m_solver).problem_graph();
     }
 
     auto UnSolvable::explain_problems_to(
-        Database& pool,
+        Database& database,
         std::ostream& out,
         const ProblemsMessageFormat& format
     ) const -> std::ostream&
     {
         out << "Could not solve for environment specs\n";
-        const auto pbs = problems_graph(pool);
+        const auto pbs = problems_graph(database);
         const auto pbs_simplified = simplify_conflicts(pbs);
         const auto cp_pbs = CompressedProblemsGraph::from_problems_graph(pbs_simplified);
         print_problem_tree_msg(out, cp_pbs, format);
         return out;
     }
 
-    auto UnSolvable::explain_problems(Database& pool, const ProblemsMessageFormat& format) const
+    auto UnSolvable::explain_problems(Database& database, const ProblemsMessageFormat& format) const
         -> std::string
 
     {
         std::stringstream ss;
-        explain_problems_to(pool, ss, format);
+        explain_problems_to(database, ss, format);
         return ss.str();
     }
 }

--- a/libmamba/src/specs/channel.cpp
+++ b/libmamba/src/specs/channel.cpp
@@ -288,7 +288,7 @@ namespace mamba::specs
             );
         }
 
-        void set_fallback_credential_from_db(CondaURL& url, const AuthenticationDataBase& db)
+        void set_fallback_credential_from_db(CondaURL& url, const AuthenticationDataBase& database)
         {
             if (!url.has_token() || !url.has_user() || !url.has_password())
             {
@@ -297,7 +297,7 @@ namespace mamba::specs
                     '/',
                     CondaURL::Credentials::Remove
                 );
-                if (auto it = db.find_weaken(key); it != db.end())
+                if (auto it = database.find_weaken(key); it != database.end())
                 {
                     set_fallback_credential_from_auth(url, it->second);
                 }

--- a/libmamba/tests/src/solver/test_problems_graph.cpp
+++ b/libmamba/tests/src/solver/test_problems_graph.cpp
@@ -329,7 +329,7 @@ namespace
     auto load_channels(
         Context& ctx,
         ChannelContext& channel_context,
-        solver::libsolv::Database& db,
+        solver::libsolv::Database& database,
         MultiPackageCache& cache,
         std::vector<std::string>&& channels
     )
@@ -353,7 +353,7 @@ namespace
 
         for (auto& sub_dir : sub_dirs)
         {
-            auto repo = load_subdir_in_database(ctx, db, sub_dir);
+            auto repo = load_subdir_in_database(ctx, database, sub_dir);
         }
     }
 

--- a/libmambapy/src/libmambapy/bindings/legacy.cpp
+++ b/libmambapy/src/libmambapy/bindings/legacy.cpp
@@ -513,11 +513,11 @@ bind_submodule_impl(pybind11::module_ m)
     py::class_<SubdirData>(m, "SubdirData")
         .def(
             "create_repo",
-            [](SubdirData& self, Context& context, solver::libsolv::Database& db
+            [](SubdirData& self, Context& context, solver::libsolv::Database& database
             ) -> solver::libsolv::RepoInfo
             {
                 deprecated("Use libmambapy.load_subdir_in_database instead", "2.0");
-                return extract(load_subdir_in_database(context, db, self));
+                return extract(load_subdir_in_database(context, database, self));
             },
             py::arg("context"),
             py::arg("db")

--- a/libmambapy/src/libmambapy/bindings/solver_libsolv.cpp
+++ b/libmambapy/src/libmambapy/bindings/solver_libsolv.cpp
@@ -140,7 +140,10 @@ namespace mambapy
             )
             .def(
                 "add_repo_from_packages",
-                [](Database& db, py::iterable packages, std::string_view name, PipAsPythonDependency add)
+                [](Database& database,
+                   py::iterable packages,
+                   std::string_view name,
+                   PipAsPythonDependency add)
                 {
                     // TODO(C++20): No need to copy in a vector, simply transform the input range.
                     auto pkg_infos = std::vector<specs::PackageInfo>();
@@ -148,7 +151,7 @@ namespace mambapy
                     {
                         pkg_infos.push_back(pkg.cast<specs::PackageInfo>());
                     }
-                    return db.add_repo_from_packages(pkg_infos, name, add);
+                    return database.add_repo_from_packages(pkg_infos, name, add);
                 },
                 py::arg("packages"),
                 py::arg("name") = "",
@@ -169,12 +172,12 @@ namespace mambapy
             .def("package_count", &Database::package_count)
             .def(
                 "packages_in_repo",
-                [](const Database& db, RepoInfo repo)
+                [](const Database& database, RepoInfo repo)
                 {
                     // TODO(C++20): When Database function are refactored to use range, take the
                     // opportunity here to make a Python iterator to avoid large alloc.
                     auto out = py::list();
-                    db.for_each_package_in_repo(
+                    database.for_each_package_in_repo(
                         repo,
                         [&](specs::PackageInfo&& pkg) { out.append(std::move(pkg)); }
                     );
@@ -184,12 +187,12 @@ namespace mambapy
             )
             .def(
                 "packages_matching",
-                [](Database& db, const specs::MatchSpec& ms)
+                [](Database& database, const specs::MatchSpec& ms)
                 {
                     // TODO(C++20): When Database function are refactored to use range, take the
                     // opportunity here to make a Python iterator to avoid large alloc.
                     auto out = py::list();
-                    db.for_each_package_matching(
+                    database.for_each_package_matching(
                         ms,
                         [&](specs::PackageInfo&& pkg) { out.append(std::move(pkg)); }
                     );
@@ -199,12 +202,12 @@ namespace mambapy
             )
             .def(
                 "packages_depending_on",
-                [](Database& db, const specs::MatchSpec& ms)
+                [](Database& database, const specs::MatchSpec& ms)
                 {
                     // TODO(C++20): When Database function are refactored to use range, take the
                     // opportunity here to make a Python iterator to avoid large alloc.
                     auto out = py::list();
-                    db.for_each_package_depending_on(
+                    database.for_each_package_depending_on(
                         ms,
                         [&](specs::PackageInfo&& pkg) { out.append(std::move(pkg)); }
                     );
@@ -236,8 +239,8 @@ namespace mambapy
             .def(py::init())
             .def(
                 "solve",
-                [](Solver& self, Database& db, const solver::Request& request)
-                { return self.solve(db, request); }
+                [](Solver& self, Database& database, const solver::Request& request)
+                { return self.solve(database, request); }
             )
             .def("add_jobs", solver_job_v2_migrator)
             .def("add_global_job", solver_job_v2_migrator)


### PR DESCRIPTION
So as to properly distinguish them from `pools` wrapped by `ObjPool*`, etc.