### PR TITLE
fix: precedence for rc files, CONDARC/MAMBARC env vars

### DIFF
--- a/docs/source/user_guide/configuration.rst
+++ b/docs/source/user_guide/configuration.rst
@@ -118,14 +118,27 @@ RC files have their own precedence order and use the same resolution process as 
         { root_prefix }/condarc
         { root_prefix }/condarc.d
         { root_prefix }/.mambarc
+
+	{ $XDG_CONFIG_HOME | ~/.config}/conda/.condarc
+	{ $XDG_CONFIG_HOME | ~/.config}/conda/condarc
+	{ $XDG_CONFIG_HOME | ~/.config}/condarc.d
         ~/.conda/.condarc
         ~/.conda/condarc
         ~/.conda/condarc.d
         ~/.condarc
+
+        { $XDG_CONFIG_HOME | ~/.config}/mamba/.mambarc
+        { $XDG_CONFIG_HOME | ~/.config}/mamba/mambarc
+	{ $XDG_CONFIG_HOME | ~/.config}/mamba/mambarc.d
+        ~/.mamba/.mambarc
+        ~/.mamba/mambarc
+        ~/.mamba/mambarc.d
         ~/.mambarc
+
         { target_prefix }/.condarc
         { target_prefix }/condarc
         { target_prefix }/condarc.d
         { target_prefix }/.mambarc
+
         $CONDARC,
         $MAMBARC;

--- a/libmamba/src/api/configuration.cpp
+++ b/libmamba/src/api/configuration.cpp
@@ -2030,9 +2030,10 @@ namespace mamba
                     not be considered as logs (see log_level).)")));
 
         // Config
+
+        // MAMBARC/CONDARC env dirs get parsed in target/root prefix hooks
         insert(Configurable("rc_files", std::vector<fs::u8path>({}))
                    .group("Config sources")
-                   .set_env_var_names({ "MAMBARC", "CONDARC" })
                    .needs({ "no_rc" })
                    .set_post_merge_hook<std::vector<fs::u8path>>(
                        [this](std::vector<fs::u8path>& value)
@@ -2093,12 +2094,6 @@ namespace mamba
     // Precedence is initially set least to most, and then at the end the list is reversed.
     // Configuration::set_rc_values iterates over all config options, and then over all config
     // file source. Essentially first come first serve.
-    // just FYI re "../conda": env::user_config_dir's default value is $XDG_CONFIG_HOME/mamba
-    // But we wanted to also allow $XDG_CONFIG_HOME/conda and '..' seems like the best way to
-    // make it conda/mamba compatible. Otherwise I would have to set user_config_dir to either
-    // be just $XDG_CONFIG_HOME and always supply mamba after calling it, or I would have to
-    // give env::user_config_dir a mamba argument, all so I can supply conda in a few default
-    // cases. It seems like ../conda is an easier solution
     //
     std::vector<fs::u8path>
     Configuration::compute_default_rc_sources(const Context& context, const RCConfigLevel& level)
@@ -2143,18 +2138,11 @@ namespace mamba
                 conda_user.push_back(fs::u8path(xgd_config_home) / "conda" / path);
             }
         }
-        if (util::get_env("CONDA_PREFIX"))
-        {
-            const std::string conda_prefix = util::get_env("CONDA_PREFIX").value();
-            for (const auto& path : condarc_list)
-            {
-                conda_user.push_back(fs::u8path(conda_prefix) / path);
-            }
-        }
 
+        std::vector<fs::u8path> env_var;
         if (util::get_env("CONDARC"))
         {
-            conda_user.push_back(fs::u8path(util::get_env("CONDARC").value()));
+            env_var.push_back(fs::u8path(util::get_env("CONDARC").value()));
         }
 
         std::vector<fs::u8path> mamba_user = {
@@ -2168,7 +2156,7 @@ namespace mamba
         };
         if (util::get_env("MAMBARC"))
         {
-            mamba_user.push_back(fs::u8path(util::get_env("MAMBARC").value()));
+            env_var.push_back(fs::u8path(util::get_env("MAMBARC").value()));
         }
 
         std::vector<fs::u8path> prefix = { context.prefix_params.target_prefix / ".condarc",
@@ -2216,6 +2204,7 @@ namespace mamba
             insertIntoSources(prefix);
         }
 
+        insertIntoSources(env_var);
         // Sort by precedence
         std::reverse(sources.begin(), sources.end());
 


### PR DESCRIPTION
This code changes the rc file precedence to match the documentation and fixes a bug where if CONDARC or MAMBARC were set that it was ignoring all other configuration files.

This should solve #3126 (~~and maybe #2135 and possibly even #3841- I need to check~~).