### PR TITLE
Make `self-update` a command for micromamba only

### DIFF
--- a/micromamba/CMakeLists.txt
+++ b/micromamba/CMakeLists.txt
@@ -68,6 +68,10 @@ macro(mambaexe_create_target target_name linkage output_name)
     mamba_target_set_lto(${target_name} MODE ${MAMBA_LTO})
     set_property(TARGET ${target_name} PROPERTY CXX_STANDARD 17)
 
+    if(${target_name} STREQUAL "micromamba")
+        target_compile_definitions(${target_name} PRIVATE BUILDING_MICROMAMBA)
+    endif()
+
     target_link_libraries(${target_name} PRIVATE Threads::Threads reproc reproc++)
 
     # Static build

--- a/micromamba/CMakeLists.txt
+++ b/micromamba/CMakeLists.txt
@@ -68,10 +68,6 @@ macro(mambaexe_create_target target_name linkage output_name)
     mamba_target_set_lto(${target_name} MODE ${MAMBA_LTO})
     set_property(TARGET ${target_name} PROPERTY CXX_STANDARD 17)
 
-    if(${target_name} STREQUAL "micromamba")
-        target_compile_definitions(${target_name} PRIVATE BUILDING_MICROMAMBA)
-    endif()
-
     target_link_libraries(${target_name} PRIVATE Threads::Threads reproc reproc++)
 
     # Static build
@@ -106,6 +102,7 @@ endif()
 if(BUILD_STATIC)
     message(STATUS "Adding executable micromamba")
     mambaexe_create_target(micromamba STATIC micromamba)
+    target_compile_definitions(micromamba PRIVATE BUILDING_MICROMAMBA)
 endif()
 
 # Installation

--- a/micromamba/src/umamba.cpp
+++ b/micromamba/src/umamba.cpp
@@ -51,8 +51,10 @@ set_umamba_command(CLI::App* com, mamba::Configuration& config)
     CLI::App* update_subcom = com->add_subcommand("update", "Update packages in active environment");
     set_update_command(update_subcom, config);
 
+#ifdef BUILDING_MICROMAMBA
     CLI::App* self_update_subcom = com->add_subcommand("self-update", "Update micromamba");
     set_self_update_command(self_update_subcom, config);
+#endif
 
     CLI::App* repoquery_subcom = com->add_subcommand(
         "repoquery",

--- a/micromamba/src/umamba.hpp
+++ b/micromamba/src/umamba.hpp
@@ -52,8 +52,10 @@ set_umamba_command(CLI::App* com, mamba::Configuration& config);
 void
 set_update_command(CLI::App* subcom, mamba::Configuration& config);
 
+#ifdef BUILDING_MICROMAMBA
 void
 set_self_update_command(CLI::App* subcom, mamba::Configuration& config);
+#endif
 
 void
 set_repoquery_search_command(CLI::App* subcmd, mamba::Configuration& config);

--- a/micromamba/tests/test_activation.py
+++ b/micromamba/tests/test_activation.py
@@ -901,6 +901,10 @@ def tmp_umamba():
     os.chmod(mamba_exe, 0o755)
 
 
+@pytest.mark.skipif(
+    "micromamba" not in Path(helpers.get_umamba()).stem,
+    reason="micromamba-only test",
+)
 @pytest.mark.parametrize("shared_pkgs_dirs", [True], indirect=True)
 @pytest.mark.parametrize("interpreter", get_self_update_interpreters())
 def test_self_update(


### PR DESCRIPTION
Fix https://github.com/conda-forge/miniforge/issues/769.

With those changes:
```bash
./build/micromamba/micromamba --help | grep update
    42:   update                      Update packages in active environment 
    43:   self-update                 Update micromamba 
```
but
```bash
./build/micromamba/mamba --help | grep update 
    42:   update                      Update packages in active environment 
```