### PR TITLE
fix: Modify cache directory permissions in two steps

### DIFF
--- a/libmamba/src/core/subdirdata.cpp
+++ b/libmamba/src/core/subdirdata.cpp
@@ -962,17 +962,20 @@ namespace mamba
 
         const auto permissions = fs::perms::owner_all | fs::perms::group_all
                                  | fs::perms::others_read | fs::perms::others_exec;
-        fs::permissions(cache_dir.string().c_str(), permissions, fs::perm_options::replace);
+        fs::permissions(cache_dir, permissions, fs::perm_options::replace);
         LOG_TRACE << "Set permissions on cache directory " << cache_dir << " to 'rwxrwxr-x'";
 
-        try
+        std::error_code ec;
+        fs::permissions(cache_dir, fs::perms::set_gid, fs::perm_options::add, ec);
+
+        if (!ec)
         {
-            fs::permissions(cache_dir.string().c_str(), fs::perms::set_gid, fs::perm_options::add);
             LOG_TRACE << "Set setgid bit on cache directory " << cache_dir;
         }
-        catch (...)
+        else
         {
-            LOG_TRACE << "Could not set setgid bit on cache directory " << cache_dir << ": ignoring";
+            LOG_TRACE << "Could not set setgid bit on cache directory " << cache_dir
+                      << "\nReason:" << ec.message() << "; ignoring and continuing";
         }
 
         return cache_dir.string();

--- a/libmamba/src/core/subdirdata.cpp
+++ b/libmamba/src/core/subdirdata.cpp
@@ -956,7 +956,7 @@ namespace mamba
         fs::create_directories(cache_dir);
 
         // Some filesystems don't support special permissions such as setgid on directories (e.g.
-        // FAT32, NTFS). In this case, we proceed in two steps to set the permissions:
+        // FAT32, NFS). In this case, we proceed in two steps to set the permissions:
         // 1. Set the permissions to the desired value without setgid.
         // 2. Set the setgid bit on the directory and ignore the error if it fails.
 

--- a/libmamba/src/core/subdirdata.cpp
+++ b/libmamba/src/core/subdirdata.cpp
@@ -956,9 +956,13 @@ namespace mamba
         fs::create_directories(cache_dir);
 
         // Some filesystems don't support special permissions such as setgid on directories (e.g.
-        // FAT32, NFS). In this case, we proceed in two steps to set the permissions:
-        // 1. Set the permissions to the desired value without setgid.
-        // 2. Set the setgid bit on the directory and ignore the error if it fails.
+        // NFS). and fail if we try to set the setgid bit on the cache directory.
+        //
+        // We want to set the setgid bit on the cache directory to preserve the permissions as much
+        // as possible if we can; hence we proceed in two steps to set the permissions by
+        //   1. Setting the permissions without the setgid bit to the desired value without.
+        //   2. Trying to set the setgid bit on the directory and report success or failure in log
+        //   without raising an error or propagating an error which was raised.
 
         const auto permissions = fs::perms::owner_all | fs::perms::group_all
                                  | fs::perms::others_read | fs::perms::others_exec;

--- a/libmamba/tests/src/core/test_filesystem.cpp
+++ b/libmamba/tests/src/core/test_filesystem.cpp
@@ -363,9 +363,7 @@ namespace mamba
                 }
             );
 
-            // Get the information about whether the filesystem supports special bits permissions
-            // For this test, we need to check if the filesystem supports the sticky bit using try
-            // catch
+            // Get the information about whether the filesystem supports the `set_gid` bit.
             bool supports_setgid_bit = false;
 
             try
@@ -381,7 +379,7 @@ namespace mamba
 
             fs::create_directories(create_cache_dir);
 
-            // Check that the permissions of `tmp_dir` are 'rwxr-xr-x'
+            // Check that the permissions of `create_cache_dir` are 'rwxr-xr-x'
             auto create_cache_dir_permissions = fs::status(create_cache_dir).permissions();
 
             REQUIRE((create_cache_dir_permissions & fs::perms::owner_all) == fs::perms::owner_all);

--- a/libmamba/tests/src/core/test_filesystem.cpp
+++ b/libmamba/tests/src/core/test_filesystem.cpp
@@ -367,6 +367,7 @@ namespace mamba
 
             // Get the information about whether the filesystem supports the `set_gid` bit.
             bool supports_setgid_bit = false;
+            fs::create_directories(set_gid_tmp_dir);
 
             std::error_code ec;
             fs::permissions(set_gid_tmp_dir, fs::perms::set_gid, fs::perm_options::add, ec);

