### PR TITLE
Make integration tests not rely on specific organisation of packages

### DIFF
--- a/micromamba/tests/helpers.py
+++ b/micromamba/tests/helpers.py
@@ -541,7 +541,7 @@ def create_with_chan_pkg(env_name, channels, package):
 
 
 class PackageChecker:
-    # Provides integrity checking operations for an installed package, based on it's manifest.
+    # Provides integrity checking operations for an installed package, based on its manifest.
 
     package_name: string
     install_prefix_root_dir: Path

--- a/micromamba/tests/helpers.py
+++ b/micromamba/tests/helpers.py
@@ -584,7 +584,7 @@ class PackageChecker:
             assert installed_file_path.is_file()
 
     def get_manifest_info(self) -> object:
-        # Look for and read the manifest file for the package and returns a dict with it's content.
+        # Look for and read the manifest file for the package and returns a dict with its content.
         # If the manifest file is not found or if opening it fails, an assertion will fail.
         if not hasattr(self, "_manifest_info") or not self._manifest_info:
             manifest_json_paths = list(self.manifests_dir.glob(f"{self.package_name}-*.*.*-*.json"))

--- a/micromamba/tests/helpers.py
+++ b/micromamba/tests/helpers.py
@@ -539,19 +539,20 @@ def create_with_chan_pkg(env_name, channels, package):
 
     return create(*cmd, default_channel=False, no_rc=False)
 
+
 class PackageChecker:
     # Provides integrity checking operations for an installed package, based on it's manifest.
 
-    package_name : string
+    package_name: string
     install_prefix_root_dir: Path
     manifests_dir: Path
 
+    _manifest_info: object
+    _manifest_json_path: Path
 
-    _manifest_info : object
-    _manifest_json_path : Path
-
-
-    def __init__(self, package_name: string, install_prefix_root_dir: Path, require_manifest: bool = True):
+    def __init__(
+        self, package_name: string, install_prefix_root_dir: Path, require_manifest: bool = True
+    ):
         # package_name : the name of the package to work with, without version or build name, for example 'xtensor'
         # install_prefix_root_dir : the absolute path to the directory in which the package should be installed and found
 
@@ -562,19 +563,23 @@ class PackageChecker:
         self.package_name = package_name
 
         assert install_prefix_root_dir
-        assert os.path.isdir(install_prefix_root_dir), f"not a directory or doesnt exist: {install_prefix_root_dir}"
+        assert os.path.isdir(install_prefix_root_dir), (
+            f"not a directory or doesnt exist: {install_prefix_root_dir}"
+        )
         self.install_prefix_root_dir = install_prefix_root_dir
 
         if require_manifest:
             self.manifests_dir = self.install_prefix_root_dir / "conda-meta"
-            assert os.path.isdir(self.manifests_dir), f"not a directory or doesnt exist: {self.manifests_dir}"
+            assert os.path.isdir(self.manifests_dir), (
+                f"not a directory or doesnt exist: {self.manifests_dir}"
+            )
 
     def check_install_integrity(self):
         # Checks that the manifest of the package is installed and checks that every file listed in it
         # exists. An assertion will fail otherwise.
         manifest_info = self.get_manifest_info()
 
-        for file in manifest_info['files']:
+        for file in manifest_info["files"]:
             installed_file_path = self.install_prefix_root_dir.joinpath(file)
             assert installed_file_path.is_file()
 
@@ -582,13 +587,12 @@ class PackageChecker:
         # Look for and read the manifest file for the package and returns a dict with it's content.
         # If the manifest file is not found or if opening it fails, an assertion will fail.
         if not hasattr(self, "_manifest_info") or not self._manifest_info:
-
             manifest_json_paths = list(self.manifests_dir.glob(f"{self.package_name}-*.*.*-*.json"))
             assert manifest_json_paths
             assert len(manifest_json_paths) == 1
 
             manifest_json_path = manifest_json_paths[0]
-            with open(manifest_json_path, 'r') as json_file:
+            with open(manifest_json_path) as json_file:
                 self._manifest_info = json.load(json_file)
 
         assert self._manifest_info
@@ -602,7 +606,7 @@ class PackageChecker:
         if self._require_manifest:
             manifest_info = self.get_manifest_info()
 
-            for file in manifest_info['files']:
+            for file in manifest_info["files"]:
                 if file.endswith(name_or_relative_path):
                     absolute_path = self.install_prefix_root_dir.joinpath(file).absolute()
                     assert absolute_path.exists()
