### PR TITLE
fix: Requalify warning when parsing the "mod/etag" header

### DIFF
--- a/libmamba/src/core/subdirdata.cpp
+++ b/libmamba/src/core/subdirdata.cpp
@@ -307,7 +307,7 @@ namespace mamba
         }
         catch (std::exception& e)
         {
-            LOG_WARNING << "Could not parse mod/etag header";
+            LOG_DEBUG << "Could not parse mod/etag header";
             return make_unexpected(
                 fmt::format("File: {}: Could not parse mod/etag header ({})", repodata_file, e.what()),
                 mamba_error_code::cache_not_loaded


### PR DESCRIPTION
Fix https://github.com/mamba-org/mamba/issues/2392.

I also find this is quite irritating when this happens (no explanation, no possibility to remove the warning, etc.). The parsing failure (which might be due to the absence of field) has no impact on the overall process.

Let's just re-qualify this warning as a debug log.