### PR TITLE
Rename str > to_string

### DIFF
--- a/libmamba/include/mamba/specs/build_number_spec.hpp
+++ b/libmamba/include/mamba/specs/build_number_spec.hpp
@@ -44,7 +44,7 @@ namespace mamba::specs
          */
         [[nodiscard]] auto contains(const BuildNumber& point) const -> bool;
 
-        [[nodiscard]] auto str() const -> std::string;
+        [[nodiscard]] auto to_string() const -> std::string;
 
     private:
 
@@ -118,7 +118,7 @@ namespace mamba::specs
          * May not always be the same as the parsed string (due to reconstruction) but reparsing
          * this string will give the same build number spec.
          */
-        [[nodiscard]] auto str() const -> std::string;
+        [[nodiscard]] auto to_string() const -> std::string;
 
         /**
          * True if the set described by the BuildNumberSpec contains the given version.
@@ -172,7 +172,7 @@ struct std::hash<mamba::specs::BuildNumberSpec>
 {
     auto operator()(const mamba::specs::BuildNumberSpec& spec) const -> std::size_t
     {
-        return mamba::util::hash_vals(spec.str());
+        return mamba::util::hash_vals(spec.to_string());
     }
 };
 

--- a/libmamba/include/mamba/specs/chimera_string_spec.hpp
+++ b/libmamba/include/mamba/specs/chimera_string_spec.hpp
@@ -50,7 +50,7 @@ namespace mamba::specs
          */
         [[nodiscard]] auto is_glob() const -> bool;
 
-        [[nodiscard]] auto str() const -> const std::string&;
+        [[nodiscard]] auto to_string() const -> const std::string&;
 
         // TODO(C++20): replace by the `= default` implementation of `operator==`
         [[nodiscard]] auto operator==(const ChimeraStringSpec& other) const -> bool
@@ -83,7 +83,7 @@ struct std::hash<mamba::specs::ChimeraStringSpec>
 {
     auto operator()(const mamba::specs::ChimeraStringSpec& spec) const -> std::size_t
     {
-        return mamba::util::hash_vals(spec.str());
+        return mamba::util::hash_vals(spec.to_string());
     }
 };
 

--- a/libmamba/include/mamba/specs/glob_spec.hpp
+++ b/libmamba/include/mamba/specs/glob_spec.hpp
@@ -41,7 +41,7 @@ namespace mamba::specs
          */
         [[nodiscard]] auto is_exact() const -> bool;
 
-        [[nodiscard]] auto str() const -> const std::string&;
+        [[nodiscard]] auto to_string() const -> const std::string&;
 
         // TODO(C++20): replace by the `= default` implementation of `operator==`
         [[nodiscard]] auto operator==(const GlobSpec& other) const -> bool
@@ -74,7 +74,7 @@ struct std::hash<mamba::specs::GlobSpec>
 {
     auto operator()(const mamba::specs::GlobSpec& spec) const -> std::size_t
     {
-        return std::hash<std::string>{}(spec.str());
+        return std::hash<std::string>{}(spec.to_string());
     }
 };
 

--- a/libmamba/include/mamba/specs/match_spec.hpp
+++ b/libmamba/include/mamba/specs/match_spec.hpp
@@ -105,7 +105,7 @@ namespace mamba::specs
         void set_optional(bool opt);
 
         [[nodiscard]] auto conda_build_form() const -> std::string;
-        [[nodiscard]] auto str() const -> std::string;
+        [[nodiscard]] auto to_string() const -> std::string;
 
         /**
          * Return true if the MatchSpec can be written as ``<name> <version> <build_string>``.

--- a/libmamba/include/mamba/specs/package_info.hpp
+++ b/libmamba/include/mamba/specs/package_info.hpp
@@ -72,6 +72,7 @@ namespace mamba::specs
         PackageInfo(std::string name, std::string version, std::string build_string, std::string channel);
 
         [[nodiscard]] auto json_signable() const -> nlohmann::json;
+        // TODO: rename to_string, following C++ conventions
         [[nodiscard]] auto str() const -> std::string;
         [[nodiscard]] auto long_str() const -> std::string;
 

--- a/libmamba/include/mamba/specs/regex_spec.hpp
+++ b/libmamba/include/mamba/specs/regex_spec.hpp
@@ -45,7 +45,7 @@ namespace mamba::specs
          */
         [[nodiscard]] auto is_exact() const -> bool;
 
-        [[nodiscard]] auto str() const -> const std::string&;
+        [[nodiscard]] auto to_string() const -> const std::string&;
 
         // TODO(C++20): replace by the `= default` implementation of `operator==`
         [[nodiscard]] auto operator==(const RegexSpec& other) const -> bool
@@ -80,7 +80,7 @@ struct std::hash<mamba::specs::RegexSpec>
 {
     auto operator()(const mamba::specs::RegexSpec& spec) const -> std::size_t
     {
-        return std::hash<std::string>{}(spec.str());
+        return std::hash<std::string>{}(spec.to_string());
     }
 };
 

--- a/libmamba/include/mamba/specs/version.hpp
+++ b/libmamba/include/mamba/specs/version.hpp
@@ -41,7 +41,7 @@ namespace mamba::specs
         [[nodiscard]] auto literal() const& noexcept -> const std::string&;
         auto literal() && noexcept -> std::string;
 
-        [[nodiscard]] auto str() const -> std::string;
+        [[nodiscard]] auto to_string() const -> std::string;
 
     private:
 
@@ -91,7 +91,7 @@ namespace mamba::specs
         VersionPart(std::initializer_list<VersionPartAtom> init);
         VersionPart(std::vector<VersionPartAtom> atoms, bool implicit_leading_zero);
 
-        [[nodiscard]] auto str() const -> std::string;
+        [[nodiscard]] auto to_string() const -> std::string;
     };
 
     auto operator==(const VersionPart& left, const VersionPart& other) -> bool;
@@ -149,9 +149,9 @@ namespace mamba::specs
          *
          * May not always be the same as the parsed string (due to reconstruction) but reparsing
          * this string will give the same version.
-         * ``v == Version::parse(v.str())``.
+         * ``v == Version::parse(v.to_string())``.
          */
-        [[nodiscard]] auto str() const -> std::string;
+        [[nodiscard]] auto to_string() const -> std::string;
 
         /**
          * A string truncated of extended representation of the version.
@@ -160,7 +160,7 @@ namespace mamba::specs
          * If the actual number of parts is larger, then the string is truncated.
          * If the actual number of parts is smalle, then the string is expanded with zeros.
          */
-        [[nodiscard]] auto str(std::size_t level) const -> std::string;
+        [[nodiscard]] auto to_string(std::size_t level) const -> std::string;
 
         /**
          * String representation that treats ``*`` as glob pattern.
@@ -168,7 +168,7 @@ namespace mamba::specs
          * Instead of printing them as ``0*`` (as a special literal), it formats them as ``*``.
          * In full, a version like ``*.1.*`` will print as such instead of ``0*.1.0*``.
          */
-        [[nodiscard]] auto str_glob() const -> std::string;
+        [[nodiscard]] auto to_string_glob() const -> std::string;
 
         /**
          * Return true if this version starts with the other prefix.

--- a/libmamba/include/mamba/specs/version_spec.hpp
+++ b/libmamba/include/mamba/specs/version_spec.hpp
@@ -57,14 +57,14 @@ namespace mamba::specs
          */
         [[nodiscard]] auto has_glob() const -> bool;
 
-        [[nodiscard]] auto str() const -> std::string;
+        [[nodiscard]] auto to_string() const -> std::string;
 
         /**
          * An alternative string representation of the version spec.
          *
          * Attempts to be compatible with conda-build/libsolv.
          */
-        [[nodiscard]] auto str_conda_build() const -> std::string;
+        [[nodiscard]] auto to_string_conda_build() const -> std::string;
 
     private:
 
@@ -215,14 +215,14 @@ namespace mamba::specs
          * May not always be the same as the parsed string (due to reconstruction) but reparsing
          * this string will give the same version spec.
          */
-        [[nodiscard]] auto str() const -> std::string;
+        [[nodiscard]] auto to_string() const -> std::string;
 
         /**
          * An alternative string representation of the version spec.
          *
          * Attempts to be compatible with conda-build/libsolv.
          */
-        [[nodiscard]] auto str_conda_build() const -> std::string;
+        [[nodiscard]] auto to_string_conda_build() const -> std::string;
 
         /**
          * True if the set described by the VersionSpec contains the given version.
@@ -290,7 +290,7 @@ struct std::hash<mamba::specs::VersionPredicate>
 {
     auto operator()(const mamba::specs::VersionPredicate& pred) const -> std::size_t
     {
-        return mamba::util::hash_vals(pred.str());
+        return mamba::util::hash_vals(pred.to_string());
     }
 };
 
@@ -299,7 +299,7 @@ struct std::hash<mamba::specs::VersionSpec>
 {
     auto operator()(const mamba::specs::VersionSpec& spec) const -> std::size_t
     {
-        return mamba::util::hash_vals(spec.str());
+        return mamba::util::hash_vals(spec.to_string());
     }
 };
 

--- a/libmamba/src/api/install.cpp
+++ b/libmamba/src/api/install.cpp
@@ -417,7 +417,7 @@ namespace mamba
                             out << "\nPinned packages:\n\n";
                             first = false;
                         }
-                        out << "  - " << item.spec.str() << '\n';
+                        out << "  - " << item.spec.to_string() << '\n';
                     }
                 },
                 req

--- a/libmamba/src/api/remove.cpp
+++ b/libmamba/src/api/remove.cpp
@@ -176,7 +176,7 @@ namespace mamba
                     const auto& installed = prefix_data.records();
                     // TODO should itreate over all packages and use MatchSpec.contains
                     // TODO should move such method over Pool for consistent use
-                    if (auto iter = installed.find(spec.name().str()); iter != installed.cend())
+                    if (auto iter = installed.find(spec.name().to_string()); iter != installed.cend())
                     {
                         pkgs_to_remove.push_back(iter->second);
                     }

--- a/libmamba/src/api/update.cpp
+++ b/libmamba/src/api/update.cpp
@@ -82,15 +82,19 @@ namespace mamba
                                                  { throw std::move(err); })
                                         .value()
                                         .name()
-                                        .str();
+                                        .to_string();
                                 }
                             );
 
-                            if (std::find(spec_names.begin(), spec_names.end(), it.second.name().str())
+                            if (std::find(
+                                    spec_names.begin(),
+                                    spec_names.end(),
+                                    it.second.name().to_string()
+                                )
                                 == spec_names.end())
                             {
                                 request.jobs.emplace_back(Request::Remove{
-                                    specs::MatchSpec::parse(it.second.name().str())
+                                    specs::MatchSpec::parse(it.second.name().to_string())
                                         .or_else([](specs::ParseError&& err)
                                                  { throw std::move(err); })
                                         .value(),

--- a/libmamba/src/core/history.cpp
+++ b/libmamba/src/core/history.cpp
@@ -256,17 +256,17 @@ namespace mamba
             auto remove_specs = to_specs(request.remove);
             for (auto& spec : remove_specs)
             {
-                map.erase(spec.name().str());
+                map.erase(spec.name().to_string());
             }
             auto update_specs = to_specs(request.update);
             for (auto& spec : update_specs)
             {
-                map[spec.name().str()] = spec;
+                map[spec.name().to_string()] = spec;
             }
             auto neutered_specs = to_specs(request.neutered);
             for (auto& spec : neutered_specs)
             {
-                map[spec.name().str()] = spec;
+                map[spec.name().to_string()] = spec;
             }
         }
 

--- a/libmamba/src/core/link.cpp
+++ b/libmamba/src/core/link.cpp
@@ -1004,7 +1004,7 @@ namespace mamba
                 requested_spec = &ms;
             }
         }
-        out_json["requested_spec"] = requested_spec != nullptr ? requested_spec->str() : "";
+        out_json["requested_spec"] = requested_spec != nullptr ? requested_spec->to_string() : "";
         out_json["package_tarball_full_path"] = m_source.string() + ".tar.bz2";
         out_json["extracted_package_dir"] = m_source.string();
 

--- a/libmamba/src/core/prefix_data.cpp
+++ b/libmamba/src/core/prefix_data.cpp
@@ -129,7 +129,7 @@ namespace mamba
                                   .value();
                     // Ignoring unmatched dependencies, the environment could be broken
                     // or it could be a matchspec
-                    const auto from_iter = name_to_node_id.find(ms.name().str());
+                    const auto from_iter = name_to_node_id.find(ms.name().to_string());
                     if (from_iter != name_to_node_id.cend())
                     {
                         dep_graph.add_edge(from_iter->second, to_id);

--- a/libmamba/src/core/transaction.cpp
+++ b/libmamba/src/core/transaction.cpp
@@ -182,7 +182,7 @@ namespace mamba
             auto spec = explicit_spec(pkg);
             if (!database_has_package(database, spec))
             {
-                not_found << "\n - " << spec.str();
+                not_found << "\n - " << spec.to_string();
             }
         }
 
@@ -207,12 +207,12 @@ namespace mamba
         m_history_entry.update.reserve(pkgs_to_install.size());
         for (auto& pkg : pkgs_to_install)
         {
-            m_history_entry.update.push_back(explicit_spec(pkg).str());
+            m_history_entry.update.push_back(explicit_spec(pkg).to_string());
         }
         m_history_entry.remove.reserve(pkgs_to_remove.size());
         for (auto& pkg : pkgs_to_remove)
         {
-            m_history_entry.remove.push_back(explicit_spec(pkg).str());
+            m_history_entry.remove.push_back(explicit_spec(pkg).to_string());
         }
 
         m_solution.actions.reserve(pkgs_to_install.size() + pkgs_to_remove.size());
@@ -264,11 +264,11 @@ namespace mamba
             using Request = solver::Request;
             solver::for_each_of<Request::Install, Request::Update>(
                 request,
-                [&](const auto& item) { m_history_entry.update.push_back(item.spec.str()); }
+                [&](const auto& item) { m_history_entry.update.push_back(item.spec.to_string()); }
             );
             solver::for_each_of<Request::Remove, Request::Update>(
                 request,
-                [&](const auto& item) { m_history_entry.remove.push_back(item.spec.str()); }
+                [&](const auto& item) { m_history_entry.remove.push_back(item.spec.to_string()); }
             );
         }
         else

--- a/libmamba/src/solver/libsolv/helpers.cpp
+++ b/libmamba/src/solver/libsolv/helpers.cpp
@@ -992,15 +992,15 @@ namespace mamba::solver::libsolv
         {
             return check_dep_error(
                 pool.add_legacy_conda_dependency(ms.conda_build_form()),
-                [&]() { return ms.str(); }
+                [&]() { return ms.to_string(); }
             );
         }
         else if (parser == MatchSpecParser::Mamba)
         {
-            const auto [first, second] = make_abused_namespace_dep_args(pool, ms.str());
+            const auto [first, second] = make_abused_namespace_dep_args(pool, ms.to_string());
             return check_dep_error(
                 pool.add_dependency(first, REL_NAMESPACE, second),
-                [&]() { return ms.str(); }
+                [&]() { return ms.to_string(); }
             );
         }
 
@@ -1062,7 +1062,10 @@ namespace mamba::solver::libsolv
         if (pool.disttype() != DISTTYPE_CONDA)
         {
             return make_unexpected(
-                fmt::format(R"(Cannot add pin "{}" to a pool that is not of Conda distype)", pin.str()),
+                fmt::format(
+                    R"(Cannot add pin "{}" to a pool that is not of Conda distype)",
+                    pin.to_string()
+                ),
                 mamba_error_code::incorrect_usage
             );
         }
@@ -1526,7 +1529,7 @@ namespace mamba::solver::libsolv
                 // This has the effect of reinstalling in libsolv.
                 const auto [first, second] = make_abused_namespace_dep_args(
                     pool,
-                    match_as_closely(solvable.value()).str(),
+                    match_as_closely(solvable.value()).to_string(),
                     { /* .skip_installed= */ true }
                 );
                 const auto job_id = pool.add_dependency(first, REL_NAMESPACE, second);
