### PR TITLE
support installing pip dependencies with uv

### DIFF
--- a/libmamba/include/mamba/api/install.hpp
+++ b/libmamba/include/mamba/api/install.hpp
@@ -105,8 +105,12 @@ namespace mamba
 
         bool eval_selector(const std::string& selector, const std::string& platform);
 
-        yaml_file_contents
-        read_yaml_file(const Context& ctx, const std::string& yaml_file, const std::string& platform);
+        yaml_file_contents read_yaml_file(
+            const Context& ctx,
+            const std::string& yaml_file,
+            const std::string& platform,
+            bool use_uv
+        );
 
         inline void to_json(nlohmann::json&, const other_pkg_mgr_spec&)
         {

--- a/libmamba/include/mamba/core/context.hpp
+++ b/libmamba/include/mamba/core/context.hpp
@@ -130,6 +130,7 @@ namespace mamba
         bool experimental_repodata_parsing = true;
         bool experimental_matchspec_parsing = false;
         bool debug = false;
+        bool use_uv = false;
 
         // TODO check writable and add other potential dirs
         std::vector<fs::u8path> envs_dirs;

--- a/libmamba/src/api/configuration.cpp
+++ b/libmamba/src/api/configuration.cpp
@@ -1857,6 +1857,13 @@ namespace mamba
                    .set_env_var_names()
                    .description("Defines if PYC files will be compiled or not"));
 
+        insert(Configurable("use_uv", &m_context.use_uv)
+                   .group("Extract, Link & Install")
+                   .set_rc_configurable()
+                   .set_env_var_names()
+                   .description("Whether to use uv for installing pip dependencies. Defaults to false."
+                   ));
+
         // Output, Prompt and Flow
         insert(Configurable("always_yes", &m_context.always_yes)
                    .group("Output, Prompt and Flow Control")

--- a/libmamba/tests/data/env_file/env_4.yaml
+++ b/libmamba/tests/data/env_file/env_4.yaml
@@ -1,0 +1,9 @@
+name: env_4
+channels: [conda-forge, bioconda]
+dependencies:
+  - test1
+  - test2
+  - uv
+  - pip:
+      - pytest
+      - numpy

--- a/libmamba/tests/src/core/test_env_file_reading.cpp
+++ b/libmamba/tests/src/core/test_env_file_reading.cpp
@@ -50,7 +50,8 @@ namespace mamba
             auto res = detail::read_yaml_file(
                 context,
                 mambatests::test_data_dir / "env_file/env_1.yaml",
-                context.platform
+                context.platform,
+                false
             );
             REQUIRE(res.name == "env_1");
             REQUIRE(res.channels == V({ "conda-forge", "bioconda" }));
@@ -60,7 +61,8 @@ namespace mamba
             auto res2 = detail::read_yaml_file(
                 context,
                 mambatests::test_data_dir / "env_file/env_2.yaml",
-                context.platform
+                context.platform,
+                false
             );
             REQUIRE(res2.name == "env_2");
             REQUIRE(res2.channels == V({ "conda-forge", "bioconda" }));
@@ -81,7 +83,8 @@ namespace mamba
             auto res = detail::read_yaml_file(
                 context,
                 mambatests::test_data_dir / "env_file/env_3.yaml",
-                context.platform
+                context.platform,
+                false
             );
             REQUIRE(res.name == "env_3");
             REQUIRE(res.channels == V({ "conda-forge", "bioconda" }));
@@ -103,7 +106,8 @@ namespace mamba
                 auto res = detail::read_yaml_file(
                     context,
                     "https://raw.githubusercontent.com/mamba-org/mamba/refs/heads/main/micromamba/tests/env-create-export.yaml",
-                    context.platform
+                    context.platform,
+                    false
                 );
                 REQUIRE(res.name == "");
                 REQUIRE(res.channels == V({ "https://conda.anaconda.org/conda-forge" }));
@@ -117,7 +121,8 @@ namespace mamba
                 auto res = detail::read_yaml_file(
                     context,
                     "https://raw.githubusercontent.com/mamba-org/mamba/refs/heads/main/libmamba/tests/data/env_file/env_3.yaml",
-                    context.platform
+                    context.platform,
+                    false
                 );
                 REQUIRE(res.name == "env_3");
                 REQUIRE(res.channels == V({ "conda-forge", "bioconda" }));
@@ -132,6 +137,52 @@ namespace mamba
                 );
             }
 
