### PR TITLE
Matchspec hardening

### DIFF
--- a/libmamba/include/mamba/core/context.hpp
+++ b/libmamba/include/mamba/core/context.hpp
@@ -17,6 +17,7 @@
 #include "mamba/core/tasksync.hpp"
 #include "mamba/download/mirror_map.hpp"
 #include "mamba/fs/filesystem.hpp"
+#include "mamba/solver/libsolv/parameters.hpp"
 #include "mamba/solver/request.hpp"
 #include "mamba/specs/authentication_info.hpp"
 #include "mamba/specs/platform.hpp"
@@ -146,6 +147,7 @@ namespace mamba
         // Configurable
         bool experimental = false;
         bool experimental_repodata_parsing = true;
+        bool experimental_matchspec_parsing = false;
         bool debug = false;
 
         // TODO check writable and add other potential dirs

--- a/libmamba/include/mamba/solver/libsolv/database.hpp
+++ b/libmamba/include/mamba/solver/libsolv/database.hpp
@@ -75,7 +75,8 @@ namespace mamba::solver::libsolv
             PipAsPythonDependency add = PipAsPythonDependency::No,
             PackageTypes package_types = PackageTypes::CondaOrElseTarBz2,
             VerifyPackages verify_packages = VerifyPackages::No,
-            RepodataParser parser = RepodataParser::Mamba
+            RepodataParser repo_parser = RepodataParser::Mamba,
+            MatchSpecParser ms_parser = MatchSpecParser::Libsolv
         ) -> expected_t<RepoInfo>;
 
         auto add_repo_from_native_serialization(
@@ -90,14 +91,16 @@ namespace mamba::solver::libsolv
             Iter first_package,
             Iter last_package,
             std::string_view name = "",
-            PipAsPythonDependency add = PipAsPythonDependency::No
+            PipAsPythonDependency add = PipAsPythonDependency::No,
+            MatchSpecParser ms_parser = MatchSpecParser::Libsolv
         ) -> RepoInfo;
 
         template <typename Range>
         auto add_repo_from_packages(
             const Range& packages,
             std::string_view name = "",
-            PipAsPythonDependency add = PipAsPythonDependency::No
+            PipAsPythonDependency add = PipAsPythonDependency::No,
+            MatchSpecParser ms_parser = MatchSpecParser::Libsolv
         ) -> RepoInfo;
 
         auto
@@ -151,7 +154,11 @@ namespace mamba::solver::libsolv
         [[nodiscard]] auto pool() const -> const solv::ObjPool&;
 
         auto add_repo_from_packages_impl_pre(std::string_view name) -> RepoInfo;
-        void add_repo_from_packages_impl_loop(const RepoInfo& repo, const specs::PackageInfo& pkg);
+        void add_repo_from_packages_impl_loop(
+            const RepoInfo& repo,
+            const specs::PackageInfo& pkg,
+            MatchSpecParser ms_parser
+        );
         void add_repo_from_packages_impl_post(const RepoInfo& repo, PipAsPythonDependency add);
 
         enum class PackageId : int;
@@ -176,24 +183,28 @@ namespace mamba::solver::libsolv
         Iter first_package,
         Iter last_package,
         std::string_view name,
-        PipAsPythonDependency add
+        PipAsPythonDependency add,
+        MatchSpecParser ms_parser
     ) -> RepoInfo
     {
         auto repo = add_repo_from_packages_impl_pre(name);
         for (; first_package != last_package; ++first_package)
         {
-            add_repo_from_packages_impl_loop(repo, *first_package);
+            add_repo_from_packages_impl_loop(repo, *first_package, ms_parser);
         }
         add_repo_from_packages_impl_post(repo, add);
         return repo;
     }
 
     template <typename Range>
-    auto
-    Database::add_repo_from_packages(const Range& packages, std::string_view name, PipAsPythonDependency add)
-        -> RepoInfo
+    auto Database::add_repo_from_packages(
+        const Range& packages,
+        std::string_view name,
+        PipAsPythonDependency add,
+        MatchSpecParser ms_parser
+    ) -> RepoInfo
     {
-        return add_repo_from_packages(packages.begin(), packages.end(), name, add);
+        return add_repo_from_packages(packages.begin(), packages.end(), name, add, ms_parser);
     }
 
     // TODO(C++20): Use ranges::transform

--- a/libmamba/include/mamba/solver/libsolv/database.hpp
+++ b/libmamba/include/mamba/solver/libsolv/database.hpp
@@ -53,9 +53,18 @@ namespace mamba::solver::libsolv
     {
     public:
 
+        /**
+         * Global Database settings.
+         */
+        struct Settings
+        {
+            MatchSpecParser matchspec_parser = MatchSpecParser::Libsolv;
+        };
+
         using logger_type = std::function<void(LogLevel, std::string_view)>;
 
         explicit Database(specs::ChannelResolveParams channel_params);
+        Database(specs::ChannelResolveParams channel_params, Settings settings);
         Database(const Database&) = delete;
         Database(Database&&);
 
@@ -66,6 +75,8 @@ namespace mamba::solver::libsolv
 
         [[nodiscard]] auto channel_params() const -> const specs::ChannelResolveParams&;
 
+        [[nodiscard]] auto settings() const -> const Settings&;
+
         void set_logger(logger_type callback);
 
         auto add_repo_from_repodata_json(
@@ -75,8 +86,7 @@ namespace mamba::solver::libsolv
             PipAsPythonDependency add = PipAsPythonDependency::No,
             PackageTypes package_types = PackageTypes::CondaOrElseTarBz2,
             VerifyPackages verify_packages = VerifyPackages::No,
-            RepodataParser repo_parser = RepodataParser::Mamba,
-            MatchSpecParser ms_parser = MatchSpecParser::Libsolv
+            RepodataParser repo_parser = RepodataParser::Mamba
         ) -> expected_t<RepoInfo>;
 
         auto add_repo_from_native_serialization(
@@ -91,16 +101,14 @@ namespace mamba::solver::libsolv
             Iter first_package,
             Iter last_package,
             std::string_view name = "",
-            PipAsPythonDependency add = PipAsPythonDependency::No,
-            MatchSpecParser ms_parser = MatchSpecParser::Libsolv
+            PipAsPythonDependency add = PipAsPythonDependency::No
         ) -> RepoInfo;
 
         template <typename Range>
         auto add_repo_from_packages(
             const Range& packages,
             std::string_view name = "",
-            PipAsPythonDependency add = PipAsPythonDependency::No,
-            MatchSpecParser ms_parser = MatchSpecParser::Libsolv
+            PipAsPythonDependency add = PipAsPythonDependency::No
         ) -> RepoInfo;
 
         auto
@@ -154,11 +162,7 @@ namespace mamba::solver::libsolv
         [[nodiscard]] auto pool() const -> const solv::ObjPool&;
 
         auto add_repo_from_packages_impl_pre(std::string_view name) -> RepoInfo;
-        void add_repo_from_packages_impl_loop(
-            const RepoInfo& repo,
-            const specs::PackageInfo& pkg,
-            MatchSpecParser ms_parser
-        );
+        void add_repo_from_packages_impl_loop(const RepoInfo& repo, const specs::PackageInfo& pkg);
         void add_repo_from_packages_impl_post(const RepoInfo& repo, PipAsPythonDependency add);
 
         enum class PackageId : int;
@@ -183,28 +187,24 @@ namespace mamba::solver::libsolv
         Iter first_package,
         Iter last_package,
         std::string_view name,
-        PipAsPythonDependency add,
-        MatchSpecParser ms_parser
+        PipAsPythonDependency add
     ) -> RepoInfo
     {
         auto repo = add_repo_from_packages_impl_pre(name);
         for (; first_package != last_package; ++first_package)
         {
-            add_repo_from_packages_impl_loop(repo, *first_package, ms_parser);
+            add_repo_from_packages_impl_loop(repo, *first_package);
         }
         add_repo_from_packages_impl_post(repo, add);
         return repo;
     }
 
     template <typename Range>