@@ -1622,7 +1625,7 @@ namespace mamba::solver::libsolv
                                 // package name, not the full spec.
                                 if (job.spec.name().is_exact())
                                 {
-                                    auto name_id = pool.add_string(job.spec.name().str());
+                                    auto name_id = pool.add_string(job.spec.name().to_string());
                                     raw_jobs.push_back(SOLVER_UPDATE | clean_deps, name_id);
                                 }
                                 // And we add an install statement to be sure the full spec is

--- a/libmamba/src/solver/libsolv/matcher.cpp
+++ b/libmamba/src/solver/libsolv/matcher.cpp
@@ -76,7 +76,7 @@ namespace mamba::solver::libsolv
         if (ms.name().is_exact())
         {
             // Name does not have glob so we can use it as index into packages with exact name.
-            auto name_id = pool.add_string(ms.name().str());
+            auto name_id = pool.add_string(ms.name().to_string());
             pool.for_each_whatprovides(name_id, add_pkg_if_matching);
         }
         else

--- a/libmamba/src/solver/libsolv/solver.cpp
+++ b/libmamba/src/solver/libsolv/solver.cpp
@@ -42,7 +42,7 @@ namespace mamba::solver::libsolv
                     using Itm = std::decay_t<decltype(lhs)>;
                     if constexpr (!std::is_same_v<Itm, Request::UpdateAll>)
                     {
-                        return lhs.spec.name().str() < rhs.spec.name().str();
+                        return lhs.spec.name().to_string() < rhs.spec.name().to_string();
                     }
                     return false;
                 }

--- a/libmamba/src/solver/libsolv/unsolvable.cpp
+++ b/libmamba/src/solver/libsolv/unsolvable.cpp
@@ -315,7 +315,7 @@ namespace mamba::solver::libsolv
             // They are added with a install top-level dependency
             // ``Install{ "pin-fsej43208fsd"_ms }``.
             // We need to change their name to make them look more readable.
-            if (auto id = pool.find_string(ms.name().str()))
+            if (auto id = pool.find_string(ms.name().to_string()))
             {
                 pool.for_each_whatprovides(
                     *id,
@@ -540,8 +540,8 @@ namespace mamba::solver::libsolv
                         // dependency.
                         auto edge = make_match_spec_str(source.value().name);
                         // The package cannot exist without its name in the pool
-                        assert(m_pool.find_string(edge.name().str()).has_value());
-                        const auto dep_id = m_pool.find_string(edge.name().str()).value();
+                        assert(m_pool.find_string(edge.name().to_string()).has_value());
+                        const auto dep_id = m_pool.find_string(edge.name().to_string()).value();
                         const bool added = add_expanded_deps_edges(m_root_node, dep_id, edge);
                         if (!added)
                         {

--- a/libmamba/src/solver/problems_graph.cpp
+++ b/libmamba/src/solver/problems_graph.cpp
@@ -278,7 +278,7 @@ namespace mamba::solver
             Ver v = std::invoke(&TT::version, std::forward<T>(e));
             if constexpr (std::is_same_v<std::decay_t<decltype(v)>, specs::VersionSpec>)
             {
-                return std::forward<Ver>(v).str();
+                return std::forward<Ver>(v).to_string();
             }
             else
             {
@@ -294,7 +294,7 @@ namespace mamba::solver
             Num num = std::invoke(&TT::build_number, std::forward<T>(e));
             if constexpr (std::is_same_v<std::decay_t<decltype(num)>, specs::BuildNumberSpec>)
             {
-                return std::forward<Num>(num).str();
+                return std::forward<Num>(num).to_string();
             }
             else
             {
@@ -310,7 +310,7 @@ namespace mamba::solver
             Build bld = std::invoke(&TT::build_string, std::forward<T>(e));
             if constexpr (std::is_same_v<std::decay_t<decltype(bld)>, specs::ChimeraStringSpec>)
             {
-                return std::forward<Build>(bld).str();
+                return std::forward<Build>(bld).to_string();
             }
             else
             {
@@ -326,7 +326,7 @@ namespace mamba::solver
             Name name = std::invoke(&TT::name, std::forward<T>(e));
             if constexpr (std::is_same_v<std::decay_t<decltype(name)>, specs::GlobSpec>)
             {
-                return std::forward<Name>(name).str();
+                return std::forward<Name>(name).to_string();
             }
             else
             {

--- a/libmamba/src/specs/build_number_spec.cpp
+++ b/libmamba/src/specs/build_number_spec.cpp
@@ -69,7 +69,7 @@ namespace mamba::specs
         return BuildNumberPredicate(std::move(ver), std::less_equal<BuildNumber>{});
     }
 
-    auto BuildNumberPredicate::str() const -> std::string
+    auto BuildNumberPredicate::to_string() const -> std::string
     {
         return fmt::format("{}", *this);
     }
@@ -231,7 +231,7 @@ namespace mamba::specs
         return m_predicate == BuildNumberPredicate::make_free();
     }
 
-    auto BuildNumberSpec::str() const -> std::string
+    auto BuildNumberSpec::to_string() const -> std::string
     {
         return fmt::format("{}", *this);
     }

--- a/libmamba/src/specs/chimera_string_spec.cpp
+++ b/libmamba/src/specs/chimera_string_spec.cpp
@@ -37,7 +37,7 @@ namespace mamba::specs
                         }
                         if (spec.is_exact())
                         {
-                            return ChimeraStringSpec{ GlobSpec(std::move(spec).str()) };
+                            return ChimeraStringSpec{ GlobSpec(std::move(spec).to_string()) };
                         }
                         return ChimeraStringSpec{ std::move(spec) };
                     }
@@ -119,9 +119,9 @@ namespace mamba::specs
         return std::holds_alternative<GlobSpec>(m_spec);
     }
 
-    auto ChimeraStringSpec::str() const -> const std::string&
+    auto ChimeraStringSpec::to_string() const -> const std::string&
     {
-        return std::visit([](const auto& s) -> decltype(auto) { return s.str(); }, m_spec);
+        return std::visit([](const auto& s) -> decltype(auto) { return s.to_string(); }, m_spec);
     }
 }
 
@@ -143,5 +143,5 @@ fmt::formatter<mamba::specs::ChimeraStringSpec>::format(
     format_context& ctx
 ) const -> decltype(ctx.out())
 {
-    return fmt::format_to(ctx.out(), "{}", spec.str());
+    return fmt::format_to(ctx.out(), "{}", spec.to_string());
 }

--- a/libmamba/src/specs/glob_spec.cpp
+++ b/libmamba/src/specs/glob_spec.cpp
@@ -38,7 +38,7 @@ namespace mamba::specs
         return !util::contains(m_pattern, glob_pattern);
     }
 
-    auto GlobSpec::str() const -> const std::string&
+    auto GlobSpec::to_string() const -> const std::string&
     {
         return m_pattern;
     }
@@ -59,5 +59,5 @@ auto
 fmt::formatter<mamba::specs::GlobSpec>::format(const ::mamba::specs::GlobSpec& spec, format_context& ctx) const
     -> decltype(ctx.out())
 {
-    return fmt::format_to(ctx.out(), "{}", spec.str());
+    return fmt::format_to(ctx.out(), "{}", spec.to_string());
 }

--- a/libmamba/src/specs/match_spec.cpp
+++ b/libmamba/src/specs/match_spec.cpp
@@ -1013,7 +1013,7 @@ namespace mamba::specs
         };
     }
 
-    auto MatchSpec::str() const -> std::string
+    auto MatchSpec::to_string() const -> std::string
     {
         return fmt::format("{}", *this);
     }

--- a/libmamba/src/specs/regex_spec.cpp
+++ b/libmamba/src/specs/regex_spec.cpp
@@ -121,7 +121,7 @@ namespace mamba::specs
         return std::all_of(m_raw_pattern.cbegin() + 1, m_raw_pattern.cend() - 1, no_special_meaning);
     }
 
-    auto RegexSpec::str() const -> const std::string&
+    auto RegexSpec::to_string() const -> const std::string&
     {
         return m_raw_pattern;
     }
@@ -144,5 +144,5 @@ fmt::formatter<mamba::specs::RegexSpec>::format(
     format_context& ctx
 ) const -> decltype(ctx.out())
 {
-    return fmt::format_to(ctx.out(), "{}", spec.str());
+    return fmt::format_to(ctx.out(), "{}", spec.to_string());
 }

--- a/libmamba/src/specs/repo_data.cpp
+++ b/libmamba/src/specs/repo_data.cpp
@@ -16,7 +16,7 @@ namespace mamba::specs
     void to_json(nlohmann::json& j, const RepoDataPackage& p)
     {
         j["name"] = p.name;
-        j["version"] = p.version.str();
+        j["version"] = p.version.to_string();
         j["build"] = p.build_string;
         j["build_number"] = p.build_number;
         j["subdir"] = p.subdir;

--- a/libmamba/src/specs/version.cpp
+++ b/libmamba/src/specs/version.cpp
@@ -175,7 +175,7 @@ namespace mamba::specs
         return std::move(m_literal);
     }
 
-    auto VersionPartAtom::str() const -> std::string
+    auto VersionPartAtom::to_string() const -> std::string
     {
         return fmt::format("{}", *this);
     }
@@ -308,7 +308,7 @@ namespace mamba::specs
     {
     }
 
-    auto VersionPart::str() const -> std::string
+    auto VersionPart::to_string() const -> std::string
     {
         return fmt::format("{}", *this);
     }
@@ -431,12 +431,12 @@ namespace mamba::specs
         return m_local;
     }
 
-    auto Version::str() const -> std::string
+    auto Version::to_string() const -> std::string
     {
         return fmt::format("{}", *this);
     }
 
-    auto Version::str(std::size_t level) const -> std::string
+    auto Version::to_string(std::size_t level) const -> std::string
     {
         // We should be able to do, as it works with numbers but it is not clear how this works
         // with the custom parser
@@ -445,7 +445,7 @@ namespace mamba::specs
         return fmt::format(fmt, *this);
     }
 
-    auto Version::str_glob() const -> std::string
+    auto Version::to_string_glob() const -> std::string
     {
         return fmt::format("{:g}", *this);
     }

--- a/libmamba/src/specs/version_spec.cpp
+++ b/libmamba/src/specs/version_spec.cpp
@@ -272,12 +272,12 @@ namespace mamba::specs
         return VersionPredicate(std::move(pattern), not_version_glob{});
     }
 
-    auto VersionPredicate::str() const -> std::string
+    auto VersionPredicate::to_string() const -> std::string
     {
         return fmt::format("{}", *this);
     }
 
-    auto VersionPredicate::str_conda_build() const -> std::string
+    auto VersionPredicate::to_string_conda_build() const -> std::string
     {
         return fmt::format("{:b}", *this);
     }
@@ -392,7 +392,7 @@ fmt::formatter<mamba::specs::VersionPredicate>::format(
                     out,
                     "{}{}",
                     VersionSpec::compatible_str,
-                    pred.m_version.str(format_level)
+                    pred.m_version.to_string(format_level)
                 );
             }
             if constexpr (std::is_same_v<Op, VersionPredicate::version_glob>)
@@ -462,12 +462,12 @@ namespace mamba::specs
         return found;
     }
 
-    auto VersionSpec::str() const -> std::string
+    auto VersionSpec::to_string() const -> std::string
     {
         return fmt::format("{}", *this);
     }
 
-    auto VersionSpec::str_conda_build() const -> std::string
+    auto VersionSpec::to_string_conda_build() const -> std::string
     {
         return fmt::format("{:b}", *this);
     }

