### PR TITLE
Remove implicit zero in Version formatting

### DIFF
--- a/libmamba/include/mamba/specs/version.hpp
+++ b/libmamba/include/mamba/specs/version.hpp
@@ -89,6 +89,9 @@ namespace mamba::specs
 
         VersionPart();
         VersionPart(std::initializer_list<VersionPartAtom> init);
+        VersionPart(std::vector<VersionPartAtom> atoms, bool implicit_leading_zero);
+
+        [[nodiscard]] auto str() const -> std::string;
 
         auto operator==(const VersionPart& other) const -> bool;
         auto operator!=(const VersionPart& other) const -> bool;

--- a/libmamba/include/mamba/specs/version.hpp
+++ b/libmamba/include/mamba/specs/version.hpp
@@ -62,13 +62,37 @@ namespace mamba::specs
     /**
      * A sequence of VersionPartAtom meant to represent a part of a version (e.g. major, minor).
      *
+     * In a version like ``1.3.0post1dev``, the parts are ``1``, ``3``, and ``0post1dev``.
      * Version parts can have a arbitrary number of atoms, such as {0, "post"} {1, "dev"}
-     * in 0post1dev
+     * in ``0post1dev``.
      *
      * @see  Version::parse for how this is computed from strings.
      * @todo Use a small vector of expected size 1 if performance ar not good enough.
      */
-    using VersionPart = std::vector<VersionPartAtom>;
+    struct VersionPart
+    {
+        /** The atoms of the version part */
+        std::vector<VersionPartAtom> atoms = {};
+
+        /**
+         * Whether a potential leading zero in the first atom should be considered implicit.
+         *
+         * During parsing of ``Version``, if a part starts with a literal atom, it is considered
+         * the same as if it started with a leading ``0``.
+         * For instance ``0post1dev`` is parsed in the same way as ``post1dev``.
+         * Marking it as implicit enables the possibility to remove it when reconstructing a string
+         * representation.
+         * This is desirable for compatibility with other version formats, such as Python, where
+         * a version modifier might be expressed as ``1.3.0.dev3``.
+         */
+        bool implicit_leading_zero = false;
+
+        VersionPart() = default;
+        VersionPart(std::initializer_list<VersionPartAtom> init);
+
+        auto operator==(const VersionPart& other) const -> bool;
+        auto operator!=(const VersionPart& other) const -> bool;
+    };
 
     /**
      * A sequence of VersionPart meant to represent all parts of a version.

--- a/libmamba/include/mamba/specs/version.hpp
+++ b/libmamba/include/mamba/specs/version.hpp
@@ -43,19 +43,19 @@ namespace mamba::specs
 
         [[nodiscard]] auto str() const -> std::string;
 
-        auto operator==(const VersionPartAtom& other) const -> bool;
-        auto operator!=(const VersionPartAtom& other) const -> bool;
-        auto operator<(const VersionPartAtom& other) const -> bool;
-        auto operator<=(const VersionPartAtom& other) const -> bool;
-        auto operator>(const VersionPartAtom& other) const -> bool;
-        auto operator>=(const VersionPartAtom& other) const -> bool;
-
     private:
 
         // Stored in decreasing size order for performance
         std::string m_literal = "";
         std::size_t m_numeral = 0;
     };
+
+    auto operator==(const VersionPartAtom& left, const VersionPartAtom& right) -> bool;
+    auto operator!=(const VersionPartAtom& left, const VersionPartAtom& right) -> bool;
+    auto operator<(const VersionPartAtom& left, const VersionPartAtom& right) -> bool;
+    auto operator<=(const VersionPartAtom& left, const VersionPartAtom& right) -> bool;
+    auto operator>(const VersionPartAtom& left, const VersionPartAtom& right) -> bool;
+    auto operator>=(const VersionPartAtom& left, const VersionPartAtom& right) -> bool;
 
     extern template VersionPartAtom::VersionPartAtom(std::size_t, std::string);
 
@@ -92,14 +92,14 @@ namespace mamba::specs
         VersionPart(std::vector<VersionPartAtom> atoms, bool implicit_leading_zero);
 
         [[nodiscard]] auto str() const -> std::string;
-
-        auto operator==(const VersionPart& other) const -> bool;
-        auto operator!=(const VersionPart& other) const -> bool;
-        auto operator<(const VersionPart& other) const -> bool;
-        auto operator<=(const VersionPart& other) const -> bool;
-        auto operator>(const VersionPart& other) const -> bool;
-        auto operator>=(const VersionPart& other) const -> bool;
     };
+
+    auto operator==(const VersionPart& left, const VersionPart& other) -> bool;
+    auto operator!=(const VersionPart& left, const VersionPart& other) -> bool;
+    auto operator<(const VersionPart& left, const VersionPart& other) -> bool;
+    auto operator<=(const VersionPart& left, const VersionPart& other) -> bool;
+    auto operator>(const VersionPart& left, const VersionPart& other) -> bool;
+    auto operator>=(const VersionPart& left, const VersionPart& other) -> bool;
 
     /**
      * A sequence of VersionPart meant to represent all parts of a version.
@@ -170,13 +170,6 @@ namespace mamba::specs
          */
         [[nodiscard]] auto str_glob() const -> std::string;
 