-    auto Database::add_repo_from_packages(
-        const Range& packages,
-        std::string_view name,
-        PipAsPythonDependency add,
-        MatchSpecParser ms_parser
-    ) -> RepoInfo
+    auto
+    Database::add_repo_from_packages(const Range& packages, std::string_view name, PipAsPythonDependency add)
+        -> RepoInfo
     {
-        return add_repo_from_packages(packages.begin(), packages.end(), name, add, ms_parser);
+        return add_repo_from_packages(packages.begin(), packages.end(), name, add);
     }
 
     // TODO(C++20): Use ranges::transform

--- a/libmamba/include/mamba/solver/libsolv/solver.hpp
+++ b/libmamba/include/mamba/solver/libsolv/solver.hpp
@@ -8,6 +8,7 @@
 #define MAMBA_SOLVER_LIBSOLV_SOLVER_HPP
 
 #include "mamba/core/error_handling.hpp"
+#include "mamba/solver/libsolv/parameters.hpp"
 #include "mamba/solver/libsolv/unsolvable.hpp"
 #include "mamba/solver/request.hpp"
 #include "mamba/solver/solution.hpp"
@@ -22,12 +23,18 @@ namespace mamba::solver::libsolv
 
         using Outcome = std::variant<Solution, UnSolvable>;
 
-        [[nodiscard]] auto solve(Database& database, Request&& request) -> expected_t<Outcome>;
-        [[nodiscard]] auto solve(Database& database, const Request& request) -> expected_t<Outcome>;
+        [[nodiscard]] auto
+        solve(Database& database, Request&& request, MatchSpecParser ms_parser = MatchSpecParser::Mixed)
+            -> expected_t<Outcome>;
+
+        [[nodiscard]] auto
+        solve(Database& database, const Request& request, MatchSpecParser ms_parser = MatchSpecParser::Mixed)
+            -> expected_t<Outcome>;
 
     private:
 
-        auto solve_impl(Database& database, const Request& request) -> expected_t<Outcome>;
+        auto solve_impl(Database& database, const Request& request, MatchSpecParser ms_parser)
+            -> expected_t<Outcome>;
     };
 }
 #endif

--- a/libmamba/src/api/configuration.cpp
+++ b/libmamba/src/api/configuration.cpp
@@ -1426,7 +1426,7 @@ namespace mamba
         insert(Configurable("experimental_matchspec_parsing", &m_context.experimental_matchspec_parsing)
                    .group("Basic")
                    .description(  //
-                       "Enable experimental parsing and matching of MatchSpecs using Mamba implementation.\n"
+                       "Enable internal parsing and matching of MatchSpecs using Mamba's experimental implementation rather than Libsolv's.\n"
                        "This is not mean for production"
                    )
                    .set_env_var_names());

--- a/libmamba/src/api/configuration.cpp
+++ b/libmamba/src/api/configuration.cpp
@@ -1423,6 +1423,14 @@ namespace mamba
                    .set_env_var_names()
                    .set_post_merge_hook(detail::not_supported_option_hook));
 
+        insert(Configurable("experimental_matchspec_parsing", &m_context.experimental_matchspec_parsing)
+                   .group("Basic")
+                   .description(  //
+                       "Enable experimental parsing and matching of MatchSpecs using Mamba implementation.\n"
+                       "This is not mean for production"
+                   )
+                   .set_env_var_names());
+
         insert(Configurable("debug", &m_context.debug)
                    .group("Basic")
                    .set_env_var_names()

--- a/libmamba/src/api/install.cpp
+++ b/libmamba/src/api/install.cpp
@@ -500,7 +500,15 @@ namespace mamba
                 // Console stream prints on destruction
             }
 
-            auto outcome = solver::libsolv::Solver().solve(db, request).value();
+            auto outcome = solver::libsolv::Solver()
+                               .solve(
+                                   db,
+                                   request,
+                                   ctx.experimental_matchspec_parsing
+                                       ? solver::libsolv::MatchSpecParser::Mamba
+                                       : solver::libsolv::MatchSpecParser::Mixed
+                               )
+                               .value();
 
             if (auto* unsolvable = std::get_if<solver::libsolv::UnSolvable>(&outcome))
             {

--- a/libmamba/src/api/install.cpp
+++ b/libmamba/src/api/install.cpp
@@ -465,7 +465,13 @@ namespace mamba
                 LOG_WARNING << "No 'channels' specified";
             }
 
-            solver::libsolv::Database db{ channel_context.params() };
+            solver::libsolv::Database db{
+                channel_context.params(),
+                {
+                    ctx.experimental_matchspec_parsing ? solver::libsolv::MatchSpecParser::Mamba
+                                                       : solver::libsolv::MatchSpecParser::Libsolv,
+                },
+            };
             add_spdlog_logger_to_database(db);
 
             auto exp_load = load_channels(ctx, channel_context, db, package_caches);