--- a/libmamba/tests/src/core/test_filesystem.cpp
+++ b/libmamba/tests/src/core/test_filesystem.cpp
@@ -354,39 +354,36 @@ namespace mamba
 
         TEST_CASE("create_cache_dir")
         {
-            const auto cache_dir = fs::temp_directory_path() / "mamba-fs-cache-dir";
-            const auto set_gid_tmp_dir = fs::temp_directory_path() / "mamba-fs-set_gid_tmp_dir";
+            // `create_cache_dir` create a `cache` subdirectory at a given path given as an
+            // argument.
+            const auto cache_path = fs::temp_directory_path() / "mamba-fs-cache-path";
+            const auto cache_dir = cache_path / "cache";
 
-            mamba::on_scope_exit _(
-                [&]
-                {
-                    fs::remove_all(cache_dir);
-                    fs::remove_all(set_gid_tmp_dir);
-                }
-            );
+            mamba::on_scope_exit _([&] { fs::remove_all(cache_path); });
 
             // Get the information about whether the filesystem supports the `set_gid` bit.
             bool supports_setgid_bit = false;
-            fs::create_directories(set_gid_tmp_dir);
+            fs::create_directories(cache_path);
 
             std::error_code ec;
-            fs::permissions(set_gid_tmp_dir, fs::perms::set_gid, fs::perm_options::add, ec);
+            fs::permissions(cache_path, fs::perms::set_gid, fs::perm_options::add, ec);
 
             if (!ec)
             {
-                supports_setgid_bit = (fs::status(set_gid_tmp_dir).permissions() & fs::perms::set_gid)
+                supports_setgid_bit = (fs::status(cache_path).permissions() & fs::perms::set_gid)
                                       == fs::perms::set_gid;
             }
 
             // Check that `cache_dir` does not exist before calling `create_cache_dir`
             REQUIRE_FALSE(fs::exists(cache_dir));
 
-            create_cache_dir(cache_dir);
+            create_cache_dir(cache_path);
 
             REQUIRE(fs::exists(cache_dir));
             REQUIRE(fs::is_directory(cache_dir));
 
-            // Check that the permissions of `cache_dir` are _at least_ `rwxr-xr-x`
+            // Check that the permissions of `cache_dir` are _at least_ `rwxr-xr-x` because
+            // `std::fs::temp_directory_path` might not have `rwxrwxr-x` permissions.
             auto cache_dir_permissions = fs::status(cache_dir).permissions();
             auto expected_min_owner_perm = fs::perms::owner_all;
             auto expected_min_group_perm = fs::perms::group_read | fs::perms::group_exec;

--- a/libmamba/tests/src/core/test_filesystem.cpp
+++ b/libmamba/tests/src/core/test_filesystem.cpp
@@ -366,15 +366,13 @@ namespace mamba
             // Get the information about whether the filesystem supports the `set_gid` bit.
             bool supports_setgid_bit = false;
 
-            try
+            std::error_code ec;
+            fs::permissions(set_gid_tmp_dir, fs::perms::set_gid, fs::perm_options::add, ec);
+
+            if (!ec)
             {
-                fs::permissions(set_gid_tmp_dir, fs::perms::set_gid, fs::perm_options::add);
                 supports_setgid_bit = (fs::status(set_gid_tmp_dir).permissions() & fs::perms::set_gid)
                                       == fs::perms::set_gid;
-            }
-            catch (const fs::filesystem_error&)
-            {
-                supports_setgid_bit = false;
             }
 
             fs::create_directories(create_cache_dir);

--- a/libmamba/tests/src/core/test_filesystem.cpp
+++ b/libmamba/tests/src/core/test_filesystem.cpp
@@ -378,7 +378,12 @@ namespace mamba
                                       == fs::perms::set_gid;
             }
 
+            // Check that `cache_dir` does not exist before calling `create_cache_dir`
+            REQUIRE_FALSE(fs::exists(cache_dir));
+
             create_cache_dir(cache_dir);
+
+            REQUIRE(fs::exists(cache_dir));
             REQUIRE(fs::is_directory(cache_dir));
 
             // Check that the permissions of `cache_dir` are _at least_ `rwxr-xr-x`

--- a/libmamba/tests/src/core/test_filesystem.cpp
+++ b/libmamba/tests/src/core/test_filesystem.cpp
@@ -8,6 +8,7 @@
 
 #include <catch2/catch_all.hpp>
 
+#include "mamba/core/subdirdata.hpp"
 #include "mamba/core/util.hpp"
 #include "mamba/core/util_scope.hpp"
 #include "mamba/fs/filesystem.hpp"
@@ -352,13 +353,13 @@ namespace mamba
 
         TEST_CASE("create_cache_dir")
         {
-            const auto create_cache_dir = fs::temp_directory_path() / "mamba-fs-create-cache-dir";
+            const auto cache_dir = fs::temp_directory_path() / "mamba-fs-cache-dir";
             const auto set_gid_tmp_dir = fs::temp_directory_path() / "mamba-fs-set_gid_tmp_dir";
 
             mamba::on_scope_exit _(
                 [&]
                 {
-                    fs::remove_all(create_cache_dir);
+                    fs::remove_all(cache_dir);
                     fs::remove_all(set_gid_tmp_dir);
                 }
             );
@@ -375,24 +376,24 @@ namespace mamba
                                       == fs::perms::set_gid;
             }
 
-            fs::create_directories(create_cache_dir);
+            create_cache_dir(cache_dir);
 