@@ -618,4 +622,3 @@ class PackageChecker:
         # A name that matches what `get_concrete_pkg` would return: `package_name-X.Y.Z-build_number``
         manifest_info = self.get_manifest_info()
         return f"{manifest_info['name']}-{manifest_info['version']}-{manifest_info['build_string']}"
-

--- a/micromamba/tests/helpers.py
+++ b/micromamba/tests/helpers.py
@@ -599,7 +599,7 @@ class PackageChecker:
         return self._manifest_info
 
     def find_installed(self, name_or_relative_path: string) -> Path:
-        # Search in the manifest of the package a given file name or relative path that must have been installed.
+        # Searches in the manifest of the package a given file name or relative path that must have been installed.
         # Returns the absolute path to that file once found, or None if not found.
         # An assertion will fail if the file is found in the manifst but does not exist in the install directory.
 

--- a/micromamba/tests/test_activation.py
+++ b/micromamba/tests/test_activation.py
@@ -814,7 +814,7 @@ def test_unicode_activation(
             else:
                 include_dir = tmp_root_prefix / f"envs/{u}/include"
 
-            assert (include_dir / "xtensor/containers/xtensor.hpp").exists()
+            helpers.check_cpp_package_install("xtensor", u)
 
         # unicode activation on win: todo
         if plat == "win":

--- a/micromamba/tests/test_activation.py
+++ b/micromamba/tests/test_activation.py
@@ -807,14 +807,15 @@ def test_unicode_activation(
         call(s3)
 
         for u in [u1, u2, u3]:
-            assert (tmp_root_prefix / f"envs/{u}/conda-meta").is_dir()
-            assert (tmp_root_prefix / f"envs/{u}/conda-meta/history").exists()
+            install_prefix_root_dir = tmp_root_prefix / f"envs/{u}"
+            assert (install_prefix_root_dir/"conda-meta").is_dir()
+            assert (install_prefix_root_dir/"conda-meta/history").exists()
             if plat == "win":
-                include_dir = tmp_root_prefix / f"envs/{u}/Library/include"
+                include_dir = install_prefix_root_dir/"Library/include"
             else:
-                include_dir = tmp_root_prefix / f"envs/{u}/include"
-
-            helpers.check_cpp_package_install("xtensor", u)
+                include_dir = install_prefix_root_dir/"include"
+            assert include_dir.is_dir()
+            helpers.PackageChecker("xtensor", install_prefix_root_dir).check_install_integrity()
 
         # unicode activation on win: todo
         if plat == "win":

--- a/micromamba/tests/test_activation.py
+++ b/micromamba/tests/test_activation.py
@@ -808,12 +808,12 @@ def test_unicode_activation(
 
         for u in [u1, u2, u3]:
             install_prefix_root_dir = tmp_root_prefix / f"envs/{u}"
-            assert (install_prefix_root_dir/"conda-meta").is_dir()
-            assert (install_prefix_root_dir/"conda-meta/history").exists()
+            assert (install_prefix_root_dir / "conda-meta").is_dir()
+            assert (install_prefix_root_dir / "conda-meta/history").exists()
             if plat == "win":
-                include_dir = install_prefix_root_dir/"Library/include"
+                include_dir = install_prefix_root_dir / "Library/include"
             else:
-                include_dir = install_prefix_root_dir/"include"
+                include_dir = install_prefix_root_dir / "include"
             assert include_dir.is_dir()
             helpers.PackageChecker("xtensor", install_prefix_root_dir).check_install_integrity()
 

--- a/micromamba/tests/test_create.py
+++ b/micromamba/tests/test_create.py
@@ -583,8 +583,8 @@ def test_classic_specs(tmp_home, tmp_root_prefix, tmp_path, outside_root_prefix)
 
     if helpers.dry_run_tests == helpers.DryRun.OFF:
         pkg_name = helpers.get_concrete_pkg(res, "xtensor")
-        cached_file = tmp_pkgs_dirs / pkg_name / helpers.xtensor_hpp
-        assert cached_file.exists()
+        pkg_name_checked = helpers.check_cpp_package_install("xtensor", p)
+        assert pkg_name == pkg_name_checked
 
 
 @pytest.mark.parametrize("output_flag", ["", "--json", "--quiet"])

--- a/micromamba/tests/test_create.py
+++ b/micromamba/tests/test_create.py
@@ -583,8 +583,8 @@ def test_classic_specs(tmp_home, tmp_root_prefix, tmp_path, outside_root_prefix)
 
     if helpers.dry_run_tests == helpers.DryRun.OFF:
         pkg_name = helpers.get_concrete_pkg(res, "xtensor")
-        pkg_name_checked = helpers.check_cpp_package_install("xtensor", p)
-        assert pkg_name == pkg_name_checked
+        pkg_checker = helpers.PackageChecker("xtensor", p)
+        assert pkg_name == pkg_checker.get_name_version_build()
 
 
 @pytest.mark.parametrize("output_flag", ["", "--json", "--quiet"])

--- a/micromamba/tests/test_install.py
+++ b/micromamba/tests/test_install.py
@@ -415,10 +415,9 @@ class TestInstall:
 
             if not helpers.dry_run_tests:
                 pkg_name = helpers.get_concrete_pkg(res, "xtensor")
-                orig_file_path = helpers.get_pkg(
-                    pkg_name, helpers.xtensor_hpp, TestInstall.current_root_prefix
-                )
-                assert orig_file_path.exists()
+                checker = helpers.PackageChecker("xtensor", TestInstall.current_root_prefix)
+                checker.check_install_integrity()
+                assert checker.get_name_version_build() == pkg_name
 
     @pytest.mark.skipif(
         helpers.dry_run_tests is helpers.DryRun.ULTRA_DRY,

--- a/micromamba/tests/test_linking.py
+++ b/micromamba/tests/test_linking.py
@@ -9,10 +9,8 @@ import pytest
 from .helpers import *  # noqa: F403
 from . import helpers
 
-if platform.system() == "Windows":
-    xtensor_hpp = "Library/include/xtensor/containers/xtensor.hpp"
-else:
-    xtensor_hpp = "include/xtensor/containers/xtensor.hpp"
+package_to_test = "xtensor"
+file_in_package_to_test = "xtensor.hpp"
 
 
 class TestLinking:
@@ -41,32 +39,40 @@ class TestLinking:
             helpers.rmtree(TestLinking.prefix)
 
     def test_link(self, existing_cache, test_pkg):
-        helpers.create("xtensor", "-n", TestLinking.env_name, "--json", no_dry_run=True)
+        helpers.create(package_to_test, "-n", TestLinking.env_name, "--json", no_dry_run=True)
 
-        linked_file = helpers.get_env(TestLinking.env_name, xtensor_hpp)
-        assert linked_file.exists()
-        assert not linked_file.is_symlink()
+        install_env_dir = helpers.get_env(TestLinking.env_name)
+        pkg_checker = helpers.PackageChecker(package_to_test, install_env_dir)
+        linked_file_path = pkg_checker.find_installed(file_in_package_to_test)
+        assert linked_file_path
+        assert linked_file_path.exists()
+        assert not linked_file_path.is_symlink()
 
-        cache_file = existing_cache / test_pkg / xtensor_hpp
-        assert cache_file.stat().st_dev == linked_file.stat().st_dev
-        assert cache_file.stat().st_ino == linked_file.stat().st_ino
+        linked_file_rel_path = linked_file_path.relative_to(install_env_dir)
+        cache_file = existing_cache / test_pkg / linked_file_rel_path
+        assert cache_file.stat().st_dev == linked_file_path.stat().st_dev
+        assert cache_file.stat().st_ino == linked_file_path.stat().st_ino
 
     def test_copy(self, existing_cache, test_pkg):
         helpers.create(
-            "xtensor",
+            package_to_test,
             "-n",
             TestLinking.env_name,
             "--json",
             "--always-copy",
             no_dry_run=True,
         )
-        linked_file = helpers.get_env(TestLinking.env_name, xtensor_hpp)
-        assert linked_file.exists()
-        assert not linked_file.is_symlink()
+        install_env_dir = helpers.get_env(TestLinking.env_name)
+        pkg_checker = helpers.PackageChecker(package_to_test, install_env_dir)
+        linked_file_path = pkg_checker.find_installed(file_in_package_to_test)
+        assert linked_file_path
+        assert linked_file_path.exists()
+        assert not linked_file_path.is_symlink()
 
-        cache_file = existing_cache / test_pkg / xtensor_hpp
-        assert cache_file.stat().st_dev == linked_file.stat().st_dev
-        assert cache_file.stat().st_ino != linked_file.stat().st_ino
+        linked_file_rel_path = linked_file_path.relative_to(install_env_dir)
+        cache_file = existing_cache / test_pkg / linked_file_rel_path
+        assert cache_file.stat().st_dev == linked_file_path.stat().st_dev
+        assert cache_file.stat().st_ino != linked_file_path.stat().st_ino
 
     @pytest.mark.skipif(
         platform.system() == "Windows",
@@ -74,23 +80,26 @@ class TestLinking:
     )
     def test_always_softlink(self, existing_cache, test_pkg):
         helpers.create(
-            "xtensor",
+            package_to_test,
             "-n",
             TestLinking.env_name,
             "--json",
             "--always-softlink",
             no_dry_run=True,
         )
-        linked_file = helpers.get_env(TestLinking.env_name, xtensor_hpp)
+        install_env_dir = helpers.get_env(TestLinking.env_name)
+        pkg_checker = helpers.PackageChecker(package_to_test, install_env_dir)
+        linked_file_path = pkg_checker.find_installed(file_in_package_to_test)
+        assert linked_file_path
+        assert linked_file_path.exists()
+        assert linked_file_path.is_symlink()
 
-        assert linked_file.exists()
-        assert linked_file.is_symlink()
+        linked_file_rel_path = linked_file_path.relative_to(install_env_dir)
+        cache_file = existing_cache / test_pkg / linked_file_rel_path
 
-        cache_file = existing_cache / test_pkg / xtensor_hpp
-
-        assert cache_file.stat().st_dev == linked_file.stat().st_dev
-        assert cache_file.stat().st_ino == linked_file.stat().st_ino
-        assert os.readlink(linked_file) == str(cache_file)
+        assert cache_file.stat().st_dev == linked_file_path.stat().st_dev
+        assert cache_file.stat().st_ino == linked_file_path.stat().st_ino
+        assert os.readlink(linked_file_path) == str(cache_file)
 
     @pytest.mark.parametrize("allow_softlinks", [True, False])
     @pytest.mark.parametrize("always_copy", [True, False])
@@ -98,7 +107,7 @@ class TestLinking:
         if platform.system() != "Linux":
             pytest.skip("o/s is not linux")
 
-        create_args = ["xtensor", "-n", TestLinking.env_name, "--json"]
+        create_args = [package_to_test, "-n", TestLinking.env_name, "--json"]
         if allow_softlinks:
             create_args.append("--allow-softlinks")
         if always_copy:
@@ -109,23 +118,29 @@ class TestLinking:
         is_softlink = not same_device and allow_softlinks and not always_copy
         is_hardlink = same_device and not always_copy
 
-        linked_file = helpers.get_env(TestLinking.env_name, xtensor_hpp)
-        assert linked_file.exists()
+        install_env_dir = helpers.get_env(TestLinking.env_name)
+        pkg_checker = helpers.PackageChecker(package_to_test, install_env_dir)
+        linked_file_path = pkg_checker.find_installed(file_in_package_to_test)
+        assert linked_file_path
+        assert linked_file_path.exists()
 
-        cache_file = existing_cache / test_pkg / xtensor_hpp
-        assert cache_file.stat().st_dev == linked_file.stat().st_dev
-        assert (cache_file.stat().st_ino == linked_file.stat().st_ino) == is_hardlink
-        assert linked_file.is_symlink() == is_softlink
+        linked_file_rel_path = linked_file_path.relative_to(install_env_dir)
+        cache_file = existing_cache / test_pkg / linked_file_rel_path
+        assert cache_file.stat().st_dev == linked_file_path.stat().st_dev
+        assert (cache_file.stat().st_ino == linked_file_path.stat().st_ino) == is_hardlink
+        assert linked_file_path.is_symlink() == is_softlink
 
     def test_unlink_missing_file(self):
-        helpers.create("xtensor", "-n", TestLinking.env_name, "--json", no_dry_run=True)
+        helpers.create(package_to_test, "-n", TestLinking.env_name, "--json", no_dry_run=True)
 
-        linked_file = helpers.get_env(TestLinking.env_name, xtensor_hpp)
-        assert linked_file.exists()
-        assert not linked_file.is_symlink()
+        pkg_checker = helpers.PackageChecker(package_to_test, helpers.get_env(TestLinking.env_name))
+        linked_file_path = pkg_checker.find_installed(file_in_package_to_test)
+        assert linked_file_path
+        assert linked_file_path.exists()
+        assert not linked_file_path.is_symlink()
 
-        os.remove(linked_file)
-        helpers.remove("xtensor", "-n", TestLinking.env_name)
+        os.remove(linked_file_path)
+        helpers.remove(package_to_test, "-n", TestLinking.env_name)
 
     @pytest.mark.skipif(
         sys.platform == "darwin" and platform.machine() == "arm64",

--- a/micromamba/tests/test_pkg_cache.py
+++ b/micromamba/tests/test_pkg_cache.py
@@ -13,6 +13,7 @@ from . import helpers
 package_to_check = "xtensor"
 file_to_find_in_package = "xtensor.hpp"
 
+
 def find_cache_archive(cache: Path, pkg_name: str) -> Optional[Path]:
     """Find the archive used in cache from the complete build name."""
     tar_bz2 = cache / f"{pkg_name}.tar.bz2"
@@ -84,12 +85,16 @@ def tmp_cache_test_pkg(tmp_cache: Path) -> Path:
 @pytest.fixture
 def tmp_cache_file_in_test_package(tmp_cache_test_package_dir: Path) -> Path:
     """The location of the file in the package to test within the cache directory."""
-    pkg_checker = helpers.PackageChecker(package_to_check, tmp_cache_test_package_dir, require_manifest=False)
+    pkg_checker = helpers.PackageChecker(
+        package_to_check, tmp_cache_test_package_dir, require_manifest=False
+    )
     return pkg_checker.find_installed(file_to_find_in_package)
 
 
 class TestPkgCache:
-    def test_extracted_file_deleted(self, tmp_home, tmp_cache_file_in_test_package, tmp_root_prefix):
+    def test_extracted_file_deleted(
+        self, tmp_home, tmp_cache_file_in_test_package, tmp_root_prefix
+    ):
         old_ino = tmp_cache_file_in_test_package.stat().st_ino
         os.remove(tmp_cache_file_in_test_package)
 
@@ -330,7 +335,9 @@ class TestMultiplePkgCaches:
     def test_no_writable_extracted_dir_corrupted(self, tmp_home, tmp_root_prefix, tmp_cache):
         old_cache_dir = tmp_cache / find_pkg_build(tmp_cache, package_to_check)
         if old_cache_dir.is_dir():
-            files = glob.glob(f"**{file_to_find_in_package}", recursive=True, root_dir=old_cache_dir)
+            files = glob.glob(
+                f"**{file_to_find_in_package}", recursive=True, root_dir=old_cache_dir
+            )
             for file in files:
                 file.unlink()
         helpers.recursive_chmod(tmp_cache, 0o500)
@@ -562,7 +569,6 @@ class TestMultiplePkgCaches:
         # check extracted dir
         assert (tmp_cache / test_pkg_bld).exists()
         assert not (tmp_cache_alt / test_pkg_bld).exists()
-
 
         linked_file_rel_path = linked_file.relative_to(install_env_dir)
         non_writable_cache_file = tmp_cache / test_pkg_bld / linked_file_rel_path


### PR DESCRIPTION
This PR changes the mamba/micromamba integration tests to not (or less) rely on knowledge of how some packages (usually `xtensor`) are organized to check that operations are producing the expected output (package files are installed correctly, as files or links etc.)
The need came because of these integration tests failing suddenly after an `xtensor` package's release where file organisation changed, for example `xtensor.hpp` wasnt anymore in the root `include/xtensor/` directory but somewhere else, breaking the tests that were looking for this specific file in the install at a location only valid on previous versions. This kind of change in file organization of a package are not only legitimate but expected for long-term maintenance and usually advertised through semantic versioning and release notes.

To make these tests less reliant upon this kind of change, this pr:
- remove attempts to locate a specific file with a specific path in the install (usually `xtensor.hpp`) and instead provides ways to search that file in the install directory, either using the package's manifest info (validating the integrity of the install, if the file is where the manifest says it should be) or through file search (when it's installed without an available manifest, which occurs when testing the cache, see `test_pkg_cache.py`)
- provides tooling for doing all that and for checking the integrity of an installed package on-demand by comparing what the manifest says files should exist and their actual location
- applies these changes for the main breaking places;

More improvements in that direction could be made but I stopped where I could run the tests after deleting `helpers.xtensor_hpp`. Most of the following improvements would be renamings of references to `xtensor` for more generic names, as these tests should be able to wokr whatever the package we are testing.