@@ -643,7 +649,13 @@ namespace mamba
             bool remove_prefix_on_failure
         )
         {
-            solver::libsolv::Database database{ channel_context.params() };
+            solver::libsolv::Database database{
+                channel_context.params(),
+                {
+                    ctx.experimental_matchspec_parsing ? solver::libsolv::MatchSpecParser::Mamba
+                                                       : solver::libsolv::MatchSpecParser::Libsolv,
+                },
+            };
             add_spdlog_logger_to_database(database);
 
             init_channels(ctx, channel_context);

--- a/libmamba/src/api/remove.cpp
+++ b/libmamba/src/api/remove.cpp
@@ -196,7 +196,15 @@ namespace mamba
                     /* .strict_repo_priority= */ ctx.channel_priority == ChannelPriority::Strict,
                 };
 
-                auto outcome = solver::libsolv::Solver().solve(database, request).value();
+                auto outcome = solver::libsolv::Solver()
+                                   .solve(
+                                       database,
+                                       request,
+                                       ctx.experimental_matchspec_parsing
+                                           ? solver::libsolv::MatchSpecParser::Mamba
+                                           : solver::libsolv::MatchSpecParser::Mixed
+                                   )
+                                   .value();
                 if (auto* unsolvable = std::get_if<solver::libsolv::UnSolvable>(&outcome))
                 {
                     if (ctx.output_params.json)

--- a/libmamba/src/api/remove.cpp
+++ b/libmamba/src/api/remove.cpp
@@ -136,7 +136,13 @@ namespace mamba
             }
             PrefixData& prefix_data = exp_prefix_data.value();
 
-            solver::libsolv::Database database{ channel_context.params() };
+            solver::libsolv::Database database{
+                channel_context.params(),
+                {
+                    ctx.experimental_matchspec_parsing ? solver::libsolv::MatchSpecParser::Mamba
+                                                       : solver::libsolv::MatchSpecParser::Libsolv,
+                },
+            };
             add_spdlog_logger_to_database(database);
             load_installed_packages_in_database(ctx, database, prefix_data);
 

--- a/libmamba/src/api/repoquery.cpp
+++ b/libmamba/src/api/repoquery.cpp
@@ -34,7 +34,13 @@ namespace mamba
             config.load();
 
             auto channel_context = ChannelContext::make_conda_compatible(ctx);
-            solver::libsolv::Database db{ channel_context.params() };
+            solver::libsolv::Database db{
+                channel_context.params(),
+                {
+                    ctx.experimental_matchspec_parsing ? solver::libsolv::MatchSpecParser::Mamba
+                                                       : solver::libsolv::MatchSpecParser::Libsolv,
+                },
+            };
             add_spdlog_logger_to_database(db);
 
             // bool installed = (type == QueryType::kDepends) || (type == QueryType::kWhoneeds);

--- a/libmamba/src/api/update.cpp
+++ b/libmamba/src/api/update.cpp
@@ -197,7 +197,15 @@ namespace mamba
             // Console stream prints on destruction
         }
 