--- a/libmamba/tests/src/solver/test_problems_graph.cpp
+++ b/libmamba/tests/src/solver/test_problems_graph.cpp
@@ -581,7 +581,7 @@ namespace
                 else if constexpr (std::is_same_v<Node, ProblemsGraph::UnresolvedDependencyNode>
                                    || std::is_same_v<Node, ProblemsGraph::ConstraintNode>)
                 {
-                    return util::starts_with(std::invoke(&Node::name, n).str(), "__");
+                    return util::starts_with(std::invoke(&Node::name, n).to_string(), "__");
                 }
                 else
                 {

--- a/libmamba/tests/src/specs/test_build_number_spec.cpp
+++ b/libmamba/tests/src/specs/test_build_number_spec.cpp
@@ -20,43 +20,43 @@ namespace
         REQUIRE(free.contains(0));
         REQUIRE(free.contains(1));
         REQUIRE(free.contains(2));
-        REQUIRE(free.str() == "=*");
+        REQUIRE(free.to_string() == "=*");
 
         const auto eq = BuildNumberPredicate::make_equal_to(1);
         REQUIRE_FALSE(eq.contains(0));
         REQUIRE(eq.contains(1));
         REQUIRE_FALSE(eq.contains(2));
-        REQUIRE(eq.str() == "=1");
+        REQUIRE(eq.to_string() == "=1");
 
         const auto ne = BuildNumberPredicate::make_not_equal_to(1);
         REQUIRE(ne.contains(0));
         REQUIRE_FALSE(ne.contains(1));
         REQUIRE(ne.contains(2));
-        REQUIRE(ne.str() == "!=1");
+        REQUIRE(ne.to_string() == "!=1");
 
         const auto gt = BuildNumberPredicate::make_greater(1);
         REQUIRE_FALSE(gt.contains(0));
         REQUIRE_FALSE(gt.contains(1));
         REQUIRE(gt.contains(2));
-        REQUIRE(gt.str() == ">1");
+        REQUIRE(gt.to_string() == ">1");
 
         const auto ge = BuildNumberPredicate::make_greater_equal(1);
         REQUIRE_FALSE(ge.contains(0));
         REQUIRE(ge.contains(1));
         REQUIRE(ge.contains(2));
-        REQUIRE(ge.str() == ">=1");
+        REQUIRE(ge.to_string() == ">=1");
 
         const auto lt = BuildNumberPredicate::make_less(1);
         REQUIRE(lt.contains(0));
         REQUIRE_FALSE(lt.contains(1));
         REQUIRE_FALSE(lt.contains(2));
-        REQUIRE(lt.str() == "<1");
+        REQUIRE(lt.to_string() == "<1");
 
         const auto le = BuildNumberPredicate::make_less_equal(1);
         REQUIRE(le.contains(0));
         REQUIRE(le.contains(1));
         REQUIRE_FALSE(le.contains(2));
-        REQUIRE(le.str() == "<=1");
+        REQUIRE(le.to_string() == "<=1");
 
         const auto predicates = std::array{ free, eq, ne, lt, le, gt, ge };
         for (std::size_t i = 0; i < predicates.size(); ++i)
@@ -126,9 +126,9 @@ namespace
 
     TEST_CASE("BuildNumberSepc::str")
     {
-        REQUIRE(BuildNumberSpec::parse("=3").value().str() == "=3");
-        REQUIRE(BuildNumberSpec::parse("<2").value().str() == "<2");
-        REQUIRE(BuildNumberSpec::parse("*").value().str() == "=*");
+        REQUIRE(BuildNumberSpec::parse("=3").value().to_string() == "=3");
+        REQUIRE(BuildNumberSpec::parse("<2").value().to_string() == "<2");
+        REQUIRE(BuildNumberSpec::parse("*").value().to_string() == "=*");
     }
 
     TEST_CASE("BuildNumberSepc::is_explicitly_free")

--- a/libmamba/tests/src/specs/test_chimera_string_spec.cpp
+++ b/libmamba/tests/src/specs/test_chimera_string_spec.cpp
@@ -19,7 +19,7 @@ namespace
         REQUIRE(spec.contains(""));
         REQUIRE(spec.contains("hello"));
 
-        REQUIRE(spec.str() == "*");
+        REQUIRE(spec.to_string() == "*");
         REQUIRE(spec.is_explicitly_free());
         REQUIRE_FALSE(spec.is_exact());
         REQUIRE(spec.is_glob());
@@ -34,7 +34,7 @@ namespace
         REQUIRE_FALSE(spec.contains("nomkl"));
         REQUIRE_FALSE(spec.contains("hello"));
 
-        REQUIRE(spec.str() == "mkl");
+        REQUIRE(spec.to_string() == "mkl");
         REQUIRE_FALSE(spec.is_explicitly_free());
         REQUIRE(spec.is_exact());
         REQUIRE(spec.is_glob());
@@ -50,7 +50,7 @@ namespace
         REQUIRE_FALSE(spec.contains(""));
         REQUIRE_FALSE(spec.contains("cpython"));
 
-        REQUIRE(spec.str() == "^py.*$");
+        REQUIRE(spec.to_string() == "^py.*$");
         REQUIRE_FALSE(spec.is_explicitly_free());
         REQUIRE_FALSE(spec.is_exact());
         REQUIRE_FALSE(spec.is_glob());
@@ -65,7 +65,7 @@ namespace
         REQUIRE_FALSE(spec.contains(""));
         REQUIRE_FALSE(spec.contains("openblas"));
 
-        REQUIRE(spec.str() == "^.*(accelerate|mkl)$");
+        REQUIRE(spec.to_string() == "^.*(accelerate|mkl)$");
         REQUIRE_FALSE(spec.is_explicitly_free());
         REQUIRE_FALSE(spec.is_exact());
         REQUIRE_FALSE(spec.is_glob());

--- a/libmamba/tests/src/specs/test_glob_spec.cpp
+++ b/libmamba/tests/src/specs/test_glob_spec.cpp
@@ -21,7 +21,7 @@ namespace
         REQUIRE(spec.contains(""));
         REQUIRE(spec.contains("hello"));
 
-        REQUIRE(spec.str() == "*");
+        REQUIRE(spec.to_string() == "*");
         REQUIRE(spec.is_free());
         REQUIRE_FALSE(spec.is_exact());
     }
@@ -35,7 +35,7 @@ namespace
         REQUIRE_FALSE(spec.contains("nomkl"));
         REQUIRE_FALSE(spec.contains("hello"));
 
-        REQUIRE(spec.str() == "mkl");
+        REQUIRE(spec.to_string() == "mkl");
         REQUIRE_FALSE(spec.is_free());
         REQUIRE(spec.is_exact());
     }
@@ -51,7 +51,7 @@ namespace
         REQUIRE_FALSE(spec.contains("rust"));
         REQUIRE_FALSE(spec.contains("hello"));
 
-        REQUIRE(spec.str() == "*py*");
+        REQUIRE(spec.to_string() == "*py*");
         REQUIRE_FALSE(spec.is_free());
         REQUIRE_FALSE(spec.is_exact());
     }

--- a/libmamba/tests/src/specs/test_match_spec.cpp
+++ b/libmamba/tests/src/specs/test_match_spec.cpp
@@ -31,125 +31,125 @@ namespace
             REQUIRE(ms.version().is_explicitly_free());
             REQUIRE(ms.build_string().is_explicitly_free());
             REQUIRE(ms.build_number().is_explicitly_free());
-            REQUIRE(ms.str() == "*");
+            REQUIRE(ms.to_string() == "*");
             REQUIRE_FALSE(ms.is_only_package_name());
         }
 
         SECTION("xtensor==0.12.3")
         {
             auto ms = MatchSpec::parse("xtensor==0.12.3").value();
-            REQUIRE(ms.name().str() == "xtensor");
-            REQUIRE(ms.version().str() == "==0.12.3");
-            REQUIRE(ms.str() == "xtensor==0.12.3");
+            REQUIRE(ms.name().to_string() == "xtensor");
+            REQUIRE(ms.version().to_string() == "==0.12.3");
+            REQUIRE(ms.to_string() == "xtensor==0.12.3");
             REQUIRE_FALSE(ms.is_only_package_name());
         }
 
         SECTION("xtensor      >=       0.12.3")
         {
             auto ms = MatchSpec::parse("xtensor      >=       0.12.3").value();
-            REQUIRE(ms.name().str() == "xtensor");
-            REQUIRE(ms.version().str() == ">=0.12.3");
+            REQUIRE(ms.name().to_string() == "xtensor");
+            REQUIRE(ms.version().to_string() == ">=0.12.3");
             REQUIRE(ms.build_string().is_explicitly_free());
             REQUIRE(ms.build_number().is_explicitly_free());
-            REQUIRE(ms.str() == "xtensor>=0.12.3");
+            REQUIRE(ms.to_string() == "xtensor>=0.12.3");
             REQUIRE_FALSE(ms.is_only_package_name());
         }
 
         SECTION("python > 3.11")
         {
             auto ms = MatchSpec::parse("python > 3.11").value();
-            REQUIRE(ms.name().str() == "python");
-            REQUIRE(ms.version().str() == ">3.11");
+            REQUIRE(ms.name().to_string() == "python");
+            REQUIRE(ms.version().to_string() == ">3.11");
             REQUIRE(ms.build_string().is_explicitly_free());
             REQUIRE(ms.build_number().is_explicitly_free());
-            REQUIRE(ms.str() == "python>3.11");
+            REQUIRE(ms.to_string() == "python>3.11");
             REQUIRE_FALSE(ms.is_only_package_name());
         }
 
         SECTION("numpy < 2.0")
         {
             auto ms = MatchSpec::parse("numpy < 2.0").value();
-            REQUIRE(ms.name().str() == "numpy");
-            REQUIRE(ms.version().str() == "<2.0");
+            REQUIRE(ms.name().to_string() == "numpy");
+            REQUIRE(ms.version().to_string() == "<2.0");
             REQUIRE(ms.build_string().is_explicitly_free());
             REQUIRE(ms.build_number().is_explicitly_free());
-            REQUIRE(ms.str() == "numpy<2.0");
+            REQUIRE(ms.to_string() == "numpy<2.0");
             REQUIRE_FALSE(ms.is_only_package_name());
         }
 
         SECTION("pytorch-cpu = 1.13.0")
         {
             auto ms = MatchSpec::parse("pytorch-cpu = 1.13.0").value();
-            REQUIRE(ms.name().str() == "pytorch-cpu");
-            REQUIRE(ms.version().str() == "=1.13.0");
+            REQUIRE(ms.name().to_string() == "pytorch-cpu");
+            REQUIRE(ms.version().to_string() == "=1.13.0");
             REQUIRE(ms.build_string().is_explicitly_free());
             REQUIRE(ms.build_number().is_explicitly_free());
-            REQUIRE(ms.str() == "pytorch-cpu=1.13.0");
+            REQUIRE(ms.to_string() == "pytorch-cpu=1.13.0");
             REQUIRE_FALSE(ms.is_only_package_name());
         }
 
         SECTION("scipy   >=    1.5.0,  < 2.0.0")
         {
             auto ms = MatchSpec::parse("scipy   >=    1.5.0,  < 2.0.0").value();
-            REQUIRE(ms.name().str() == "scipy");
-            REQUIRE(ms.version().str() == ">=1.5.0,<2.0.0");
+            REQUIRE(ms.name().to_string() == "scipy");
+            REQUIRE(ms.version().to_string() == ">=1.5.0,<2.0.0");
             REQUIRE(ms.build_string().is_explicitly_free());
             REQUIRE(ms.build_number().is_explicitly_free());
-            REQUIRE(ms.str() == "scipy[version=\">=1.5.0,<2.0.0\"]");
+            REQUIRE(ms.to_string() == "scipy[version=\">=1.5.0,<2.0.0\"]");
             REQUIRE_FALSE(ms.is_only_package_name());
         }
 
         SECTION("scikit-learn >1.0.0")
         {
             auto ms = MatchSpec::parse("scikit-learn >1.0.0").value();
-            REQUIRE(ms.name().str() == "scikit-learn");
-            REQUIRE(ms.version().str() == ">1.0.0");
+            REQUIRE(ms.name().to_string() == "scikit-learn");
+            REQUIRE(ms.version().to_string() == ">1.0.0");
             REQUIRE(ms.build_string().is_explicitly_free());
             REQUIRE(ms.build_number().is_explicitly_free());
-            REQUIRE(ms.str() == "scikit-learn>1.0.0");
+            REQUIRE(ms.to_string() == "scikit-learn>1.0.0");
         }
 
         SECTION("kytea >=0.1.4, 0.2.0")
         {
             auto ms = MatchSpec::parse("kytea >=0.1.4, 0.2.0").value();
-            REQUIRE(ms.name().str() == "kytea");
-            REQUIRE(ms.version().str() == ">=0.1.4,==0.2.0");
+            REQUIRE(ms.name().to_string() == "kytea");
+            REQUIRE(ms.version().to_string() == ">=0.1.4,==0.2.0");
             REQUIRE(ms.build_string().is_explicitly_free());
             REQUIRE(ms.build_number().is_explicitly_free());
-            REQUIRE(ms.str() == "kytea[version=\">=0.1.4,==0.2.0\"]");
+            REQUIRE(ms.to_string() == "kytea[version=\">=0.1.4,==0.2.0\"]");
         }
 
         SECTION("abc>12")
         {
             auto ms = MatchSpec::parse("abc>12").value();
-            REQUIRE(ms.name().str() == "abc");
-            REQUIRE(ms.version().str() == ">12");
+            REQUIRE(ms.name().to_string() == "abc");
+            REQUIRE(ms.version().to_string() == ">12");
             REQUIRE(ms.build_string().is_explicitly_free());
             REQUIRE(ms.build_number().is_explicitly_free());
-            REQUIRE(ms.str() == "abc>12");
+            REQUIRE(ms.to_string() == "abc>12");
         }
 
         SECTION("abc[version='>3']")
         {
             auto ms = MatchSpec::parse("abc[version='>3']").value();
-            REQUIRE(ms.name().str() == "abc");
-            REQUIRE(ms.version().str() == ">3");
+            REQUIRE(ms.name().to_string() == "abc");
+            REQUIRE(ms.version().to_string() == ">3");
             REQUIRE(ms.build_string().is_explicitly_free());
             REQUIRE(ms.build_number().is_explicitly_free());
-            REQUIRE(ms.str() == "abc>3");
+            REQUIRE(ms.to_string() == "abc>3");
         }
 
         SECTION("numpy~=1.26.0")
         {
             auto ms = MatchSpec::parse("numpy~=1.26.0").value();
-            REQUIRE(ms.name().str() == "numpy");
-            REQUIRE(ms.version().str() == "~=1.26.0");
+            REQUIRE(ms.name().to_string() == "numpy");
+            REQUIRE(ms.version().to_string() == "~=1.26.0");
             REQUIRE(ms.build_string().is_explicitly_free());
             REQUIRE(ms.build_number().is_explicitly_free());
-            REQUIRE(ms.str() == "numpy~=1.26.0");
+            REQUIRE(ms.to_string() == "numpy~=1.26.0");
 
             // TODO: test this assumption for many more cases
-            auto ms2 = MatchSpec::parse(ms.str()).value();
+            auto ms2 = MatchSpec::parse(ms.to_string()).value();
             REQUIRE(ms2 == ms);
         }
 