-        [[nodiscard]] auto operator==(const Version& other) const -> bool;
-        [[nodiscard]] auto operator!=(const Version& other) const -> bool;
-        [[nodiscard]] auto operator<(const Version& other) const -> bool;
-        [[nodiscard]] auto operator<=(const Version& other) const -> bool;
-        [[nodiscard]] auto operator>(const Version& other) const -> bool;
-        [[nodiscard]] auto operator>=(const Version& other) const -> bool;
-
         /**
          * Return true if this version starts with the other prefix.
          *
@@ -204,6 +197,13 @@ namespace mamba::specs
         CommonVersion m_local = {};
         std::size_t m_epoch = 0;
     };
+
+    auto operator==(const Version& left, const Version& other) -> bool;
+    auto operator!=(const Version& left, const Version& other) -> bool;
+    auto operator<(const Version& left, const Version& other) -> bool;
+    auto operator<=(const Version& left, const Version& other) -> bool;
+    auto operator>(const Version& left, const Version& other) -> bool;
+    auto operator>=(const Version& left, const Version& other) -> bool;
 
     namespace version_literals
     {

--- a/libmamba/include/mamba/specs/version.hpp
+++ b/libmamba/include/mamba/specs/version.hpp
@@ -87,7 +87,7 @@ namespace mamba::specs
          */
         bool implicit_leading_zero = false;
 
-        VersionPart() = default;
+        VersionPart();
         VersionPart(std::initializer_list<VersionPartAtom> init);
 
         auto operator==(const VersionPart& other) const -> bool;
@@ -214,6 +214,15 @@ struct fmt::formatter<mamba::specs::VersionPartAtom>
     auto parse(format_parse_context& ctx) -> decltype(ctx.begin());
 
     auto format(const ::mamba::specs::VersionPartAtom atom, format_context& ctx) const
+        -> decltype(ctx.out());
+};
+
+template <>
+struct fmt::formatter<mamba::specs::VersionPart>
+{
+    auto parse(format_parse_context& ctx) -> decltype(ctx.begin());
+
+    auto format(const ::mamba::specs::VersionPart atom, format_context& ctx) const
         -> decltype(ctx.out());
 };
 

--- a/libmamba/include/mamba/specs/version.hpp
+++ b/libmamba/include/mamba/specs/version.hpp
@@ -92,6 +92,10 @@ namespace mamba::specs
 
         auto operator==(const VersionPart& other) const -> bool;
         auto operator!=(const VersionPart& other) const -> bool;