-        auto outcome = solver::libsolv::Solver().solve(db, request).value();
+        auto outcome = solver::libsolv::Solver()
+                           .solve(
+                               db,
+                               request,
+                               ctx.experimental_matchspec_parsing
+                                   ? solver::libsolv::MatchSpecParser::Mamba
+                                   : solver::libsolv::MatchSpecParser::Mixed
+                           )
+                           .value();
         if (auto* unsolvable = std::get_if<solver::libsolv::UnSolvable>(&outcome))
         {
             unsolvable->explain_problems_to(

--- a/libmamba/src/api/update.cpp
+++ b/libmamba/src/api/update.cpp
@@ -152,7 +152,13 @@ namespace mamba
 
         populate_context_channels_from_specs(raw_update_specs, ctx);
 
-        solver::libsolv::Database db{ channel_context.params() };
+        solver::libsolv::Database db{
+            channel_context.params(),
+            {
+                ctx.experimental_matchspec_parsing ? solver::libsolv::MatchSpecParser::Mamba
+                                                   : solver::libsolv::MatchSpecParser::Libsolv,
+            },
+        };
         add_spdlog_logger_to_database(db);
 
         MultiPackageCache package_caches(ctx.pkgs_dirs, ctx.validation_params);

--- a/libmamba/src/solver/libsolv/database.cpp
+++ b/libmamba/src/solver/libsolv/database.cpp
@@ -189,7 +189,9 @@ namespace mamba::solver::libsolv
             if (settings().matchspec_parser != MatchSpecParser::Libsolv)
             {
                 return make_unexpected(
-                    "Libsolv repodata parser uses only its own MatchSpec parser",
+                    " Libsolv repodata parser can only be used with Libsolv MatchSpec parser."
+                    "A Libsolv Repodata parser option been passed to this function while a"
+                    " non-Libsolv MatchSpec parser option has been give to the Database constructor.",
                     mamba_error_code::incorrect_usage
                 );
             }

--- a/libmamba/src/solver/libsolv/database.cpp
+++ b/libmamba/src/solver/libsolv/database.cpp
@@ -29,8 +29,8 @@ namespace mamba::solver::libsolv
 {
     struct Database::DatabaseImpl
     {
-        explicit DatabaseImpl(specs::ChannelResolveParams p_channel_params, Settings settings)
-            : settings(std::move(settings))
+        explicit DatabaseImpl(specs::ChannelResolveParams p_channel_params, Settings settings_)
+            : settings(std::move(settings_))
             , matcher(std::move(p_channel_params))
         {
         }

--- a/libmamba/src/solver/libsolv/solver.cpp
+++ b/libmamba/src/solver/libsolv/solver.cpp
@@ -50,17 +50,13 @@ namespace mamba::solver::libsolv
         }
     }
 
-    auto Solver::solve_impl(Database& mpool, const Request& request) -> expected_t<Outcome>
+    auto Solver::solve_impl(Database& mpool, const Request& request, MatchSpecParser ms_parser)
+        -> expected_t<Outcome>
     {
         auto& pool = Database::Impl::get(mpool);
         const auto& flags = request.flags;
 
-        return solver::libsolv::request_to_decision_queue(
-                   request,
-                   pool,
-                   flags.force_reinstall,
-                   MatchSpecParser::Mixed
-        )
+        return solver::libsolv::request_to_decision_queue(request, pool, flags.force_reinstall, ms_parser)
             .transform(
                 [&](auto&& jobs) -> Outcome
                 {
@@ -90,24 +86,26 @@ namespace mamba::solver::libsolv
             );
     }
 
-    auto Solver::solve(Database& mpool, Request&& request) -> expected_t<Outcome>
+    auto Solver::solve(Database& mpool, Request&& request, MatchSpecParser ms_parser)
+        -> expected_t<Outcome>
     {
         if (request.flags.order_request)
         {
             std::sort(request.jobs.begin(), request.jobs.end(), make_request_cmp());
         }
-        return solve_impl(mpool, request);
+        return solve_impl(mpool, request, ms_parser);
     }
 
-    auto Solver::solve(Database& mpool, const Request& request) -> expected_t<Outcome>
+    auto Solver::solve(Database& mpool, const Request& request, MatchSpecParser ms_parser)
+        -> expected_t<Outcome>
     {
         if (request.flags.order_request)
         {
             auto sorted_request = request;
             std::sort(sorted_request.jobs.begin(), sorted_request.jobs.end(), make_request_cmp());
-            return solve_impl(mpool, sorted_request);
+            return solve_impl(mpool, sorted_request, ms_parser);
         }
-        return solve_impl(mpool, request);
+        return solve_impl(mpool, request, ms_parser);
     }
 
 }  // namespace mamba

--- a/libmamba/tests/src/solver/libsolv/test_database.cpp
+++ b/libmamba/tests/src/solver/libsolv/test_database.cpp
@@ -37,7 +37,7 @@ namespace
 {
     using PackageInfo = specs::PackageInfo;
 
-    TEST_CASE("Create a database")
+    TEST_CASE("Create a database", "[mamba::solver][mamba::solver::libsolv]")
     {
         auto db = libsolv::Database({});
         REQUIRE(std::is_move_constructible_v<libsolv::Database>);

--- a/libmamba/tests/src/solver/libsolv/test_database.cpp
+++ b/libmamba/tests/src/solver/libsolv/test_database.cpp
@@ -39,7 +39,14 @@ namespace
 
     TEST_CASE("Create a database", "[mamba::solver][mamba::solver::libsolv]")
     {
-        auto db = libsolv::Database({});
+        const auto matchspec_parser = GENERATE(
+            libsolv::MatchSpecParser::Libsolv,
+            libsolv::MatchSpecParser::Mixed,
+            libsolv::MatchSpecParser::Mamba
+        );
+        CAPTURE(matchspec_parser);
+
+        auto db = libsolv::Database({}, { matchspec_parser });
         REQUIRE(std::is_move_constructible_v<libsolv::Database>);
         REQUIRE(db.repo_count() == 0);
 
@@ -162,6 +169,12 @@ namespace
 
                 SECTION("Depending on a given dependency")
                 {
+                    // Complex repoqueries do not work with namespace callbacks
+                    if (matchspec_parser != libsolv::MatchSpecParser::Libsolv)
+                    {
+                        return;
+                    }
+
                     std::size_t count = 0;
                     db.for_each_package_depending_on(
                         specs::MatchSpec::parse("x").value(),
@@ -351,6 +364,14 @@ namespace
                     libsolv::VerifyPackages::Yes,
                     libsolv::RepodataParser::Libsolv
                 );
+
+                // Libsolv repodata parser only works with its own matchspec
+                if (matchspec_parser != libsolv::MatchSpecParser::Libsolv)
+                {
+                    REQUIRE_FALSE(repo1.has_value());
+                    return;
+                }
+
                 REQUIRE(repo1.has_value());
                 REQUIRE(repo1->package_count() == 33);
 
@@ -420,6 +441,14 @@ namespace
                     libsolv::VerifyPackages::No,
                     libsolv::RepodataParser::Libsolv
                 );
+
+                // Libsolv repodata parser only works with its own matchspec
+                if (matchspec_parser != libsolv::MatchSpecParser::Libsolv)
+                {
+                    REQUIRE_FALSE(repo1.has_value());
+                    return;
+                }
+
                 REQUIRE(repo1.has_value());
                 REQUIRE(repo1->package_count() == 33);
 

--- a/libmamba/tests/src/solver/libsolv/test_solver.cpp
+++ b/libmamba/tests/src/solver/libsolv/test_solver.cpp
@@ -67,7 +67,7 @@ namespace
 {
     using namespace specs::match_spec_literals;
 
-    TEST_CASE("Solve a fresh environment with one repository")
+    TEST_CASE("Solve a fresh environment with one repository", "[mamba::solver][mamba::solver::libsolv]")
     {
         auto db = libsolv::Database({});
 
@@ -212,7 +212,7 @@ namespace
         }
     }
 
-    TEST_CASE("Remove packages")
+    TEST_CASE("Remove packages", "[mamba::solver][mamba::solver::libsolv]")
     {
         auto db = libsolv::Database({});
 
@@ -306,7 +306,7 @@ namespace
         }
     }
 
-    TEST_CASE("Reinstall packages")
+    TEST_CASE("Reinstall packages", "[mamba::solver][mamba::solver::libsolv]")
     {
         auto db = libsolv::Database({});
 
@@ -345,7 +345,7 @@ namespace
         }
     }
 
-    TEST_CASE("Solve a existing environment with one repository")
+    TEST_CASE("Solve a existing environment with one repository", "[mamba::solver][mamba::solver::libsolv]")
     {
         auto db = libsolv::Database({});
 
@@ -625,7 +625,7 @@ namespace
         }
     }
 
-    TEST_CASE("Solve a fresh environment with multiple repositories")
+    TEST_CASE("Solve a fresh environment with multiple repositories", "[mamba::solver][mamba::solver::libsolv]")
     {
         auto db = libsolv::Database({});
 
@@ -671,7 +671,7 @@ namespace
         }
     }
 
-    TEST_CASE("Install highest priority package")
+    TEST_CASE("Install highest priority package", "[mamba::solver][mamba::solver::libsolv]")
     {
         auto db = libsolv::Database({});
 
@@ -800,7 +800,7 @@ namespace
         }
     }
 