@@ -159,11 +159,13 @@ namespace
             // which is currently supported but which must not.
             auto ms = MatchSpec::parse("mingw-w64-ucrt-x86_64-crt-git v12.0.0.r2.ggc561118da h707e725_0")
                           .value();
-            REQUIRE(ms.name().str() == "mingw-w64-ucrt-x86_64-crt-git");
-            REQUIRE(ms.version().str() == "==v12.0.0.r2.ggc561118da");
-            REQUIRE(ms.build_string().str() == "h707e725_0");
+            REQUIRE(ms.name().to_string() == "mingw-w64-ucrt-x86_64-crt-git");
+            REQUIRE(ms.version().to_string() == "==v12.0.0.r2.ggc561118da");
+            REQUIRE(ms.build_string().to_string() == "h707e725_0");
             REQUIRE(ms.build_number().is_explicitly_free());
-            REQUIRE(ms.str() == "mingw-w64-ucrt-x86_64-crt-git==v12.0.0.r2.ggc561118da=h707e725_0");
+            REQUIRE(
+                ms.to_string() == "mingw-w64-ucrt-x86_64-crt-git==v12.0.0.r2.ggc561118da=h707e725_0"
+            );
         }
 
         SECTION("openblas 0.2.18|0.2.18.*.")
@@ -171,43 +173,43 @@ namespace
             // Invalid case from `inform2w64-sysroot_win-64-v12.0.0.r2.ggc561118da-h707e725_0.conda`
             // which is currently supported but which must not.
             auto ms = MatchSpec::parse("openblas 0.2.18|0.2.18.*.").value();
-            REQUIRE(ms.name().str() == "openblas");
-            REQUIRE(ms.version().str() == "==0.2.18|=0.2.18");
+            REQUIRE(ms.name().to_string() == "openblas");
+            REQUIRE(ms.version().to_string() == "==0.2.18|=0.2.18");
         }
 
         SECTION("_libgcc_mutex 0.1 conda_forge")
         {
             auto ms = MatchSpec::parse("_libgcc_mutex 0.1 conda_forge").value();
-            REQUIRE(ms.name().str() == "_libgcc_mutex");
-            REQUIRE(ms.version().str() == "==0.1");
-            REQUIRE(ms.build_string().str() == "conda_forge");
+            REQUIRE(ms.name().to_string() == "_libgcc_mutex");
+            REQUIRE(ms.version().to_string() == "==0.1");
+            REQUIRE(ms.build_string().to_string() == "conda_forge");
             REQUIRE(ms.build_number().is_explicitly_free());
-            REQUIRE(ms.str() == "_libgcc_mutex==0.1=conda_forge");
+            REQUIRE(ms.to_string() == "_libgcc_mutex==0.1=conda_forge");
         }
 
         SECTION("_libgcc_mutex    0.1       conda_forge     ")
         {
             auto ms = MatchSpec::parse("_libgcc_mutex    0.1       conda_forge     ").value();
-            REQUIRE(ms.name().str() == "_libgcc_mutex");
-            REQUIRE(ms.version().str() == "==0.1");
-            REQUIRE(ms.build_string().str() == "conda_forge");
+            REQUIRE(ms.name().to_string() == "_libgcc_mutex");
+            REQUIRE(ms.version().to_string() == "==0.1");
+            REQUIRE(ms.build_string().to_string() == "conda_forge");
             REQUIRE(ms.build_number().is_explicitly_free());
-            REQUIRE(ms.str() == "_libgcc_mutex==0.1=conda_forge");
+            REQUIRE(ms.to_string() == "_libgcc_mutex==0.1=conda_forge");
         }
 
         SECTION("ipykernel")
         {
             auto ms = MatchSpec::parse("ipykernel").value();
-            REQUIRE(ms.name().str() == "ipykernel");
+            REQUIRE(ms.name().to_string() == "ipykernel");
             REQUIRE(ms.version().is_explicitly_free());
-            REQUIRE(ms.str() == "ipykernel");
+            REQUIRE(ms.to_string() == "ipykernel");
             REQUIRE(ms.is_only_package_name());
         }
 
         SECTION("ipykernel ")
         {
             auto ms = MatchSpec::parse("ipykernel ").value();
-            REQUIRE(ms.name().str() == "ipykernel");
+            REQUIRE(ms.name().to_string() == "ipykernel");
             REQUIRE(ms.version().is_explicitly_free());
             REQUIRE(ms.is_only_package_name());
         }
@@ -215,21 +217,21 @@ namespace
         SECTION("disperse=v0.9.24")
         {
             auto ms = MatchSpec::parse("disperse=v0.9.24").value();
-            REQUIRE(ms.name().str() == "disperse");
-            REQUIRE(ms.version().str() == "=v0.9.24");
+            REQUIRE(ms.name().to_string() == "disperse");
+            REQUIRE(ms.version().to_string() == "=v0.9.24");
             REQUIRE(ms.build_string().is_explicitly_free());
             REQUIRE(ms.build_number().is_explicitly_free());
-            REQUIRE(ms.str() == "disperse=v0.9.24");
+            REQUIRE(ms.to_string() == "disperse=v0.9.24");
         }
 
         SECTION("disperse v0.9.24")
         {
             auto ms = MatchSpec::parse("disperse v0.9.24").value();
-            REQUIRE(ms.name().str() == "disperse");
-            REQUIRE(ms.version().str() == "==v0.9.24");
+            REQUIRE(ms.name().to_string() == "disperse");
+            REQUIRE(ms.version().to_string() == "==v0.9.24");
             REQUIRE(ms.build_string().is_explicitly_free());
             REQUIRE(ms.build_number().is_explicitly_free());
-            REQUIRE(ms.str() == "disperse==v0.9.24");
+            REQUIRE(ms.to_string() == "disperse==v0.9.24");
         }
 
         SECTION("foo V0.9.24")
@@ -243,94 +245,94 @@ namespace
         {
             auto ms = MatchSpec::parse("importlib-metadata  # drop this when dropping Python 3.8")
                           .value();
-            REQUIRE(ms.name().str() == "importlib-metadata");
+            REQUIRE(ms.name().to_string() == "importlib-metadata");
             REQUIRE(ms.version().is_explicitly_free());
-            REQUIRE(ms.str() == "importlib-metadata");
+            REQUIRE(ms.to_string() == "importlib-metadata");
         }
 
         SECTION("foo=V0.9.24")
         {
             auto ms = MatchSpec::parse("foo=V0.9.24").value();
-            REQUIRE(ms.name().str() == "foo");
-            REQUIRE(ms.version().str() == "=v0.9.24");
+            REQUIRE(ms.name().to_string() == "foo");
+            REQUIRE(ms.version().to_string() == "=v0.9.24");
             REQUIRE(ms.build_string().is_explicitly_free());
             REQUIRE(ms.build_number().is_explicitly_free());
-            REQUIRE(ms.str() == "foo=v0.9.24");
+            REQUIRE(ms.to_string() == "foo=v0.9.24");
         }
 
         SECTION("numpy 1.7*")
         {
             auto ms = MatchSpec::parse("numpy 1.7*").value();
-            REQUIRE(ms.name().str() == "numpy");
-            REQUIRE(ms.version().str() == "=1.7");
+            REQUIRE(ms.name().to_string() == "numpy");
+            REQUIRE(ms.version().to_string() == "=1.7");
             REQUIRE(ms.conda_build_form() == "numpy 1.7.*");
-            REQUIRE(ms.str() == "numpy=1.7");
+            REQUIRE(ms.to_string() == "numpy=1.7");
         }
 
         SECTION("conda-forge:pypi:xtensor==0.12.3")
         {
             auto ms = MatchSpec::parse("conda-forge:pypi:xtensor==0.12.3").value();
-            REQUIRE(ms.name().str() == "xtensor");
-            REQUIRE(ms.version().str() == "==0.12.3");
+            REQUIRE(ms.name().to_string() == "xtensor");
+            REQUIRE(ms.version().to_string() == "==0.12.3");
             REQUIRE(ms.channel().value().str() == "conda-forge");
             REQUIRE(ms.name_space() == "pypi");
-            REQUIRE(ms.str() == "conda-forge:pypi:xtensor==0.12.3");
+            REQUIRE(ms.to_string() == "conda-forge:pypi:xtensor==0.12.3");
         }
 
         SECTION("conda-forge/linux-64::xtensor==0.12.3")
         {
             auto ms = MatchSpec::parse("numpy[version='1.7|1.8']").value();
-            REQUIRE(ms.name().str() == "numpy");
-            REQUIRE(ms.version().str() == "==1.7|==1.8");
-            REQUIRE(ms.str() == R"(numpy[version="==1.7|==1.8"])");
+            REQUIRE(ms.name().to_string() == "numpy");
+            REQUIRE(ms.version().to_string() == "==1.7|==1.8");
+            REQUIRE(ms.to_string() == R"(numpy[version="==1.7|==1.8"])");
         }
 
         SECTION("conda-forge/linux-64::xtensor==0.12.3")
         {
             auto ms = MatchSpec::parse("conda-forge/linux-64::xtensor==0.12.3").value();
-            REQUIRE(ms.name().str() == "xtensor");
-            REQUIRE(ms.version().str() == "==0.12.3");
+            REQUIRE(ms.name().to_string() == "xtensor");
+            REQUIRE(ms.version().to_string() == "==0.12.3");
             REQUIRE(ms.channel().has_value());
             REQUIRE(ms.channel()->location() == "conda-forge");
             REQUIRE(ms.platforms().value().get() == PlatformSet{ "linux-64" });
-            REQUIRE(ms.str() == "conda-forge[linux-64]::xtensor==0.12.3");
+            REQUIRE(ms.to_string() == "conda-forge[linux-64]::xtensor==0.12.3");
         }
 
         SECTION("conda-forge::foo[build=bld](target=blarg,optional)")
         {
             auto ms = MatchSpec::parse("conda-forge::foo[build=bld](target=blarg,optional)").value();
-            REQUIRE(ms.name().str() == "foo");
+            REQUIRE(ms.name().to_string() == "foo");
             REQUIRE(ms.version().is_explicitly_free());
             REQUIRE(ms.channel().has_value());
             REQUIRE(ms.channel()->location() == "conda-forge");
-            REQUIRE(ms.build_string().str() == "bld");
+            REQUIRE(ms.build_string().to_string() == "bld");
             REQUIRE(ms.optional() == true);
-            REQUIRE(ms.str() == "conda-forge::foo=*=bld[optional]");
+            REQUIRE(ms.to_string() == "conda-forge::foo=*=bld[optional]");
         }
 
         SECTION("python[build_number=3]")
         {
             auto ms = MatchSpec::parse("python[build_number=3]").value();
-            REQUIRE(ms.name().str() == "python");
-            REQUIRE(ms.version().str() == "=*");
-            REQUIRE(ms.build_number().str() == "=3");
-            REQUIRE(ms.str() == R"(python[build_number="=3"])");
+            REQUIRE(ms.name().to_string() == "python");
+            REQUIRE(ms.version().to_string() == "=*");
+            REQUIRE(ms.build_number().to_string() == "=3");
+            REQUIRE(ms.to_string() == R"(python[build_number="=3"])");
         }
 
         SECTION(R"(blas[track_features="mkl avx"])")
         {
             auto ms = MatchSpec::parse(R"(blas[track_features="mkl avx"])").value();
-            REQUIRE(ms.name().str() == "blas");
+            REQUIRE(ms.name().to_string() == "blas");
             REQUIRE(ms.track_features().value().get() == MatchSpec::string_set{ "avx", "mkl" });
-            REQUIRE(ms.str() == R"(blas[track_features="avx mkl"])");
+            REQUIRE(ms.to_string() == R"(blas[track_features="avx mkl"])");
         }
 
         SECTION("python[build_number='<=3']")
         {
             auto ms = MatchSpec::parse("python[build_number='<=3']").value();
-            REQUIRE(ms.name().str() == "python");
-            REQUIRE(ms.build_number().str() == "<=3");
-            REQUIRE(ms.str() == R"(python[build_number="<=3"])");
+            REQUIRE(ms.name().to_string() == "python");
+            REQUIRE(ms.build_number().to_string() == "<=3");
+            REQUIRE(ms.to_string() == R"(python[build_number="<=3"])");
         }
 
         SECTION("https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.4-h59595ed_2.conda#7dbaa197d7ba6032caf7ae7f32c1efa0"
@@ -342,16 +344,16 @@ namespace
             };
 
             auto ms = MatchSpec::parse(str).value();
