### PR TITLE
Avoid ODR violation for `type_caster<mamba::fs::u8path>`

### DIFF
--- a/libmambapy/src/libmambapy/bindings/path_caster.hpp
+++ b/libmambapy/src/libmambapy/bindings/path_caster.hpp
@@ -4,27 +4,13 @@
 //
 // The full license is in the file LICENSE, distributed with this software.
 
+#ifndef LIBMAMBAPY_PATH_CASTER_HPP
+#define LIBMAMBAPY_PATH_CASTER_HPP
+
 #include <pybind11/pybind11.h>
 #include <pybind11/stl/filesystem.h>
 
 #include "mamba/fs/filesystem.hpp"
-
-// The ODR warning occurs because pybind11's type_caster is defined in multiple translation units.
-// This is unavoidable because:
-//
-// 1. The `type_caster` specialization must be defined in a header file to be available to all
-// translation units
-// 2. pybind11's own type_caster is defined in `cast.h` which is included in multiple places
-// 3. We cannot make the specialization inline or move it to a source file without breaking
-// pybind11's type system.
-//
-// Therefore, we silence the warning as it's a false positive in this case -
-// the definitions are identical.
-
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wodr"
-#endif
 
 namespace PYBIND11_NAMESPACE
 {
@@ -37,6 +23,4 @@ namespace PYBIND11_NAMESPACE
     }
 }
 
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
 #endif

--- a/libmambapy/src/libmambapy/bindings/path_caster.hpp
+++ b/libmambapy/src/libmambapy/bindings/path_caster.hpp
@@ -9,6 +9,23 @@
 
 #include "mamba/fs/filesystem.hpp"
 
+// The ODR warning occurs because pybind11's type_caster is defined in multiple translation units.
+// This is unavoidable because:
+//
+// 1. The `type_caster` specialization must be defined in a header file to be available to all
+// translation units
+// 2. pybind11's own type_caster is defined in `cast.h` which is included in multiple places
+// 3. We cannot make the specialization inline or move it to a source file without breaking
+// pybind11's type system.
+//
+// Therefore, we silence the warning as it's a false positive in this case -
+// the definitions are identical.
+
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wodr"
+#endif
+
 namespace PYBIND11_NAMESPACE
 {
     namespace detail
@@ -19,3 +36,7 @@ namespace PYBIND11_NAMESPACE
         };
     }
 }
+
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif

--- a/libmambapy/src/libmambapy/bindings/specs.cpp
+++ b/libmambapy/src/libmambapy/bindings/specs.cpp
@@ -26,6 +26,7 @@
 #include "bindings.hpp"
 #include "expected_caster.hpp"
 #include "flat_set_caster.hpp"
+#include "path_caster.hpp"
 #include "weakening_map_bind.hpp"
 
 using OldVersionPart = std::vector<mamba::specs::VersionPartAtom>;

--- a/libmambapy/src/libmambapy/bindings/utils.cpp
+++ b/libmambapy/src/libmambapy/bindings/utils.cpp
@@ -13,6 +13,7 @@
 #include <pybind11/stl_bind.h>
 
 #include "bind_utils.hpp"
+#include "path_caster.hpp"
 
 namespace mambapy
 {


### PR DESCRIPTION
Resolve the ODR violation causing this warning:

```
.../mamba/libmambapy/src/libmambapy/bindings/path_caster.hpp:17:16: warning: type 'struct type_caster' violates the C++ One Definition Rule [-Wodr]
   17 |         struct type_caster<mamba::fs::u8path> : path_caster<mamba::fs::u8path>
      |                ^
.../include/pybind11/cast.h:38:7: note: a type with different bases is defined in another translation unit
   38 | class type_caster : public type_caster_base<type> {};
      |       ^
```