+        auto operator<(const VersionPart& other) const -> bool;
+        auto operator<=(const VersionPart& other) const -> bool;
+        auto operator>(const VersionPart& other) const -> bool;
+        auto operator>=(const VersionPart& other) const -> bool;
     };
 
     /**

--- a/libmamba/src/specs/version.cpp
+++ b/libmamba/src/specs/version.cpp
@@ -228,38 +228,38 @@ namespace mamba::specs
         }
     }
 
-    auto VersionPartAtom::operator==(const VersionPartAtom& other) const -> bool
+    auto operator==(const VersionPartAtom& left, const VersionPartAtom& right) -> bool
     {
         // More efficient than three way comparison because of edge cases
         auto attrs = [](const VersionPartAtom& a) -> std::tuple<std::size_t, const std::string&>
         { return { a.numeral(), a.literal() }; };
-        return attrs(*this) == attrs(other);
+        return attrs(left) == attrs(right);
     }
 
-    auto VersionPartAtom::operator!=(const VersionPartAtom& other) const -> bool
+    auto operator!=(const VersionPartAtom& left, const VersionPartAtom& right) -> bool
     {
         // More efficient than three way comparison
-        return !(*this == other);
+        return !(left == right);
     }
 
-    auto VersionPartAtom::operator<(const VersionPartAtom& other) const -> bool
+    auto operator<(const VersionPartAtom& left, const VersionPartAtom& right) -> bool
     {
-        return compare_three_way(*this, other) == strong_ordering::less;
+        return compare_three_way(left, right) == strong_ordering::less;
     }
 
-    auto VersionPartAtom::operator<=(const VersionPartAtom& other) const -> bool
+    auto operator<=(const VersionPartAtom& left, const VersionPartAtom& right) -> bool
     {
-        return compare_three_way(*this, other) != strong_ordering::greater;
+        return compare_three_way(left, right) != strong_ordering::greater;
     }
 
-    auto VersionPartAtom::operator>(const VersionPartAtom& other) const -> bool
+    auto operator>(const VersionPartAtom& left, const VersionPartAtom& right) -> bool
     {
-        return compare_three_way(*this, other) == strong_ordering::greater;
+        return compare_three_way(left, right) == strong_ordering::greater;
     }
 
-    auto VersionPartAtom::operator>=(const VersionPartAtom& other) const -> bool
+    auto operator>=(const VersionPartAtom& left, const VersionPartAtom& other) -> bool
     {
-        return compare_three_way(*this, other) != strong_ordering::less;
+        return compare_three_way(left, other) != strong_ordering::less;
     }
 }
 
@@ -329,34 +329,34 @@ namespace mamba::specs
         }
     }
 
-    auto VersionPart::operator==(const VersionPart& other) const -> bool
+    auto operator==(const VersionPart& left, const VersionPart& right) -> bool
     {
-        return compare_three_way(*this, other) == strong_ordering::equal;
+        return compare_three_way(left, right) == strong_ordering::equal;
     }
 
-    auto VersionPart::operator!=(const VersionPart& other) const -> bool
+    auto operator!=(const VersionPart& left, const VersionPart& right) -> bool
     {
-        return !(*this == other);
+        return !(left == right);
     }
 
-    auto VersionPart::operator<(const VersionPart& other) const -> bool
+    auto operator<(const VersionPart& left, const VersionPart& right) -> bool
     {
-        return compare_three_way(*this, other) == strong_ordering::less;
+        return compare_three_way(left, right) == strong_ordering::less;
     }
 
-    auto VersionPart::operator<=(const VersionPart& other) const -> bool
+    auto operator<=(const VersionPart& left, const VersionPart& right) -> bool
     {
-        return compare_three_way(*this, other) != strong_ordering::greater;
+        return compare_three_way(left, right) != strong_ordering::greater;
     }
 
-    auto VersionPart::operator>(const VersionPart& other) const -> bool
+    auto operator>(const VersionPart& left, const VersionPart& right) -> bool
     {
-        return compare_three_way(*this, other) == strong_ordering::greater;
+        return compare_three_way(left, right) == strong_ordering::greater;
     }
 
-    auto VersionPart::operator>=(const VersionPart& other) const -> bool
+    auto operator>=(const VersionPart& left, const VersionPart& right) -> bool
     {
-        return compare_three_way(*this, other) != strong_ordering::less;
+        return compare_three_way(left, right) != strong_ordering::less;
     }
 }
 
@@ -481,34 +481,34 @@ namespace mamba::specs
     }
 
     // TODO(C++20) use operator<=> to simplify code and improve operator<=
-    auto Version::operator==(const Version& other) const -> bool
+    auto operator==(const Version& left, const Version& right) -> bool
     {
-        return compare_three_way(*this, other) == strong_ordering::equal;
+        return compare_three_way(left, right) == strong_ordering::equal;
     }
 
-    auto Version::operator!=(const Version& other) const -> bool
+    auto operator!=(const Version& left, const Version& right) -> bool
     {
-        return !(*this == other);
+        return !(left == right);
     }
 
-    auto Version::operator<(const Version& other) const -> bool
+    auto operator<(const Version& left, const Version& right) -> bool
     {
-        return compare_three_way(*this, other) == strong_ordering::less;
+        return compare_three_way(left, right) == strong_ordering::less;
     }
 
-    auto Version::operator<=(const Version& other) const -> bool
+    auto operator<=(const Version& left, const Version& right) -> bool
     {
-        return compare_three_way(*this, other) != strong_ordering::greater;
+        return compare_three_way(left, right) != strong_ordering::greater;
     }
 
-    auto Version::operator>(const Version& other) const -> bool
+    auto operator>(const Version& left, const Version& right) -> bool
     {
-        return compare_three_way(*this, other) == strong_ordering::greater;
+        return compare_three_way(left, right) == strong_ordering::greater;
     }
 
-    auto Version::operator>=(const Version& other) const -> bool
+    auto operator>=(const Version& left, const Version& right) -> bool
     {
-        return compare_three_way(*this, other) != strong_ordering::less;
+        return compare_three_way(left, right) != strong_ordering::less;
     }
 
     namespace

--- a/libmamba/src/specs/version.cpp
+++ b/libmamba/src/specs/version.cpp
@@ -291,25 +291,26 @@ namespace mamba::specs
      *  Implementation of VersionPart  *
      ***********************************/
 
-    VersionPart::VersionPart(std::initializer_list<VersionPartAtom> init)
-        : atoms(init)
-    {
-    }
-
     VersionPart::VersionPart()
         : atoms()
         , implicit_leading_zero(false)
     {
     }
 
-    auto VersionPart::operator==(const VersionPart& other) const -> bool
+    VersionPart::VersionPart(std::initializer_list<VersionPartAtom> init)
+        : atoms(init)
     {
-        return atoms == other.atoms;
     }
 
-    auto VersionPart::operator!=(const VersionPart& other) const -> bool
+    VersionPart::VersionPart(std::vector<VersionPartAtom> atoms, bool implicit_leading_zero)
+        : atoms(std::move(atoms))
+        , implicit_leading_zero(implicit_leading_zero)
     {
-        return !(*this == other);
+    }
+
+    auto VersionPart::str() const -> std::string
+    {
+        return fmt::format("{}", *this);
     }
 
     namespace
@@ -326,6 +327,16 @@ namespace mamba::specs
                        [](const auto& x, const auto& y) { return compare_three_way(x, y); }
             ).first;
         }
+    }
+
+    auto VersionPart::operator==(const VersionPart& other) const -> bool
+    {
+        return compare_three_way(*this, other) == strong_ordering::equal;
+    }
+
+    auto VersionPart::operator!=(const VersionPart& other) const -> bool
+    {
+        return !(*this == other);
     }
 
     auto VersionPart::operator<(const VersionPart& other) const -> bool

--- a/libmamba/src/specs/version.cpp
+++ b/libmamba/src/specs/version.cpp
@@ -302,9 +302,9 @@ namespace mamba::specs
     {
     }
 