-            REQUIRE(ms.name().str() == "ncurses");
-            REQUIRE(ms.version().str() == "==6.4");
-            REQUIRE(ms.build_string().str() == "h59595ed_2");
+            REQUIRE(ms.name().to_string() == "ncurses");
+            REQUIRE(ms.version().to_string() == "==6.4");
+            REQUIRE(ms.build_string().to_string() == "h59595ed_2");
             REQUIRE(
                 ms.channel().value().str()
                 == "https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.4-h59595ed_2.conda"
             );
             REQUIRE(ms.filename() == "ncurses-6.4-h59595ed_2.conda");
             REQUIRE(ms.md5() == "7dbaa197d7ba6032caf7ae7f32c1efa0");
-            REQUIRE(ms.str() == str);
+            REQUIRE(ms.to_string() == str);
         }
 
         SECTION("https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2")
@@ -360,15 +362,15 @@ namespace
                 "https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2"
             };
             auto ms = MatchSpec::parse(str).value();
-            REQUIRE(ms.name().str() == "_libgcc_mutex");
-            REQUIRE(ms.version().str() == "==0.1");
-            REQUIRE(ms.build_string().str() == "conda_forge");
+            REQUIRE(ms.name().to_string() == "_libgcc_mutex");
+            REQUIRE(ms.version().to_string() == "==0.1");
+            REQUIRE(ms.build_string().to_string() == "conda_forge");
             REQUIRE(
                 ms.channel().value().str()
                 == "https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2"
             );
             REQUIRE(ms.filename() == "_libgcc_mutex-0.1-conda_forge.tar.bz2");
-            REQUIRE(ms.str() == str);
+            REQUIRE(ms.to_string() == str);
         }
 
         SECTION("https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-11.2.0-h1d223b6_13.tar.bz2")
@@ -377,15 +379,15 @@ namespace
                 "https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-11.2.0-h1d223b6_13.tar.bz2"
             };
             auto ms = MatchSpec::parse(str).value();
-            REQUIRE(ms.name().str() == "libgcc-ng");
-            REQUIRE(ms.version().str() == "==11.2.0");
-            REQUIRE(ms.build_string().str() == "h1d223b6_13");
+            REQUIRE(ms.name().to_string() == "libgcc-ng");
+            REQUIRE(ms.version().to_string() == "==11.2.0");
+            REQUIRE(ms.build_string().to_string() == "h1d223b6_13");
             REQUIRE(
                 ms.channel().value().str()
                 == "https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-11.2.0-h1d223b6_13.tar.bz2"
             );
             REQUIRE(ms.filename() == "libgcc-ng-11.2.0-h1d223b6_13.tar.bz2");
-            REQUIRE(ms.str() == str);
+            REQUIRE(ms.to_string() == str);
         }
 
         SECTION("https://conda.anaconda.org/conda-canary/linux-64/conda-4.3.21.post699+1dab973-py36h4a561cd_0.tar.bz2"
@@ -395,10 +397,10 @@ namespace
                 "https://conda.anaconda.org/conda-canary/linux-64/conda-4.3.21.post699+1dab973-py36h4a561cd_0.tar.bz2"
             };
             auto ms = MatchSpec::parse(str).value();
-            REQUIRE(ms.name().str() == "conda");
-            REQUIRE(ms.version().str() == "==4.3.21.post699+1dab973");
-            REQUIRE(ms.build_string().str() == "py36h4a561cd_0");
-            REQUIRE(ms.str() == str);
+            REQUIRE(ms.name().to_string() == "conda");
+            REQUIRE(ms.version().to_string() == "==4.3.21.post699+1dab973");
+            REQUIRE(ms.build_string().to_string() == "py36h4a561cd_0");
+            REQUIRE(ms.to_string() == str);
         }
 
         SECTION("/home/randomguy/Downloads/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2")
@@ -407,15 +409,15 @@ namespace
                 "/home/randomguy/Downloads/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2"
             };
             auto ms = MatchSpec::parse(str).value();
-            REQUIRE(ms.name().str() == "_libgcc_mutex");
-            REQUIRE(ms.version().str() == "==0.1");
-            REQUIRE(ms.build_string().str() == "conda_forge");
+            REQUIRE(ms.name().to_string() == "_libgcc_mutex");
+            REQUIRE(ms.version().to_string() == "==0.1");
+            REQUIRE(ms.build_string().to_string() == "conda_forge");
             REQUIRE(
                 ms.channel().value().str()
                 == "/home/randomguy/Downloads/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2"
             );
             REQUIRE(ms.filename() == "_libgcc_mutex-0.1-conda_forge.tar.bz2");
-            REQUIRE(ms.str() == str);
+            REQUIRE(ms.to_string() == str);
         }
 
         SECTION("xtensor[url=file:///home/wolfv/Downloads/xtensor-0.21.4-hc9558a2_0.tar.bz2]")
@@ -424,43 +426,45 @@ namespace
                           "xtensor[url=file:///home/wolfv/Downloads/xtensor-0.21.4-hc9558a2_0.tar.bz2]"
             )
                           .value();
-            REQUIRE(ms.name().str() == "xtensor");
+            REQUIRE(ms.name().to_string() == "xtensor");
             REQUIRE(
                 ms.channel().value().str()
                 == "file:///home/wolfv/Downloads/xtensor-0.21.4-hc9558a2_0.tar.bz2"
             );
-            REQUIRE(ms.str() == "file:///home/wolfv/Downloads/xtensor-0.21.4-hc9558a2_0.tar.bz2");
+            REQUIRE(ms.to_string() == "file:///home/wolfv/Downloads/xtensor-0.21.4-hc9558a2_0.tar.bz2");
         }
 
         SECTION("foo=1.0=2")
         {
             auto ms = MatchSpec::parse("foo=1.0=2").value();
             REQUIRE(ms.conda_build_form() == "foo 1.0.* 2");
-            REQUIRE(ms.name().str() == "foo");
-            REQUIRE(ms.version().str() == "=1.0");
-            REQUIRE(ms.build_string().str() == "2");
-            REQUIRE(ms.str() == "foo=1.0=2");
+            REQUIRE(ms.name().to_string() == "foo");
+            REQUIRE(ms.version().to_string() == "=1.0");
+            REQUIRE(ms.build_string().to_string() == "2");
+            REQUIRE(ms.to_string() == "foo=1.0=2");
         }
 
         SECTION("foo   =    1.0    =    2")
         {
             auto ms = MatchSpec::parse("foo   =    1.0    =    2").value();
             REQUIRE(ms.conda_build_form() == "foo 1.0.* 2");
-            REQUIRE(ms.name().str() == "foo");
-            REQUIRE(ms.version().str() == "=1.0");
-            REQUIRE(ms.build_string().str() == "2");
-            REQUIRE(ms.str() == "foo=1.0=2");
+            REQUIRE(ms.name().to_string() == "foo");
+            REQUIRE(ms.version().to_string() == "=1.0");
+            REQUIRE(ms.build_string().to_string() == "2");
+            REQUIRE(ms.to_string() == "foo=1.0=2");
         }
 
         SECTION("foo=1.0=2[md5=123123123, license=BSD-3, fn='test 123.tar.bz2']")
         {
             auto ms = MatchSpec::parse("foo=1.0=2[md5=123123123, license=BSD-3, fn='test 123.tar.bz2']")
                           .value();
-            REQUIRE(ms.name().str() == "foo");
-            REQUIRE(ms.version().str() == "=1.0");
-            REQUIRE(ms.build_string().str() == "2");
+            REQUIRE(ms.name().to_string() == "foo");
+            REQUIRE(ms.version().to_string() == "=1.0");
+            REQUIRE(ms.build_string().to_string() == "2");
             REQUIRE(ms.conda_build_form() == "foo 1.0.* 2");
-            REQUIRE(ms.str() == R"ms(foo=1.0=2[fn="test 123.tar.bz2",md5=123123123,license=BSD-3])ms");
+            REQUIRE(
+                ms.to_string() == R"ms(foo=1.0=2[fn="test 123.tar.bz2",md5=123123123,license=BSD-3])ms"
+            );
         }
 
         SECTION("foo=1.0=2[md5=123123123, license=BSD-3, fn='test 123.tar.bz2', url='abcdef']")
@@ -470,12 +474,13 @@ namespace
             )
                           .value();
             REQUIRE(ms.channel().value().str() == "abcdef");
-            REQUIRE(ms.name().str() == "foo");
-            REQUIRE(ms.version().str() == "=1.0");
-            REQUIRE(ms.build_string().str() == "2");
+            REQUIRE(ms.name().to_string() == "foo");
+            REQUIRE(ms.version().to_string() == "=1.0");
+            REQUIRE(ms.build_string().to_string() == "2");
             REQUIRE(ms.conda_build_form() == "foo 1.0.* 2");
             REQUIRE(
-                ms.str() == R"ms(abcdef::foo=1.0=2[fn="test 123.tar.bz2",md5=123123123,license=BSD-3])ms"
+                ms.to_string()
+                == R"ms(abcdef::foo=1.0=2[fn="test 123.tar.bz2",md5=123123123,license=BSD-3])ms"
             );
         }
 
@@ -487,10 +492,10 @@ namespace
             )
                           .value();
             REQUIRE(ms.channel().value().str() == "anaconda");
-            REQUIRE(ms.name().str() == "numpy");
-            REQUIRE(ms.version().str() == "=1.8");
-            REQUIRE(ms.build_string().str() == "py27_0");
-            REQUIRE(ms.str() == R"(anaconda::numpy=1.8=py27_0)");
+            REQUIRE(ms.name().to_string() == "numpy");
+            REQUIRE(ms.version().to_string() == "=1.8");
+            REQUIRE(ms.build_string().to_string() == "py27_0");
+            REQUIRE(ms.to_string() == R"(anaconda::numpy=1.8=py27_0)");
         }
 
         SECTION(R"(defaults::numpy [ name="pytorch",channel='anaconda',version=">=1.8,<2|1.9", build='3'])"
@@ -501,46 +506,47 @@ namespace
             )
                           .value();
             REQUIRE(ms.channel().value().str() == "anaconda");
-            REQUIRE(ms.name().str() == "numpy");
-            REQUIRE(ms.version().str() == ">=1.8,(<2|==1.9)");
-            REQUIRE(ms.build_string().str() == "3");
-            REQUIRE(ms.str() == R"ms(anaconda::numpy[version=">=1.8,(<2|==1.9)",build="3"])ms");
+            REQUIRE(ms.name().to_string() == "numpy");
+            REQUIRE(ms.version().to_string() == ">=1.8,(<2|==1.9)");
+            REQUIRE(ms.build_string().to_string() == "3");
+            REQUIRE(ms.to_string() == R"ms(anaconda::numpy[version=">=1.8,(<2|==1.9)",build="3"])ms");
         }
 
         SECTION("numpy >1.8,<2|==1.7,!=1.9,~=1.7.1 py34_0")
         {
             auto ms = MatchSpec::parse(R"(numpy >1.8,<2|==1.7,!=1.9,~=1.7.1 py34_0)").value();
-            REQUIRE(ms.name().str() == "numpy");
-            REQUIRE(ms.version().str() == ">1.8,((<2|==1.7),(!=1.9,~=1.7.1))");
-            REQUIRE(ms.build_string().str() == "py34_0");
+            REQUIRE(ms.name().to_string() == "numpy");
+            REQUIRE(ms.version().to_string() == ">1.8,((<2|==1.7),(!=1.9,~=1.7.1))");
+            REQUIRE(ms.build_string().to_string() == "py34_0");
             REQUIRE(
-                ms.str() == R"ms(numpy[version=">1.8,((<2|==1.7),(!=1.9,~=1.7.1))",build="py34_0"])ms"
+                ms.to_string()
+                == R"ms(numpy[version=">1.8,((<2|==1.7),(!=1.9,~=1.7.1))",build="py34_0"])ms"
             );
         }
 
         SECTION("python-graphviz~=0.20")
         {
             auto ms = MatchSpec::parse("python-graphviz~=0.20").value();
-            REQUIRE(ms.name().str() == "python-graphviz");
-            REQUIRE(ms.version().str() == "~=0.20");
-            REQUIRE(ms.str() == R"ms(python-graphviz~=0.20)ms");
+            REQUIRE(ms.name().to_string() == "python-graphviz");
+            REQUIRE(ms.version().to_string() == "~=0.20");
+            REQUIRE(ms.to_string() == R"ms(python-graphviz~=0.20)ms");
         }
 
         SECTION("python-graphviz  ~=      0.20")
         {
             auto ms = MatchSpec::parse("python-graphviz  ~=      0.20").value();
-            REQUIRE(ms.name().str() == "python-graphviz");
-            REQUIRE(ms.version().str() == "~=0.20");
-            REQUIRE(ms.str() == R"ms(python-graphviz~=0.20)ms");
+            REQUIRE(ms.name().to_string() == "python-graphviz");
+            REQUIRE(ms.version().to_string() == "~=0.20");
+            REQUIRE(ms.to_string() == R"ms(python-graphviz~=0.20)ms");
         }
 
         SECTION("python[version='~=3.11.0',build=*_cpython]")
         {
             auto ms = MatchSpec::parse("python[version='~=3.11.0',build=*_cpython]").value();
-            REQUIRE(ms.name().str() == "python");
-            REQUIRE(ms.version().str() == "~=3.11.0");
-            REQUIRE(ms.build_string().str() == "*_cpython");
-            REQUIRE(ms.str() == R"ms(python[version="~=3.11.0",build="*_cpython"])ms");
+            REQUIRE(ms.name().to_string() == "python");
+            REQUIRE(ms.version().to_string() == "~=3.11.0");
+            REQUIRE(ms.build_string().to_string() == "*_cpython");
+            REQUIRE(ms.to_string() == R"ms(python[version="~=3.11.0",build="*_cpython"])ms");
         }
 
         SECTION("*[md5=fewjaflknd]")
@@ -548,16 +554,16 @@ namespace
             auto ms = MatchSpec::parse("*[md5=fewjaflknd]").value();
             REQUIRE(ms.name().is_free());
             REQUIRE(ms.md5() == "fewjaflknd");
