### PR TITLE
Use range in subdir iteration

### DIFF
--- a/libmamba/include/mamba/core/subdirdata.hpp
+++ b/libmamba/include/mamba/core/subdirdata.hpp
@@ -7,6 +7,7 @@
 #ifndef MAMBA_CORE_SUBDIRDATA_HPP
 #define MAMBA_CORE_SUBDIRDATA_HPP
 
+#include <algorithm>
 #include <memory>
 #include <string>
 
@@ -131,8 +132,21 @@ namespace mamba
          * The result can be inspected with the input subdirs methods, such as
          * @ref valid_cache_found, @ref valid_json_cache_path etc.
          */
+        template <typename SubdirIter1, typename SubdirIter2>
         [[nodiscard]] static auto download_required_indexes(
-            std::vector<SubdirData>& subdirs,
+            SubdirIter1&& subdirs_first,
+            SubdirIter2&& subdirs_last,
+            const SubdirParams& subdir_params,
+            const specs::AuthenticationDataBase& auth_info,
+            const download::mirror_map& mirrors,
+            const download::Options& download_options,
+            const download::RemoteFetchParams& remote_fetch_params,
+            download::Monitor* check_monitor = nullptr,
+            download::Monitor* download_monitor = nullptr
+        ) -> expected_t<void>;
+        template <typename Subdirs>
+        [[nodiscard]] static auto download_required_indexes(
+            Subdirs& subdirs,
             const SubdirParams& subdir_params,
             const specs::AuthenticationDataBase& auth_info,
             const download::mirror_map& mirrors,
@@ -196,6 +210,10 @@ namespace mamba
 
         [[nodiscard]] auto repodata_url_path() const -> std::string;
 
+        /**************************************************
+         *  Implementation details of SubdirData::create  *
+         **************************************************/
+
         void load(
             const MultiPackageCache& caches,
             ChannelContext& channel_context,
@@ -209,12 +227,42 @@ namespace mamba
             const specs::Channel& channel
         );
 
-        auto build_check_requests(const SubdirParams& params) -> download::MultiRequest;
-        auto build_index_request() -> download::Request;
+        /*********************************************************************
+         *  Implementation details of SubdirData::download_required_indexes  *
+         *********************************************************************/
 
         auto use_existing_cache() -> expected_t<void>;
         auto finalize_transfer(SubdirMetadata::HttpMetadata http_data) -> expected_t<void>;
         void refresh_last_write_time(const fs::u8path& json_file, const fs::u8path& solv_file);
+
+        template <typename First, typename End>
+        static auto
+        build_all_check_requests(First&& subdirs_first, End&& subdirs_last, const SubdirParams& params)
+            -> download::MultiRequest;
+        auto build_check_requests(const SubdirParams& params) -> download::MultiRequest;
+
+        static auto process_all_check_requests(
+            download::MultiRequest check_requests,
+            const specs::AuthenticationDataBase& auth_info,
+            const download::mirror_map& mirrors,
+            const download::Options& download_options,
+            const download::RemoteFetchParams& remote_fetch_params,
+            download::Monitor* check_monitor
+        ) -> expected_t<void>;
+
+        template <typename First, typename End>
+        static auto build_all_index_requests(First&& subdirs_first, End&& subdirs_last)
+            -> download::MultiRequest;
+        auto build_index_request() -> download::Request;
+
+        static auto process_all_index_requests(
+            download::MultiRequest index_requests,
+            const specs::AuthenticationDataBase& auth_info,
+            const download::mirror_map& mirrors,
+            const download::Options& download_options,
+            const download::RemoteFetchParams& remote_fetch_params,
+            download::Monitor* download_monitor
+        ) -> expected_t<void>;
     };
 
     /**
@@ -242,6 +290,109 @@ namespace mamba
      * @return The path to the directory created
      */
     auto create_cache_dir(const fs::u8path& cache_path) -> std::string;
