### PR TITLE
fix: ProgressBar member initialization order

### DIFF
--- a/libmamba/src/core/progress_bar_impl.cpp
+++ b/libmamba/src/core/progress_bar_impl.cpp
@@ -1286,9 +1286,9 @@ namespace mamba
         : m_progress(0)
         , m_total(total)
         , m_width(width)
-        , m_repr(this)
         , m_options(options)
         , m_is_spinner(false)
+        , m_repr(this)
     {
         m_repr.prefix.set_value(prefix);
     }

--- a/libmamba/src/core/progress_bar_impl.hpp
+++ b/libmamba/src/core/progress_bar_impl.hpp
@@ -394,13 +394,14 @@ namespace mamba
         std::string m_last_active_task = "";
         time_point_t m_task_time, m_avg_speed_time;
 
-        ProgressBarRepr m_repr;
         ProgressBarOptions m_options;
 
         bool m_is_spinner;
         bool m_completed = false;
 
         std::mutex m_mutex;
+
+        ProgressBarRepr m_repr;
 
         void run();
 


### PR DESCRIPTION
When ProgressBarRepr m_repr is being constructed, it copies the m_options from the ProgressBar. However, m_options is not yet set at this moment.

Swap m_options and m_repr to fix this.

Change-Id: I78ba6763d508c7c67b24e7e778db83670d0a5a70