-            REQUIRE(ms.str() == "*[md5=fewjaflknd]");
+            REQUIRE(ms.to_string() == "*[md5=fewjaflknd]");
         }
 
         SECTION("libblas=*=*mkl")
         {
             auto ms = MatchSpec::parse("libblas=*=*mkl").value();
-            REQUIRE(ms.name().str() == "libblas");
+            REQUIRE(ms.name().to_string() == "libblas");
             REQUIRE(ms.version().is_explicitly_free());
-            REQUIRE(ms.build_string().str() == "*mkl");
-            REQUIRE(ms.str() == R"(libblas[build="*mkl"])");
+            REQUIRE(ms.build_string().to_string() == "*mkl");
+            REQUIRE(ms.to_string() == R"(libblas[build="*mkl"])");
             REQUIRE(ms.conda_build_form() == "libblas * *mkl");
         }
 
@@ -565,10 +571,10 @@ namespace
         {
             // '*' is part of the version, not the glob
             auto ms = MatchSpec::parse("libblas=0.15*").value();
-            REQUIRE(ms.name().str() == "libblas");
-            REQUIRE(ms.version().str() == "=0.15*");
+            REQUIRE(ms.name().to_string() == "libblas");
+            REQUIRE(ms.version().to_string() == "=0.15*");
             REQUIRE(ms.build_string().is_explicitly_free());
-            REQUIRE(ms.str() == "libblas=0.15*");
+            REQUIRE(ms.to_string() == "libblas=0.15*");
             REQUIRE(ms.conda_build_form() == "libblas 0.15*.*");
         }
 
@@ -576,70 +582,70 @@ namespace
         {
             // '*' is part of the version, not the glob
             auto ms = MatchSpec::parse("xtensor =0.15*").value();
-            REQUIRE(ms.name().str() == "xtensor");
-            REQUIRE(ms.version().str() == "=0.15*");
+            REQUIRE(ms.name().to_string() == "xtensor");
+            REQUIRE(ms.version().to_string() == "=0.15*");
             REQUIRE(ms.build_string().is_explicitly_free());
-            REQUIRE(ms.str() == "xtensor=0.15*");
+            REQUIRE(ms.to_string() == "xtensor=0.15*");
             REQUIRE(ms.conda_build_form() == "xtensor 0.15*.*");
         }
 
         SECTION("numpy=1.20")
         {
             auto ms = MatchSpec::parse("numpy=1.20").value();
-            REQUIRE(ms.name().str() == "numpy");
-            REQUIRE(ms.version().str() == "=1.20");
+            REQUIRE(ms.name().to_string() == "numpy");
+            REQUIRE(ms.version().to_string() == "=1.20");
             REQUIRE(ms.build_string().is_explicitly_free());
-            REQUIRE(ms.str() == "numpy=1.20");
+            REQUIRE(ms.to_string() == "numpy=1.20");
         }
 
         SECTION("conda-forge::tzdata")
         {
             auto ms = MatchSpec::parse("conda-forge::tzdata").value();
             REQUIRE(ms.channel().value().str() == "conda-forge");
-            REQUIRE(ms.name().str() == "tzdata");
+            REQUIRE(ms.name().to_string() == "tzdata");
             REQUIRE(ms.version().is_explicitly_free());
             REQUIRE(ms.build_string().is_explicitly_free());
-            REQUIRE(ms.str() == "conda-forge::tzdata");
+            REQUIRE(ms.to_string() == "conda-forge::tzdata");
         }
 
         SECTION("conda-forge/noarch::tzdata")
         {
             auto ms = MatchSpec::parse("conda-forge/noarch::tzdata").value();
             REQUIRE(ms.channel().value().str() == "conda-forge[noarch]");
-            REQUIRE(ms.name().str() == "tzdata");
+            REQUIRE(ms.name().to_string() == "tzdata");
             REQUIRE(ms.version().is_explicitly_free());
             REQUIRE(ms.build_string().is_explicitly_free());
-            REQUIRE(ms.str() == "conda-forge[noarch]::tzdata");
+            REQUIRE(ms.to_string() == "conda-forge[noarch]::tzdata");
         }
 
         SECTION("conda-forge[noarch]::tzdata")
         {
             auto ms = MatchSpec::parse("conda-forge/noarch::tzdata").value();
             REQUIRE(ms.channel().value().str() == "conda-forge[noarch]");
-            REQUIRE(ms.name().str() == "tzdata");
+            REQUIRE(ms.name().to_string() == "tzdata");
             REQUIRE(ms.version().is_explicitly_free());
             REQUIRE(ms.build_string().is_explicitly_free());
-            REQUIRE(ms.str() == "conda-forge[noarch]::tzdata");
+            REQUIRE(ms.to_string() == "conda-forge[noarch]::tzdata");
         }
 
         SECTION("pkgs/main::tzdata")
         {
             auto ms = MatchSpec::parse("pkgs/main::tzdata").value();
             REQUIRE(ms.channel().value().str() == "pkgs/main");
-            REQUIRE(ms.name().str() == "tzdata");
+            REQUIRE(ms.name().to_string() == "tzdata");
             REQUIRE(ms.version().is_explicitly_free());
             REQUIRE(ms.build_string().is_explicitly_free());
-            REQUIRE(ms.str() == "pkgs/main::tzdata");
+            REQUIRE(ms.to_string() == "pkgs/main::tzdata");
         }
 
         SECTION("pkgs/main/noarch::tzdata")
         {
             auto ms = MatchSpec::parse("pkgs/main/noarch::tzdata").value();
             REQUIRE(ms.channel().value().str() == "pkgs/main[noarch]");
-            REQUIRE(ms.name().str() == "tzdata");
+            REQUIRE(ms.name().to_string() == "tzdata");
             REQUIRE(ms.version().is_explicitly_free());
             REQUIRE(ms.build_string().is_explicitly_free());
-            REQUIRE(ms.str() == "pkgs/main[noarch]::tzdata");
+            REQUIRE(ms.to_string() == "pkgs/main[noarch]::tzdata");
         }
 
         SECTION("conda-forge[noarch]::tzdata[subdir=linux64]")
@@ -647,10 +653,10 @@ namespace
             auto ms = MatchSpec::parse("conda-forge[noarch]::tzdata[subdir=linux64]").value();
             REQUIRE(ms.channel().value().str() == "conda-forge[noarch]");
             REQUIRE(ms.platforms().value().get() == MatchSpec::platform_set{ "noarch" });
-            REQUIRE(ms.name().str() == "tzdata");
+            REQUIRE(ms.name().to_string() == "tzdata");
             REQUIRE(ms.version().is_explicitly_free());
             REQUIRE(ms.build_string().is_explicitly_free());
-            REQUIRE(ms.str() == "conda-forge[noarch]::tzdata");
+            REQUIRE(ms.to_string() == "conda-forge[noarch]::tzdata");
         }
 
         SECTION("conda-forge::tzdata[subdir=mamba-37]")
@@ -658,10 +664,10 @@ namespace
             auto ms = MatchSpec::parse("conda-forge::tzdata[subdir=mamba-37]").value();
             REQUIRE(ms.channel().value().str() == "conda-forge[mamba-37]");
             REQUIRE(ms.platforms().value().get() == MatchSpec::platform_set{ "mamba-37" });
-            REQUIRE(ms.name().str() == "tzdata");
+            REQUIRE(ms.name().to_string() == "tzdata");
             REQUIRE(ms.version().is_explicitly_free());
             REQUIRE(ms.build_string().is_explicitly_free());
-            REQUIRE(ms.str() == "conda-forge[mamba-37]::tzdata");
+            REQUIRE(ms.to_string() == "conda-forge[mamba-37]::tzdata");
         }
 
         SECTION("conda-canary/linux-64::conda==4.3.21.post699+1dab973=py36h4a561cd_0")
@@ -672,17 +678,19 @@ namespace
                           .value();
             REQUIRE(ms.channel().value().str() == "conda-canary[linux-64]");
             REQUIRE(ms.platforms().value().get() == MatchSpec::platform_set{ "linux-64" });
-            REQUIRE(ms.name().str() == "conda");
-            REQUIRE(ms.version().str() == "==4.3.21.post699+1dab973");
-            REQUIRE(ms.build_string().str() == "py36h4a561cd_0");
-            REQUIRE(ms.str() == "conda-canary[linux-64]::conda==4.3.21.post699+1dab973=py36h4a561cd_0");
+            REQUIRE(ms.name().to_string() == "conda");
+            REQUIRE(ms.version().to_string() == "==4.3.21.post699+1dab973");
+            REQUIRE(ms.build_string().to_string() == "py36h4a561cd_0");
+            REQUIRE(
+                ms.to_string() == "conda-canary[linux-64]::conda==4.3.21.post699+1dab973=py36h4a561cd_0"
+            );
         }
 
         SECTION("libblas[build=^.*(accelerate|mkl)$]")
         {
             auto ms = MatchSpec::parse("libblas[build=^.*(accelerate|mkl)$]").value();
-            REQUIRE(ms.name().str() == "libblas");
-            REQUIRE(ms.build_string().str() == "^.*(accelerate|mkl)$");
+            REQUIRE(ms.name().to_string() == "libblas");
+            REQUIRE(ms.build_string().to_string() == "^.*(accelerate|mkl)$");
             REQUIRE_FALSE(ms.build_string().is_glob());
         }
     }
@@ -693,10 +701,10 @@ namespace
         {
             auto ms = MatchSpec::parse_url("https://conda.com/pkg-2-bld.conda").value();
             REQUIRE(ms.is_file());
-            REQUIRE(ms.name().str() == "pkg");
-            REQUIRE(ms.version().str() == "==2");
-            REQUIRE(ms.str() == "https://conda.com/pkg-2-bld.conda");
-            REQUIRE(ms.build_string().str() == "bld");
+            REQUIRE(ms.name().to_string() == "pkg");
+            REQUIRE(ms.version().to_string() == "==2");
+            REQUIRE(ms.to_string() == "https://conda.com/pkg-2-bld.conda");
+            REQUIRE(ms.build_string().to_string() == "bld");
             REQUIRE(ms.filename() == "pkg-2-bld.conda");
         }
 
@@ -707,10 +715,12 @@ namespace
             )
                           .value();
             REQUIRE(ms.is_file());
-            REQUIRE(ms.name().str() == "cph_test_data");
-            REQUIRE(ms.version().str() == "==0.0.1");
-            REQUIRE(ms.str() == "/home/usr/mamba/micromamba/tests/data/cph_test_data-0.0.1-0.tar.bz2");
-            REQUIRE(ms.build_string().str() == "0");
+            REQUIRE(ms.name().to_string() == "cph_test_data");
+            REQUIRE(ms.version().to_string() == "==0.0.1");
+            REQUIRE(
+                ms.to_string() == "/home/usr/mamba/micromamba/tests/data/cph_test_data-0.0.1-0.tar.bz2"
+            );
+            REQUIRE(ms.build_string().to_string() == "0");
             REQUIRE(ms.filename() == "cph_test_data-0.0.1-0.tar.bz2");
         }
 
@@ -723,12 +733,13 @@ namespace
                 )
                               .value();
                 REQUIRE(ms.is_file());
-                REQUIRE(ms.name().str() == "cph_test_data");
-                REQUIRE(ms.version().str() == "==0.0.1");
+                REQUIRE(ms.name().to_string() == "cph_test_data");
+                REQUIRE(ms.version().to_string() == "==0.0.1");
                 REQUIRE(
-                    ms.str() == "D:/a/mamba/mamba/micromamba/tests/data/cph_test_data-0.0.1-0.tar.bz2"
+                    ms.to_string()
+                    == "D:/a/mamba/mamba/micromamba/tests/data/cph_test_data-0.0.1-0.tar.bz2"
                 );
-                REQUIRE(ms.build_string().str() == "0");
+                REQUIRE(ms.build_string().to_string() == "0");
                 REQUIRE(ms.filename() == "cph_test_data-0.0.1-0.tar.bz2");
             }
         }
@@ -742,8 +753,8 @@ namespace
             // `python=3.7=bld`.
             // It is `=3.7` and `==3.7` in the later.
             auto ms = MatchSpec::parse("python=3.7=bld").value();
-            REQUIRE(ms.version().str() == "=3.7");
-            REQUIRE(ms.build_string().str() == "bld");
+            REQUIRE(ms.version().to_string() == "=3.7");
+            REQUIRE(ms.build_string().to_string() == "bld");
         }
 
         SECTION("python[version>3]")
@@ -758,7 +769,7 @@ namespace
             // Ambiguous, `version=` parsed as attribute assignment, which leads to
             // `3.7` (similar to `==3.7`) being parsed as VersionSpec
             auto ms = MatchSpec::parse("python[version=3.7]").value();
-            REQUIRE(ms.version().str() == "==3.7");
+            REQUIRE(ms.version().to_string() == "==3.7");
         }
     }
 

--- a/libmamba/tests/src/specs/test_regex_spec.cpp
+++ b/libmamba/tests/src/specs/test_regex_spec.cpp
@@ -19,7 +19,7 @@ namespace
         REQUIRE(spec.contains(""));
         REQUIRE(spec.contains("hello"));
 
-        REQUIRE(spec.str() == "^.*$");
+        REQUIRE(spec.to_string() == "^.*$");
         REQUIRE(spec.is_explicitly_free());
         REQUIRE_FALSE(spec.is_exact());
     }
@@ -33,7 +33,7 @@ namespace
         REQUIRE_FALSE(spec.contains("nomkl"));
         REQUIRE_FALSE(spec.contains("hello"));
 
-        REQUIRE(spec.str() == "^mkl$");
+        REQUIRE(spec.to_string() == "^mkl$");
         REQUIRE_FALSE(spec.is_explicitly_free());
         REQUIRE(spec.is_exact());
     }
@@ -48,7 +48,7 @@ namespace
         REQUIRE_FALSE(spec.contains(""));
         REQUIRE_FALSE(spec.contains("cpython"));
 