+
+    /**********************************
+     *  Implementation of Subdirdata  *
+     **********************************/
+
+    template <typename SubdirIter1, typename SubdirIter2>
+    auto SubdirData::download_required_indexes(
+        SubdirIter1&& subdirs_first,
+        SubdirIter2&& subdirs_last,
+        const SubdirParams& subdir_params,
+        const specs::AuthenticationDataBase& auth_info,
+        const download::mirror_map& mirrors,
+        const download::Options& download_options,
+        const download::RemoteFetchParams& remote_fetch_params,
+        download::Monitor* check_monitor,
+        download::Monitor* download_monitor
+    ) -> expected_t<void>
+    {
+        auto check_requests = build_all_check_requests(subdirs_first, subdirs_last, subdir_params);
+        process_all_check_requests(
+            std::move(check_requests),
+            auth_info,
+            mirrors,
+            download_options,
+            remote_fetch_params,
+            check_monitor
+        );
+
+        // TODO load local channels even when offline if (!ctx.offline)
+        if (subdir_params.offline)
+        {
+            return expected_t<void>();
+        }
+
+        auto index_requests = build_all_index_requests(subdirs_first, subdirs_last);
+        return process_all_index_requests(
+            std::move(index_requests),
+            auth_info,
+            mirrors,
+            download_options,
+            remote_fetch_params,
+            download_monitor
+        );
+    }
+
+    template <typename Subdirs>
+    auto SubdirData::download_required_indexes(
+        Subdirs& subdirs,
+        const SubdirParams& subdir_params,
+        const specs::AuthenticationDataBase& auth_info,
+        const download::mirror_map& mirrors,
+        const download::Options& download_options,
+        const download::RemoteFetchParams& remote_fetch_params,
+        download::Monitor* check_monitor,
+        download::Monitor* download_monitor
+    ) -> expected_t<void>
+    {
+        return download_required_indexes(
+            subdirs.begin(),
+            subdirs.end(),
+            subdir_params,
+            auth_info,
+            mirrors,
+            download_options,
+            remote_fetch_params,
+            check_monitor,
+            download_monitor
+        );
+    }
+
+    template <typename First, typename End>
+    auto SubdirData::build_all_check_requests(
+        First&& subdirs_first,
+        End&& subdirs_last,
+        const SubdirParams& params
+    ) -> download::MultiRequest
+    {
+        download::MultiRequest requests;
+        for (; subdirs_first != subdirs_last; ++subdirs_first)
+        {
+            if (!subdirs_first->valid_cache_found())
+            {
+                auto check_list = subdirs_first->build_check_requests(params);
+                std::move(check_list.begin(), check_list.end(), std::back_inserter(requests));
+            }
+        }
+        return requests;
+    }
+
+    template <typename First, typename End>
+    auto SubdirData::build_all_index_requests(First&& subdirs_first, End&& subdirs_last)
+        -> download::MultiRequest
+    {
+        download::MultiRequest requests;
+        for (; subdirs_first != subdirs_last; ++subdirs_first)
+        {
+            if (!subdirs_first->valid_cache_found())
+            {
+                requests.push_back(subdirs_first->build_index_request());
+            }
+        }
+        return requests;
+    }
 
 }
 #endif

