### PR TITLE
Simplify SubdirData

### DIFF
--- a/libmamba/include/mamba/core/context.hpp
+++ b/libmamba/include/mamba/core/context.hpp
@@ -14,6 +14,7 @@
 
 #include "mamba/core/common_types.hpp"
 #include "mamba/core/palette.hpp"
+#include "mamba/core/subdir_parameters.hpp"
 #include "mamba/core/tasksync.hpp"
 #include "mamba/download/mirror_map.hpp"
 #include "mamba/download/parameters.hpp"
@@ -174,6 +175,14 @@ namespace mamba
         // micromamba only
         bool shell_completion = true;
 
+        OutputParams output_params;
+        GraphicsParams graphics_params;
+        SrcParams src_params;
+        CommandParams command_params;
+        ThreadsParams threads_params;
+        PrefixParams prefix_params;
+        ValidationParams validation_params;
+
         download::RemoteFetchParams remote_fetch_params = {
             /* .ssl_verify */ { "" },
             /* .ssl_no_revoke */ false,
@@ -196,13 +205,15 @@ namespace mamba
             };
         }
 
-        OutputParams output_params;
-        GraphicsParams graphics_params;
-        SrcParams src_params;
-        CommandParams command_params;
-        ThreadsParams threads_params;
-        PrefixParams prefix_params;
-        ValidationParams validation_params;
+        SubdirParams subdir_params() const
+        {
+            return {
+                /* .local_repodata_ttl */ this->local_repodata_ttl,
+                /* .offline */ this->offline,
+                /* .use_index_cache */ this->use_index_cache,
+                /* .repodata_use_zst */ this->repodata_use_zst,
+            };
+        }
 
         std::size_t lock_timeout = 0;
         bool use_lockfiles = true;

--- a/libmamba/include/mamba/core/subdir_parameters.hpp
+++ b/libmamba/include/mamba/core/subdir_parameters.hpp
@@ -1,0 +1,23 @@
+// Copyright (c) 2025, QuantStack and Mamba Contributors
+//
+// Distributed under the terms of the BSD 3-Clause License.
+//
+// The full license is in the file LICENSE, distributed with this software.
+
+#ifndef MAMBA_CORE_SUBDIR_PARAMETERS_HPP
+#define MAMBA_CORE_SUBDIR_PARAMETERS_HPP
+
+#include <cstddef>
+
+namespace mamba
+{
+    struct SubdirParams
+    {
+        std::size_t local_repodata_ttl = 1;
+        bool offline = false;
+        bool use_index_cache = true;
+        bool repodata_use_zst = true;
+    };
+}
+
+#endif

--- a/libmamba/include/mamba/core/subdirdata.hpp
+++ b/libmamba/include/mamba/core/subdirdata.hpp
@@ -14,6 +14,7 @@
 
 #include "mamba/core/error_handling.hpp"
 #include "mamba/core/package_cache.hpp"
+#include "mamba/core/subdir_parameters.hpp"
 #include "mamba/core/util.hpp"
 #include "mamba/download/downloader.hpp"
 #include "mamba/fs/filesystem.hpp"