-    TEST_CASE("Respect channel-specific MatchSpec")
+    TEST_CASE("Respect channel-specific MatchSpec", "[mamba::solver][mamba::solver::libsolv]")
     {
         auto db = libsolv::Database({
             /* .platforms= */ { "linux-64", "noarch" },
@@ -940,7 +940,7 @@ namespace
         }
     }
 
-    TEST_CASE("Respect pins")
+    TEST_CASE("Respect pins", "[mamba::solver][mamba::solver::libsolv]")
     {
         using PackageInfo = specs::PackageInfo;
 
@@ -1058,7 +1058,7 @@ namespace
         }
     }
 
-    TEST_CASE("Handle complex matchspecs")
+    TEST_CASE("Handle complex matchspecs", "[mamba::solver][mamba::solver::libsolv]")
     {
         using PackageInfo = specs::PackageInfo;
 

--- a/libmamba/tests/src/solver/libsolv/test_solver.cpp
+++ b/libmamba/tests/src/solver/libsolv/test_solver.cpp
@@ -75,7 +75,7 @@ namespace
             libsolv::MatchSpecParser::Mamba
         );
 
-        auto db = libsolv::Database({});
+        auto db = libsolv::Database({}, { matchspec_parser });
 
         // A conda-forge/linux-64 subsample with one version of numpy and pip and their dependencies
         const auto repo = db.add_repo_from_repodata_json(
@@ -85,8 +85,7 @@ namespace
             libsolv::PipAsPythonDependency::No,
             libsolv::PackageTypes::CondaOrElseTarBz2,
             libsolv::VerifyPackages::No,
-            libsolv::RepodataParser::Mamba,
-            matchspec_parser
+            libsolv::RepodataParser::Mamba
         );
         REQUIRE(repo.has_value());
 
@@ -230,7 +229,7 @@ namespace
             libsolv::MatchSpecParser::Mamba
         );
 
-        auto db = libsolv::Database({});
+        auto db = libsolv::Database({}, { matchspec_parser });
 
         // A conda-forge/linux-64 subsample with one version of numpy and pip and their dependencies
         const auto repo = db.add_repo_from_repodata_json(
@@ -240,8 +239,7 @@ namespace
             libsolv::PipAsPythonDependency::No,
             libsolv::PackageTypes::CondaOrElseTarBz2,
             libsolv::VerifyPackages::No,
-            libsolv::RepodataParser::Mamba,
-            matchspec_parser
+            libsolv::RepodataParser::Mamba
         );
         REQUIRE(repo.has_value());
         db.set_installed_repo(repo.value());
@@ -335,7 +333,7 @@ namespace
             libsolv::MatchSpecParser::Mamba
         );
 
-        auto db = libsolv::Database({});
+        auto db = libsolv::Database({}, { matchspec_parser });
 
         // A conda-forge/linux-64 subsample with one version of numpy and pip and their dependencies
         const auto repo_installed = db.add_repo_from_repodata_json(
@@ -345,8 +343,7 @@ namespace
             libsolv::PipAsPythonDependency::No,
             libsolv::PackageTypes::CondaOrElseTarBz2,
             libsolv::VerifyPackages::No,
-            libsolv::RepodataParser::Mamba,
-            matchspec_parser
+            libsolv::RepodataParser::Mamba
         );
         REQUIRE(repo_installed.has_value());
         db.set_installed_repo(repo_installed.value());
@@ -357,8 +354,7 @@ namespace
             libsolv::PipAsPythonDependency::No,
             libsolv::PackageTypes::CondaOrElseTarBz2,
             libsolv::VerifyPackages::No,
-            libsolv::RepodataParser::Mamba,
-            matchspec_parser
+            libsolv::RepodataParser::Mamba
         );
         REQUIRE(repo.has_value());
 
@@ -389,7 +385,7 @@ namespace
             libsolv::MatchSpecParser::Mixed,
             libsolv::MatchSpecParser::Mamba
         );
-        auto db = libsolv::Database({});
+        auto db = libsolv::Database({}, { matchspec_parser });
 
         // A conda-forge/linux-64 subsample with one version of numpy and pip and their dependencies
         const auto repo = db.add_repo_from_repodata_json(
@@ -399,8 +395,7 @@ namespace
             libsolv::PipAsPythonDependency::No,
             libsolv::PackageTypes::CondaOrElseTarBz2,
             libsolv::VerifyPackages::No,
-            libsolv::RepodataParser::Mamba,
-            matchspec_parser
+            libsolv::RepodataParser::Mamba
         );
         REQUIRE(repo.has_value());
 
@@ -411,8 +406,7 @@ namespace
                     specs::PackageInfo("numpy", "1.0.0", "phony", 0),
                 },
                 "installed",
-                libsolv::PipAsPythonDependency::No,
-                matchspec_parser
+                libsolv::PipAsPythonDependency::No
             );
             db.set_installed_repo(installed);
 
@@ -484,8 +478,7 @@ namespace
                     specs::PackageInfo("foo"),
                 },
                 "installed",
-                libsolv::PipAsPythonDependency::No,
-                matchspec_parser
+                libsolv::PipAsPythonDependency::No
             );
             db.set_installed_repo(installed);
 
@@ -618,8 +611,7 @@ namespace
             const auto installed = db.add_repo_from_packages(
                 std::array{ pkg_numpy, pkg_foo, specs::PackageInfo("python", "4.0.0", "phony", 0) },
                 "installed",
-                libsolv::PipAsPythonDependency::No,
-                matchspec_parser
+                libsolv::PipAsPythonDependency::No
             );
             db.set_installed_repo(installed);
 
@@ -689,19 +681,17 @@ namespace
             libsolv::MatchSpecParser::Mixed,
             libsolv::MatchSpecParser::Mamba
         );
-        auto db = libsolv::Database({});
+        auto db = libsolv::Database({}, { matchspec_parser });
 
         const auto repo1 = db.add_repo_from_packages(
             std::array{ specs::PackageInfo("numpy", "1.0.0", "repo1", 0) },
             "repo1",
-            libsolv::PipAsPythonDependency::No,
-            matchspec_parser
+            libsolv::PipAsPythonDependency::No
         );
         const auto repo2 = db.add_repo_from_packages(
             std::array{ specs::PackageInfo("numpy", "2.0.0", "repo2", 0) },
-            "installed",
-            libsolv::PipAsPythonDependency::No,
-            matchspec_parser
+            "repo2",
+            libsolv::PipAsPythonDependency::No
         );
         db.set_repo_priority(repo1, { 2, 0 });
         db.set_repo_priority(repo2, { 1, 0 });