--- a/libmamba/include/mamba/core/subdirdata.hpp
+++ b/libmamba/include/mamba/core/subdirdata.hpp
@@ -134,8 +134,8 @@ namespace mamba
          */
         template <typename SubdirIter1, typename SubdirIter2>
         [[nodiscard]] static auto download_required_indexes(
-            SubdirIter1&& subdirs_first,
-            SubdirIter2&& subdirs_last,
+            SubdirIter1 subdirs_first,
+            SubdirIter2 subdirs_last,
             const SubdirParams& subdir_params,
             const specs::AuthenticationDataBase& auth_info,
             const download::mirror_map& mirrors,
@@ -237,12 +237,12 @@ namespace mamba
 
         template <typename First, typename End>
         static auto
-        build_all_check_requests(First&& subdirs_first, End&& subdirs_last, const SubdirParams& params)
+        build_all_check_requests(First subdirs_first, End subdirs_last, const SubdirParams& params)
             -> download::MultiRequest;
         auto build_check_requests(const SubdirParams& params) -> download::MultiRequest;
 
         template <typename First, typename End>
-        static auto build_all_index_requests(First&& subdirs_first, End&& subdirs_last)
+        static auto build_all_index_requests(First subdirs_first, End subdirs_last)
             -> download::MultiRequest;
         auto build_index_request() -> download::Request;
 
@@ -288,8 +288,8 @@ namespace mamba
 
     template <typename SubdirIter1, typename SubdirIter2>
     auto SubdirData::download_required_indexes(
-        SubdirIter1&& subdirs_first,
-        SubdirIter2&& subdirs_last,
+        SubdirIter1 subdirs_first,
+        SubdirIter2 subdirs_last,
         const SubdirParams& subdir_params,
         const specs::AuthenticationDataBase& auth_info,
         const download::mirror_map& mirrors,
@@ -358,11 +358,9 @@ namespace mamba
     }
 
     template <typename First, typename End>
-    auto SubdirData::build_all_check_requests(
-        First&& subdirs_first,
-        End&& subdirs_last,
-        const SubdirParams& params
-    ) -> download::MultiRequest
+    auto
+    SubdirData::build_all_check_requests(First subdirs_first, End subdirs_last, const SubdirParams& params)
+        -> download::MultiRequest
     {
         download::MultiRequest requests;
         for (; subdirs_first != subdirs_last; ++subdirs_first)
@@ -377,7 +375,7 @@ namespace mamba
     }
 
     template <typename First, typename End>
-    auto SubdirData::build_all_index_requests(First&& subdirs_first, End&& subdirs_last)
+    auto SubdirData::build_all_index_requests(First subdirs_first, End subdirs_last)
         -> download::MultiRequest
     {
         download::MultiRequest requests;

--- a/libmamba/src/core/subdirdata.cpp
+++ b/libmamba/src/core/subdirdata.cpp
@@ -521,55 +521,33 @@ namespace mamba
         return make_unexpected("Cache not loaded", mamba_error_code::cache_not_loaded);
     }
 
-    auto SubdirData::process_all_check_requests(
-        download::MultiRequest check_requests,
+    auto SubdirData::download_requests(
+        download::MultiRequest requests,
         const specs::AuthenticationDataBase& auth_info,
         const download::mirror_map& mirrors,
         const download::Options& download_options,
         const download::RemoteFetchParams& remote_fetch_params,
-        download::Monitor* check_monitor
-    ) -> expected_t<void>
-    {
-        // TODO why no try and why not check is_sig_interrupted in other?
-        download::download(
-            std::move(check_requests),
-            mirrors,
-            remote_fetch_params,
-            auth_info,
-            download_options,
-            check_monitor
-        );
-
-        if (is_sig_interrupted())
-        {
-            return make_unexpected("Interrupted by user", mamba_error_code::user_interrupted);
-        }
-        return expected_t<void>();
-    }
-
-    auto SubdirData::process_all_index_requests(
-        download::MultiRequest index_requests,
-        const specs::AuthenticationDataBase& auth_info,
-        const download::mirror_map& mirrors,
-        const download::Options& download_options,
-        const download::RemoteFetchParams& remote_fetch_params,
-        download::Monitor* download_monitor
+        download::Monitor* monitor
     ) -> expected_t<void>
     {
         try
         {
             download::download(
-                std::move(index_requests),
+                std::move(requests),
                 mirrors,
                 remote_fetch_params,
                 auth_info,
                 download_options,
-                download_monitor
+                monitor
             );
         }
         catch (const std::runtime_error& e)
         {
             return make_unexpected(e.what(), mamba_error_code::repodata_not_loaded);
+        }
+        if (is_sig_interrupted())
+        {
+            return make_unexpected("Interrupted by user", mamba_error_code::user_interrupted);
         }
 
         return expected_t<void>();

--- a/libmamba/src/core/subdirdata.cpp
+++ b/libmamba/src/core/subdirdata.cpp
@@ -521,26 +521,16 @@ namespace mamba
         return make_unexpected("Cache not loaded", mamba_error_code::cache_not_loaded);
     }
 
-    expected_t<void> SubdirData::download_required_indexes(
-        std::vector<SubdirData>& subdirs,
-        const SubdirParams& subdir_params,
+    auto SubdirData::process_all_check_requests(
+        download::MultiRequest check_requests,
         const specs::AuthenticationDataBase& auth_info,
         const download::mirror_map& mirrors,
         const download::Options& download_options,
         const download::RemoteFetchParams& remote_fetch_params,
-        download::Monitor* check_monitor,
-        download::Monitor* download_monitor
-    )
+        download::Monitor* check_monitor
+    ) -> expected_t<void>
     {
-        download::MultiRequest check_requests;
-        for (auto& subdir : subdirs)
-        {
-            if (!subdir.valid_cache_found())
-            {
-                download::MultiRequest check_list = subdir.build_check_requests(subdir_params);
-                std::move(check_list.begin(), check_list.end(), std::back_inserter(check_requests));
-            }
-        }
+        // TODO why no try and why not check is_sig_interrupted in other?
         download::download(
             std::move(check_requests),
             mirrors,
@@ -554,34 +544,32 @@ namespace mamba
         {
             return make_unexpected("Interrupted by user", mamba_error_code::user_interrupted);
         }
+        return expected_t<void>();
+    }
 
-        // TODO load local channels even when offline if (!ctx.offline)
-        if (!subdir_params.offline)
+    auto SubdirData::process_all_index_requests(
+        download::MultiRequest index_requests,
+        const specs::AuthenticationDataBase& auth_info,
+        const download::mirror_map& mirrors,
+        const download::Options& download_options,
+        const download::RemoteFetchParams& remote_fetch_params,
+        download::Monitor* download_monitor
+    ) -> expected_t<void>
+    {
+        try
         {
-            download::MultiRequest index_requests;
-            for (auto& subdir : subdirs)
-            {
-                if (!subdir.valid_cache_found())
-                {
-                    index_requests.push_back(subdir.build_index_request());
-                }
-            }
-
-            try
-            {
-                download::download(
-                    std::move(index_requests),
-                    mirrors,
-                    remote_fetch_params,
-                    auth_info,
-                    download_options,
-                    download_monitor
-                );
-            }
-            catch (const std::runtime_error& e)
-            {
-                return make_unexpected(e.what(), mamba_error_code::repodata_not_loaded);
-            }
+            download::download(
+                std::move(index_requests),
+                mirrors,
+                remote_fetch_params,
+                auth_info,
+                download_options,
+                download_monitor
+            );
+        }
+        catch (const std::runtime_error& e)
+        {
+            return make_unexpected(e.what(), mamba_error_code::repodata_not_loaded);
         }
 
         return expected_t<void>();


### PR DESCRIPTION
A bit verbose, but the use of a general range input over a vector is required for making a straightforward binding to Python compatbile with lists and iterables.