-    VersionPart::VersionPart(std::vector<VersionPartAtom> atoms, bool implicit_leading_zero)
-        : atoms(std::move(atoms))
-        , implicit_leading_zero(implicit_leading_zero)
+    VersionPart::VersionPart(std::vector<VersionPartAtom> p_atoms, bool p_implicit_leading_zero)
+        : atoms(std::move(p_atoms))
+        , implicit_leading_zero(p_implicit_leading_zero)
     {
     }
 
@@ -722,6 +722,7 @@ namespace mamba::specs
             assert(!str.empty());
 
             auto atoms = VersionPart();
+            atoms.implicit_leading_zero = !util::is_digit(str.front());
 
             while (!str.empty())
             {

--- a/libmamba/tests/src/specs/test_match_spec.cpp
+++ b/libmamba/tests/src/specs/test_match_spec.cpp
@@ -160,10 +160,10 @@ namespace
             auto ms = MatchSpec::parse("mingw-w64-ucrt-x86_64-crt-git v12.0.0.r2.ggc561118da h707e725_0")
                           .value();
             REQUIRE(ms.name().str() == "mingw-w64-ucrt-x86_64-crt-git");
-            REQUIRE(ms.version().str() == "==0v12.0.0.0r2.0ggc561118da");
+            REQUIRE(ms.version().str() == "==v12.0.0.r2.ggc561118da");
             REQUIRE(ms.build_string().str() == "h707e725_0");
             REQUIRE(ms.build_number().is_explicitly_free());
-            REQUIRE(ms.str() == "mingw-w64-ucrt-x86_64-crt-git==0v12.0.0.0r2.0ggc561118da=h707e725_0");
+            REQUIRE(ms.str() == "mingw-w64-ucrt-x86_64-crt-git==v12.0.0.r2.ggc561118da=h707e725_0");
         }
 
         SECTION("openblas 0.2.18|0.2.18.*.")
@@ -216,20 +216,20 @@ namespace
         {
             auto ms = MatchSpec::parse("disperse=v0.9.24").value();
             REQUIRE(ms.name().str() == "disperse");
-            REQUIRE(ms.version().str() == "=0v0.9.24");
+            REQUIRE(ms.version().str() == "=v0.9.24");
             REQUIRE(ms.build_string().is_explicitly_free());
             REQUIRE(ms.build_number().is_explicitly_free());
-            REQUIRE(ms.str() == "disperse=0v0.9.24");
+            REQUIRE(ms.str() == "disperse=v0.9.24");
         }
 
         SECTION("disperse v0.9.24")
         {
             auto ms = MatchSpec::parse("disperse v0.9.24").value();
             REQUIRE(ms.name().str() == "disperse");
-            REQUIRE(ms.version().str() == "==0v0.9.24");
+            REQUIRE(ms.version().str() == "==v0.9.24");
             REQUIRE(ms.build_string().is_explicitly_free());
             REQUIRE(ms.build_number().is_explicitly_free());
-            REQUIRE(ms.str() == "disperse==0v0.9.24");
+            REQUIRE(ms.str() == "disperse==v0.9.24");
         }
 
         SECTION("foo V0.9.24")
@@ -252,10 +252,10 @@ namespace
         {
             auto ms = MatchSpec::parse("foo=V0.9.24").value();
             REQUIRE(ms.name().str() == "foo");
-            REQUIRE(ms.version().str() == "=0v0.9.24");
+            REQUIRE(ms.version().str() == "=v0.9.24");
             REQUIRE(ms.build_string().is_explicitly_free());
             REQUIRE(ms.build_number().is_explicitly_free());
-            REQUIRE(ms.str() == "foo=0v0.9.24");
+            REQUIRE(ms.str() == "foo=v0.9.24");
         }
 
         SECTION("numpy 1.7*")
@@ -396,7 +396,7 @@ namespace
             };
             auto ms = MatchSpec::parse(str).value();
             REQUIRE(ms.name().str() == "conda");
-            REQUIRE(ms.version().str() == "==4.3.21.0post699+1dab973");  // Note the ``.0post``
+            REQUIRE(ms.version().str() == "==4.3.21.post699+1dab973");
             REQUIRE(ms.build_string().str() == "py36h4a561cd_0");
             REQUIRE(ms.str() == str);
         }
@@ -673,11 +673,9 @@ namespace
             REQUIRE(ms.channel().value().str() == "conda-canary[linux-64]");
             REQUIRE(ms.platforms().value().get() == MatchSpec::platform_set{ "linux-64" });
             REQUIRE(ms.name().str() == "conda");
-            REQUIRE(ms.version().str() == "==4.3.21.0post699+1dab973");  // Not ``.0post`` diff
+            REQUIRE(ms.version().str() == "==4.3.21.post699+1dab973");
             REQUIRE(ms.build_string().str() == "py36h4a561cd_0");
-            REQUIRE(
-                ms.str() == "conda-canary[linux-64]::conda==4.3.21.0post699+1dab973=py36h4a561cd_0"
-            );
+            REQUIRE(ms.str() == "conda-canary[linux-64]::conda==4.3.21.post699+1dab973=py36h4a561cd_0");
         }
 
         SECTION("libblas[build=^.*(accelerate|mkl)$]")

--- a/libmamba/tests/src/specs/test_version.cpp
+++ b/libmamba/tests/src/specs/test_version.cpp
@@ -12,6 +12,7 @@
 #include <fmt/format.h>
 
 #include "mamba/specs/version.hpp"
