### PR TITLE
Use Simdjson ondemand parser instead of DOM parser

### DIFF
--- a/libmamba/include/mamba/util/flat_set.hpp
+++ b/libmamba/include/mamba/util/flat_set.hpp
@@ -112,11 +112,7 @@ namespace mamba::util
         auto erase(const_iterator first, const_iterator last) -> const_iterator;
         auto erase(const value_type& value) -> size_type;
 
-        template <
-            class T,
-            // TODO: C++ >= 20 replace by concept
-            class = std::enable_if_t<
-                std::is_convertible_v<T, value_type> || std::is_convertible_v<value_type, T>>>
+        template <class T>
         auto contains(const T& value) const -> bool;
 
     private:
@@ -416,7 +412,7 @@ namespace mamba::util
     }
 
     template <typename K, typename C, typename A>
-    template <class T, class>
+    template <class T>
     auto flat_set<K, C, A>::contains(const T& value) const -> bool
     {
         return std::binary_search(begin(), end(), value);

--- a/libmamba/include/mamba/util/flat_set.hpp
+++ b/libmamba/include/mamba/util/flat_set.hpp
@@ -112,10 +112,11 @@ namespace mamba::util
         auto erase(const_iterator first, const_iterator last) -> const_iterator;
         auto erase(const value_type& value) -> size_type;
 
-        template<class T,
+        template <
+            class T,
             // TODO: C++ >= 20 replace by concept
-            class = std::enable_if_t< std::is_convertible_v<T, value_type> || std::is_convertible_v<value_type, T> >
-        >
+            class = std::enable_if_t<
+                std::is_convertible_v<T, value_type> || std::is_convertible_v<value_type, T>>>
         auto contains(const T& value) const -> bool;
 
     private:
@@ -415,7 +416,7 @@ namespace mamba::util
     }
 
     template <typename K, typename C, typename A>
-    template<class T, class>
+    template <class T, class>
     auto flat_set<K, C, A>::contains(const T& value) const -> bool
     {
         return std::binary_search(begin(), end(), value);

--- a/libmamba/include/mamba/util/flat_set.hpp
+++ b/libmamba/include/mamba/util/flat_set.hpp
@@ -112,7 +112,11 @@ namespace mamba::util
         auto erase(const_iterator first, const_iterator last) -> const_iterator;
         auto erase(const value_type& value) -> size_type;
 
-        auto contains(const value_type&) const -> bool;
+        template<class T,
+            // TODO: C++ >= 20 replace by concept
+            class = std::enable_if_t< std::is_convertible_v<T, value_type> || std::is_convertible_v<value_type, T> >
+        >
+        auto contains(const T& value) const -> bool;
 
     private:
 
@@ -411,7 +415,8 @@ namespace mamba::util
     }
 
     template <typename K, typename C, typename A>
-    auto flat_set<K, C, A>::contains(const value_type& value) const -> bool
+    template<class T, class>
+    auto flat_set<K, C, A>::contains(const T& value) const -> bool
     {
         return std::binary_search(begin(), end(), value);
     }

--- a/libmamba/src/solver/libsolv/database.cpp
+++ b/libmamba/src/solver/libsolv/database.cpp
@@ -195,7 +195,9 @@ namespace mamba::solver::libsolv
                     return RepoInfo{ p_repo.raw() };
                 }
             )
-            .or_else([&](const auto&) { pool().remove_repo(repo.id(), /* reuse_ids= */ true); });
+            .or_else([&](const auto&) {
+                pool().remove_repo(repo.id(), /* reuse_ids= */ true);
+            });
     }
 
     auto Database::add_repo_from_native_serialization(

--- a/libmamba/src/solver/libsolv/database.cpp
+++ b/libmamba/src/solver/libsolv/database.cpp
@@ -195,9 +195,7 @@ namespace mamba::solver::libsolv
                     return RepoInfo{ p_repo.raw() };
                 }
             )