@@ -114,14 +115,14 @@ namespace mamba
     {
     public:
 
-        static expected_t<SubdirData> create(
-            Context& ctx,
+        static auto create(
+            const SubdirParams& params,
             ChannelContext& channel_context,
             const specs::Channel& channel,
             specs::DynamicPlatform platform,
             MultiPackageCache& caches,
             std::string repodata_filename = "repodata.json"
-        );
+        ) -> expected_t<SubdirData>;
 
         [[nodiscard]] auto is_noarch() const -> bool;
         [[nodiscard]] auto is_loaded() const -> bool;
@@ -139,19 +140,20 @@ namespace mamba
         [[deprecated("since version 2.0 use ``valid_solv_cache`` or ``valid_json_cache`` instead")]]
         auto cache_path() const -> expected_t<std::string>;
 
-        static expected_t<void> download_indexes(
+        static auto download_indexes(
             std::vector<SubdirData>& subdirs,
             const Context& context,
             download::Monitor* check_monitor = nullptr,
             download::Monitor* download_monitor = nullptr
-        );
+        ) -> expected_t<void>;
 
     private:
 
-        static std::string get_name(const std::string& channel_id, const std::string& platform);
+        static auto get_name(const std::string& channel_id, const std::string& platform)
+            -> std::string;
 
         SubdirData(
-            Context& ctx,
+            const SubdirParams& params,
             ChannelContext& channel_context,
             const specs::Channel& channel,
             std::string platform,
@@ -159,24 +161,27 @@ namespace mamba
             std::string repodata_fn = "repodata.json"
         );
 
-        std::string repodata_url_path() const;
-        const std::string& repodata_full_url() const;
+        [[nodiscard]] auto repodata_url_path() const -> std::string;
+        [[nodiscard]] auto repodata_full_url() const -> const std::string&;
 
         void load(
             MultiPackageCache& caches,
             ChannelContext& channel_context,
-            const Context& ctx,
+            const SubdirParams& params,
             const specs::Channel& channel
         );
-        void load_cache(MultiPackageCache& caches, const Context& ctx);
-        void
-        update_metadata_zst(ChannelContext& context, const Context& ctx, const specs::Channel& channel);
+        void load_cache(MultiPackageCache& caches, const SubdirParams& params);
+        void update_metadata_zst(
+            ChannelContext& context,
+            const SubdirParams& params,
+            const specs::Channel& channel
+        );
 
-        download::MultiRequest build_check_requests(const Context& ctx);
-        download::Request build_index_request();
+        auto build_check_requests(const SubdirParams& params) -> download::MultiRequest;
+        auto build_index_request() -> download::Request;
 
-        expected_t<void> use_existing_cache();
-        expected_t<void> finalize_transfer(SubdirMetadata::HttpMetadata http_data);
+        auto use_existing_cache() -> expected_t<void>;
+        auto finalize_transfer(SubdirMetadata::HttpMetadata http_data) -> expected_t<void>;
         void refresh_last_write_time(const fs::u8path& json_file, const fs::u8path& solv_file);
 
         bool m_loaded = false;

--- a/libmamba/include/mamba/core/subdirdata.hpp
+++ b/libmamba/include/mamba/core/subdirdata.hpp
@@ -17,6 +17,7 @@
 #include "mamba/core/util.hpp"
 #include "mamba/download/downloader.hpp"
 #include "mamba/fs/filesystem.hpp"
+#include "mamba/specs/platform.hpp"
 
 namespace mamba
 {
@@ -117,35 +118,26 @@ namespace mamba
             Context& ctx,
             ChannelContext& channel_context,
             const specs::Channel& channel,
-            const std::string& platform,
+            specs::DynamicPlatform platform,
             MultiPackageCache& caches,
-            const std::string& repodata_fn = "repodata.json"
+            std::string repodata_filename = "repodata.json"
         );
 
-        ~SubdirData() = default;
+        [[nodiscard]] auto is_noarch() const -> bool;
+        [[nodiscard]] auto is_loaded() const -> bool;
+        [[nodiscard]] auto name() const -> const std::string&;
+        [[nodiscard]] auto channel_id() const -> const std::string&;
+        [[nodiscard]] auto platform() const -> const specs::DynamicPlatform&;
+        [[nodiscard]] auto metadata() const -> const SubdirMetadata&;
 
-        SubdirData(const SubdirData&) = delete;
-        SubdirData& operator=(const SubdirData&) = delete;
+        [[nodiscard]] auto valid_libsolv_cache_path() const -> expected_t<fs::u8path>;
+        [[nodiscard]] auto writable_libsolv_cache_path() const -> fs::u8path;
+        [[nodiscard]] auto valid_json_cache_path() const -> expected_t<fs::u8path>;
 
-        SubdirData(SubdirData&&) = default;
-        SubdirData& operator=(SubdirData&&) = default;
-
-        bool is_noarch() const;
-        bool is_loaded() const;
-        void clear_cache();
-
-        const std::string& name() const;
-        const std::string& channel_id() const;
-        const std::string& platform() const;
-
-        const SubdirMetadata& metadata() const;
-
-        expected_t<fs::u8path> valid_solv_cache() const;
-        fs::u8path writable_solv_cache() const;
-        expected_t<fs::u8path> valid_json_cache() const;
+        void clear_cache_files();
 
         [[deprecated("since version 2.0 use ``valid_solv_cache`` or ``valid_json_cache`` instead")]]
-        expected_t<std::string> cache_path() const;
+        auto cache_path() const -> expected_t<std::string>;
 
         static expected_t<void> download_indexes(
             std::vector<SubdirData>& subdirs,
@@ -162,9 +154,9 @@ namespace mamba
             Context& ctx,
             ChannelContext& channel_context,
             const specs::Channel& channel,
-            const std::string& platform,
+            std::string platform,
             MultiPackageCache& caches,
-            const std::string& repodata_fn = "repodata.json"
+            std::string repodata_fn = "repodata.json"
         );
 
         std::string repodata_url_path() const;
@@ -196,13 +188,12 @@ namespace mamba
         fs::u8path m_expired_cache_path;
         fs::u8path m_writable_pkgs_dir;
 
+        specs::DynamicPlatform m_platform;
         std::string m_channel_id;
-        std::string m_platform;
         std::string m_name;
         std::string m_repodata_fn;
-        std::string m_json_fn;
-        std::string m_solv_fn;
-        bool m_is_noarch;
+        std::string m_json_filename;
+        std::string m_solv_filename;
 
         std::string m_full_url;
 

--- a/libmamba/include/mamba/core/subdirdata.hpp
+++ b/libmamba/include/mamba/core/subdirdata.hpp
@@ -61,7 +61,7 @@ namespace mamba
         /** Read the metadata from the ``repodata.json`` header. */
         static auto read_from_repodata_json(const fs::u8path& json) -> expected_subdir_metadata;
 
-        /** Read from any of state file or ``repodata.json``depending on extension. */
+        /** Read from any of state file or ``repodata.json`` depending on extension. */
         static auto read(const fs::u8path& file) -> expected_subdir_metadata;
 
         [[nodiscard]] auto is_valid_metadata(const fs::u8path& file) const -> bool;
@@ -112,20 +112,20 @@ namespace mamba
      * Channel sub-directory (i.e. a platform) packages index.
      *
      * Handles downloading of the index from the server and cache generation.
-     * This only handle traditional ``repodata.json`` full index.
+     * This only handles traditional ``repodata.json`` full indexes.
      * This abstraction does not load the index in memory, with is done by the @ref Database.
      *
      * Upon creation, the caches are checked for a valid and up to date index.
      * This can be inspected with @ref valid_cache_found.
      * The created subdirs are typically used with @ref SubdirData::download_required_indexes
-     * which will download the missing, invalid, or outdaded indexes as needed.
+     * which will download the missing, invalid, or outdated indexes as needed.
      */
     class SubdirData
     {
     public:
 
         /**
-         * Download the missing, invalid, or outdaded indexes as needed in parallel.
+         * Download the missing, invalid, or outdated indexes as needed in parallel.
          *
          * It first creates check requests to update some metadata, then download the indexes.
          * The result can be inspected with the input subdirs methods, such as

--- a/libmamba/include/mamba/core/subdirdata.hpp
+++ b/libmamba/include/mamba/core/subdirdata.hpp
@@ -166,6 +166,23 @@ namespace mamba
 
     private:
 
+        SubdirMetadata m_metadata;
+        fs::u8path m_valid_cache_path;
+        fs::u8path m_expired_cache_path;
+        fs::u8path m_writable_pkgs_dir;
+        specs::DynamicPlatform m_platform;
+        std::string m_channel_id;
+        std::string m_name;
+        std::string m_repodata_filename;
+        std::string m_json_filename;
+        std::string m_solv_filename;
+        std::string m_full_url;
+        bool m_valid_cache_found = false;
+        bool m_forbid_cache = false;
+        bool m_json_cache_valid = false;
+        bool m_solv_cache_valid = false;
+        std::unique_ptr<TemporaryFile> m_temp_file;
+
         [[nodiscard]] static auto get_name(std::string_view channel_id, std::string_view platform)
             -> std::string;
 
@@ -200,27 +217,6 @@ namespace mamba
         auto use_existing_cache() -> expected_t<void>;
         auto finalize_transfer(SubdirMetadata::HttpMetadata http_data) -> expected_t<void>;
         void refresh_last_write_time(const fs::u8path& json_file, const fs::u8path& solv_file);
-
-        bool m_valid_cache_found = false;
-        bool m_forbid_cache = false;
-        bool m_json_cache_valid = false;
-        bool m_solv_cache_valid = false;
-
-        fs::u8path m_valid_cache_path;
-        fs::u8path m_expired_cache_path;
-        fs::u8path m_writable_pkgs_dir;
-
-        specs::DynamicPlatform m_platform;
-        std::string m_channel_id;
-        std::string m_name;
-        std::string m_repodata_filename;
-        std::string m_json_filename;
-        std::string m_solv_filename;
-
-        std::string m_full_url;
-
-        SubdirMetadata m_metadata;
-        std::unique_ptr<TemporaryFile> m_temp_file;
     };
 
     /**

--- a/libmamba/include/mamba/core/subdirdata.hpp
+++ b/libmamba/include/mamba/core/subdirdata.hpp
@@ -128,6 +128,8 @@ namespace mamba
          * Download the missing, invalid, or outdaded indexes as needed in parallel.
          *
          * It first creates check requests to update some metadata, then download the indexes.
+         * The result can be inspected with the input subdirs methods, such as
+         * @ref valid_cache_found, @ref valid_json_cache_path etc.
          */
         [[nodiscard]] static auto download_required_indexes(
             std::vector<SubdirData>& subdirs,

--- a/libmamba/include/mamba/core/subdirdata.hpp
+++ b/libmamba/include/mamba/core/subdirdata.hpp
@@ -17,6 +17,7 @@
 #include "mamba/core/subdir_parameters.hpp"
 #include "mamba/core/util.hpp"
 #include "mamba/download/downloader.hpp"
+#include "mamba/download/parameters.hpp"
 #include "mamba/fs/filesystem.hpp"
 #include "mamba/specs/platform.hpp"
 
@@ -27,7 +28,6 @@ namespace mamba
         class Channel;
     }
 
-    class Context;
     class ChannelContext;
 
     /**
@@ -129,7 +129,11 @@ namespace mamba
          */
         [[nodiscard]] static auto download_required_indexes(
             std::vector<SubdirData>& subdirs,
-            const Context& context,
+            const SubdirParams& subdir_params,
+            const specs::AuthenticationDataBase& auth_info,
+            const download::mirror_map& mirrors,
+            const download::Options& download_options,
+            const download::RemoteFetchParams& remote_fetch_params,
             download::Monitor* check_monitor = nullptr,
             download::Monitor* download_monitor = nullptr
         ) -> expected_t<void>;

--- a/libmamba/include/mamba/core/subdirdata.hpp
+++ b/libmamba/include/mamba/core/subdirdata.hpp
@@ -213,7 +213,7 @@ namespace mamba
         specs::DynamicPlatform m_platform;
         std::string m_channel_id;
         std::string m_name;
-        std::string m_repodata_fn;
+        std::string m_repodata_filename;
         std::string m_json_filename;
         std::string m_solv_filename;
 

--- a/libmamba/include/mamba/core/subdirdata.hpp
+++ b/libmamba/include/mamba/core/subdirdata.hpp
@@ -19,6 +19,8 @@
 #include "mamba/download/downloader.hpp"
 #include "mamba/download/parameters.hpp"
 #include "mamba/fs/filesystem.hpp"
+#include "mamba/specs/channel.hpp"
+#include "mamba/specs/conda_url.hpp"
 #include "mamba/specs/platform.hpp"
 
 namespace mamba
@@ -142,18 +144,22 @@ namespace mamba
         static auto create(
             const SubdirParams& params,
             ChannelContext& channel_context,
-            const specs::Channel& channel,
+            specs::Channel channel,
             specs::DynamicPlatform platform,
             MultiPackageCache& caches,
             std::string repodata_filename = "repodata.json"
         ) -> expected_t<SubdirData>;
 
         [[nodiscard]] auto is_noarch() const -> bool;
-        [[nodiscard]] auto name() const -> const std::string&;
+        [[nodiscard]] auto is_local() const -> bool;
+        [[nodiscard]] auto channel() const -> const specs::Channel&;
+        [[nodiscard]] auto name() const -> std::string;
         [[nodiscard]] auto channel_id() const -> const std::string&;
         [[nodiscard]] auto platform() const -> const specs::DynamicPlatform&;
         [[nodiscard]] auto metadata() const -> const SubdirMetadata&;
+        [[nodiscard]] auto repodata_url() const -> specs::CondaURL;
 
+        [[nodiscard]] auto caching_is_forbidden() const -> bool;
         [[nodiscard]] auto valid_cache_found() const -> bool;
         [[nodiscard]] auto valid_libsolv_cache_path() const -> expected_t<fs::u8path>;
         [[nodiscard]] auto writable_libsolv_cache_path() const -> fs::u8path;
@@ -167,36 +173,29 @@ namespace mamba
     private:
 
         SubdirMetadata m_metadata;
+        specs::Channel m_channel;
         fs::u8path m_valid_cache_path;
         fs::u8path m_expired_cache_path;
         fs::u8path m_writable_pkgs_dir;
         specs::DynamicPlatform m_platform;
-        std::string m_channel_id;
-        std::string m_name;
         std::string m_repodata_filename;
         std::string m_json_filename;
         std::string m_solv_filename;
-        std::string m_full_url;
         bool m_valid_cache_found = false;
-        bool m_forbid_cache = false;
         bool m_json_cache_valid = false;
         bool m_solv_cache_valid = false;
         std::unique_ptr<TemporaryFile> m_temp_file;
 
-        [[nodiscard]] static auto get_name(std::string_view channel_id, std::string_view platform)
-            -> std::string;
-
         SubdirData(
             const SubdirParams& params,
             ChannelContext& channel_context,
-            const specs::Channel& channel,
+            specs::Channel channel,
             std::string platform,
             MultiPackageCache& caches,
             std::string repodata_fn = "repodata.json"
         );
 
         [[nodiscard]] auto repodata_url_path() const -> std::string;
-        [[nodiscard]] auto repodata_full_url() const -> const std::string&;
 
         void load(
             const MultiPackageCache& caches,

--- a/libmamba/include/mamba/core/subdirdata.hpp
+++ b/libmamba/include/mamba/core/subdirdata.hpp
@@ -157,12 +157,17 @@ namespace mamba
         std::string repodata_url_path() const;
         const std::string& repodata_full_url() const;
 
+        void load(
+            MultiPackageCache& caches,
+            ChannelContext& channel_context,
+            const Context& ctx,
+            const specs::Channel& channel
+        );
+        void load_cache(MultiPackageCache& caches, const Context& ctx);
         void
-        load(MultiPackageCache& caches, ChannelContext& channel_context, const specs::Channel& channel);
-        void load_cache(MultiPackageCache& caches);
-        void update_metadata_zst(ChannelContext& context, const specs::Channel& channel);
+        update_metadata_zst(ChannelContext& context, const Context& ctx, const specs::Channel& channel);
 
-        download::MultiRequest build_check_requests();
+        download::MultiRequest build_check_requests(const Context& ctx);
         download::Request build_index_request();
 
         expected_t<void> use_existing_cache();
@@ -190,7 +195,6 @@ namespace mamba
 
         SubdirMetadata m_metadata;
         std::unique_ptr<TemporaryFile> m_temp_file;
-        const Context* p_context;
     };
 
     [[nodiscard]] std::string cache_name_from_url(std::string_view url);

--- a/libmamba/include/mamba/core/subdirdata.hpp
+++ b/libmamba/include/mamba/core/subdirdata.hpp
@@ -167,9 +167,6 @@ namespace mamba
 
         void clear_cache_files();
 
-        [[deprecated("since version 2.0 use ``valid_solv_cache`` or ``valid_json_cache`` instead")]]
-        auto cache_path() const -> expected_t<std::string>;
-
     private:
 
         SubdirMetadata m_metadata;

--- a/libmamba/include/mamba/specs/platform.hpp
+++ b/libmamba/include/mamba/specs/platform.hpp
@@ -78,6 +78,9 @@ namespace mamba::specs
     [[nodiscard]] auto platform_is_win(KnownPlatform plat) -> bool;
     [[nodiscard]] auto platform_is_win(DynamicPlatform plat) -> bool;
 
+    [[nodiscard]] auto platform_is_noarch(KnownPlatform plat) -> bool;
+    [[nodiscard]] auto platform_is_noarch(DynamicPlatform plat) -> bool;
+
     /**
      * Detect the platform on which mamba was built.
      */

--- a/libmamba/src/api/channel_loader.cpp
+++ b/libmamba/src/api/channel_loader.cpp
@@ -267,7 +267,7 @@ namespace mamba
                             {
                                 LOG_WARNING << "Could not load repodata.json for " << subdir.name()
                                             << ". Deleting cache, and retrying.";
-                                subdir.clear_cache();
+                                subdir.clear_cache_files();
                                 loading_failed = true;
                             }
                         }

--- a/libmamba/src/api/channel_loader.cpp
+++ b/libmamba/src/api/channel_loader.cpp
@@ -206,14 +206,25 @@ namespace mamba
                 SubdirDataMonitor index_monitor;
                 download_res = SubdirData::download_required_indexes(
                     subdirs,
-                    ctx,
+                    ctx.subdir_params(),
+                    ctx.authentication_info(),
+                    ctx.mirrors,
+                    ctx.download_options(),
+                    ctx.remote_fetch_params,
                     &check_monitor,
                     &index_monitor
                 );
             }
             else
             {
-                download_res = SubdirData::download_required_indexes(subdirs, ctx);
+                download_res = SubdirData::download_required_indexes(
+                    subdirs,
+                    ctx.subdir_params(),
+                    ctx.authentication_info(),
+                    ctx.mirrors,
+                    ctx.download_options(),
+                    ctx.remote_fetch_params
+                );
             }
 
             if (!download_res)