@@ -747,7 +737,7 @@ namespace
             libsolv::MatchSpecParser::Mamba
         );
 
-        auto db = libsolv::Database({});
+        auto db = libsolv::Database({}, { matchspec_parser });
 
         auto mkfoo = [](std::string version,
                         std::size_t build_number = 0,
@@ -770,8 +760,7 @@ namespace
                     mkfoo("2.0.0", 1, {}, 1),
                 },
                 "repo",
-                libsolv::PipAsPythonDependency::No,
-                matchspec_parser
+                libsolv::PipAsPythonDependency::No
             );
 
             auto request = Request{
@@ -798,8 +787,7 @@ namespace
                     mkfoo("2.0.0", 1, { "feat" }, 1),
                 },
                 "repo",
-                libsolv::PipAsPythonDependency::No,
-                matchspec_parser
+                libsolv::PipAsPythonDependency::No
             );
             auto request = Request{
                 /* .flags= */ {},
@@ -824,9 +812,8 @@ namespace
                     mkfoo("2.0.0", 0, {}, 0),
                     mkfoo("1.0.0", 1, {}, 1),
                 },
-                "installed",
-                libsolv::PipAsPythonDependency::No,
-                matchspec_parser
+                "repo",
+                libsolv::PipAsPythonDependency::No
             );
             auto request = Request{
                 /* .flags= */ {},
@@ -851,9 +838,8 @@ namespace
                     mkfoo("2.0.0", 1, {}, 0),
                     mkfoo("2.0.0", 0, {}, 1),
                 },
-                "installed",
-                libsolv::PipAsPythonDependency::No,
-                matchspec_parser
+                "repo",
+                libsolv::PipAsPythonDependency::No
             );
             auto request = Request{
                 /* .flags= */ {},
@@ -878,9 +864,8 @@ namespace
                     mkfoo("2.0.0", 0, {}, 0),
                     mkfoo("2.0.0", 0, {}, 1),
                 },
-                "installed",
-                libsolv::PipAsPythonDependency::No,
-                matchspec_parser
+                "repo",
+                libsolv::PipAsPythonDependency::No
             );
             auto request = Request{
                 /* .flags= */ {},
@@ -907,29 +892,22 @@ namespace
             libsolv::MatchSpecParser::Mamba
         );
 
-        auto db = libsolv::Database({
-            /* .platforms= */ { "linux-64", "noarch" },
-            /* .channel_alias= */ specs::CondaURL::parse("https://conda.anaconda.org/").value(),
-        });
+        auto db = libsolv::Database(
+            {
+                /* .platforms= */ { "linux-64", "noarch" },
+                /* .channel_alias= */ specs::CondaURL::parse("https://conda.anaconda.org/").value(),
+            },
+            { matchspec_parser }
+        );
 
         SECTION("Different channels")
         {
             auto pkg1 = specs::PackageInfo("foo", "1.0.0", "conda", 0);
             pkg1.package_url = "https://conda.anaconda.org/conda-forge/linux-64/foo-1.0.0-phony.conda";
-            db.add_repo_from_packages(
-                std::array{ pkg1 },
-                "repo1",
-                libsolv::PipAsPythonDependency::No,
-                matchspec_parser
-            );
+            db.add_repo_from_packages(std::array{ pkg1 }, "repo1", libsolv::PipAsPythonDependency::No);
             auto pkg2 = specs::PackageInfo("foo", "1.0.0", "mamba", 0);
             pkg2.package_url = "https://conda.anaconda.org/mamba-forge/linux-64/foo-1.0.0-phony.conda";
-            db.add_repo_from_packages(
-                std::array{ pkg2 },
-                "repo2",
-                libsolv::PipAsPythonDependency::No,
-                matchspec_parser
-            );
+            db.add_repo_from_packages(std::array{ pkg2 }, "repo2", libsolv::PipAsPythonDependency::No);
 
             SECTION("conda-forge::foo")
             {
@@ -1008,8 +986,7 @@ namespace
                 libsolv::PipAsPythonDependency::No,
                 libsolv::PackageTypes::CondaOrElseTarBz2,
                 libsolv::VerifyPackages::No,
-                libsolv::RepodataParser::Mamba,
-                matchspec_parser
+                libsolv::RepodataParser::Mamba
             );
             REQUIRE(repo_linux.has_value());
 
@@ -1023,8 +1000,7 @@ namespace
                 libsolv::PipAsPythonDependency::No,
                 libsolv::PackageTypes::CondaOrElseTarBz2,
                 libsolv::VerifyPackages::No,
-                libsolv::RepodataParser::Mamba,
-                matchspec_parser
+                libsolv::RepodataParser::Mamba
             );
             REQUIRE(repo_noarch.has_value());
 
@@ -1073,7 +1049,7 @@ namespace
             libsolv::MatchSpecParser::Mamba
         );
 