+            SECTION("env_yaml_file_with_uv_override")
+            {
+                const auto& context = mambatests::context();
+                using V = std::vector<std::string>;
+                auto res = detail::read_yaml_file(
+                    context,
+                    "https://raw.githubusercontent.com/iisakkirotko/mamba/refs/heads/yaml-install-uv/libmamba/tests/data/env_file/env_4.yaml",
+                    context.platform,
+                    false
+                );
+                REQUIRE(res.name == "env_4");
+                REQUIRE(res.channels == V({ "conda-forge", "bioconda" }));
+                REQUIRE(res.dependencies == V({ "test1", "test2", "uv" }));
+
+                REQUIRE(res.others_pkg_mgrs_specs.size() == 1);
+                auto o = res.others_pkg_mgrs_specs[0];
+                REQUIRE(o.pkg_mgr == "uv");
+                REQUIRE(o.deps == V({ "pytest", "numpy" }));
+                REQUIRE(
+                    o.cwd == "https://raw.githubusercontent.com/iisakkirotko/mamba/refs/heads/yaml-install-uv/libmamba/tests/data/env_file/env_4.yaml"
+                );
+            }
+
+            SECTION("env_yaml_file_with_uv")
+            {
+                const auto& context = mambatests::context();
+                using V = std::vector<std::string>;
+                auto res = detail::read_yaml_file(
+                    context,
+                    "https://raw.githubusercontent.com/mamba-org/mamba/refs/heads/main/libmamba/tests/data/env_file/env_3.yaml",
+                    context.platform,
+                    true
+                );
+                REQUIRE(res.name == "env_3");
+                REQUIRE(res.channels == V({ "conda-forge", "bioconda" }));
+                REQUIRE(res.dependencies == V({ "test1", "test2", "test3", "uv" }));
+
+                REQUIRE(res.others_pkg_mgrs_specs.size() == 1);
+                auto o = res.others_pkg_mgrs_specs[0];
+                REQUIRE(o.pkg_mgr == "uv");
+                REQUIRE(o.deps == V({ "pytest", "numpy" }));
+                REQUIRE(
+                    o.cwd == "https://raw.githubusercontent.com/mamba-org/mamba/refs/heads/main/libmamba/tests/data/env_file/env_3.yaml"
+                );
+            }
+
             SECTION("env_yaml_file_with_specs_selection")
             {
                 const auto& context = mambatests::context();
@@ -139,7 +190,8 @@ namespace mamba
                 auto res = detail::read_yaml_file(
                     context,
                     "https://raw.githubusercontent.com/mamba-org/mamba/refs/heads/main/libmamba/tests/data/env_file/env_2.yaml",
-                    context.platform
+                    context.platform,
+                    false
                 );
                 REQUIRE(res.name == "env_2");
                 REQUIRE(res.channels == V({ "conda-forge", "bioconda" }));

--- a/micromamba/src/common_options.cpp
+++ b/micromamba/src/common_options.cpp
@@ -88,6 +88,9 @@ init_general_options(CLI::App* subcom, Configuration& config)
         ->add_flag("--experimental", experimental.get_cli_config<bool>(), experimental.description())
         ->group(cli_group);
 
+    auto& use_uv = config.at("use_uv");
+    subcom->add_flag("--use-uv", use_uv.get_cli_config<bool>(), use_uv.description())->group(cli_group);
+
     auto& debug = config.at("debug");
     subcom->add_flag("--debug", debug.get_cli_config<bool>(), "Debug mode")->group("");
 


### PR DESCRIPTION
Hey! 

This PR aims to add support for using uv instead of pip to install pip dependencies into an environment in a couple ways:
- As was suggested in https://github.com/mamba-org/mamba/issues/3332#issuecomment-2528019001, use uv to install any pip dependencies if uv is present in the environment specs already.
- If the `--use-uv` command line option is present (or the corresponding config setting is set to true) and there are pip dependencies to be installed, use uv to install the dependencies instead. Furthermore, if uv is not in the environment specs already, it will be added as is the case with pip currently.

Closes https://github.com/mamba-org/mamba/issues/3332

Edit: Since one of the new tests uses a file that should be fetched from github (https://raw.githubusercontent.com/mamba-org/mamba/refs/heads/main/libmamba/tests/data/env_file/env_4.yaml vs https://raw.githubusercontent.com/iisakkirotko/mamba/refs/heads/yaml-install-uv/libmamba/tests/data/env_file/env_4.yaml), what should the link be set to pre-merge? Currently it points to my fork, but at time of merge it should probably point to main here.