-        REQUIRE(spec.str() == "^py.*$");
+        REQUIRE(spec.to_string() == "^py.*$");
         REQUIRE_FALSE(spec.is_explicitly_free());
         REQUIRE_FALSE(spec.is_exact());
     }
@@ -62,7 +62,7 @@ namespace
         REQUIRE_FALSE(spec.contains(""));
         REQUIRE_FALSE(spec.contains("openblas"));
 
-        REQUIRE(spec.str() == "^.*(accelerate|mkl)$");
+        REQUIRE(spec.to_string() == "^.*(accelerate|mkl)$");
         REQUIRE_FALSE(spec.is_explicitly_free());
         REQUIRE_FALSE(spec.is_exact());
     }

--- a/libmamba/tests/src/specs/test_repo_data.cpp
+++ b/libmamba/tests/src/specs/test_repo_data.cpp
@@ -30,7 +30,7 @@ namespace
 
         const nl::json j = p;
         REQUIRE(j.at("name") == p.name);
-        REQUIRE(j.at("version") == p.version.str());
+        REQUIRE(j.at("version") == p.version.to_string());
         REQUIRE(j.at("build") == p.build_string);
         REQUIRE(j.at("build_number") == p.build_number);
         REQUIRE(j.at("subdir") == p.subdir);
@@ -55,7 +55,7 @@ namespace
             const auto p = j.get<RepoDataPackage>();
             REQUIRE(p.name == j.at("name"));
             // Note Version::parse is not injective
-            REQUIRE(p.version.str() == j.at("version"));
+            REQUIRE(p.version.to_string() == j.at("version"));
             REQUIRE(p.build_string == j.at("build"));
             REQUIRE(p.build_number == j.at("build_number"));
             REQUIRE(p.subdir == j.at("subdir"));

--- a/libmamba/tests/src/specs/test_version.cpp
+++ b/libmamba/tests/src/specs/test_version.cpp
@@ -62,8 +62,8 @@ namespace
 
     TEST_CASE("VersionPartAtom::str", "[mamba::specs][mamba::specs::Version]")
     {
-        REQUIRE(VersionPartAtom(1, "dev").str() == "1dev");
-        REQUIRE(VersionPartAtom(2).str() == "2");
+        REQUIRE(VersionPartAtom(1, "dev").to_string() == "1dev");
+        REQUIRE(VersionPartAtom(2).to_string() == "2");
     }
 
     TEST_CASE("VersionPart", "[mamba::specs][mamba::specs::Version]")
@@ -94,13 +94,15 @@ namespace
 
     TEST_CASE("VersionPart::str", "[mamba::specs][mamba::specs::Version]")
     {
-        REQUIRE(VersionPart{ { 1, "dev" } }.str() == "1dev");
-        REQUIRE(VersionPart{ { 1, "dev" }, { 2, "" } }.str() == "1dev2");
-        REQUIRE(VersionPart{ { 1, "dev" }, { 2, "foo" }, { 33, "bar" } }.str() == "1dev2foo33bar");
-        REQUIRE(VersionPart({ { 0, "dev" }, { 2, "" } }, false).str() == "0dev2");
-        REQUIRE(VersionPart({ { 0, "dev" }, { 2, "" } }, true).str() == "dev2");
-        REQUIRE(VersionPart({ { 0, "dev" } }, true).str() == "dev");
-        REQUIRE(VersionPart({ { 0, "" } }, true).str() == "0");
+        REQUIRE(VersionPart{ { 1, "dev" } }.to_string() == "1dev");
+        REQUIRE(VersionPart{ { 1, "dev" }, { 2, "" } }.to_string() == "1dev2");
+        REQUIRE(
+            VersionPart{ { 1, "dev" }, { 2, "foo" }, { 33, "bar" } }.to_string() == "1dev2foo33bar"
+        );
+        REQUIRE(VersionPart({ { 0, "dev" }, { 2, "" } }, false).to_string() == "0dev2");
+        REQUIRE(VersionPart({ { 0, "dev" }, { 2, "" } }, true).to_string() == "dev2");
+        REQUIRE(VersionPart({ { 0, "dev" } }, true).to_string() == "dev");
+        REQUIRE(VersionPart({ { 0, "" } }, true).to_string() == "0");
     }
 
     TEST_CASE("Version cmp", "[mamba::specs][mamba::specs::Version]")
@@ -185,7 +187,11 @@ namespace
             for (const auto& [prefix, ver] : versions)
             {
                 // Working around clang compilation issue.
-                const auto msg = fmt::format(R"(prefix="{}" version="{}")", prefix.str(), ver.str());
+                const auto msg = fmt::format(
+                    R"(prefix="{}" version="{}")",
+                    prefix.to_string(),
+                    ver.to_string()
+                );
                 CAPTURE(msg);
                 REQUIRE(ver.starts_with(prefix));
             }
@@ -219,7 +225,11 @@ namespace
             for (const auto& [prefix, ver] : versions)
             {
                 // Working around clang compilation issue.
-                const auto msg = fmt::format(R"(prefix="{}" version="{}")", prefix.str(), ver.str());
+                const auto msg = fmt::format(
+                    R"(prefix="{}" version="{}")",
+                    prefix.to_string(),
+                    ver.to_string()
+                );
                 CAPTURE(msg);
                 REQUIRE_FALSE(ver.starts_with(prefix));
             }
@@ -283,8 +293,8 @@ namespace
                 const auto msg = fmt::format(
                     R"(level={} prefix="{}" version="{}")",
                     level,
-                    older.str(),
-                    newer.str()
+                    older.to_string(),
+                    newer.to_string()
                 );
                 CAPTURE(msg);
                 REQUIRE(newer.compatible_with(older, level));
@@ -332,8 +342,8 @@ namespace
                 const auto msg = fmt::format(
                     R"(level={} prefix="{}" version="{}")",
                     level,
-                    older.str(),
-                    newer.str()
+                    older.to_string(),
+                    newer.to_string()
                 );
                 CAPTURE(msg);
                 REQUIRE_FALSE(newer.compatible_with(older, level));
@@ -346,22 +356,22 @@ namespace
         SECTION("11a0post.3.4dev")
         {
             const auto v = Version(0, { { { 11, "a" }, { 0, "post" } }, { { 3 } }, { { 4, "dev" } } });
-            REQUIRE(v.str() == "11a0post.3.4dev");
-            REQUIRE(v.str(1) == "11a0post");
-            REQUIRE(v.str(2) == "11a0post.3");
-            REQUIRE(v.str(3) == "11a0post.3.4dev");
-            REQUIRE(v.str(4) == "11a0post.3.4dev.0");
-            REQUIRE(v.str(5) == "11a0post.3.4dev.0.0");
+            REQUIRE(v.to_string() == "11a0post.3.4dev");
+            REQUIRE(v.to_string(1) == "11a0post");
+            REQUIRE(v.to_string(2) == "11a0post.3");
+            REQUIRE(v.to_string(3) == "11a0post.3.4dev");
+            REQUIRE(v.to_string(4) == "11a0post.3.4dev.0");
+            REQUIRE(v.to_string(5) == "11a0post.3.4dev.0.0");
         }
 
         SECTION("1!11a0.3.4dev")
         {
             const auto v = Version(1, { { { 11, "a" }, { 0 } }, { { 3 } }, { { 4, "dev" } } });
-            REQUIRE(v.str() == "1!11a0.3.4dev");
-            REQUIRE(v.str(1) == "1!11a0");
-            REQUIRE(v.str(2) == "1!11a0.3");
-            REQUIRE(v.str(3) == "1!11a0.3.4dev");
-            REQUIRE(v.str(4) == "1!11a0.3.4dev.0");
+            REQUIRE(v.to_string() == "1!11a0.3.4dev");
+            REQUIRE(v.to_string(1) == "1!11a0");
+            REQUIRE(v.to_string(2) == "1!11a0.3");
+            REQUIRE(v.to_string(3) == "1!11a0.3.4dev");
+            REQUIRE(v.to_string(4) == "1!11a0.3.4dev.0");
         }
 
         SECTION("1!11a0.3.4dev+1.2")
@@ -371,22 +381,22 @@ namespace
                 { { { 11, "a" }, { 0 } }, { { 3 } }, { { 4, "dev" } } },
                 { { { 1 } }, { { 2 } } }
             );
-            REQUIRE(v.str() == "1!11a0.3.4dev+1.2");
-            REQUIRE(v.str(1) == "1!11a0+1");
-            REQUIRE(v.str(2) == "1!11a0.3+1.2");
-            REQUIRE(v.str(3) == "1!11a0.3.4dev+1.2.0");
-            REQUIRE(v.str(4) == "1!11a0.3.4dev.0+1.2.0.0");
+            REQUIRE(v.to_string() == "1!11a0.3.4dev+1.2");
+            REQUIRE(v.to_string(1) == "1!11a0+1");
+            REQUIRE(v.to_string(2) == "1!11a0.3+1.2");
+            REQUIRE(v.to_string(3) == "1!11a0.3.4dev+1.2.0");
+            REQUIRE(v.to_string(4) == "1!11a0.3.4dev.0+1.2.0.0");
         }
 
         SECTION("*.1.*")
         {
             const auto v = Version(0, { { { 0, "*" } }, { { 1 } }, { { 0, "*" } } }, {});
-            REQUIRE(v.str() == "0*.1.0*");
-            REQUIRE(v.str(1) == "0*");
-            REQUIRE(v.str(2) == "0*.1");
-            REQUIRE(v.str(3) == "0*.1.0*");
-            REQUIRE(v.str(4) == "0*.1.0*.0");
-            REQUIRE(v.str_glob() == "*.1.*");
+            REQUIRE(v.to_string() == "0*.1.0*");
+            REQUIRE(v.to_string(1) == "0*");
+            REQUIRE(v.to_string(2) == "0*.1");
+            REQUIRE(v.to_string(3) == "0*.1.0*");
+            REQUIRE(v.to_string(4) == "0*.1.0*.0");
+            REQUIRE(v.to_string_glob() == "*.1.*");
         }
     }
 
@@ -482,8 +492,8 @@ namespace
 
         // Parse implicit zeros
         REQUIRE(Version::parse("0.4.a1").value().version()[2].implicit_leading_zero);
-        REQUIRE(Version::parse("0.4.a1").value().str() == "0.4.a1");
-        REQUIRE(Version::parse("g56ffd88f").value().str() == "g56ffd88f");
+        REQUIRE(Version::parse("0.4.a1").value().to_string() == "0.4.a1");
+        REQUIRE(Version::parse("g56ffd88f").value().to_string() == "g56ffd88f");
 
         // These are valid versions with the special '*' ordering AND they are also used as such
         // with version globs in VersionSpec

--- a/libmamba/tests/src/specs/test_version_spec.cpp
+++ b/libmamba/tests/src/specs/test_version_spec.cpp
@@ -31,7 +31,7 @@ namespace
         REQUIRE(free.contains(v2));
         REQUIRE(free.contains(v3));
         REQUIRE(free.contains(v4));
-        REQUIRE(free.str() == "=*");
+        REQUIRE(free.to_string() == "=*");
         REQUIRE_FALSE(free.has_glob());
 
         const auto eq = VersionPredicate::make_equal_to(v2);
@@ -39,7 +39,7 @@ namespace
         REQUIRE(eq.contains(v2));
         REQUIRE_FALSE(eq.contains(v3));
         REQUIRE_FALSE(eq.contains(v4));
-        REQUIRE(eq.str() == "==2.0");
+        REQUIRE(eq.to_string() == "==2.0");
         REQUIRE_FALSE(eq.has_glob());
 
         const auto ne = VersionPredicate::make_not_equal_to(v2);
@@ -47,7 +47,7 @@ namespace
         REQUIRE_FALSE(ne.contains(v2));
         REQUIRE(ne.contains(v3));
         REQUIRE(ne.contains(v4));
-        REQUIRE(ne.str() == "!=2.0");
+        REQUIRE(ne.to_string() == "!=2.0");
         REQUIRE_FALSE(ne.has_glob());
 
         const auto gt = VersionPredicate::make_greater(v2);
@@ -55,7 +55,7 @@ namespace
         REQUIRE_FALSE(gt.contains(v2));
         REQUIRE(gt.contains(v3));
         REQUIRE(gt.contains(v4));
-        REQUIRE(gt.str() == ">2.0");
+        REQUIRE(gt.to_string() == ">2.0");
         REQUIRE_FALSE(gt.has_glob());
 
         const auto ge = VersionPredicate::make_greater_equal(v2);
@@ -63,7 +63,7 @@ namespace
         REQUIRE(ge.contains(v2));
         REQUIRE(ge.contains(v3));
         REQUIRE(ge.contains(v4));
-        REQUIRE(ge.str() == ">=2.0");
+        REQUIRE(ge.to_string() == ">=2.0");
         REQUIRE_FALSE(ge.has_glob());
 
         const auto lt = VersionPredicate::make_less(v2);
@@ -71,7 +71,7 @@ namespace
         REQUIRE_FALSE(lt.contains(v2));
         REQUIRE_FALSE(lt.contains(v3));
         REQUIRE_FALSE(lt.contains(v4));
-        REQUIRE(lt.str() == "<2.0");
+        REQUIRE(lt.to_string() == "<2.0");
         REQUIRE_FALSE(lt.has_glob());
 
         const auto le = VersionPredicate::make_less_equal(v2);
@@ -79,7 +79,7 @@ namespace
         REQUIRE(le.contains(v2));
         REQUIRE_FALSE(le.contains(v3));
         REQUIRE_FALSE(le.contains(v4));
-        REQUIRE(le.str() == "<=2.0");
+        REQUIRE(le.to_string() == "<=2.0");
         REQUIRE_FALSE(le.has_glob());
 
         const auto sw = VersionPredicate::make_starts_with(v2);