+#include "mamba/util/string.hpp"
 
 using namespace mamba::specs;
 
@@ -75,7 +76,7 @@ namespace
         REQUIRE(VersionPart{{0, "dev"} } != VersionPart{{0, "dev"}, {2, ""}});
 
         auto const sorted_parts = std::array{
-            VersionPart{{0, ""}}, 
+            VersionPart{{0, ""}},
             VersionPart{{1, "dev"}, {0, "alpha"}},
             VersionPart{{1, "dev"}},
             VersionPart{{1, "dev"}, {1, "dev"}},
@@ -225,7 +226,7 @@ namespace
         }
     }
 
-    TEST_CASE("compatible_with", "[mamba::specs][mamba::specs::Version]")
+    TEST_CASE("Version compatible_with", "[mamba::specs][mamba::specs::Version]")
     {
         SECTION("positive")
         {
@@ -340,7 +341,7 @@ namespace
         }
     }
 
-    TEST_CASE("version_format", "[mamba::specs][mamba::specs::Version]")
+    TEST_CASE("Version::str", "[mamba::specs][mamba::specs::Version]")
     {
         SECTION("11a0post.3.4dev")
         {
@@ -394,65 +395,65 @@ namespace
      *
      * @see https://github.com/conda/conda/blob/main/tests/models/test_version.py
      */
-    TEST_CASE("Version parse", "[mamba::specs][mamba::specs::Version]")
+    TEST_CASE("Version::parse", "[mamba::specs][mamba::specs::Version]")
     {
         // clang-format off
-            auto sorted_version = std::vector<std::pair<std::string_view, Version>>{
-                {"0.4",         Version(0, {{{0}}, {{4}}})},
-                {"0.4.0",       Version(0, {{{0}}, {{4}}, {{0}}})},
-                {"0.4.1a.vc11", Version(0, {{{0}}, {{4}}, {{1, "a"}}, {{0, "vc"}, {11}}})},
-                {"0.4.1.rc",    Version(0, {{{0}}, {{4}}, {{1}}, {{0, "rc"}}})},
-                {"0.4.1.vc11",  Version(0, {{{0}}, {{4}}, {{1}}, {{0, "vc"}, {11}}})},
-                {"0.4.1",       Version(0, {{{0}}, {{4}}, {{1}}})},
-                {"0.5*",        Version(0, {{{0}}, {{5, "*"}}})},
-                {"0.5a1",       Version(0, {{{0}}, {{5, "a"}, {1}}})},
-                {"0.5b3",       Version(0, {{{0}}, {{5, "b"}, {3}}})},
-                {"0.5C1",       Version(0, {{{0}}, {{5, "c"}, {1}}})},
-                {"0.5z",        Version(0, {{{0}}, {{5, "z"}}})},
-                {"0.5za",       Version(0, {{{0}}, {{5, "za"}}})},
-                {"0.5",         Version(0, {{{0}}, {{5}}})},
-                {"0.5_5",       Version(0, {{{0}}, {{5}}, {{5}}})},
-                {"0.5-5",       Version(0, {{{0}}, {{5}}, {{5}}})},
-                {"0.9.6",       Version(0, {{{0}}, {{9}}, {{6}}})},
-                {"0.960923",    Version(0, {{{0}}, {{960923}}})},
-                {"1.0",         Version(0, {{{1}}, {{0}}})},
-                {"1.0.4a3",     Version(0, {{{1}}, {{0}}, {{4, "a"}, {3}}})},
-                {"1.0.4b1",     Version(0, {{{1}}, {{0}}, {{4, "b"}, {1}}})},
-                {"1.0.4",       Version(0, {{{1}}, {{0}}, {{4}}})},
-                {"1.1dev1",     Version(0, {{{1}}, {{1, "dev"}, {1}}})},
-                {"1.1_",        Version(0, {{{1}}, {{1, "_"}}})},
-                {"1.1a1",       Version(0, {{{1}}, {{1, "a"}, {1}}})},
-                {"1.1.dev1",    Version(0, {{{1}}, {{1}}, {{0, "dev"}, {1}}})},
-                {"1.1.a1",      Version(0, {{{1}}, {{1}}, {{0, "a"}, {1}}})},
-                {"1.1",         Version(0, {{{1}}, {{1}}})},
-                {"1.1.post1",   Version(0, {{{1}}, {{1}}, {{0, "post"}, {1}}})},
-                {"1.1.1dev1",   Version(0, {{{1}}, {{1}}, {{1, "dev"}, {1}}})},
-                {"1.1.1rc1",    Version(0, {{{1}}, {{1}}, {{1, "rc"}, {1}}})},
-                {"1.1.1",       Version(0, {{{1}}, {{1}}, {{1}}})},
-                {"1.1.1post1",  Version(0, {{{1}}, {{1}}, {{1, "post"}, {1}}})},
-                {"1.1post1",    Version(0, {{{1}}, {{1, "post"}, {1}}})},
-                {"2g6",         Version(0, {{{2, "g"}, {6}}})},
-                {"2.0b1pr0",    Version(0, {{{2}}, {{0, "b"}, {1, "pr"}, {0}}})},
-                {"2.2be.ta29",  Version(0, {{{2}}, {{2, "be"}}, {{0, "ta"}, {29}}})},
-                {"2.2be5ta29",  Version(0, {{{2}}, {{2, "be"}, {5, "ta"}, {29}}})},
-                {"2.2beta29",   Version(0, {{{2}}, {{2, "beta"}, {29}}})},
-                {"2.2.0.1",     Version(0, {{{2}}, {{2}}, {{0}}, {{1}}})},
-                {"3.1.1.6",     Version(0, {{{3}}, {{1}}, {{1}}, {{6}}})},
-                {"3.2.p.r0",    Version(0, {{{3}}, {{2}}, {{0, "p"}}, {{0, "r"}, {0}}})},
-                {"3.2.pr0",     Version(0, {{{3}}, {{2}}, {{0, "pr"}, {0}}})},
-                {"3.2.pr.1",    Version(0, {{{3}}, {{2}}, {{0, "pr"}}, {{1}}})},
-                {"5.5.kw",      Version(0, {{{5}}, {{5}}, {{0, "kw"}}})},
-                {"11g",         Version(0, {{{11, "g"}}})},
-                {"14.3.1",      Version(0, {{{14}}, {{3}}, {{1}}})},
-                {
-                    "14.3.1.post26.g9d75ca2",
-                    Version( 0, {{{14}}, {{3}}, {{1}}, {{0, "post"}, {26}}, {{0, "g"}, {9, "d"}, {75, "ca"}, {2}}})
-                },
-                {"1996.07.12",  Version(0, {{{1996}}, {{7}}, {{12}}})},
-                {"1!0.4.1",     Version(1, {{{0}}, {{4}}, {{1}}})},
-                {"1!3.1.1.6",   Version(1, {{{3}}, {{1}}, {{1}}, {{6}}})},
-                {"2!0.4.1",     Version(2, {{{0}}, {{4}}, {{1}}})},
-            };
+        auto const sorted_version = std::vector<std::pair<std::string_view, Version>>{
+            {"0.4",         Version(0, {{{0}}, {{4}}})},
+            {"0.4.0",       Version(0, {{{0}}, {{4}}, {{0}}})},
+            {"0.4.1a.vc11", Version(0, {{{0}}, {{4}}, {{1, "a"}}, {{0, "vc"}, {11}}})},
+            {"0.4.1.rc",    Version(0, {{{0}}, {{4}}, {{1}}, {{0, "rc"}}})},
+            {"0.4.1.vc11",  Version(0, {{{0}}, {{4}}, {{1}}, {{0, "vc"}, {11}}})},
+            {"0.4.1",       Version(0, {{{0}}, {{4}}, {{1}}})},
+            {"0.5*",        Version(0, {{{0}}, {{5, "*"}}})},
+            {"0.5a1",       Version(0, {{{0}}, {{5, "a"}, {1}}})},
+            {"0.5b3",       Version(0, {{{0}}, {{5, "b"}, {3}}})},
+            {"0.5C1",       Version(0, {{{0}}, {{5, "c"}, {1}}})},
+            {"0.5z",        Version(0, {{{0}}, {{5, "z"}}})},
+            {"0.5za",       Version(0, {{{0}}, {{5, "za"}}})},
+            {"0.5",         Version(0, {{{0}}, {{5}}})},
+            {"0.5_5",       Version(0, {{{0}}, {{5}}, {{5}}})},
+            {"0.5-5",       Version(0, {{{0}}, {{5}}, {{5}}})},
+            {"0.9.6",       Version(0, {{{0}}, {{9}}, {{6}}})},
+            {"0.960923",    Version(0, {{{0}}, {{960923}}})},
+            {"1.0",         Version(0, {{{1}}, {{0}}})},
+            {"1.0.4a3",     Version(0, {{{1}}, {{0}}, {{4, "a"}, {3}}})},
+            {"1.0.4b1",     Version(0, {{{1}}, {{0}}, {{4, "b"}, {1}}})},
+            {"1.0.4",       Version(0, {{{1}}, {{0}}, {{4}}})},
+            {"1.1dev1",     Version(0, {{{1}}, {{1, "dev"}, {1}}})},
+            {"1.1_",        Version(0, {{{1}}, {{1, "_"}}})},
+            {"1.1a1",       Version(0, {{{1}}, {{1, "a"}, {1}}})},
+            {"1.1.dev1",    Version(0, {{{1}}, {{1}}, {{0, "dev"}, {1}}})},
+            {"1.1.a1",      Version(0, {{{1}}, {{1}}, {{0, "a"}, {1}}})},
+            {"1.1",         Version(0, {{{1}}, {{1}}})},
+            {"1.1.post1",   Version(0, {{{1}}, {{1}}, {{0, "post"}, {1}}})},
+            {"1.1.1dev1",   Version(0, {{{1}}, {{1}}, {{1, "dev"}, {1}}})},
+            {"1.1.1rc1",    Version(0, {{{1}}, {{1}}, {{1, "rc"}, {1}}})},
+            {"1.1.1",       Version(0, {{{1}}, {{1}}, {{1}}})},
+            {"1.1.1post1",  Version(0, {{{1}}, {{1}}, {{1, "post"}, {1}}})},
+            {"1.1post1",    Version(0, {{{1}}, {{1, "post"}, {1}}})},
+            {"2g6",         Version(0, {{{2, "g"}, {6}}})},
+            {"2.0b1pr0",    Version(0, {{{2}}, {{0, "b"}, {1, "pr"}, {0}}})},
+            {"2.2be.ta29",  Version(0, {{{2}}, {{2, "be"}}, {{0, "ta"}, {29}}})},
+            {"2.2be5ta29",  Version(0, {{{2}}, {{2, "be"}, {5, "ta"}, {29}}})},
+            {"2.2beta29",   Version(0, {{{2}}, {{2, "beta"}, {29}}})},
+            {"2.2.0.1",     Version(0, {{{2}}, {{2}}, {{0}}, {{1}}})},
+            {"3.1.1.6",     Version(0, {{{3}}, {{1}}, {{1}}, {{6}}})},
+            {"3.2.p.r0",    Version(0, {{{3}}, {{2}}, {{0, "p"}}, {{0, "r"}, {0}}})},
+            {"3.2.pr0",     Version(0, {{{3}}, {{2}}, {{0, "pr"}, {0}}})},
+            {"3.2.pr.1",    Version(0, {{{3}}, {{2}}, {{0, "pr"}}, {{1}}})},
+            {"5.5.kw",      Version(0, {{{5}}, {{5}}, {{0, "kw"}}})},
+            {"11g",         Version(0, {{{11, "g"}}})},
+            {"14.3.1",      Version(0, {{{14}}, {{3}}, {{1}}})},
+            {
+                "14.3.1.post26.g9d75ca2",
+                Version( 0, {{{14}}, {{3}}, {{1}}, {{0, "post"}, {26}}, {{0, "g"}, {9, "d"}, {75, "ca"}, {2}}})
+            },
+            {"1996.07.12",  Version(0, {{{1996}}, {{7}}, {{12}}})},
+            {"1!0.4.1",     Version(1, {{{0}}, {{4}}, {{1}}})},
+            {"1!3.1.1.6",   Version(1, {{{3}}, {{1}}, {{1}}, {{6}}})},
+            {"2!0.4.1",     Version(2, {{{0}}, {{4}}, {{1}}})},
+        };
         // clang-format on
         for (const auto& [raw, expected] : sorted_version)
         {
@@ -479,6 +480,11 @@ namespace
         REQUIRE(Version::parse("0.4.a1").value() == Version::parse("0.4.0a1"));
         REQUIRE(Version::parse("0.4.a1").value() != Version::parse("0.4.1a1"));
 
+        // Parse implicit zeros
+        REQUIRE(Version::parse("0.4.a1").value().version()[2].implicit_leading_zero);
+        REQUIRE(Version::parse("0.4.a1").value().str() == "0.4.a1");
+        REQUIRE(Version::parse("g56ffd88f").value().str() == "g56ffd88f");
+
         // These are valid versions with the special '*' ordering AND they are also used as such
         // with version globs in VersionSpec
         REQUIRE(Version::parse("*") == Version(0, { { { 0, "*" } } }));
@@ -493,7 +499,7 @@ namespace
         REQUIRE(Version::parse("1.*") == Version(0, { { { 1, "" } }, { { 0, "*" } } }));
     }
 
-    TEST_CASE("parse_invalid", "[mamba::specs][mamba::specs::Version]")
+    TEST_CASE("Version::parse negative", "[mamba::specs][mamba::specs::Version]")
     {
         // Wrong epoch
         REQUIRE_FALSE(Version::parse("!1.1").has_value());

--- a/libmamba/tests/src/specs/test_version.cpp
+++ b/libmamba/tests/src/specs/test_version.cpp
@@ -17,7 +17,7 @@ using namespace mamba::specs;
 
 namespace
 {
-    TEST_CASE("atom_comparison", "[mamba::specs][mamba::specs::Version]")
+    TEST_CASE("VersionPartAtom", "[mamba::specs][mamba::specs::Version]")
     {
         // No literal
         REQUIRE(VersionPartAtom(1) == VersionPartAtom(1, ""));
@@ -37,20 +37,20 @@ namespace
         REQUIRE(VersionPartAtom(1, "a") >= VersionPartAtom(1, "dev"));
 
         // clang-format off
-            auto sorted_atoms = std::array{
-               VersionPartAtom{ 1, "*" },
-               VersionPartAtom{ 1, "dev" },
-               VersionPartAtom{ 1, "_" },
-               VersionPartAtom{ 1, "a" },
-               VersionPartAtom{ 1, "alpha" },
-               VersionPartAtom{ 1, "b" },
-               VersionPartAtom{ 1, "beta" },
-               VersionPartAtom{ 1, "c" },
-               VersionPartAtom{ 1, "r" },
-               VersionPartAtom{ 1, "rc" },
-               VersionPartAtom{ 1, "" },
-               VersionPartAtom{ 1, "post" },
-            };
+        auto const sorted_atoms = std::array{
+           VersionPartAtom{ 1, "*" },
+           VersionPartAtom{ 1, "dev" },
+           VersionPartAtom{ 1, "_" },
+           VersionPartAtom{ 1, "a" },
+           VersionPartAtom{ 1, "alpha" },
+           VersionPartAtom{ 1, "b" },
+           VersionPartAtom{ 1, "beta" },
+           VersionPartAtom{ 1, "c" },
+           VersionPartAtom{ 1, "r" },
+           VersionPartAtom{ 1, "rc" },
+           VersionPartAtom{ 1, "" },
+           VersionPartAtom{ 1, "post" },
+        };
         // clang-format on
 
         // Strict ordering
@@ -59,13 +59,50 @@ namespace
         REQUIRE(std::adjacent_find(sorted_atoms.cbegin(), sorted_atoms.cend()) == sorted_atoms.cend());
     }
 
-    TEST_CASE("atom_format", "[mamba::specs][mamba::specs::Version]")
+    TEST_CASE("VersionPartAtom::str", "[mamba::specs][mamba::specs::Version]")
     {
         REQUIRE(VersionPartAtom(1, "dev").str() == "1dev");
         REQUIRE(VersionPartAtom(2).str() == "2");
     }
 
-    TEST_CASE("version_comparison", "[mamba::specs][mamba::specs::Version]")
+    TEST_CASE("VersionPart", "[mamba::specs][mamba::specs::Version]")
+    {
+        // clang-format off
+        REQUIRE(VersionPart{{1, "dev"}} == VersionPart{{1, "dev"}});
+        REQUIRE(VersionPart{{1, "dev"}} == VersionPart{{1, "dev"}, {0, ""}});
+        REQUIRE(VersionPart{{1, "dev"}, {2, ""}} == VersionPart{{1, "dev"}, {2, ""}});
+        REQUIRE(VersionPart({{0, "dev"}, {2, ""}}, true) == VersionPart{{0, "dev"}, {2, ""}});
+        REQUIRE(VersionPart{{0, "dev"} } != VersionPart{{0, "dev"}, {2, ""}});
+
+        auto const sorted_parts = std::array{
+            VersionPart{{0, ""}}, 
+            VersionPart{{1, "dev"}, {0, "alpha"}},
+            VersionPart{{1, "dev"}},
+            VersionPart{{1, "dev"}, {1, "dev"}},
+            VersionPart{{2, "dev"}, {1, "dev"}},
+            VersionPart{{2, ""}},
+            VersionPart{{2, ""}, {0, "post"}},
+        };
+        // clang-format on
+
+        // Strict ordering
+        REQUIRE(std::is_sorted(sorted_parts.cbegin(), sorted_parts.cend()));
+        // None compare equal (given the is_sorted assumption)
+        REQUIRE(std::adjacent_find(sorted_parts.cbegin(), sorted_parts.cend()) == sorted_parts.cend());
+    }
+
+    TEST_CASE("VersionPart::str", "[mamba::specs][mamba::specs::Version]")
+    {
+        REQUIRE(VersionPart{ { 1, "dev" } }.str() == "1dev");
+        REQUIRE(VersionPart{ { 1, "dev" }, { 2, "" } }.str() == "1dev2");
+        REQUIRE(VersionPart{ { 1, "dev" }, { 2, "foo" }, { 33, "bar" } }.str() == "1dev2foo33bar");
+        REQUIRE(VersionPart({ { 0, "dev" }, { 2, "" } }, false).str() == "0dev2");
+        REQUIRE(VersionPart({ { 0, "dev" }, { 2, "" } }, true).str() == "dev2");
+        REQUIRE(VersionPart({ { 0, "dev" } }, true).str() == "dev");
+        REQUIRE(VersionPart({ { 0, "" } }, true).str() == "0");
+    }
+
+    TEST_CASE("Version cmp", "[mamba::specs][mamba::specs::Version]")
     {
         auto v = Version(0, { { { 1, "post" } } });
         REQUIRE(v.version().size() == 1);

--- a/libmamba/tests/src/specs/test_version.cpp
+++ b/libmamba/tests/src/specs/test_version.cpp
@@ -69,8 +69,8 @@ namespace
     {
         auto v = Version(0, { { { 1, "post" } } });
         REQUIRE(v.version().size() == 1);
-        REQUIRE(v.version().front().size() == 1);
-        REQUIRE(v.version().front().front() == VersionPartAtom(1, "post"));
+        REQUIRE(v.version().front().atoms.size() == 1);
+        REQUIRE(v.version().front().atoms.front() == VersionPartAtom(1, "post"));
 
         // Same empty 0!1post version
         REQUIRE(Version(0, { { { 1, "post" } } }) == Version(0, { { { 1, "post" } } }));

--- a/libmambapy/tests/test_specs.py
+++ b/libmambapy/tests/test_specs.py
@@ -598,8 +598,10 @@ def test_VersionPart():
     VersionPartAtom = libmambapy.specs.VersionPartAtom
     VersionPart = libmambapy.specs.VersionPart
 
-    p = VersionPart([VersionPartAtom(1, "a"), VersionPartAtom(3)])
-    assert len(p) == 2
+    atoms = [VersionPartAtom(1, "a"), VersionPartAtom(3)]
+    p = VersionPart(atoms)
+    assert len(p) == len(atoms)
+    assert p == p
 
 
 def test_CommonVersion():


### PR DESCRIPTION
Before: ``Version::parse("1.0.2.dev4").str() == "1.0.2.0dev4"``
After: ``Version::parse("1.0.2.dev4").str() == "1.0.2.dev4"``

Note that ``Version::parse(s).str() == s`` is still not true for all s.
For instance, text is converted to lowercase, ``_`` separators are converted to ``.``.

Fix #3904

