### PR TITLE
fix: Adapt root prefix' precedence for CONDA_ENVS_PATH

### DIFF
--- a/libmamba/src/api/configuration.cpp
+++ b/libmamba/src/api/configuration.cpp
@@ -1007,22 +1007,17 @@ namespace mamba
         {
             // Check that "root_prefix/envs" is already in the dirs,
             // and append if not - to match `conda`
-            fs::u8path default_env_dir = context.prefix_params.root_prefix / "envs";
-            if (std::find(dirs.begin(), dirs.end(), default_env_dir) == dirs.end())
-            {
-                dirs.push_back(default_env_dir);
-            }
 
-            // Also add all the directories in the environment variable `CONDA_ENVS_PATH`.
+            // Also prepend all the directories in the environment variable `CONDA_ENVS_PATH`.
             auto conda_envs_path = util::get_env("CONDA_ENVS_PATH");
             if (conda_envs_path)
             {
                 auto paths_separator = util::pathsep();
 
                 auto paths = util::split(conda_envs_path.value(), paths_separator);
-                for (auto& p : paths)
-                {
-                    dirs.push_back(fs::u8path(p));
+                for (auto it = paths.rbegin(); it != paths.rend(); ++it)
+                {  // prepend conda_envs_path to dirs while maintaining order
+                    dirs.insert(dirs.begin(), fs::u8path(*it));
                 }
             }
 
@@ -1035,6 +1030,12 @@ namespace mamba
                     LOG_ERROR << "Env dir specified is not a directory: " << d.string();
                     throw std::runtime_error("Aborting.");
                 }
+            }
+
+            fs::u8path default_env_dir = context.prefix_params.root_prefix / "envs";
+            if (std::find(dirs.begin(), dirs.end(), default_env_dir) == dirs.end())
+            {
+                dirs.push_back(default_env_dir);
             }
         }
 

--- a/libmamba/src/api/configuration.cpp
+++ b/libmamba/src/api/configuration.cpp
@@ -1005,10 +1005,7 @@ namespace mamba
 
         void envs_dirs_hook(const Context& context, std::vector<fs::u8path>& dirs)
         {
-            // Check that "root_prefix/envs" is already in the dirs,
-            // and append if not - to match `conda`
-
-            // Also prepend all the directories in the environment variable `CONDA_ENVS_PATH`.
+            // Prepend all the directories in the environment variable `CONDA_ENVS_PATH`.
             auto conda_envs_path = util::get_env("CONDA_ENVS_PATH");
             if (conda_envs_path)
             {
@@ -1032,6 +1029,8 @@ namespace mamba
                 }
             }
 
+            // Check that "root_prefix/envs" is already in the dirs,
+            // and append if not - to match `conda`
             fs::u8path default_env_dir = context.prefix_params.root_prefix / "envs";
             if (std::find(dirs.begin(), dirs.end(), default_env_dir) == dirs.end())
             {

--- a/micromamba/tests/test_create.py
+++ b/micromamba/tests/test_create.py
@@ -670,7 +670,6 @@ def test_create_envs_dirs(tmp_root_prefix: Path, tmp_path: Path, monkeypatch):
     noperm_envs_dir = noperm_root_dir / "envs"
 
     monkeypatch.setenv("CONDA_ENVS_DIRS", f"{noperm_envs_dir},{tmp_path}")
-    #    monkeypatch.setenv("CONDA_ENVS_PATH", f"{noperm_envs_dir}:{tmp_path}")
     env_name = "myenv"
     os.makedirs(noperm_root_dir, exist_ok=True)
 

--- a/micromamba/tests/test_create.py
+++ b/micromamba/tests/test_create.py
@@ -670,6 +670,7 @@ def test_create_envs_dirs(tmp_root_prefix: Path, tmp_path: Path, monkeypatch):
     noperm_envs_dir = noperm_root_dir / "envs"
 
     monkeypatch.setenv("CONDA_ENVS_DIRS", f"{noperm_envs_dir},{tmp_path}")
+    #    monkeypatch.setenv("CONDA_ENVS_PATH", f"{noperm_envs_dir}:{tmp_path}")
     env_name = "myenv"
     os.makedirs(noperm_root_dir, exist_ok=True)
 
@@ -757,6 +758,7 @@ def test_env_dir_idempotence(tmp_path, tmp_home, tmp_root_prefix):
         assert Path(condarc_envs_dirs / env_name).exists()
 
 
+@pytest.mark.parametrize("conda_envs_x", ("CONDA_ENVS_DIRS", "CONDA_ENVS_PATH"))
 @pytest.mark.parametrize("set_in_conda_envs_dirs", (False, True))
 @pytest.mark.parametrize("set_in_condarc", (False, True))
 @pytest.mark.parametrize("cli_root_prefix", (False, True))
@@ -765,6 +767,7 @@ def test_root_prefix_precedence(
     tmp_path,
     tmp_home,
     monkeypatch,
+    conda_envs_x,
     set_in_condarc,
     set_in_conda_envs_dirs,
     cli_root_prefix,
@@ -794,7 +797,7 @@ def test_root_prefix_precedence(
     env_name = "foo"
     monkeypatch.setenv("MAMBA_ROOT_PREFIX", str(mamba_root_prefix))
     if set_in_conda_envs_dirs:
-        monkeypatch.setenv("CONDA_ENVS_DIRS", str(conda_envs_dirs))
+        monkeypatch.setenv(conda_envs_x, str(conda_envs_dirs))
 
     with open(tmp_home / ".condarc", "w+") as f:
         if set_in_condarc:


### PR DESCRIPTION
Fixes #3851.

```
$ mkdir -p /tmp/test/envs && CONDA_ENVS_PATH=/tmp/test/envs mamba create -n test1
Empty environment created at prefix: /tmp/test/envs/test1
```