@@ -88,8 +88,8 @@ namespace
         REQUIRE(sw.contains(v201));
         REQUIRE_FALSE(sw.contains(v3));
         REQUIRE_FALSE(sw.contains(v4));
-        REQUIRE(sw.str() == "=2.0");
-        REQUIRE(sw.str_conda_build() == "2.0.*");
+        REQUIRE(sw.to_string() == "=2.0");
+        REQUIRE(sw.to_string_conda_build() == "2.0.*");
         REQUIRE_FALSE(sw.has_glob());
 
         const auto nsw = VersionPredicate::make_not_starts_with(v2);
@@ -98,7 +98,7 @@ namespace
         REQUIRE_FALSE(nsw.contains(v201));
         REQUIRE(nsw.contains(v3));
         REQUIRE(nsw.contains(v4));
-        REQUIRE(nsw.str() == "!=2.0.*");
+        REQUIRE(nsw.to_string() == "!=2.0.*");
         REQUIRE_FALSE(nsw.has_glob());
 
         const auto cp2 = VersionPredicate::make_compatible_with(v2, 2);
@@ -107,7 +107,7 @@ namespace
         REQUIRE(cp2.contains(v201));
         REQUIRE_FALSE(cp2.contains(v3));
         REQUIRE_FALSE(cp2.contains(v4));
-        REQUIRE(cp2.str() == "~=2.0");
+        REQUIRE(cp2.to_string() == "~=2.0");
         REQUIRE_FALSE(cp2.has_glob());
 
         const auto cp3 = VersionPredicate::make_compatible_with(v2, 3);
@@ -116,7 +116,7 @@ namespace
         REQUIRE_FALSE(cp3.contains(v201));
         REQUIRE_FALSE(cp3.contains(v3));
         REQUIRE_FALSE(cp3.contains(v4));
-        REQUIRE(cp3.str() == "~=2.0.0");
+        REQUIRE(cp3.to_string() == "~=2.0.0");
 
         const auto g1 = VersionPredicate::make_version_glob("*"_v);
         REQUIRE(g1.contains(v1));
@@ -124,7 +124,7 @@ namespace
         REQUIRE(g1.contains(v201));
         REQUIRE(g1.contains(v3));
         REQUIRE(g1.contains(v4));
-        REQUIRE(g1.str() == "*");
+        REQUIRE(g1.to_string() == "*");
         REQUIRE(g1.has_glob());
 
         const auto g2 = VersionPredicate::make_version_glob("*.0.*"_v);
@@ -134,7 +134,7 @@ namespace
         REQUIRE_FALSE(g2.contains(v3));
         REQUIRE_FALSE(g2.contains(v4));
         REQUIRE(g2.contains("1.0.1.1.1"_v));
-        REQUIRE(g2.str() == "*.0.*");
+        REQUIRE(g2.to_string() == "*.0.*");
 
         const auto g3 = VersionPredicate::make_version_glob("*.0"_v);
         REQUIRE(g3.contains(v1));
@@ -142,7 +142,7 @@ namespace
         REQUIRE_FALSE(g3.contains(v201));
         REQUIRE(g3.contains(v3));
         REQUIRE(g3.contains(v4));
-        REQUIRE(g3.str() == "*.0");
+        REQUIRE(g3.to_string() == "*.0");
 
         const auto g4 = VersionPredicate::make_version_glob("2.*"_v);
         REQUIRE_FALSE(g4.contains(v1));
@@ -150,7 +150,7 @@ namespace
         REQUIRE(g4.contains(v201));
         REQUIRE_FALSE(g4.contains(v3));
         REQUIRE_FALSE(g4.contains(v4));
-        REQUIRE(g4.str() == "2.*");
+        REQUIRE(g4.to_string() == "2.*");
 
         const auto g5 = VersionPredicate::make_version_glob("2.0"_v);
         REQUIRE_FALSE(g5.contains(v1));
@@ -158,7 +158,7 @@ namespace
         REQUIRE_FALSE(g5.contains(v201));
         REQUIRE_FALSE(g5.contains(v3));
         REQUIRE_FALSE(g5.contains(v4));
-        REQUIRE(g5.str() == "2.0");
+        REQUIRE(g5.to_string() == "2.0");
 
         const auto g6 = VersionPredicate::make_version_glob("2.*.1"_v);
         REQUIRE_FALSE(g6.contains(v1));
@@ -166,14 +166,14 @@ namespace
         REQUIRE(g6.contains(v201));
         REQUIRE_FALSE(g6.contains(v3));
         REQUIRE_FALSE(g6.contains(v4));
-        REQUIRE(g6.str() == "2.*.1");
+        REQUIRE(g6.to_string() == "2.*.1");
 
         const auto g7 = VersionPredicate::make_version_glob("2.*.1.1.*"_v);
         REQUIRE_FALSE(g7.contains(v1));
         REQUIRE_FALSE(g7.contains(v2));
         REQUIRE_FALSE(g7.contains(v201));
         REQUIRE(g7.contains("2.0.1.0.1.1.3"_v));
-        REQUIRE(g7.str() == "2.*.1.1.*");
+        REQUIRE(g7.to_string() == "2.*.1.1.*");
 
         const auto ng1 = VersionPredicate::make_not_version_glob("2.*.1"_v);
         REQUIRE(ng1.contains(v1));
@@ -181,7 +181,7 @@ namespace
         REQUIRE_FALSE(ng1.contains(v201));
         REQUIRE(ng1.contains(v3));
         REQUIRE(ng1.contains(v4));
-        REQUIRE(ng1.str() == "!=2.*.1");
+        REQUIRE(ng1.to_string() == "!=2.*.1");
         REQUIRE(ng1.has_glob());
 
         const auto predicates = std::array{
@@ -204,7 +204,7 @@ namespace
         {
             auto spec = VersionSpec();
             REQUIRE(spec.contains(Version()));
-            REQUIRE(spec.str() == "=*");
+            REQUIRE(spec.to_string() == "=*");
         }
 
         SECTION("from_predicate")
@@ -214,7 +214,7 @@ namespace
             auto spec = VersionSpec::from_predicate(VersionPredicate::make_equal_to(v1));
             REQUIRE(spec.contains(v1));
             REQUIRE_FALSE(spec.contains(v2));
-            REQUIRE(spec.str() == "==1.0");
+            REQUIRE(spec.to_string() == "==1.0");
         }
 
         SECTION("<2.0|(>2.3,<=2.8.0)")
@@ -247,7 +247,7 @@ namespace
 
             // Note this won't always be the same as the parsed string because of the tree
             // serialization
-            REQUIRE(spec.str() == "<2.0|(>2.3,<=2.8.0)");
+            REQUIRE(spec.to_string() == "<2.0|(>2.3,<=2.8.0)");
         }
     }
 
@@ -519,36 +519,36 @@ namespace
         SECTION("2.3")
         {
             auto vs = VersionSpec::parse("2.3").value();
-            REQUIRE(vs.str() == "==2.3");
-            REQUIRE(vs.str_conda_build() == "==2.3");
+            REQUIRE(vs.to_string() == "==2.3");
+            REQUIRE(vs.to_string_conda_build() == "==2.3");
         }
 
         SECTION("=2.3,<3.0")
         {
             auto vs = VersionSpec::parse("=2.3,<3.0").value();
-            REQUIRE(vs.str() == "=2.3,<3.0");
-            REQUIRE(vs.str_conda_build() == "2.3.*,<3.0");
+            REQUIRE(vs.to_string() == "=2.3,<3.0");
+            REQUIRE(vs.to_string_conda_build() == "2.3.*,<3.0");
         }
 
         SECTION("~=1")
         {
             auto vs = VersionSpec::parse("~=1").value();
-            REQUIRE(vs.str() == "~=1");
-            REQUIRE(vs.str_conda_build() == "~=1");
+            REQUIRE(vs.to_string() == "~=1");
+            REQUIRE(vs.to_string_conda_build() == "~=1");
         }
 
         SECTION("~=1.8")
         {
             auto vs = VersionSpec::parse("~=1.8").value();
-            REQUIRE(vs.str() == "~=1.8");
-            REQUIRE(vs.str_conda_build() == "~=1.8");
+            REQUIRE(vs.to_string() == "~=1.8");
+            REQUIRE(vs.to_string_conda_build() == "~=1.8");
         }
 
         SECTION("~=1.8.0")
         {
             auto vs = VersionSpec::parse("~=1.8.0").value();
-            REQUIRE(vs.str() == "~=1.8.0");
-            REQUIRE(vs.str_conda_build() == "~=1.8.0");
+            REQUIRE(vs.to_string() == "~=1.8.0");
+            REQUIRE(vs.to_string_conda_build() == "~=1.8.0");
         }
     }
 

--- a/libmambapy/src/libmambapy/bindings/specs.cpp
+++ b/libmambapy/src/libmambapy/bindings/specs.cpp
@@ -522,7 +522,7 @@ namespace mambapy
                 "literal",
                 [](const VersionPartAtom& atom) { return atom.literal(); }
             )
-            .def("__str__", &VersionPartAtom::str)
+            .def("__str__", &VersionPartAtom::to_string)
             .def(py::self == py::self)
             .def(py::self != py::self)
             .def(py::self < py::self)
@@ -579,11 +579,11 @@ namespace mambapy
             )
             .def("starts_with", &Version::starts_with, py::arg("prefix"))
             .def("compatible_with", &Version::compatible_with, py::arg("older"), py::arg("level"))
-            .def("__str__", [](const Version& v) { return v.str(); })
-            .def("str", [](const Version& v) { return v.str(); })
+            .def("__str__", [](const Version& v) { return v.to_string(); })
+            .def("str", [](const Version& v) { return v.to_string(); })
             .def(
                 "str",
-                [](const Version& v, std::size_t level) { return v.str(level); },
+                [](const Version& v, std::size_t level) { return v.to_string(level); },
                 py::arg("level")
             )
             .def(py::self == py::self)
@@ -608,8 +608,8 @@ namespace mambapy
             .def_static("make_compatible_with", &VersionPredicate::make_compatible_with)
             .def(py::init())
             .def("contains", &VersionPredicate::contains)
-            .def("str_conda_build", &VersionPredicate::str_conda_build)
-            .def("__str__", &VersionPredicate::str)
+            .def("str_conda_build", &VersionPredicate::to_string_conda_build)
+            .def("__str__", &VersionPredicate::to_string)
             .def(py::self == py::self)
             .def(py::self != py::self)
             .def("__copy__", &copy<VersionPredicate>)
@@ -641,8 +641,8 @@ namespace mambapy
             .def("contains", &VersionSpec::contains, py::arg("point"))
             .def("is_explicitly_free", &VersionSpec::is_explicitly_free)
             .def("expression_size", &VersionSpec::expression_size)
-            .def("str_conda_build", &VersionSpec::str_conda_build)
-            .def("__str__", &VersionSpec::str)
+            .def("str_conda_build", &VersionSpec::to_string_conda_build)
+            .def("__str__", &VersionSpec::to_string)
             .def("__copy__", &copy<VersionSpec>)
             .def("__deepcopy__", &deepcopy<VersionSpec>, py::arg("memo"));
 
@@ -760,7 +760,7 @@ namespace mambapy
             .def("contains", &GlobSpec::contains)
             .def("is_free", &GlobSpec::is_free)
             .def("is_exact", &GlobSpec::is_exact)
-            .def("__str__", &GlobSpec::str)
+            .def("__str__", &GlobSpec::to_string)
             .def("__copy__", &copy<GlobSpec>)
             .def("__deepcopy__", &deepcopy<GlobSpec>, py::arg("memo"));
 
@@ -773,7 +773,7 @@ namespace mambapy
             .def("contains", &RegexSpec::contains)
             .def("is_explicitly_free", &RegexSpec::is_explicitly_free)
             .def("is_exact", &RegexSpec::is_exact)
-            .def("__str__", &RegexSpec::str)
+            .def("__str__", &RegexSpec::to_string)
             .def("__copy__", &copy<RegexSpec>)
             .def("__deepcopy__", &deepcopy<RegexSpec>, py::arg("memo"));
 
@@ -784,7 +784,7 @@ namespace mambapy
             .def("is_explicitly_free", &ChimeraStringSpec::is_explicitly_free)
             .def("is_exact", &ChimeraStringSpec::is_exact)
             .def("is_glob", &ChimeraStringSpec::is_glob)
-            .def("__str__", &ChimeraStringSpec::str)
+            .def("__str__", &ChimeraStringSpec::to_string)
             .def("__copy__", &copy<ChimeraStringSpec>)
             .def("__deepcopy__", &deepcopy<ChimeraStringSpec>, py::arg("memo"));
 
@@ -888,7 +888,7 @@ namespace mambapy
             .def("is_simple", &MatchSpec::is_simple)
             .def("is_only_package_name", &MatchSpec::is_only_package_name)
             .def("conda_build_form", &MatchSpec::conda_build_form)
-            .def("__str__", &MatchSpec::str)
+            .def("__str__", &MatchSpec::to_string)
             .def("__copy__", &copy<MatchSpec>)
             .def("__deepcopy__", &deepcopy<MatchSpec>, py::arg("memo"));
     }

--- a/micromamba/src/env.cpp
+++ b/micromamba/src/env.cpp
@@ -147,7 +147,7 @@ set_env_command(CLI::App* com, mamba::Configuration& config)
 
                     if (from_history)
                     {
-                        dependencies << requested_specs_map[k].str() << "\"";
+                        dependencies << requested_specs_map[k].to_string() << "\"";
                     }
                     else
                     {
@@ -242,7 +242,7 @@ set_env_command(CLI::App* com, mamba::Configuration& config)
 
                     if (from_history)
                     {
-                        dependencies << "  - " << requested_specs_map[k].str() << "\n";
+                        dependencies << "  - " << requested_specs_map[k].to_string() << "\n";
                     }
                     else
                     {


### PR DESCRIPTION
Based on #3915.
Following C++ conventions.
No changes where made to the Python side, where `str` is also more idiomatic (e.g. closer
to `__str__`).