-            // Check that the permissions of `create_cache_dir` are 'rwxr-xr-x'
-            auto create_cache_dir_permissions = fs::status(create_cache_dir).permissions();
+            // Check that the permissions of `cache_dir` are 'rwxr-xr-x'
+            auto cache_dir_permissions = fs::status(cache_dir).permissions();
 
-            REQUIRE((create_cache_dir_permissions & fs::perms::owner_all) == fs::perms::owner_all);
+            REQUIRE((cache_dir_permissions & fs::perms::owner_all) == fs::perms::owner_all);
             REQUIRE(
-                (create_cache_dir_permissions & fs::perms::group_all)
+                (cache_dir_permissions & fs::perms::group_all)
                 == (fs::perms::group_read | fs::perms::group_exec)
             );
             REQUIRE(
-                (create_cache_dir_permissions & fs::perms::others_all)
+                (cache_dir_permissions & fs::perms::others_all)
                 == (fs::perms::others_read | fs::perms::others_exec)
             );
 
             if (supports_setgid_bit)
             {
-                REQUIRE((create_cache_dir_permissions & fs::perms::set_gid) == fs::perms::set_gid);
+                REQUIRE((cache_dir_permissions & fs::perms::set_gid) == fs::perms::set_gid);
             }
         }
 

--- a/libmamba/tests/src/core/test_filesystem.cpp
+++ b/libmamba/tests/src/core/test_filesystem.cpp
@@ -379,6 +379,7 @@ namespace mamba
             }
 
             create_cache_dir(cache_dir);
+            REQUIRE(fs::is_directory(cache_dir));
 
             // Check that the permissions of `cache_dir` are _at least_ `rwxr-xr-x`
             auto cache_dir_permissions = fs::status(cache_dir).permissions();

--- a/libmamba/tests/src/core/test_filesystem.cpp
+++ b/libmamba/tests/src/core/test_filesystem.cpp
@@ -349,6 +349,27 @@ namespace mamba
             fs::remove_all(tmp_dir);
             REQUIRE_FALSE(fs::exists(tmp_dir));
         }
+
+        TEST_CASE("create_cache_dir")
+        {
+            const auto tmp_dir = fs::temp_directory_path() / "mamba-fs-create-cache-dir";
+
+            mamba::on_scope_exit _([&] { fs::remove_all(tmp_dir); });  // Cleanup if not debugging.
+
+            fs::create_directories(tmp_dir);
+
+            // Check that the permissions of `tmp_dir` are 'rwxr-xr-x'
+            REQUIRE((fs::status(tmp_dir).permissions() & fs::perms::owner_all) == fs::perms::owner_all);
+            REQUIRE(
+                (fs::status(tmp_dir).permissions() & fs::perms::group_all)
+                == (fs::perms::group_read | fs::perms::group_exec)
+            );
+            REQUIRE(
+                (fs::status(tmp_dir).permissions() & fs::perms::others_all)
+                == (fs::perms::others_read | fs::perms::others_exec)
+            );
+        }
+
     }
 
 }

--- a/libmamba/tests/src/core/test_filesystem.cpp
+++ b/libmamba/tests/src/core/test_filesystem.cpp
@@ -12,6 +12,7 @@
 #include "mamba/core/util.hpp"
 #include "mamba/core/util_scope.hpp"
 #include "mamba/fs/filesystem.hpp"
+#include "mamba/util/build.hpp"
 
 namespace mamba
 {
@@ -378,18 +379,15 @@ namespace mamba
 
             create_cache_dir(cache_dir);
 
-            // Check that the permissions of `cache_dir` are 'rwxr-xr-x'
+            // Check that the permissions of `cache_dir` are _at least_ `rwxr-xr-x`
             auto cache_dir_permissions = fs::status(cache_dir).permissions();
+            auto expected_min_owner_perm = fs::perms::owner_all;
+            auto expected_min_group_perm = fs::perms::group_read | fs::perms::group_exec;
+            auto expected_min_others_perm = fs::perms::others_read | fs::perms::others_exec;
 
-            REQUIRE((cache_dir_permissions & fs::perms::owner_all) == fs::perms::owner_all);
-            REQUIRE(
-                (cache_dir_permissions & fs::perms::group_all)
-                == (fs::perms::group_read | fs::perms::group_exec)
-            );
-            REQUIRE(
-                (cache_dir_permissions & fs::perms::others_all)
-                == (fs::perms::others_read | fs::perms::others_exec)
-            );
+            REQUIRE((cache_dir_permissions & expected_min_owner_perm) == expected_min_owner_perm);
+            REQUIRE((cache_dir_permissions & expected_min_group_perm) == expected_min_group_perm);
+            REQUIRE((cache_dir_permissions & expected_min_others_perm) == expected_min_others_perm);
 
             if (supports_setgid_bit)
             {


### PR DESCRIPTION
Fix https://github.com/mamba-org/mamba/issues/3840.

Though this fixes the problem (as reported by @chrisburr in https://github.com/mamba-org/mamba/issues/3840#issuecomment-2684940010), I do not know how we could test this yet.