### PR TITLE
hotfix: in integration tests assume xtensor is v0.26

### DIFF
--- a/micromamba/tests/helpers.py
+++ b/micromamba/tests/helpers.py
@@ -56,7 +56,7 @@ def lib_prefix() -> Path:
     return Path("")
 
 
-xtensor_hpp = lib_prefix() / "include/xtensor/xtensor.hpp"
+xtensor_hpp = lib_prefix() / "include/xtensor/containers/xtensor.hpp"
 xsimd_hpp = lib_prefix() / "include/xsimd/xsimd.hpp"
 
 

--- a/micromamba/tests/test_activation.py
+++ b/micromamba/tests/test_activation.py
@@ -814,7 +814,7 @@ def test_unicode_activation(
             else:
                 include_dir = tmp_root_prefix / f"envs/{u}/include"
 
-            assert (include_dir / "xtensor/xtensor.hpp").exists()
+            assert (include_dir / "xtensor/containers/xtensor.hpp").exists()
 
         # unicode activation on win: todo
         if plat == "win":

--- a/micromamba/tests/test_linking.py
+++ b/micromamba/tests/test_linking.py
@@ -10,9 +10,9 @@ from .helpers import *  # noqa: F403
 from . import helpers
 
 if platform.system() == "Windows":
-    xtensor_hpp = "Library/include/xtensor/xtensor.hpp"
+    xtensor_hpp = "Library/include/xtensor/containers/xtensor.hpp"
 else:
-    xtensor_hpp = "include/xtensor/xtensor.hpp"
+    xtensor_hpp = "include/xtensor/containers/xtensor.hpp"
 
 
 class TestLinking:


### PR DESCRIPTION
This is temporary for unlocking ci passes, a better fix would be #3891 but a more general fix would be #3897 which are still WIP at this point.