--- a/libmamba/src/api/channel_loader.cpp
+++ b/libmamba/src/api/channel_loader.cpp
@@ -77,7 +77,7 @@ namespace mamba
                 }
 
                 auto sdires = SubdirData::create(
-                    ctx,
+                    ctx.subdir_params(),
                     channel_context,
                     channel,
                     platform,

--- a/libmamba/src/api/channel_loader.cpp
+++ b/libmamba/src/api/channel_loader.cpp
@@ -204,11 +204,16 @@ namespace mamba
             {
                 SubdirDataMonitor check_monitor({ true, true });
                 SubdirDataMonitor index_monitor;
-                download_res = SubdirData::download_indexes(subdirs, ctx, &check_monitor, &index_monitor);
+                download_res = SubdirData::download_required_indexes(
+                    subdirs,
+                    ctx,
+                    &check_monitor,
+                    &index_monitor
+                );
             }
             else
             {
-                download_res = SubdirData::download_indexes(subdirs, ctx);
+                download_res = SubdirData::download_required_indexes(subdirs, ctx);
             }
 
             if (!download_res)
@@ -235,7 +240,7 @@ namespace mamba
             for (std::size_t i = 0; i < subdirs.size(); ++i)
             {
                 auto& subdir = subdirs[i];
-                if (!subdir.is_loaded())
+                if (!subdir.valid_cache_found())
                 {
                     if (!ctx.offline && subdir.is_noarch())
                     {

--- a/libmamba/src/core/package_database_loader.cpp
+++ b/libmamba/src/core/package_database_loader.cpp
@@ -72,7 +72,7 @@ namespace mamba
         // Solv files are too slow on Windows.
         if (!util::on_win)
         {
-            auto maybe_repo = subdir.valid_solv_cache().and_then(
+            auto maybe_repo = subdir.valid_libsolv_cache_path().and_then(
                 [&](fs::u8path&& solv_file)
                 {
                     return database.add_repo_from_native_serialization(
@@ -89,7 +89,7 @@ namespace mamba
             }
         }
 
-        return subdir.valid_json_cache()
+        return subdir.valid_json_cache_path()
             .and_then(
                 [&](fs::u8path&& repodata_json)
                 {
@@ -115,13 +115,18 @@ namespace mamba
                     if (!util::on_win)
                     {
                         database
-                            .native_serialize_repo(repo, subdir.writable_solv_cache(), expected_cache_origin)
+                            .native_serialize_repo(
+                                repo,
+                                subdir.writable_libsolv_cache_path(),
+                                expected_cache_origin
+                            )
                             .or_else(
                                 [&](const auto& err)
                                 {
                                     LOG_WARNING << R"(Fail to write native serialization to file ")"
-                                                << subdir.writable_solv_cache() << R"(" for repo ")"
-                                                << subdir.name() << ": " << err.what();
+                                                << subdir.writable_libsolv_cache_path()
+                                                << R"(" for repo ")" << subdir.name() << ": "
+                                                << err.what();
                                     ;
                                 }
                             );

--- a/libmamba/src/core/subdirdata.cpp
+++ b/libmamba/src/core/subdirdata.cpp
@@ -589,7 +589,7 @@ namespace mamba
         , m_platform(std::move(platform))
         , m_channel_id(channel.id())
         , m_name(get_name(m_channel_id, m_platform))
-        , m_repodata_fn(std::move(repodata_fn))
+        , m_repodata_filename(std::move(repodata_fn))
         , m_json_filename(cache_filename_from_url(name()))
         , m_solv_filename(m_json_filename.substr(0, m_json_filename.size() - 4) + "solv")
     {
@@ -602,7 +602,7 @@ namespace mamba
 
     std::string SubdirData::repodata_url_path() const
     {
-        return util::concat(m_platform, "/", m_repodata_fn);
+        return util::concat(m_platform, "/", m_repodata_filename);
     }
 
     const std::string& SubdirData::repodata_full_url() const

--- a/libmamba/src/core/subdirdata.cpp
+++ b/libmamba/src/core/subdirdata.cpp
@@ -521,20 +521,6 @@ namespace mamba
         return make_unexpected("Cache not loaded", mamba_error_code::cache_not_loaded);
     }
 
-    expected_t<std::string> SubdirData::cache_path() const
-    {
-        // TODO invalidate solv cache on version updates!!
-        if (m_json_cache_valid && m_solv_cache_valid)
-        {
-            return (get_cache_dir(m_valid_cache_path) / m_solv_filename).string();
-        }
-        else if (m_json_cache_valid)
-        {
-            return (get_cache_dir(m_valid_cache_path) / m_json_filename).string();
-        }
-        return make_unexpected("Cache not loaded", mamba_error_code::cache_not_loaded);
-    }
-
     expected_t<void> SubdirData::download_required_indexes(
         std::vector<SubdirData>& subdirs,
         const SubdirParams& subdir_params,

--- a/libmamba/src/core/subdirdata.cpp
+++ b/libmamba/src/core/subdirdata.cpp
@@ -400,6 +400,14 @@ namespace mamba
         std::string repodata_filename
     )
     {
+        if (channel.is_package())
+        {
+            return make_unexpected(
+                "Channel pointing to a single package artifacts do not have an index.",
+                mamba_error_code::incorrect_usage
+            );
+        }
+
         try
         {
             return SubdirData(

--- a/libmamba/src/specs/platform.cpp
+++ b/libmamba/src/specs/platform.cpp
@@ -68,7 +68,19 @@ namespace mamba::specs
     auto platform_is_win(DynamicPlatform plat) -> bool
     {
         static constexpr auto repr = std::string_view("win");
-        return (plat.size() >= repr.size()) && util::starts_with(util::to_lower(plat), repr);
+        return (plat.size() >= repr.size())
+               && util::starts_with(util::to_lower(std::move(plat)), repr);
+    }
+
+    auto platform_is_noarch(KnownPlatform plat) -> bool
+    {
+        return plat == KnownPlatform::noarch;
+    }
+
+    auto platform_is_noarch(DynamicPlatform plat) -> bool
+    {
+        static constexpr auto repr = std::string_view("noarch");
+        return util::starts_with(util::to_lower(std::move(plat)), repr);
     }
 
     /**

--- a/libmamba/tests/src/core/test_cpp.cpp
+++ b/libmamba/tests/src/core/test_cpp.cpp
@@ -425,7 +425,7 @@ namespace mamba
             REQUIRE(j.etag() == "something else");
             REQUIRE(j.last_modified() == "Fri, 11 Feb 2022 13:52:44 GMT");
             REQUIRE(j.url() == "https://conda.anaconda.org/conda-forge/noarch/repodata.json.zst");
-            REQUIRE(j.has_zst() == false);
+            REQUIRE(j.has_up_to_date_zst() == false);
         }
     }
 }  // namespace mamba

--- a/libmamba/tests/src/solver/test_problems_graph.cpp
+++ b/libmamba/tests/src/solver/test_problems_graph.cpp
@@ -355,7 +355,14 @@ namespace
             }
         }
 
-        const auto result = SubdirData::download_required_indexes(sub_dirs, mambatests::context());
+        const auto result = SubdirData::download_required_indexes(
+            sub_dirs,
+            mambatests::context().subdir_params(),
+            mambatests::context().authentication_info(),
+            mambatests::context().mirrors,
+            mambatests::context().download_options(),
+            mambatests::context().remote_fetch_params
+        );
         REQUIRE(result.has_value());
 
         for (auto& sub_dir : sub_dirs)

--- a/libmamba/tests/src/solver/test_problems_graph.cpp
+++ b/libmamba/tests/src/solver/test_problems_graph.cpp
@@ -355,7 +355,8 @@ namespace
             }
         }
 
-        SubdirData::download_indexes(sub_dirs, mambatests::context());
+        const auto result = SubdirData::download_required_indexes(sub_dirs, mambatests::context());
+        REQUIRE(result.has_value());
 
         for (auto& sub_dir : sub_dirs)
         {

--- a/libmamba/tests/src/solver/test_problems_graph.cpp
+++ b/libmamba/tests/src/solver/test_problems_graph.cpp
@@ -342,7 +342,13 @@ namespace
                 create_mirrors(ctx, chan);
                 for (const auto& platform : chan.platforms())
                 {
-                    auto sub_dir = SubdirData::create(ctx, channel_context, chan, platform, cache)
+                    auto sub_dir = SubdirData::create(
+                                       ctx.subdir_params(),
+                                       channel_context,
+                                       chan,
+                                       platform,
+                                       cache
+                    )
                                        .value();
                     sub_dirs.push_back(std::move(sub_dir));
                 }

--- a/libmambapy/src/libmambapy/bindings/legacy.cpp
+++ b/libmambapy/src/libmambapy/bindings/legacy.cpp
@@ -631,7 +631,7 @@ bind_submodule_impl(pybind11::module_ m)
         "cache_fn_url",
         [](std::string url)
         {
-            deprecated("This function was renamed `cache_filename_from_url`.", "2.2.0");
+            deprecated("This function was renamed `cache_filename_from_url`.", "2.3.0");
             return cache_filename_from_url(std::move(url));
         }
     );

--- a/libmambapy/src/libmambapy/bindings/legacy.cpp
+++ b/libmambapy/src/libmambapy/bindings/legacy.cpp
@@ -183,14 +183,26 @@ namespace mambapy
                 SubdirDataMonitor index_monitor;
                 download_res = SubdirData::download_required_indexes(
                     m_subdirs,
-                    ctx,
+                    ctx.subdir_params(),
+                    ctx.authentication_info(),
+                    ctx.mirrors,
+                    ctx.download_options(),
+                    ctx.remote_fetch_params,
                     &check_monitor,
                     &index_monitor
                 );
             }
             else
             {
-                download_res = SubdirData::download_required_indexes(m_subdirs, ctx);
+                download_res = SubdirData::download_required_indexes(
+                    m_subdirs,
+                    ctx.subdir_params(),
+                    ctx.authentication_info(),
+                    ctx.mirrors,
+                    ctx.download_options(),
+                    ctx.remote_fetch_params
+
+                );
             }
             return download_res.has_value();
         }

--- a/libmambapy/src/libmambapy/bindings/legacy.cpp
+++ b/libmambapy/src/libmambapy/bindings/legacy.cpp
@@ -571,7 +571,15 @@ bind_submodule_impl(pybind11::module_ m)
                     "Use `SubdirData.valid_solv_path` or `SubdirData.valid_json` path instead",
                     "2.0"
                 );
-                return extract(self.cache_path());
+                if (auto solv_path = self.valid_libsolv_cache_path())
+                {
+                    return solv_path->string();
+                }
+                else if (auto json_path = self.valid_json_cache_path())
+                {
+                    return json_path->string();
+                }
+                throw mamba_error("Cache not loaded", mamba_error_code::cache_not_loaded);
             }
         );
 

--- a/libmambapy/src/libmambapy/bindings/legacy.cpp
+++ b/libmambapy/src/libmambapy/bindings/legacy.cpp
@@ -181,11 +181,16 @@ namespace mambapy
             {
                 SubdirDataMonitor check_monitor({ true, true });
                 SubdirDataMonitor index_monitor;
-                download_res = SubdirData::download_indexes(m_subdirs, ctx, &check_monitor, &index_monitor);
+                download_res = SubdirData::download_required_indexes(
+                    m_subdirs,
+                    ctx,
+                    &check_monitor,
+                    &index_monitor
+                );
             }
             else
             {
-                download_res = SubdirData::download_indexes(m_subdirs, ctx);
+                download_res = SubdirData::download_required_indexes(m_subdirs, ctx);
             }
             return download_res.has_value();
         }
@@ -522,7 +527,7 @@ bind_submodule_impl(pybind11::module_ m)
             py::arg("context"),
             py::arg("db")
         )
-        .def("loaded", &SubdirData::is_loaded)
+        .def("loaded", &SubdirData::valid_cache_found)
         .def(
             "valid_solv_cache",
             // TODO make a proper well tested type caster for expected types.
@@ -602,7 +607,16 @@ bind_submodule_impl(pybind11::module_ m)
             py::keep_alive<0, 1>()
         );
 
-    m.def("cache_fn_url", &cache_fn_url);
+    m.def("cache_name_from_url", &cache_name_from_url);
+    m.def(
+        "cache_fn_url",
+        [](std::string url)
+        {
+            deprecated("This function was renamed `cache_filename_from_url` in libmambapy 2.2.0.");
+            return cache_filename_from_url(std::move(url));
+        }
+    );
+    m.def("cache_filename_from_url", &cache_filename_from_url);
     m.def("create_cache_dir", &create_cache_dir);
 
     py::enum_<ChannelPriority>(m, "ChannelPriority")

--- a/libmambapy/src/libmambapy/bindings/legacy.cpp
+++ b/libmambapy/src/libmambapy/bindings/legacy.cpp
@@ -201,7 +201,6 @@ namespace mambapy
                     ctx.mirrors,
                     ctx.download_options(),
                     ctx.remote_fetch_params
-
                 );
             }
             return download_res.has_value();

--- a/libmambapy/src/libmambapy/bindings/legacy.cpp
+++ b/libmambapy/src/libmambapy/bindings/legacy.cpp
@@ -528,7 +528,7 @@ bind_submodule_impl(pybind11::module_ m)
             // TODO make a proper well tested type caster for expected types.
             [](const SubdirData& self) -> std::optional<fs::u8path>
             {
-                if (auto f = self.valid_solv_cache())
+                if (auto f = self.valid_libsolv_cache_path())
                 {
                     return { *std::move(f) };
                 }
@@ -539,7 +539,7 @@ bind_submodule_impl(pybind11::module_ m)
             "valid_json_cache",
             [](const SubdirData& self) -> std::optional<fs::u8path>
             {
-                if (auto f = self.valid_json_cache())
+                if (auto f = self.valid_json_cache_path())
                 {
                     return { *std::move(f) };
                 }

--- a/libmambapy/src/libmambapy/bindings/legacy.cpp
+++ b/libmambapy/src/libmambapy/bindings/legacy.cpp
@@ -624,7 +624,7 @@ bind_submodule_impl(pybind11::module_ m)
         "cache_fn_url",
         [](std::string url)
         {
-            deprecated("This function was renamed `cache_filename_from_url` in libmambapy 2.2.0.");
+            deprecated("This function was renamed `cache_filename_from_url`.", "2.2.0");
             return cache_filename_from_url(std::move(url));
         }
     );

--- a/libmambapy/src/libmambapy/bindings/legacy.cpp
+++ b/libmambapy/src/libmambapy/bindings/legacy.cpp
@@ -162,7 +162,7 @@ namespace mambapy
         {
             using namespace mamba;
             m_subdirs.push_back(extract(
-                SubdirData::create(ctx, channel_context, channel, platform, caches, repodata_fn)
+                SubdirData::create(ctx.subdir_params(), channel_context, channel, platform, caches, repodata_fn)
             ));
             m_entries.push_back({ nullptr, platform, &channel, url });
             for (size_t i = 0; i < m_subdirs.size(); ++i)


### PR DESCRIPTION
This part of the `SubdirData` refactor. Despite big changes, this PR should be rather straightforward. The logic remains unchanged, things are only moved around. Main improvements are:
- Remove context
- Add documentation
- Reduce class-level side effects
- Explicit function names