-            .or_else([&](const auto&) {
-                pool().remove_repo(repo.id(), /* reuse_ids= */ true);
-            });
+            .or_else([&](const auto&) { pool().remove_repo(repo.id(), /* reuse_ids= */ true); });
     }
 
     auto Database::add_repo_from_native_serialization(

--- a/libmamba/src/solver/libsolv/helpers.cpp
+++ b/libmamba/src/solver/libsolv/helpers.cpp
@@ -168,10 +168,10 @@ namespace mamba::solver::libsolv
             }
         }
 
-        template<class SimdJSONValue>
+        template <class SimdJSONValue>
         std::optional<nlohmann::json> extract_signatures(std::optional<SimdJSONValue>& signatures)
         {
-            if (!signatures || signatures->error() )
+            if (!signatures || signatures->error())
             {
                 return {};
             }
@@ -182,7 +182,7 @@ namespace mamba::solver::libsolv
             return all_signatures;
         }
 
-        template<class JSONObject>
+        template <class JSONObject>
         [[nodiscard]] auto set_solvable(
             solv::ObjPool& pool,
             // const std::string& repo_url_str,
@@ -307,7 +307,9 @@ namespace mamba::solver::libsolv
                 {
                     if (!elem.error() && elem.is_string())
                     {
-                        if (const auto dep_id = pool.add_conda_dependency(std::string(elem.get_string().value_unsafe())))
+                        if (const auto dep_id = pool.add_conda_dependency(
+                                std::string(elem.get_string().value_unsafe())
+                            ))
                         {
                             solv.add_dependency(dep_id);
                         }
@@ -363,7 +365,7 @@ namespace mamba::solver::libsolv
             return true;
         }
 
-        template<class T>
+        template <class T>
         class showme;
 
         template <typename JSONObject, typename Filter, typename OnParsed>
@@ -382,7 +384,7 @@ namespace mamba::solver::libsolv
             auto packages_as_object = packages.get_object();
             for (auto pkg_field : packages_as_object)
             {
-                //showme<decltype(packages)> debug;
+                // showme<decltype(packages)> debug;
                 const std::string filename(pkg_field.unescaped_key().value());
                 if (filter(filename))
                 {
@@ -564,10 +566,13 @@ namespace mamba::solver::libsolv
 
         auto parser = simdjson::ondemand::parser();
         const auto lock = LockFile(filename);
-        const auto json_content = simdjson::padded_string::load(filename.string()); // must be kept alive while reading json
+        const auto json_content = simdjson::padded_string::load(filename.string());  // must be kept
+                                                                                     // alive while
+                                                                                     // reading json
         auto repodata_doc = parser.iterate(json_content);
 
-        const auto repodata_version = [&] {
+        const auto repodata_version = [&]
+        {
             if (auto version = repodata_doc["repodata_version"].get_int64(); !version.error())
             {
                 return version.value();
@@ -579,8 +584,9 @@ namespace mamba::solver::libsolv
         }();
 
 
-        auto info = [&]{
-            if(auto value = repodata_doc["info"]; !value.error())
+        auto info = [&]
+        {
+            if (auto value = repodata_doc["info"]; !value.error())
             {
                 if (auto object = value.get_object(); !object.error())
                 {
@@ -588,11 +594,11 @@ namespace mamba::solver::libsolv
                 }
             }
             return decltype(std::make_optional(repodata_doc["info"].get_object())){};
-
         }();
 
         // An override for missing package subdir is found at the top level
-        const auto default_subdir = [&]{
+        const auto default_subdir = [&]
+        {
             if (info)
             {
                 if (auto subdir = info.value()["subdir"]; !subdir.error())
@@ -607,7 +613,8 @@ namespace mamba::solver::libsolv
 
         // Get `base_url` in case 'repodata_version': 2
         // cf. https://github.com/conda-incubator/ceps/blob/main/cep-15.md
-        const auto base_url = [&] {
+        const auto base_url = [&]
+        {
             if (repodata_version == 2 && info)
             {
                 if (auto url = info.value()["base_url"]; !url.error())
@@ -623,7 +630,8 @@ namespace mamba::solver::libsolv
                                     .or_else([](specs::ParseError&& err) { throw std::move(err); })
                                     .value();
 
-        auto signatures = [&]{
+        auto signatures = [&]
+        {
             auto maybe_sigs = repodata_doc["signatures"];
             if (!maybe_sigs.error() && verify_artifacts)
             {

--- a/libmamba/src/solver/libsolv/helpers.cpp
+++ b/libmamba/src/solver/libsolv/helpers.cpp
@@ -164,7 +164,10 @@ namespace mamba::solver::libsolv
                         const std::string name(field.unescaped_key().value());
                         for (auto nested_dict : field.value())
                         {
-                            nested_sigs[name]["signature"] = nested_dict.value().get_string().value();
+                            if (!nested_dict.error() && nested_dict.is_string())
+                            {
+                                nested_sigs[name]["signature"] = nested_dict.value().get_string().value();
+                            }
                         }
                         glob_sigs["signatures"] = nested_sigs;
 

--- a/libmamba/src/solver/libsolv/helpers.cpp
+++ b/libmamba/src/solver/libsolv/helpers.cpp
@@ -194,9 +194,9 @@ namespace mamba::solver::libsolv
             solv.set_channel(channel_id);
 
             solv.set_file_name(filename);
-            if (auto fn = pkg["fn"].get_string(); !fn.error())
+            if (auto fn = pkg["fn"]; !fn.error())
             {
-                solv.set_name(fn.value_unsafe());
+                solv.set_name(fn.get_string().value_unsafe());
             }
             else
             {
@@ -204,9 +204,9 @@ namespace mamba::solver::libsolv
                 solv.set_file_name(filename);
             }
 
-            if (auto name = pkg["name"].get_string(); !name.error())
+            if (auto name = pkg["name"]; !name.error())
             {
-                solv.set_name(name.value_unsafe());
+                solv.set_name(name.get_string().value_unsafe());
             }
             else
             {
@@ -214,9 +214,9 @@ namespace mamba::solver::libsolv
                 return false;
             }
 
-            if (auto version = pkg["version"].get_string(); !version.error())
+            if (auto version = pkg["version"]; !version.error())
             {
-                solv.set_version(version.value_unsafe());
+                solv.set_version(version.get_string().value_unsafe());
             }
             else
             {
@@ -224,9 +224,9 @@ namespace mamba::solver::libsolv
                 return false;
             }
 
-            if (auto build_string = pkg["build"].get_string(); !build_string.error())
+            if (auto build_string = pkg["build"]; !build_string.error())
             {
-                solv.set_build_string(build_string.value_unsafe());
+                solv.set_build_string(build_string.get_string().value_unsafe());
             }
             else
             {
@@ -234,9 +234,9 @@ namespace mamba::solver::libsolv
                 return false;
             }
 
-            if (auto build_number = pkg["build_number"].get_uint64(); !build_number.error())
+            if (auto build_number = pkg["build_number"]; !build_number.error())
             {
-                solv.set_build_number(build_number.value_unsafe());
+                solv.set_build_number(build_number.get_uint64().value_unsafe());
             }
             else
             {
@@ -244,53 +244,53 @@ namespace mamba::solver::libsolv
                 return false;
             }
 
-            if (auto subdir = pkg["subdir"].get_string(); !subdir.error())
+            if (auto subdir = pkg["subdir"]; !subdir.error())
             {
-                solv.set_platform(std::string(subdir.value_unsafe()));
+                solv.set_platform(std::string(subdir.get_string().value_unsafe()));
             }
             else
             {
                 solv.set_platform(default_subdir);
             }
 
-            if (auto size = pkg["size"].get_uint64(); !size.error())
+            if (auto size = pkg["size"]; !size.error())
             {
-                solv.set_size(size.value_unsafe());
+                solv.set_size(size.get_uint64().value_unsafe());
             }
 
-            if (auto md5 = pkg["md5"].get_string(); !md5.error())
+            if (auto md5 = pkg["md5"]; !md5.error())
             {
-                solv.set_md5(std::string(md5.value_unsafe()));
+                solv.set_md5(std::string(md5.get_string().value_unsafe()));
             }
 
-            if (auto sha256 = pkg["sha256"].get_string(); !sha256.error())
+            if (auto sha256 = pkg["sha256"]; !sha256.error())
             {
-                solv.set_sha256(std::string(sha256.value_unsafe()));
+                solv.set_sha256(std::string(sha256.get_string().value_unsafe()));
             }
 
             if (auto elem = pkg["noarch"]; !elem.error())
             {
-                if (auto val = elem.get_bool(); !val.error() && val.value_unsafe())
+                if (auto noarch = elem.get_bool(); !noarch.error() && noarch.value_unsafe())
                 {
                     solv.set_noarch("generic");
                 }
-                else if (auto noarch = elem.get_string(); !noarch.error())
+                else if (elem.is_string())
                 {
-                    solv.set_noarch(std::string(noarch.value_unsafe()));
+                    solv.set_noarch(std::string(elem.get_string().value_unsafe()));
                 }
             }
 
-            if (auto license = pkg["license"].get_string(); !license.error())
+            if (auto license = pkg["license"]; !license.error())
             {
-                solv.set_license(std::string(license.value_unsafe()));
+                solv.set_license(std::string(license.get_string().value_unsafe()));
             }
 
             // TODO conda timestamp are not Unix timestamp.
             // Libsolv normalize them this way, we need to do the same here otherwise the current
             // package may get arbitrary priority.
-            if (auto timestamp = pkg["timestamp"].get_uint64(); !timestamp.error())
+            if (auto timestamp = pkg["timestamp"]; !timestamp.error())
             {
-                const auto time = timestamp.value_unsafe();
+                const auto time = timestamp.get_uint64().value_unsafe();
                 solv.set_timestamp((time > MAX_CONDA_TIMESTAMP) ? (time / 1000) : time);
             }
 
@@ -298,9 +298,9 @@ namespace mamba::solver::libsolv
             {
                 for (auto elem : depends)
                 {
-                    if (auto dep = elem.get_string(); !dep.error())
+                    if (elem.is_string())
                     {
-                        if (const auto dep_id = pool.add_conda_dependency(std::string(dep.value_unsafe())))
+                        if (const auto dep_id = pool.add_conda_dependency(std::string(elem.get_string().value_unsafe())))
                         {
                             solv.add_dependency(dep_id);
                         }
@@ -312,9 +312,11 @@ namespace mamba::solver::libsolv
             {
                 for (auto elem : constrains)
                 {
-                    if (auto cons = elem.get_string(); !cons.error())
+                    if (elem.is_string())
                     {
-                        if (const auto dep_id = pool.add_conda_dependency(std::string(cons.value_unsafe())))
+                        if (const auto dep_id = pool.add_conda_dependency(
+                                std::string(elem.get_string().value_unsafe())
+                            ))
                         {
                             solv.add_constraint(dep_id);
                         }
@@ -338,9 +340,9 @@ namespace mamba::solver::libsolv
                     // assuming obj is an array
                     for (auto elem : obj)
                     {
-                        if (auto feat = elem.get_string(); !feat.error())
+                        if (elem.is_string())
                         {
-                            solv.add_track_feature(feat.value_unsafe());
+                            solv.add_track_feature(elem.get_string().value_unsafe());
                         }
                     }
                 }
@@ -549,9 +551,9 @@ namespace mamba::solver::libsolv
 
         // An override for missing package subdir is found at the top level
         auto default_subdir = std::string();
-        if (auto subdir = repodata_doc["/info/subdir"].get_string(); !subdir.error())
+        if (auto subdir = repodata_doc["/info/subdir"]; !subdir.error())
         {
-            default_subdir = std::string(subdir.value_unsafe());
+            default_subdir = std::string(subdir.get_string().value_unsafe());
         }
 
 
@@ -563,9 +565,9 @@ namespace mamba::solver::libsolv
         {
             if (repodata_version.value_unsafe() == 2)
             {
-                if (auto url = repodata_doc["/info/base_url"].get_string(); !url.error())
+                if (auto url = repodata_doc["/info/base_url"]; !url.error())
                 {
-                    base_url = std::string(url.value_unsafe());
+                    base_url = std::string(url.get_string().value_unsafe());
                 }
             }
         }

--- a/libmamba/src/solver/libsolv/helpers.cpp
+++ b/libmamba/src/solver/libsolv/helpers.cpp
@@ -298,7 +298,7 @@ namespace mamba::solver::libsolv
             {
                 for (auto elem : depends)
                 {
-                    if (elem.is_string())
+                    if (!elem.error() && elem.is_string())
                     {
                         if (const auto dep_id = pool.add_conda_dependency(std::string(elem.get_string().value_unsafe())))
                         {
@@ -312,7 +312,7 @@ namespace mamba::solver::libsolv
             {
                 for (auto elem : constrains)
                 {
-                    if (elem.is_string())
+                    if (!elem.error() && elem.is_string())
                     {
                         if (const auto dep_id = pool.add_conda_dependency(
                                 std::string(elem.get_string().value_unsafe())
@@ -326,7 +326,7 @@ namespace mamba::solver::libsolv
 
             if (auto obj = pkg["track_features"]; !obj.error())
             {
-                if (obj.is_string())
+                if (!obj.error() && obj.is_string())
                 {
                     auto splits = lsplit_track_features(obj.get_string().value_unsafe());
                     while (!splits[0].empty())
@@ -340,7 +340,7 @@ namespace mamba::solver::libsolv
                     // assuming obj is an array
                     for (auto elem : obj)
                     {
-                        if (elem.is_string())
+                        if (!elem.error() && elem.is_string())
                         {
                             solv.add_track_feature(elem.get_string().value_unsafe());
                         }

--- a/libmamba/src/solver/libsolv/helpers.cpp
+++ b/libmamba/src/solver/libsolv/helpers.cpp
@@ -425,9 +425,9 @@ namespace mamba::solver::libsolv
             const std::string& default_subdir,
             simdjson::ondemand::object& packages,
             std::optional<simdjson::ondemand::object>& signatures
-        ) -> util::flat_set<std::string_view>
+        ) -> util::flat_set<std::string>
         {
-            auto filenames = std::vector<std::string_view>();
+            auto filenames = util::flat_set<std::string>();
             set_repo_solvables_impl(
                 pool,
                 repo,
@@ -438,12 +438,13 @@ namespace mamba::solver::libsolv
                 signatures,
                 /* filter= */ [](const auto&) { return true; },
                 /* on_parsed= */ [&](const auto& fn)
-                { filenames.push_back(specs::strip_archive_extension(fn)); }
+                { filenames.insert(std::string(specs::strip_archive_extension(fn))); }
             );
             // Sort only once
-            return util::flat_set<std::string_view>{ std::move(filenames) };
+            return filenames;
         }
 
+        template<class SortedStringRange>
         void set_repo_solvables_if_not_already_set(
             solv::ObjPool& pool,
             solv::ObjRepoView repo,
@@ -452,7 +453,7 @@ namespace mamba::solver::libsolv
             const std::string& default_subdir,
             simdjson::ondemand::object& packages,
             std::optional<simdjson::ondemand::object>& signatures,
-            const util::flat_set<std::string_view>& added
+            const SortedStringRange& added
         )
         {
             return set_repo_solvables_impl(
@@ -578,7 +579,7 @@ namespace mamba::solver::libsolv
 
         if (package_types == PackageTypes::CondaOrElseTarBz2)
         {
-            auto added = util::flat_set<std::string_view>();
+            auto added = util::flat_set<std::string>();
             if (auto pkgs = repodata_doc["packages.conda"].get_object(); !pkgs.error())
             {
                 added = set_repo_solvables_and_return_added_filename_stem(  //

--- a/libmamba/tests/src/util/test_flat_set.cpp
+++ b/libmamba/tests/src/util/test_flat_set.cpp
@@ -16,7 +16,7 @@ using namespace mamba::util;
 
 namespace
 {
-    TEST_CASE("constructor")
+    TEST_CASE("flat_set constructor")
     {
         const auto s1 = flat_set<int>();
         REQUIRE(s1.size() == 0);
@@ -35,7 +35,7 @@ namespace
         static_assert(std::is_same_v<decltype(s6)::value_type, decltype(s5)::value_type>);
     }
 
-    TEST_CASE("equality")
+    TEST_CASE("flat_set equality")
     {
         REQUIRE(flat_set<int>() == flat_set<int>());
         REQUIRE(flat_set<int>({ 1, 2 }) == flat_set<int>({ 1, 2 }));
@@ -45,7 +45,7 @@ namespace
         REQUIRE(flat_set<int>({ 2 }) != flat_set<int>({}));
     }
 
-    TEST_CASE("insert")
+    TEST_CASE("flat_set insert")
     {
         auto s = flat_set<int>();
         s.insert(33);
@@ -62,7 +62,7 @@ namespace
         REQUIRE(s == flat_set<int>({ 0, 17, 22, 33 }));
     }
 
-    TEST_CASE("insert conversion")
+    TEST_CASE("flat_set insert conversion")
     {
         auto s = flat_set<std::string>();
         const auto v = std::array<std::string_view, 2>{ "hello", "world" };
@@ -72,7 +72,7 @@ namespace
         REQUIRE(s.at(1) == "world");
     }
 
-    TEST_CASE("erase")
+    TEST_CASE("flat_set erase")
     {
         auto s = flat_set<int>{ 4, 3, 2, 1 };
         REQUIRE(s.erase(4) == 1);
@@ -85,19 +85,32 @@ namespace
         REQUIRE(s == flat_set<int>({ 2, 3 }));
     }
 
-    TEST_CASE("set_contains")
+    TEST_CASE("flat_set set_contains")
     {
-        const auto s = flat_set<int>({ 1, 3, 4, 5 });
-        REQUIRE_FALSE(s.contains(0));
-        REQUIRE(s.contains(1));
-        REQUIRE_FALSE(s.contains(2));
-        REQUIRE(s.contains(3));
-        REQUIRE(s.contains(4));
-        REQUIRE(s.contains(5));
-        REQUIRE_FALSE(s.contains(6));
+        {
+            const auto s = flat_set<int>({ 1, 3, 4, 5 });
+            REQUIRE_FALSE(s.contains(0));
+            REQUIRE(s.contains(1));
+            REQUIRE_FALSE(s.contains(2));
+            REQUIRE(s.contains(3));
+            REQUIRE(s.contains(4));
+            REQUIRE(s.contains(5));
+            REQUIRE_FALSE(s.contains(6));
+            REQUIRE_FALSE(s.contains(0.0));
+            REQUIRE(s.contains(1.0));
+            REQUIRE_FALSE(s.contains(10.0f));
+        }
+
+        {
+            const auto s = flat_set<std::string>{ "hello", "world" };
+            const std::string_view v = "hello";
+            const char* c = "world";
+            REQUIRE(s.contains(v));
+            REQUIRE(s.contains(c));
+        }
     }
 
-    TEST_CASE("key_compare")
+    TEST_CASE("flat_set key_compare")
     {
         auto s = flat_set({ 1, 3, 4, 5 }, std::greater{});
         REQUIRE(s.front() == 5);
@@ -106,7 +119,7 @@ namespace
         REQUIRE(s.front() == 6);
     }
 
-    TEST_CASE("Set operations")
+    TEST_CASE("flat_set Set operations")
     {
         const auto s1 = flat_set<int>({ 1, 3, 4, 5 });
         const auto s2 = flat_set<int>({ 3, 5 });


### PR DESCRIPTION
Running `main`'s `test_libmamba` executable currently allocates (but dont use) more than 5Gb when parsing 320Mb sized JSON files. This PR reduces this to around 2.5Gb. (observed using Visual Studio, in both Release and RelWithDebugInfo, also got some confirmation that this is observable on Linux)

- use the "on-demand" parser from simdjson instead of the "DOM" parser
- reorganize the parsing code to avoid reading json fields values more than once as this is required for proper behavior of the "on-demand" parser;
- improved `flat_set<T>` to allow `.contains(value)` where `value` has a different type than `T` but is still comparable.