-        auto db = libsolv::Database({});
+        auto db = libsolv::Database({}, { matchspec_parser });
 
         SECTION("Respect pins through direct dependencies")
         {
@@ -1085,8 +1061,7 @@ namespace
             db.add_repo_from_packages(
                 std::array{ pkg1, pkg2 },
                 "repo",
-                libsolv::PipAsPythonDependency::No,
-                matchspec_parser
+                libsolv::PipAsPythonDependency::No
             );
 
             auto request = Request{
@@ -1121,8 +1096,7 @@ namespace
             db.add_repo_from_packages(
                 std::array{ pkg1, pkg2, pkg3, pkg4 },
                 "repo",
-                libsolv::PipAsPythonDependency::No,
-                matchspec_parser
+                libsolv::PipAsPythonDependency::No
             );
 
             auto request = Request{
@@ -1156,8 +1130,7 @@ namespace
             db.add_repo_from_packages(
                 std::array{ pkg1, pkg2 },
                 "repo",
-                libsolv::PipAsPythonDependency::No,
-                matchspec_parser
+                libsolv::PipAsPythonDependency::No
             );
 
             auto request = Request{
@@ -1182,12 +1155,7 @@ namespace
             auto pkg = PackageInfo("bar");
             pkg.version = "1.0";
 
-            db.add_repo_from_packages(
-                std::array{ pkg },
-                "repo",
-                libsolv::PipAsPythonDependency::No,
-                matchspec_parser
-            );
+            db.add_repo_from_packages(std::array{ pkg }, "repo", libsolv::PipAsPythonDependency::No);
 
             auto request = Request{
                 /* .flags= */ {},
@@ -1217,7 +1185,7 @@ namespace
             libsolv::MatchSpecParser::Mamba
         );
 
-        auto db = libsolv::Database({});
+        auto db = libsolv::Database({}, { matchspec_parser });
 
         SECTION("*[md5=0bab699354cbd66959550eb9b9866620]")
         {
@@ -1229,8 +1197,7 @@ namespace
             db.add_repo_from_packages(
                 std::array{ pkg1, pkg2 },
                 "repo",
-                libsolv::PipAsPythonDependency::No,
-                matchspec_parser
+                libsolv::PipAsPythonDependency::No
             );
 
             auto request = Request{
@@ -1256,12 +1223,7 @@ namespace
             auto pkg1 = PackageInfo("foo");
             pkg1.md5 = "0bab699354cbd66959550eb9b9866620";
 
-            db.add_repo_from_packages(
-                std::array{ pkg1 },
-                "repo",
-                libsolv::PipAsPythonDependency::No,
-                matchspec_parser
-            );
+            db.add_repo_from_packages(std::array{ pkg1 }, "repo", libsolv::PipAsPythonDependency::No);
 
             auto request = Request{
                 /* .flags= */ {},
@@ -1283,8 +1245,7 @@ namespace
             db.add_repo_from_packages(
                 std::array{ pkg1, pkg2 },
                 "repo",
-                libsolv::PipAsPythonDependency::No,
-                matchspec_parser
+                libsolv::PipAsPythonDependency::No
             );
 
             auto request = Request{
@@ -1319,8 +1280,7 @@ namespace
             db.add_repo_from_packages(
                 std::array{ pkg1, pkg2, pkg3 },
                 "repo",
-                libsolv::PipAsPythonDependency::No,
-                matchspec_parser
+                libsolv::PipAsPythonDependency::No
             );
 
             auto request = Request{
@@ -1347,12 +1307,7 @@ namespace
             pkg.version = "=*,=*";
             pkg.build_string = "pyhd*";
 
-            db.add_repo_from_packages(
-                std::array{ pkg },
-                "repo",
-                libsolv::PipAsPythonDependency::No,
-                matchspec_parser
-            );
+            db.add_repo_from_packages(std::array{ pkg }, "repo", libsolv::PipAsPythonDependency::No);
 
             auto request = Request{
                 /* .flags= */ {},

--- a/libmamba/tests/src/solver/test_request.cpp
+++ b/libmamba/tests/src/solver/test_request.cpp
@@ -18,7 +18,7 @@ namespace
 {
     using namespace specs::match_spec_literals;
 
-    TEST_CASE("Create a request")
+    TEST_CASE("Create a request", "[mamba::solver]")
     {
         auto request = Request{
             {},

--- a/libmamba/tests/src/solver/test_solution.cpp
+++ b/libmamba/tests/src/solver/test_solution.cpp
@@ -17,7 +17,7 @@ namespace
 {
     using PackageInfo = specs::PackageInfo;
 
-    TEST_CASE("Create a Solution")
+    TEST_CASE("Create a Solution", "[mamba::solver]")
     {
         auto solution = Solution{ {
             Solution::Omit{ PackageInfo("omit") },

--- a/libmambapy/src/libmambapy/bindings/solver_libsolv.cpp
+++ b/libmambapy/src/libmambapy/bindings/solver_libsolv.cpp
@@ -136,7 +136,7 @@ namespace mambapy
                 py::arg("package_types") = PackageTypes::CondaOrElseTarBz2,
                 py::arg("verify_packages") = VerifyPackages::No,
                 py::arg("repodata_parser") = RepodataParser::Mamba,
-                py::arg("matchspec_parser") = RepodataParser::Libsolv
+                py::arg("matchspec_parser") = MatchSpecParser::Libsolv
             )
             .def(
                 "add_repo_from_native_serialization",
@@ -165,7 +165,7 @@ namespace mambapy
                 py::arg("packages"),
                 py::arg("name") = "",
                 py::arg("add_pip_as_python_dependency") = PipAsPythonDependency::No,
-                py::arg("matchspec_parser") = RepodataParser::Libsolv
+                py::arg("matchspec_parser") = MatchSpecParser::Libsolv
             )
             .def(
                 "native_serialize_repo",
@@ -245,12 +245,15 @@ namespace mambapy
         constexpr auto solver_job_v2_migrator = [](Solver&, py::args, py::kwargs)
         { throw std::runtime_error("All jobs need to be passed in the libmambapy.solver.Request."); };
 
-        py::class_<Solver>(m, "Solver")  //
+        py::class_<Solver>(m, "Solver")
             .def(py::init())
             .def(
                 "solve",
-                [](Solver& self, Database& database, const solver::Request& request)
-                { return self.solve(database, request); }
+                [](Solver& self, Database& database, const solver::Request& request, MatchSpecParser ms_parser
+                ) { return self.solve(database, request, ms_parser); },
+                py::arg("database"),
+                py::arg("request"),
+                py::arg("matchspec_parser") = MatchSpecParser::Mixed
             )
             .def("add_jobs", solver_job_v2_migrator)
             .def("add_global_job", solver_job_v2_migrator)

--- a/libmambapy/src/libmambapy/bindings/solver_libsolv.cpp
+++ b/libmambapy/src/libmambapy/bindings/solver_libsolv.cpp
@@ -33,6 +33,13 @@ namespace mambapy
             .def(py::init(&enum_from_str<RepodataParser>));
         py::implicitly_convertible<py::str, RepodataParser>();
 
+        py::enum_<MatchSpecParser>(m, "MatchSpecParser")
+            .value("Mixed", MatchSpecParser::Mixed)
+            .value("Mamba", MatchSpecParser::Mamba)
+            .value("Libsolv", MatchSpecParser::Libsolv)
+            .def(py::init(&enum_from_str<MatchSpecParser>));
+        py::implicitly_convertible<py::str, MatchSpecParser>();
+
         py::enum_<PipAsPythonDependency>(m, "PipAsPythonDependency")
             .value("No", PipAsPythonDependency::No)
             .value("Yes", PipAsPythonDependency::Yes)
@@ -128,7 +135,8 @@ namespace mambapy
                 py::arg("add_pip_as_python_dependency") = PipAsPythonDependency::No,
                 py::arg("package_types") = PackageTypes::CondaOrElseTarBz2,
                 py::arg("verify_packages") = VerifyPackages::No,
-                py::arg("repodata_parser") = RepodataParser::Mamba
+                py::arg("repodata_parser") = RepodataParser::Mamba,
+                py::arg("matchspec_parser") = RepodataParser::Libsolv
             )
             .def(
                 "add_repo_from_native_serialization",
@@ -143,7 +151,8 @@ namespace mambapy
                 [](Database& database,
                    py::iterable packages,
                    std::string_view name,
-                   PipAsPythonDependency add)
+                   PipAsPythonDependency add,
+                   MatchSpecParser ms_parser)
                 {
                     // TODO(C++20): No need to copy in a vector, simply transform the input range.
                     auto pkg_infos = std::vector<specs::PackageInfo>();
@@ -151,11 +160,12 @@ namespace mambapy
                     {
                         pkg_infos.push_back(pkg.cast<specs::PackageInfo>());
                     }
-                    return database.add_repo_from_packages(pkg_infos, name, add);
+                    return database.add_repo_from_packages(pkg_infos, name, add, ms_parser);
                 },
                 py::arg("packages"),
                 py::arg("name") = "",
-                py::arg("add_pip_as_python_dependency") = PipAsPythonDependency::No
+                py::arg("add_pip_as_python_dependency") = PipAsPythonDependency::No,
+                py::arg("matchspec_parser") = RepodataParser::Libsolv
             )
             .def(
                 "native_serialize_repo",

--- a/libmambapy/tests/test_legacy.py
+++ b/libmambapy/tests/test_legacy.py
@@ -3,14 +3,14 @@ import libmambapy
 
 def test_context_instance_scoped():
     ctx = libmambapy.Context()  # Initialize and then terminate libmamba internals
-    return ctx
+    assert ctx is not None
 
 
 def test_context_no_log_nor_signal_handling():
     ctx = libmambapy.Context(
         libmambapy.ContextOptions(enable_logging=False, enable_signal_handling=False)
     )
-    return ctx
+    assert ctx is not None
 
 
 def test_channel_context():

--- a/libmambapy/tests/test_solver_libsolv.py
+++ b/libmambapy/tests/test_solver_libsolv.py
@@ -1,6 +1,5 @@
 import copy
 import json
-import itertools
 
 import pytest
 

--- a/libmambapy/tests/test_solver_libsolv.py
+++ b/libmambapy/tests/test_solver_libsolv.py
@@ -31,6 +31,17 @@ def test_RepodataParser():
         libsolv.RepodataParser("NoParser")
 
 
+def test_MatchSpecParser():
+    assert libsolv.MatchSpecParser.Mamba.name == "Mamba"
+    assert libsolv.MatchSpecParser.Libsolv.name == "Libsolv"
+    assert libsolv.MatchSpecParser.Mixed.name == "Mixed"
+
+    assert libsolv.MatchSpecParser("Libsolv") == libsolv.MatchSpecParser.Libsolv
+
+    with pytest.raises(KeyError):
+        libsolv.MatchSpecParser("NoParser")
+
+
 def test_PipASPythonDependency():
     assert libsolv.PipAsPythonDependency.No.name == "No"
     assert libsolv.PipAsPythonDependency.Yes.name == "Yes"

--- a/libmambapy/tests/test_solver_libsolv.py
+++ b/libmambapy/tests/test_solver_libsolv.py
@@ -240,7 +240,7 @@ def test_Database_RepoInfo_from_repodata(
     if (repodata_parser == "Libsolv") and (matchspec_parser != "Libsolv"):
         with pytest.raises(libmambapy.MambaNativeException) as e:
             add_repo_json()
-            assert "Libsolv repodata parser uses only its own MatchSpec parser" in e
+            assert "Libsolv repodata parser can only be used with Libsolv MatchSpec parser" in e
         return
 
     repo = add_repo_json()

--- a/libmambapy/tests/test_solver_libsolv.py
+++ b/libmambapy/tests/test_solver_libsolv.py
@@ -131,7 +131,10 @@ def test_Database_logger():
 @pytest.mark.parametrize("add_pip_as_python_dependency", [True, False])
 @pytest.mark.parametrize("matchspec_parser", ["Mixed", "Mamba", "Libsolv"])
 def test_Database_RepoInfo_from_packages(add_pip_as_python_dependency, matchspec_parser):
-    db = libsolv.Database(libmambapy.specs.ChannelResolveParams())
+    db = libsolv.Database(
+        libmambapy.specs.ChannelResolveParams(),
+        matchspec_parser=matchspec_parser,
+    )
     assert db.repo_count() == 0
     assert db.installed_repo() is None
     assert db.package_count() == 0
@@ -140,7 +143,6 @@ def test_Database_RepoInfo_from_packages(add_pip_as_python_dependency, matchspec
         [libmambapy.specs.PackageInfo(name="python")],
         name="duck",
         add_pip_as_python_dependency=add_pip_as_python_dependency,
-        matchspec_parser=matchspec_parser,
     )
     db.set_installed_repo(repo)
 
@@ -207,7 +209,10 @@ def test_Database_RepoInfo_from_repodata(
     repodata_parser,
     matchspec_parser,
 ):
-    db = libsolv.Database(libmambapy.specs.ChannelResolveParams())
+    db = libsolv.Database(
+        libmambapy.specs.ChannelResolveParams(),
+        matchspec_parser=matchspec_parser,
+    )
 
     url = "https://repo.mamba.pm"
     channel_id = "conda-forge"
@@ -220,7 +225,6 @@ def test_Database_RepoInfo_from_repodata(
             add_pip_as_python_dependency=add_pip_as_python_dependency,
             package_types=package_types,
             repodata_parser=repodata_parser,
-            matchspec_parser=matchspec_parser,
         )
 
     if (repodata_parser == "Libsolv") and (matchspec_parser != "Libsolv"):


### PR DESCRIPTION
This PR adds the choice of the `MatchSpec` parser in the API of the `Database`.
- ⚠️ This **breaks** ABI
- ✅ This **does not break** API

It also introduce a temporary configuration`experimental_matchspec_parser`, only configurable only via environment variable.
The goal is not to make our parser/matcher the default now or in the future. The way we plug it in libsolv has too many limitations (pins & repoqueries not working, data duplication...). What we want it to be able to experiment how our matchspecs handle real data to be able to use them in combination with resolvo.