### PR TITLE
Refactor `SubdirData` > `SubdirIndexLoader`

### DIFF
--- a/libmamba/CMakeLists.txt
+++ b/libmamba/CMakeLists.txt
@@ -244,7 +244,7 @@ set(
     ${LIBMAMBA_SOURCE_DIR}/core/run.cpp
     ${LIBMAMBA_SOURCE_DIR}/core/shell_init.cpp
     ${LIBMAMBA_SOURCE_DIR}/core/singletons.cpp
-    ${LIBMAMBA_SOURCE_DIR}/core/subdirdata.cpp
+    ${LIBMAMBA_SOURCE_DIR}/core/subdir_index.cpp
     ${LIBMAMBA_SOURCE_DIR}/core/thread_utils.cpp
     ${LIBMAMBA_SOURCE_DIR}/core/timeref.cpp
     ${LIBMAMBA_SOURCE_DIR}/core/transaction_context.cpp
@@ -391,7 +391,7 @@ set(
     ${LIBMAMBA_INCLUDE_DIR}/mamba/core/repo_checker_store.hpp
     ${LIBMAMBA_INCLUDE_DIR}/mamba/core/run.hpp
     ${LIBMAMBA_INCLUDE_DIR}/mamba/core/shell_init.hpp
-    ${LIBMAMBA_INCLUDE_DIR}/mamba/core/subdirdata.hpp
+    ${LIBMAMBA_INCLUDE_DIR}/mamba/core/subdir_index.hpp
     ${LIBMAMBA_INCLUDE_DIR}/mamba/core/tasksync.hpp
     ${LIBMAMBA_INCLUDE_DIR}/mamba/core/thread_utils.hpp
     ${LIBMAMBA_INCLUDE_DIR}/mamba/core/timeref.hpp

--- a/libmamba/include/mamba/core/context.hpp
+++ b/libmamba/include/mamba/core/context.hpp
@@ -226,8 +226,15 @@ namespace mamba
             return {
                 /* .local_repodata_ttl */ get_local_repodata_ttl(),
                 /* .offline */ this->offline,
-                /* .repodata_check_zst */ this->repodata_use_zst,
                 /* .force_use_zst */ false  // Must override based on ChannelContext
+            };
+        }
+
+        SubdirDownloadParams subdir_download_params() const
+        {
+            return {
+                /* .offline */ this->offline,
+                /* .repodata_check_zst */ this->repodata_use_zst,
             };
         }
 

--- a/libmamba/include/mamba/core/context.hpp
+++ b/libmamba/include/mamba/core/context.hpp
@@ -227,6 +227,7 @@ namespace mamba
                 /* .local_repodata_ttl */ get_local_repodata_ttl(),
                 /* .offline */ this->offline,
                 /* .repodata_check_zst */ this->repodata_use_zst,
+                /* .force_use_zst */ false  // Must override based on ChannelContext
             };
         }
 

--- a/libmamba/include/mamba/core/context.hpp
+++ b/libmamba/include/mamba/core/context.hpp
@@ -209,7 +209,10 @@ namespace mamba
         SubdirParams subdir_params() const
         {
             return {
-                /* .local_repodata_ttl */ this->local_repodata_ttl,
+                // This is legacy where from where 1 meant to read from header
+                /* .local_repodata_ttl */ (this->local_repodata_ttl == 1)
+                    ? std::nullopt
+                    : std::optional(this->local_repodata_ttl),
                 /* .offline */ this->offline,
                 /* .use_index_cache */ this->use_index_cache,
                 /* .repodata_use_zst */ this->repodata_use_zst,

--- a/libmamba/include/mamba/core/context.hpp
+++ b/libmamba/include/mamba/core/context.hpp
@@ -208,13 +208,24 @@ namespace mamba
 
         SubdirParams subdir_params() const
         {
-            return {
+            const auto get_local_repodata_ttl = [&]() -> std::optional<std::size_t>
+            {
+                // Force the use of index cache by setting TTL to 0
+                if (this->use_index_cache)
+                {
+                    return { 0 };
+                }
                 // This is legacy where from where 1 meant to read from header
-                /* .local_repodata_ttl */ (this->local_repodata_ttl == 1)
-                    ? std::nullopt
-                    : std::optional(this->local_repodata_ttl),
+                if (this->local_repodata_ttl == 1)
+                {
+                    return std::nullopt;
+                }
+                return { this->local_repodata_ttl };
+            };
+
+            return {
+                /* .local_repodata_ttl */ get_local_repodata_ttl(),
                 /* .offline */ this->offline,
-                /* .use_index_cache */ this->use_index_cache,
                 /* .repodata_use_zst */ this->repodata_use_zst,
             };
         }

--- a/libmamba/include/mamba/core/context.hpp
+++ b/libmamba/include/mamba/core/context.hpp
@@ -226,7 +226,7 @@ namespace mamba
             return {
                 /* .local_repodata_ttl */ get_local_repodata_ttl(),
                 /* .offline */ this->offline,
-                /* .repodata_use_zst */ this->repodata_use_zst,
+                /* .repodata_check_zst */ this->repodata_use_zst,
             };
         }
 

--- a/libmamba/include/mamba/core/download_progress_bar.hpp
+++ b/libmamba/include/mamba/core/download_progress_bar.hpp
@@ -23,20 +23,20 @@ namespace mamba
         bool no_clear_progress_bar = false;
     };
 
-    class SubdirDataMonitor : public download::Monitor
+    class SubdirIndexMonitor : public download::Monitor
     {
     public:
 
         static bool can_monitor(const Context& context);
 
-        explicit SubdirDataMonitor(MonitorOptions options = {});
-        virtual ~SubdirDataMonitor() = default;
+        explicit SubdirIndexMonitor(MonitorOptions options = {});
+        virtual ~SubdirIndexMonitor() = default;
 
-        SubdirDataMonitor(const SubdirDataMonitor&) = delete;
-        SubdirDataMonitor& operator=(const SubdirDataMonitor&) = delete;
+        SubdirIndexMonitor(const SubdirIndexMonitor&) = delete;
+        SubdirIndexMonitor& operator=(const SubdirIndexMonitor&) = delete;
 
-        SubdirDataMonitor(SubdirDataMonitor&&) = delete;
-        SubdirDataMonitor& operator=(SubdirDataMonitor&&) = delete;
+        SubdirIndexMonitor(SubdirIndexMonitor&&) = delete;
+        SubdirIndexMonitor& operator=(SubdirIndexMonitor&&) = delete;
 
         void reset_options(MonitorOptions options);
 

--- a/libmamba/include/mamba/core/package_database_loader.hpp
+++ b/libmamba/include/mamba/core/package_database_loader.hpp
@@ -15,7 +15,7 @@ namespace mamba
 {
     class Context;
     class PrefixData;
-    class SubdirData;
+    class SubdirIndexLoader;
 
     namespace solver::libsolv
     {
@@ -27,7 +27,7 @@ namespace mamba
     auto load_subdir_in_database(  //
         const Context& ctx,
         solver::libsolv::Database& database,
-        const SubdirData& subdir
+        const SubdirIndexLoader& subdir
     ) -> expected_t<solver::libsolv::RepoInfo>;
 
     auto load_installed_packages_in_database(

--- a/libmamba/include/mamba/core/subdir_index.hpp
+++ b/libmamba/include/mamba/core/subdir_index.hpp
@@ -117,10 +117,10 @@ namespace mamba
      *
      * Upon creation, the caches are checked for a valid and up to date index.
      * This can be inspected with @ref valid_cache_found.
-     * The created subdirs are typically used with @ref SubdirData::download_required_indexes
+     * The created subdirs are typically used with @ref SubdirIndexLoader::download_required_indexes
      * which will download the missing, invalid, or outdated indexes as needed.
      */
-    class SubdirData
+    class SubdirIndexLoader
     {
     public:
 
@@ -163,7 +163,7 @@ namespace mamba
             specs::DynamicPlatform platform,
             MultiPackageCache& caches,
             std::string repodata_filename = "repodata.json"
-        ) -> expected_t<SubdirData>;
+        ) -> expected_t<SubdirIndexLoader>;
 
         [[nodiscard]] auto is_noarch() const -> bool;
         [[nodiscard]] auto is_local() const -> bool;
@@ -197,7 +197,7 @@ namespace mamba
         bool m_json_cache_valid = false;
         bool m_solv_cache_valid = false;
 
-        SubdirData(
+        SubdirIndexLoader(
             const SubdirParams& params,
             ChannelContext& channel_context,
             specs::Channel channel,
@@ -208,9 +208,9 @@ namespace mamba
 
         [[nodiscard]] auto repodata_url_path() const -> std::string;
 
-        /**************************************************
-         *  Implementation details of SubdirData::create  *
-         **************************************************/
+        /*********************************************************
+         *  Implementation details of SubdirIndexLoader::create  *
+         *********************************************************/
 
         void load(
             const MultiPackageCache& caches,
@@ -225,9 +225,9 @@ namespace mamba
             const specs::Channel& channel
         );
 
-        /*********************************************************************
-         *  Implementation details of SubdirData::download_required_indexes  *
-         *********************************************************************/
+        /****************************************************************************
+         *  Implementation details of SubdirIndexLoader::download_required_indexes  *
+         ****************************************************************************/
 
         auto use_existing_cache() -> expected_t<void>;
         auto finalize_transfer(SubdirMetadata::HttpMetadata http_data, const fs::u8path& artifact)
@@ -282,12 +282,12 @@ namespace mamba
      */
     auto create_cache_dir(const fs::u8path& cache_path) -> std::string;
 
-    /**********************************
-     *  Implementation of Subdirdata  *
-     **********************************/
+    /*****************************************
+     *  Implementation of SubdirIndexLoader  *
+     *****************************************/
 
     template <typename SubdirIter1, typename SubdirIter2>
-    auto SubdirData::download_required_indexes(
+    auto SubdirIndexLoader::download_required_indexes(
         SubdirIter1 subdirs_first,
         SubdirIter2 subdirs_last,
         const SubdirParams& subdir_params,
@@ -328,7 +328,7 @@ namespace mamba
     }
 
     template <typename Subdirs>
-    auto SubdirData::download_required_indexes(
+    auto SubdirIndexLoader::download_required_indexes(
         Subdirs& subdirs,
         const SubdirParams& subdir_params,
         const specs::AuthenticationDataBase& auth_info,
@@ -353,9 +353,11 @@ namespace mamba
     }
 
     template <typename First, typename End>
-    auto
-    SubdirData::build_all_check_requests(First subdirs_first, End subdirs_last, const SubdirParams& params)
-        -> download::MultiRequest
+    auto SubdirIndexLoader::build_all_check_requests(
+        First subdirs_first,
+        End subdirs_last,
+        const SubdirParams& params
+    ) -> download::MultiRequest
     {
         download::MultiRequest requests;
         for (; subdirs_first != subdirs_last; ++subdirs_first)
@@ -370,9 +372,11 @@ namespace mamba
     }
 
     template <typename First, typename End>
-    auto
-    SubdirData::build_all_index_requests(First subdirs_first, End subdirs_last, const SubdirParams& params)
-        -> download::MultiRequest
+    auto SubdirIndexLoader::build_all_index_requests(
+        First subdirs_first,
+        End subdirs_last,
+        const SubdirParams& params
+    ) -> download::MultiRequest
     {
         download::MultiRequest requests;
         for (; subdirs_first != subdirs_last; ++subdirs_first)

--- a/libmamba/include/mamba/core/subdir_index.hpp
+++ b/libmamba/include/mamba/core/subdir_index.hpp
@@ -31,8 +31,6 @@ namespace mamba
         class Channel;
     }
 
-    class ChannelContext;
-
     /**
      * Handling of a subdirectory metadata.
      *
@@ -159,7 +157,6 @@ namespace mamba
         /** Check existing caches for a valid index validity and freshness. */
         static auto create(
             const SubdirParams& params,
-            ChannelContext& channel_context,
             specs::Channel channel,
             specs::DynamicPlatform platform,
             MultiPackageCache& caches,
@@ -200,7 +197,6 @@ namespace mamba
 
         SubdirIndexLoader(
             const SubdirParams& params,
-            ChannelContext& channel_context,
             specs::Channel channel,
             std::string platform,
             MultiPackageCache& caches,
@@ -213,18 +209,8 @@ namespace mamba
          *  Implementation details of SubdirIndexLoader::create  *
          *********************************************************/
 
-        void load(
-            const MultiPackageCache& caches,
-            ChannelContext& channel_context,
-            const SubdirParams& params,
-            const specs::Channel& channel
-        );
+        void load(const MultiPackageCache& caches, const SubdirParams& params);
         void load_cache(const MultiPackageCache& caches, const SubdirParams& params);
-        void update_metadata_zst(
-            ChannelContext& context,
-            const SubdirParams& params,
-            const specs::Channel& channel
-        );
 
         /****************************************************************************
          *  Implementation details of SubdirIndexLoader::download_required_indexes  *

--- a/libmamba/include/mamba/core/subdir_index.hpp
+++ b/libmamba/include/mamba/core/subdir_index.hpp
@@ -182,10 +182,17 @@ namespace mamba
 
     private:
 
+        // This paths are pointing to what is found when iterating over the cache directories.
+        // The expired found is the first one, which could be improved by keeping the freshest one.
+        // This could improve caching in some HTTP 304 cases.
+        // A possible improvement would be to keep all path, metadatas, and writable status in a
+        // single vector and sort them by recency.
+        // This would also give a public option for `clear`-ing all writable caches, not just the
+        // valid one.
         SubdirMetadata m_metadata;
         specs::Channel m_channel;
         fs::u8path m_valid_cache_path;
-        fs::u8path m_expired_cache_path;
+        std::optional<fs::u8path> m_expired_cache_path;
         fs::u8path m_writable_pkgs_dir;
         specs::DynamicPlatform m_platform;
         std::string m_repodata_filename;

--- a/libmamba/include/mamba/core/subdir_index.hpp
+++ b/libmamba/include/mamba/core/subdir_index.hpp
@@ -178,7 +178,7 @@ namespace mamba
         [[nodiscard]] auto writable_libsolv_cache_path() const -> fs::u8path;
         [[nodiscard]] auto valid_json_cache_path() const -> expected_t<fs::u8path>;
 
-        void clear_cache_files();
+        void clear_valid_cache_files();
 
     private:
 
@@ -204,6 +204,9 @@ namespace mamba
         );
 
         [[nodiscard]] auto repodata_url_path() const -> std::string;
+        [[nodiscard]] auto valid_json_cache_path_unchecked() const -> fs::u8path;
+        [[nodiscard]] auto valid_state_file_path_unchecked() const -> fs::u8path;
+        [[nodiscard]] auto valid_libsolv_cache_path_unchecked() const -> fs::u8path;
 
         /*********************************************************
          *  Implementation details of SubdirIndexLoader::create  *

--- a/libmamba/include/mamba/core/subdir_index.hpp
+++ b/libmamba/include/mamba/core/subdir_index.hpp
@@ -134,7 +134,7 @@ namespace mamba
         [[nodiscard]] static auto download_required_indexes(
             SubdirIter1 subdirs_first,
             SubdirIter2 subdirs_last,
-            const SubdirParams& subdir_params,
+            const SubdirDownloadParams& subdir_params,
             const specs::AuthenticationDataBase& auth_info,
             const download::mirror_map& mirrors,
             const download::Options& download_options,
@@ -145,7 +145,7 @@ namespace mamba
         template <typename Subdirs>
         [[nodiscard]] static auto download_required_indexes(
             Subdirs& subdirs,
-            const SubdirParams& subdir_params,
+            const SubdirDownloadParams& subdir_params,
             const specs::AuthenticationDataBase& auth_info,
             const download::mirror_map& mirrors,
             const download::Options& download_options,
@@ -223,15 +223,16 @@ namespace mamba
 
         template <typename First, typename End>
         static auto
-        build_all_check_requests(First subdirs_first, End subdirs_last, const SubdirParams& params)
+        build_all_check_requests(First subdirs_first, End subdirs_last, const SubdirDownloadParams& params)
             -> download::MultiRequest;
-        auto build_check_requests(const SubdirParams& params) -> download::MultiRequest;
+        auto build_check_requests(const SubdirDownloadParams& params) -> download::MultiRequest;
 
         template <typename First, typename End>
         static auto
-        build_all_index_requests(First subdirs_first, End subdirs_last, const SubdirParams& params)
+        build_all_index_requests(First subdirs_first, End subdirs_last, const SubdirDownloadParams& params)
             -> download::MultiRequest;
-        auto build_index_request(const SubdirParams& params) -> std::optional<download::Request>;
+        auto build_index_request(const SubdirDownloadParams& params)
+            -> std::optional<download::Request>;
 
         [[nodiscard]] static auto download_requests(
             download::MultiRequest index_requests,
@@ -277,7 +278,7 @@ namespace mamba
     auto SubdirIndexLoader::download_required_indexes(
         SubdirIter1 subdirs_first,
         SubdirIter2 subdirs_last,
-        const SubdirParams& subdir_params,
+        const SubdirDownloadParams& subdir_params,
         const specs::AuthenticationDataBase& auth_info,
         const download::mirror_map& mirrors,
         const download::Options& download_options,
@@ -317,7 +318,7 @@ namespace mamba
     template <typename Subdirs>
     auto SubdirIndexLoader::download_required_indexes(
         Subdirs& subdirs,
-        const SubdirParams& subdir_params,
+        const SubdirDownloadParams& subdir_params,
         const specs::AuthenticationDataBase& auth_info,
         const download::mirror_map& mirrors,
         const download::Options& download_options,
@@ -343,7 +344,7 @@ namespace mamba
     auto SubdirIndexLoader::build_all_check_requests(
         First subdirs_first,
         End subdirs_last,
-        const SubdirParams& params
+        const SubdirDownloadParams& params
     ) -> download::MultiRequest
     {
         download::MultiRequest requests;
@@ -374,7 +375,7 @@ namespace mamba
     auto SubdirIndexLoader::build_all_index_requests(
         First subdirs_first,
         End subdirs_last,
-        const SubdirParams& params
+        const SubdirDownloadParams& params
     ) -> download::MultiRequest
     {
         download::MultiRequest requests;

--- a/libmamba/include/mamba/core/subdir_parameters.hpp
+++ b/libmamba/include/mamba/core/subdir_parameters.hpp
@@ -7,13 +7,18 @@
 #ifndef MAMBA_CORE_SUBDIR_PARAMETERS_HPP
 #define MAMBA_CORE_SUBDIR_PARAMETERS_HPP
 
-#include <cstddef>
+#include <optional>
 
 namespace mamba
 {
     struct SubdirParams
     {
-        std::size_t local_repodata_ttl = 1;
+        /**
+         * Repodata cache time to live in seconds.
+         *
+         * If not specified, then it is read from server headers.
+         */
+        std::optional<std::size_t> local_repodata_ttl_s = std::nullopt;
         bool offline = false;
         bool use_index_cache = true;
         bool repodata_use_zst = true;

--- a/libmamba/include/mamba/core/subdir_parameters.hpp
+++ b/libmamba/include/mamba/core/subdir_parameters.hpp
@@ -20,7 +20,8 @@ namespace mamba
          */
         std::optional<std::size_t> local_repodata_ttl_s = std::nullopt;
         bool offline = false;
-        bool repodata_use_zst = true;
+        /** Make a request to check the use of zst compression format. */
+        bool repodata_check_zst = true;
     };
 }
 

--- a/libmamba/include/mamba/core/subdir_parameters.hpp
+++ b/libmamba/include/mamba/core/subdir_parameters.hpp
@@ -20,7 +20,6 @@ namespace mamba
          */
         std::optional<std::size_t> local_repodata_ttl_s = std::nullopt;
         bool offline = false;
-        bool use_index_cache = true;
         bool repodata_use_zst = true;
     };
 }

--- a/libmamba/include/mamba/core/subdir_parameters.hpp
+++ b/libmamba/include/mamba/core/subdir_parameters.hpp
@@ -20,10 +20,15 @@ namespace mamba
          */
         std::optional<std::size_t> local_repodata_ttl_s = std::nullopt;
         bool offline = false;
-        /** Make a request to check the use of zst compression format. */
-        bool repodata_check_zst = true;
         /** Force the use of zst for this subdir without checking. */
         bool repodata_force_use_zst = false;
+    };
+
+    struct SubdirDownloadParams
+    {
+        bool offline = false;
+        /** Make a request to check the use of zst compression format. */
+        bool repodata_check_zst = true;
     };
 }
 

--- a/libmamba/include/mamba/core/subdir_parameters.hpp
+++ b/libmamba/include/mamba/core/subdir_parameters.hpp
@@ -22,6 +22,8 @@ namespace mamba
         bool offline = false;
         /** Make a request to check the use of zst compression format. */
         bool repodata_check_zst = true;
+        /** Force the use of zst for this subdir without checking. */
+        bool repodata_force_use_zst = false;
     };
 }
 

--- a/libmamba/src/api/channel_loader.cpp
+++ b/libmamba/src/api/channel_loader.cpp
@@ -10,7 +10,7 @@
 #include "mamba/core/output.hpp"
 #include "mamba/core/package_database_loader.hpp"
 #include "mamba/core/prefix_data.hpp"
-#include "mamba/core/subdirdata.hpp"
+#include "mamba/core/subdir_index.hpp"
 #include "mamba/solver/libsolv/database.hpp"
 #include "mamba/solver/libsolv/repo_info.hpp"
 #include "mamba/specs/package_info.hpp"
@@ -54,7 +54,7 @@ namespace mamba
             ChannelContext& channel_context,
             const specs::Channel& channel,
             MultiPackageCache& package_caches,
-            std::vector<SubdirData>& subdirs,
+            std::vector<SubdirIndexLoader>& subdirs,
             std::vector<mamba_error>& error_list,
             std::vector<solver::libsolv::Priorities>& priorities,
             int& max_prio,
@@ -76,7 +76,7 @@ namespace mamba
                     LOG_WARNING << "See: https://legal.anaconda.com/policies/en/";
                 }
 
-                auto sdires = SubdirData::create(
+                auto sdires = SubdirIndexLoader::create(
                     ctx.subdir_params(),
                     channel_context,
                     channel,
@@ -130,7 +130,7 @@ namespace mamba
             bool is_retry
         ) -> expected_t<void, mamba_aggregated_error>
         {
-            std::vector<SubdirData> subdirs;
+            std::vector<SubdirIndexLoader> subdirs;
 
             std::vector<solver::libsolv::Priorities> priorities;
             int max_prio = static_cast<int>(ctx.channels.size());
@@ -200,11 +200,11 @@ namespace mamba
             }
 
             expected_t<void> download_res;
-            if (SubdirDataMonitor::can_monitor(ctx))
+            if (SubdirIndexMonitor::can_monitor(ctx))
             {
-                SubdirDataMonitor check_monitor({ true, true });
-                SubdirDataMonitor index_monitor;
-                download_res = SubdirData::download_required_indexes(
+                SubdirIndexMonitor check_monitor({ true, true });
+                SubdirIndexMonitor index_monitor;
+                download_res = SubdirIndexLoader::download_required_indexes(
                     subdirs,
                     ctx.subdir_params(),
                     ctx.authentication_info(),
@@ -217,7 +217,7 @@ namespace mamba
             }
             else
             {
-                download_res = SubdirData::download_required_indexes(
+                download_res = SubdirIndexLoader::download_required_indexes(
                     subdirs,
                     ctx.subdir_params(),
                     ctx.authentication_info(),

--- a/libmamba/src/api/channel_loader.cpp
+++ b/libmamba/src/api/channel_loader.cpp
@@ -212,7 +212,7 @@ namespace mamba
                 SubdirIndexMonitor index_monitor;
                 download_res = SubdirIndexLoader::download_required_indexes(
                     subdirs,
-                    ctx.subdir_params(),
+                    ctx.subdir_download_params(),
                     ctx.authentication_info(),
                     ctx.mirrors,
                     ctx.download_options(),
@@ -225,7 +225,7 @@ namespace mamba
             {
                 download_res = SubdirIndexLoader::download_required_indexes(
                     subdirs,
-                    ctx.subdir_params(),
+                    ctx.subdir_download_params(),
                     ctx.authentication_info(),
                     ctx.mirrors,
                     ctx.download_options(),

--- a/libmamba/src/api/channel_loader.cpp
+++ b/libmamba/src/api/channel_loader.cpp
@@ -90,6 +90,11 @@ namespace mamba
                     continue;
                 }
                 auto sdir = std::move(sdires).value();
+                if (sdir.valid_cache_found())
+                {
+                    Console::stream() << fmt::format("{:<50} {:>20}", sdir.name(), "Using cache");
+                }
+
                 subdirs.push_back(std::move(sdir));
                 if (ctx.channel_priority == ChannelPriority::Disabled)
                 {

--- a/libmamba/src/api/channel_loader.cpp
+++ b/libmamba/src/api/channel_loader.cpp
@@ -76,9 +76,10 @@ namespace mamba
                     LOG_WARNING << "See: https://legal.anaconda.com/policies/en/";
                 }
 
+                auto subdir_params = ctx.subdir_params();
+                subdir_params.repodata_force_use_zst = channel_context.has_zst(channel);
                 auto sdires = SubdirIndexLoader::create(
-                    ctx.subdir_params(),
-                    channel_context,
+                    subdir_params,
                     channel,
                     platform,
                     package_caches,

--- a/libmamba/src/api/channel_loader.cpp
+++ b/libmamba/src/api/channel_loader.cpp
@@ -289,7 +289,7 @@ namespace mamba
                             {
                                 LOG_WARNING << "Could not load repodata.json for " << subdir.name()
                                             << ". Deleting cache, and retrying.";
-                                subdir.clear_cache_files();
+                                subdir.clear_valid_cache_files();
                                 loading_failed = true;
                             }
                         }

--- a/libmamba/src/core/download_progress_bar.cpp
+++ b/libmamba/src/core/download_progress_bar.cpp
@@ -128,21 +128,21 @@ namespace mamba
         }
     }
 
-    /*********************
-     * SubdirDataMonitor *
-     *********************/
+    /**********************
+     * SubdirIndexMonitor *
+     **********************/
 
-    SubdirDataMonitor::SubdirDataMonitor(MonitorOptions options)
+    SubdirIndexMonitor::SubdirIndexMonitor(MonitorOptions options)
         : m_options(std::move(options))
     {
     }
 
-    void SubdirDataMonitor::reset_options(MonitorOptions options)
+    void SubdirIndexMonitor::reset_options(MonitorOptions options)
     {
         m_options = std::move(options);
     }
 
-    bool SubdirDataMonitor::can_monitor(const Context& context)
+    bool SubdirIndexMonitor::can_monitor(const Context& context)
     {
         return !(
             context.graphics_params.no_progress_bars || context.output_params.json
@@ -150,7 +150,8 @@ namespace mamba
         );
     }
 
-    void SubdirDataMonitor::observe_impl(download::MultiRequest& requests, download::Options& options)
+    void
+    SubdirIndexMonitor::observe_impl(download::MultiRequest& requests, download::Options& options)
     {
         m_throttle_time.resize(requests.size(), std::chrono::steady_clock::now());
         m_progress_bar.reserve(requests.size());
@@ -175,7 +176,7 @@ namespace mamba
         options.on_unexpected_termination = [this]() { on_unexpected_termination(); };
     }
 
-    void SubdirDataMonitor::on_done_impl()
+    void SubdirIndexMonitor::on_done_impl()
     {
         auto& pbar_manager = Console::instance().progress_bar_manager();
         if (pbar_manager.started())
@@ -191,22 +192,23 @@ namespace mamba
         m_options = MonitorOptions{};
     }
 
-    void SubdirDataMonitor::on_unexpected_termination_impl()
+    void SubdirIndexMonitor::on_unexpected_termination_impl()
     {
         Console::instance().progress_bar_manager().terminate();
     }
 
-    void SubdirDataMonitor::update_progress_bar(std::size_t index, const download::Event& event)
+    void SubdirIndexMonitor::update_progress_bar(std::size_t index, const download::Event& event)
     {
         std::visit([this, index](auto&& arg) { update_progress_bar(index, arg); }, event);
     }
 
-    void SubdirDataMonitor::update_progress_bar(std::size_t index, const download::Progress& progress)
+    void
+    SubdirIndexMonitor::update_progress_bar(std::size_t index, const download::Progress& progress)
     {
         mamba::update_progress_bar(m_progress_bar[index], m_throttle_time[index], progress);
     }
 
-    void SubdirDataMonitor::update_progress_bar(std::size_t index, const download::Error& error)
+    void SubdirIndexMonitor::update_progress_bar(std::size_t index, const download::Error& error)
     {
         if (m_options.checking_download)
         {
@@ -218,7 +220,7 @@ namespace mamba
         }
     }
 
-    void SubdirDataMonitor::update_progress_bar(std::size_t index, const download::Success& success)
+    void SubdirIndexMonitor::update_progress_bar(std::size_t index, const download::Success& success)
     {
         if (m_options.checking_download)
         {
@@ -230,7 +232,7 @@ namespace mamba
         }
     }
 
-    void SubdirDataMonitor::complete_checking_progress_bar(std::size_t index)
+    void SubdirIndexMonitor::complete_checking_progress_bar(std::size_t index)
     {
         ProgressProxy& progress_bar = m_progress_bar[index];
         progress_bar.repr().postfix.set_value("Checked");
@@ -245,7 +247,7 @@ namespace mamba
 
     bool PackageDownloadMonitor::can_monitor(const Context& context)
     {
-        return SubdirDataMonitor::can_monitor(context);
+        return SubdirIndexMonitor::can_monitor(context);
     }
 
     PackageDownloadMonitor::~PackageDownloadMonitor()

--- a/libmamba/src/core/package_database_loader.cpp
+++ b/libmamba/src/core/package_database_loader.cpp
@@ -17,7 +17,7 @@
 #include "mamba/core/output.hpp"
 #include "mamba/core/package_database_loader.hpp"
 #include "mamba/core/prefix_data.hpp"
-#include "mamba/core/subdirdata.hpp"
+#include "mamba/core/subdir_index.hpp"
 #include "mamba/core/virtual_packages.hpp"
 #include "mamba/solver/libsolv/database.hpp"
 #include "mamba/solver/libsolv/repo_info.hpp"
@@ -52,9 +52,11 @@ namespace mamba
         );
     }
 
-    auto
-    load_subdir_in_database(const Context& ctx, solver::libsolv::Database& database, const SubdirData& subdir)
-        -> expected_t<solver::libsolv::RepoInfo>
+    auto load_subdir_in_database(
+        const Context& ctx,
+        solver::libsolv::Database& database,
+        const SubdirIndexLoader& subdir
+    ) -> expected_t<solver::libsolv::RepoInfo>
     {
         const auto expected_cache_origin = solver::libsolv::RepodataOrigin{
             /* .url= */ util::rsplit(subdir.metadata().url(), "/", 1).front(),

--- a/libmamba/src/core/repo_checker_store.cpp
+++ b/libmamba/src/core/repo_checker_store.cpp
@@ -9,7 +9,7 @@
 #include "mamba/core/output.hpp"
 #include "mamba/core/package_cache.hpp"
 #include "mamba/core/repo_checker_store.hpp"
-#include "mamba/core/subdirdata.hpp"
+#include "mamba/core/subdir_index.hpp"
 
 namespace mamba
 {

--- a/libmamba/src/core/subdir_index.cpp
+++ b/libmamba/src/core/subdir_index.cpp
@@ -608,13 +608,10 @@ namespace mamba
             load_cache(caches, params);
         }
 
-        if (m_valid_cache_found)
+        LOG_INFO << "Valid cache found  for '" << name() << "': " << valid_cache_found();
+
+        if (!valid_cache_found())
         {
-            Console::stream() << fmt::format("{:<50} {:>20}", name(), std::string("Using cache"));
-        }
-        else
-        {
-            LOG_INFO << "No valid cache found";
             if (!m_expired_cache_path.empty())
             {
                 LOG_INFO << "Expired cache (or invalid mod/etag headers) found at '"

--- a/libmamba/src/core/subdir_index.cpp
+++ b/libmamba/src/core/subdir_index.cpp
@@ -730,7 +730,7 @@ namespace mamba
     {
         download::MultiRequest request;
 
-        if ((!params.offline || caching_is_forbidden()) && params.repodata_use_zst
+        if ((!params.offline || caching_is_forbidden()) && params.repodata_check_zst
             && !m_metadata.has_up_to_date_zst())
         {
             request.push_back(download::Request(

--- a/libmamba/src/core/subdir_index.cpp
+++ b/libmamba/src/core/subdir_index.cpp
@@ -705,7 +705,8 @@ namespace mamba
         }
     }
 
-    auto SubdirIndexLoader::build_check_requests(const SubdirParams& params) -> download::MultiRequest
+    auto SubdirIndexLoader::build_check_requests(const SubdirDownloadParams& params)
+        -> download::MultiRequest
     {
         download::MultiRequest request;
 
@@ -746,7 +747,7 @@ namespace mamba
         return request;
     }
 
-    auto SubdirIndexLoader::build_index_request(const SubdirParams& params)
+    auto SubdirIndexLoader::build_index_request(const SubdirDownloadParams& params)
         -> std::optional<download::Request>
     {
         if (params.offline && !caching_is_forbidden())

--- a/libmamba/src/core/subdir_index.cpp
+++ b/libmamba/src/core/subdir_index.cpp
@@ -663,9 +663,9 @@ namespace mamba
                 {
                     return params.local_repodata_ttl_s.value();
                 }
-                if (auto max_age = get_cache_control_max_age(m_metadata.cache_control()))
+                if (auto control_max_age = get_cache_control_max_age(m_metadata.cache_control()))
                 {
-                    return max_age.value();
+                    return control_max_age.value();
                 }
                 return max_age_default;
             }();

--- a/libmamba/src/core/subdir_index.cpp
+++ b/libmamba/src/core/subdir_index.cpp
@@ -673,8 +673,7 @@ namespace mamba
 
             const auto cache_age_seconds = std::chrono::duration_cast<std::chrono::seconds>(cache_age)
                                                .count();
-            if (util::cmp_greater(max_age, cache_age_seconds) || params.offline
-                || params.use_index_cache)
+            if (util::cmp_less(cache_age_seconds, max_age) || params.offline)
             {
                 // valid json cache found
                 if (!m_valid_cache_found)

--- a/libmamba/src/core/subdir_index.cpp
+++ b/libmamba/src/core/subdir_index.cpp
@@ -605,6 +605,7 @@ namespace mamba
         const specs::Channel& channel
     )
     {
+        // For local channel subdirs, we still go through the downloaders
         if (!caching_is_forbidden())
         {
             load_cache(caches, params);

--- a/libmamba/src/core/subdir_index.cpp
+++ b/libmamba/src/core/subdir_index.cpp
@@ -30,7 +30,8 @@ namespace mamba
     namespace
     {
 #ifdef _WIN32
-        filetime_to_unix(const fs::file_time_type& filetime)
+        auto filetime_to_unix(const fs::file_time_type& filetime)
+            -> std::chrono::system_clock::time_point
         {
             // windows filetime is in 100ns intervals since 1601-01-01
             static constexpr auto epoch_offset = std::chrono::seconds(11644473600ULL);

--- a/libmamba/src/core/subdir_index.cpp
+++ b/libmamba/src/core/subdir_index.cpp
@@ -535,7 +535,7 @@ namespace mamba
     {
         try
         {
-            download::download(
+            auto results = download::download(
                 std::move(requests),
                 mirrors,
                 remote_fetch_params,
@@ -543,6 +543,15 @@ namespace mamba
                 download_options,
                 monitor
             );
+            // TODO: This is not the best handling, but we also want to be robust in the case of
+            // missing subdirs (e.g. local path as a `noarch` but no `linux-64`).
+            for (auto& result : results)
+            {
+                if (!result.has_value())
+                {
+                    LOG_WARNING << "Failed to load subdir: " << result.error().message;
+                }
+            }
         }
         catch (const std::runtime_error& e)
         {

--- a/libmamba/tests/CMakeLists.txt
+++ b/libmamba/tests/CMakeLists.txt
@@ -136,8 +136,10 @@ add_dependencies(test_libmamba test_libmamba_data)
 
 target_compile_definitions(
     test_libmamba
-    PRIVATE MAMBA_TEST_DATA_DIR="${CMAKE_CURRENT_BINARY_DIR}/data"
-            MAMBA_TEST_LOCK_EXE="$<TARGET_FILE:testing_libmamba_lock>"
+    PRIVATE
+        MAMBA_TEST_DATA_DIR="${CMAKE_CURRENT_BINARY_DIR}/data"
+        MAMBA_REPO_DIR="${CMAKE_SOURCE_DIR}"
+        MAMBA_TEST_LOCK_EXE="$<TARGET_FILE:testing_libmamba_lock>"
 )
 
 target_compile_features(test_libmamba PUBLIC cxx_std_17)

--- a/libmamba/tests/CMakeLists.txt
+++ b/libmamba/tests/CMakeLists.txt
@@ -89,6 +89,7 @@ set(
     src/core/test_pinning.cpp
     src/core/test_progress_bar.cpp
     src/core/test_shell_init.cpp
+    src/core/test_subdir_index.cpp
     src/core/test_tasksync.cpp
     src/core/test_thread_utils.cpp
     src/core/test_transaction_context.cpp

--- a/libmamba/tests/include/mambatests.hpp
+++ b/libmamba/tests/include/mambatests.hpp
@@ -24,6 +24,11 @@ namespace mambatests
 #endif
     inline static const mamba::fs::u8path test_data_dir = MAMBA_TEST_DATA_DIR;
 
+#ifndef MAMBA_REPO_DIR
+#error "MAMBA_REPO_DIR must be defined pointing to test data"
+#endif
+    inline static const mamba::fs::u8path repo_dir = MAMBA_REPO_DIR;
+
 #ifndef MAMBA_TEST_LOCK_EXE
 #error "MAMBA_TEST_LOCK_EXE must be defined pointing to testing_libmamba_lock"
 #endif

--- a/libmamba/tests/src/core/test_cpp.cpp
+++ b/libmamba/tests/src/core/test_cpp.cpp
@@ -16,7 +16,7 @@
 #include "mamba/core/history.hpp"
 #include "mamba/core/link.hpp"
 #include "mamba/core/output.hpp"
-#include "mamba/core/subdirdata.hpp"
+#include "mamba/core/subdir_index.hpp"
 #include "mamba/util/build.hpp"
 #include "mamba/util/path_manip.hpp"
 

--- a/libmamba/tests/src/core/test_filesystem.cpp
+++ b/libmamba/tests/src/core/test_filesystem.cpp
@@ -8,7 +8,7 @@
 
 #include <catch2/catch_all.hpp>
 
-#include "mamba/core/subdirdata.hpp"
+#include "mamba/core/subdir_index.hpp"
 #include "mamba/core/util.hpp"
 #include "mamba/core/util_scope.hpp"
 #include "mamba/fs/filesystem.hpp"

--- a/libmamba/tests/src/core/test_subdir_index.cpp
+++ b/libmamba/tests/src/core/test_subdir_index.cpp
@@ -103,17 +103,12 @@ TEST_CASE("SubdirIndexLoader", "[mamba::core][mamba::core::SubdirIndexLoader]")
         const auto tmp_dir = TemporaryDirectory();
         auto caches = MultiPackageCache({ tmp_dir.path() }, ValidationParams{});
 
-        const auto params = SubdirParams{
-            /* .local_repodata_ttl */ 1000000,
-            /* .offline */ false,
-            /* .repodata_use_zst */ true,
-        };
         auto subdirs = std::array{
-            SubdirIndexLoader::create(params, qs_channel, "linux-64", caches).value(),
-            SubdirIndexLoader::create(params, qs_channel, "noarch", caches).value(),
+            SubdirIndexLoader::create({}, qs_channel, "linux-64", caches).value(),
+            SubdirIndexLoader::create({}, qs_channel, "noarch", caches).value(),
         };
 
-        auto result = SubdirIndexLoader::download_required_indexes(subdirs, params, {}, mirrors, {}, {});
+        auto result = SubdirIndexLoader::download_required_indexes(subdirs, {}, {}, mirrors, {}, {});
         REQUIRE(result.has_value());
 
         const auto cache_dir = tmp_dir.path() / "cache";
@@ -136,14 +131,23 @@ TEST_CASE("SubdirIndexLoader", "[mamba::core][mamba::core::SubdirIndexLoader]")
         const auto params = SubdirParams{
             /* .local_repodata_ttl */ 1000000,
             /* .offline */ true,
-            /* .repodata_use_zst */ true,
         };
         auto subdirs = std::array{
             SubdirIndexLoader::create(params, qs_channel, "linux-64", caches).value(),
             SubdirIndexLoader::create(params, qs_channel, "noarch", caches).value(),
         };
 
-        auto result = SubdirIndexLoader::download_required_indexes(subdirs, params, {}, mirrors, {}, {});
+        const auto download_params = SubdirDownloadParams{
+            /* .offline */ true,
+        };
+        auto result = SubdirIndexLoader::download_required_indexes(
+            subdirs,
+            download_params,
+            {},
+            mirrors,
+            {},
+            {}
+        );
         REQUIRE(result.has_value());
 
         const auto cache_dir = tmp_dir.path() / "cache";
@@ -168,7 +172,7 @@ TEST_CASE("SubdirIndexLoader", "[mamba::core][mamba::core::SubdirIndexLoader]")
             SubdirIndexLoader::create(params, local_channel, "noarch", caches).value(),
         };
 
-        auto result = SubdirIndexLoader::download_required_indexes(subdirs, params, {}, mirrors, {}, {});
+        auto result = SubdirIndexLoader::download_required_indexes(subdirs, {}, {}, mirrors, {}, {});
         REQUIRE(result.has_value());
 
         CHECK_FALSE(subdirs[0].valid_cache_found());
@@ -183,8 +187,6 @@ TEST_CASE("SubdirIndexLoader", "[mamba::core][mamba::core::SubdirIndexLoader]")
 
         const auto params = SubdirParams{
             /* .local_repodata_ttl */ 0,
-            /* .offline */ false,
-            /* .repodata_use_zst */ true,
         };
         auto subdirs = std::array{
             SubdirIndexLoader::create(params, qs_channel, "linux-64", caches).value(),
@@ -193,7 +195,7 @@ TEST_CASE("SubdirIndexLoader", "[mamba::core][mamba::core::SubdirIndexLoader]")
 
         CAPTURE(tmp_dir.path());
 
-        auto result = SubdirIndexLoader::download_required_indexes(subdirs, params, {}, mirrors, {}, {});
+        auto result = SubdirIndexLoader::download_required_indexes(subdirs, {}, {}, mirrors, {}, {});
         REQUIRE(result.has_value());
 
         const auto cache_dir = tmp_dir.path() / "cache";

--- a/libmamba/tests/src/core/test_subdir_index.cpp
+++ b/libmamba/tests/src/core/test_subdir_index.cpp
@@ -122,7 +122,6 @@ TEST_CASE("SubdirIndexLoader", "[mamba::core][mamba::core::SubdirIndexLoader]")
             CHECK(is_in_directory(cache_dir, subdir.writable_libsolv_cache_path()));
         }
 
-
         SECTION("And clear them")
         {
             for (auto& subdir : subdirs)
@@ -208,8 +207,6 @@ TEST_CASE("SubdirIndexLoader", "[mamba::core][mamba::core::SubdirIndexLoader]")
             SubdirIndexLoader::create(params, qs_channel, "noarch", caches).value(),
         };
 
-        CAPTURE(tmp_dir.path());
-
         auto result = SubdirIndexLoader::download_required_indexes(subdirs, {}, {}, mirrors, {}, {});
         REQUIRE(result.has_value());
 
@@ -220,13 +217,17 @@ TEST_CASE("SubdirIndexLoader", "[mamba::core][mamba::core::SubdirIndexLoader]")
             CHECK(subdir.valid_cache_found());
         }
 
-        subdirs = std::array{
-            SubdirIndexLoader::create(params, qs_channel, "linux-64", caches).value(),
-            SubdirIndexLoader::create(params, qs_channel, "noarch", caches).value(),
-        };
-        for (const auto& subdir : subdirs)
+        SECTION("Reloading subdir are expired")
         {
-            CHECK_FALSE(subdir.valid_cache_found());
+            auto expired_subdirs = std::array{
+                SubdirIndexLoader::create(params, qs_channel, "linux-64", caches).value(),
+                SubdirIndexLoader::create(params, qs_channel, "noarch", caches).value(),
+            };
+
+            for (const auto& subdir : expired_subdirs)
+            {
+                CHECK_FALSE(subdir.valid_cache_found());
+            }
         }
     }
 }

--- a/libmamba/tests/src/core/test_subdir_index.cpp
+++ b/libmamba/tests/src/core/test_subdir_index.cpp
@@ -121,6 +121,21 @@ TEST_CASE("SubdirIndexLoader", "[mamba::core][mamba::core::SubdirIndexLoader]")
             CHECK_FALSE(subdir.valid_libsolv_cache_path().has_value());
             CHECK(is_in_directory(cache_dir, subdir.writable_libsolv_cache_path()));
         }
+
+
+        SECTION("And clear them")
+        {
+            for (auto& subdir : subdirs)
+            {
+                subdir.clear_valid_cache_files();
+
+                CHECK_FALSE(subdir.valid_cache_found());
+                CHECK_FALSE(subdir.valid_json_cache_path().has_value());
+                CHECK_FALSE(subdir.valid_libsolv_cache_path().has_value());
+            }
+
+            CHECK(fs::is_empty(cache_dir));
+        }
     }
 
     SECTION("No download offline")

--- a/libmamba/tests/src/core/test_subdir_index.cpp
+++ b/libmamba/tests/src/core/test_subdir_index.cpp
@@ -1,0 +1,187 @@
+// Copyright (c) 2023, QuantStack and Mamba Contributors
+//
+// Distributed under the terms of the BSD 3-Clause License.
+//
+// The full license is in the file LICENSE, distributed with this software.
+
+#include <array>
+#include <fstream>
+#include <sstream>
+
+#include <catch2/catch_all.hpp>
+
+#include "mamba/core/channel_context.hpp"
+#include "mamba/core/context.hpp"
+#include "mamba/core/package_cache.hpp"
+#include "mamba/core/subdir_index.hpp"
+#include "mamba/core/util.hpp"
+#include "mamba/util/string.hpp"
+
+using namespace mamba;
+
+namespace
+{
+    [[nodiscard]] auto is_in_directory(const fs::u8path& dir, const fs::u8path& file) -> bool
+    {
+        auto abs_dir = fs::absolute(dir).lexically_normal();
+        auto abs_file = fs::absolute(file).lexically_normal();
+        return abs_file.parent_path() == abs_dir;
+    }
+
+    [[nodiscard]] auto file_to_string(const fs::u8path& filename) -> std::string
+    {
+        std::ifstream file(filename.string());
+        std::ostringstream ss;
+        ss << file.rdbuf();
+        return ss.str();
+    }
+}
+
+TEST_CASE("SubdirIndexLoader", "[mamba::core][mamba::core::SubdirIndexLoader]")
+{
+    auto channel_context = ChannelContext(
+        ChannelContext::ChannelResolveParams{
+            { "linux-64", "osx-64", "noarch" },
+            specs::CondaURL::parse("https://conda.anaconda.org").value() },
+        {}
+    );
+    auto mirrors = download::mirror_map();
+    mirrors.add_unique_mirror(
+        "quantstack",
+        download::make_mirror("https://conda.anaconda.org/quantstack")
+    );
+    const auto channel = channel_context.make_channel("quantstack").front();
+
+    SECTION("Create a subdir loader")
+    {
+        constexpr auto platform = "mamba-128";
+        constexpr auto repodata_filename = "foo.json";
+
+        const auto tmp_dir = TemporaryDirectory();
+        auto caches = MultiPackageCache({ tmp_dir.path() }, ValidationParams{});
+
+        auto subdir = SubdirIndexLoader::create(
+            {},
+            channel_context,
+            channel,
+            platform,
+            caches,
+            repodata_filename
+        );
+
+        REQUIRE(subdir.has_value());
+        CHECK_FALSE(subdir->is_noarch());
+        CHECK_FALSE(subdir->is_local());
+        CHECK(subdir->channel() == channel);
+        CHECK(subdir->name() == "quantstack/mamba-128");
+        CHECK(subdir->channel_id() == "quantstack");
+        CHECK(subdir->platform() == platform);
+        CHECK(
+            subdir->repodata_url()
+            == specs::CondaURL::parse("https://conda.anaconda.org/quantstack/mamba-128/foo.json").value()
+        );
+        const auto& metadata = subdir->metadata();
+        CHECK(metadata.url() == "");
+        CHECK(metadata.etag() == "");
+
+        CHECK_FALSE(subdir->valid_cache_found());
+        CHECK_FALSE(subdir->valid_libsolv_cache_path().has_value());
+        CHECK_FALSE(subdir->valid_json_cache_path().has_value());
+    }
+
+    SECTION("Download indexes")
+    {
+        const auto tmp_dir = TemporaryDirectory();
+        auto caches = MultiPackageCache({ tmp_dir.path() }, ValidationParams{});
+
+        const auto params = SubdirParams{
+            /* .local_repodata_ttl */ 1000000,
+            /* .offline */ false,
+            /* .use_index_cache */ true,
+            /* .repodata_use_zst */ true,
+        };
+        auto subdirs = std::array{
+            SubdirIndexLoader::create(params, channel_context, channel, "linux-64", caches).value(),
+            SubdirIndexLoader::create(params, channel_context, channel, "noarch", caches).value(),
+        };
+
+        auto result = SubdirIndexLoader::download_required_indexes(subdirs, params, {}, mirrors, {}, {});
+        REQUIRE(result.has_value());
+
+        const auto cache_dir = tmp_dir.path() / "cache";
+
+        for (const auto& subdir : subdirs)
+        {
+            CHECK(subdir.valid_cache_found());
+            CHECK(is_in_directory(cache_dir, subdir.valid_json_cache_path().value()));
+            CHECK(util::contains(file_to_string(subdir.valid_json_cache_path().value()), "packages"));
+            CHECK_FALSE(subdir.valid_libsolv_cache_path().has_value());
+            CHECK(is_in_directory(cache_dir, subdir.writable_libsolv_cache_path()));
+        }
+    }
+
+    SECTION("No download offline")
+    {
+        const auto tmp_dir = TemporaryDirectory();
+        auto caches = MultiPackageCache({ tmp_dir.path() }, ValidationParams{});
+
+        const auto params = SubdirParams{
+            /* .local_repodata_ttl */ 1000000,
+            /* .offline */ true,
+            /* .use_index_cache */ true,
+            /* .repodata_use_zst */ true,
+        };
+        auto subdirs = std::array{
+            SubdirIndexLoader::create(params, channel_context, channel, "linux-64", caches).value(),
+            SubdirIndexLoader::create(params, channel_context, channel, "noarch", caches).value(),
+        };
+
+        auto result = SubdirIndexLoader::download_required_indexes(subdirs, params, {}, mirrors, {}, {});
+        REQUIRE(result.has_value());
+
+        const auto cache_dir = tmp_dir.path() / "cache";
+
+        for (const auto& subdir : subdirs)
+        {
+            CHECK_FALSE(subdir.valid_cache_found());
+        }
+    }
+
+    SECTION("Download indexes repodata ttl")
+    {
+        const auto tmp_dir = TemporaryDirectory();
+        auto caches = MultiPackageCache({ tmp_dir.path() }, ValidationParams{});
+
+        const auto params = SubdirParams{
+            /* .local_repodata_ttl */ 0,
+            /* .offline */ false,
+            /* .use_index_cache */ false,
+            /* .repodata_use_zst */ true,
+        };
+        auto subdirs = std::array{
+            SubdirIndexLoader::create(params, channel_context, channel, "linux-64", caches).value(),
+            SubdirIndexLoader::create(params, channel_context, channel, "noarch", caches).value(),
+        };
+
+        CAPTURE(tmp_dir.path());
+
+        auto result = SubdirIndexLoader::download_required_indexes(subdirs, params, {}, mirrors, {}, {});
+        REQUIRE(result.has_value());
+
+        const auto cache_dir = tmp_dir.path() / "cache";
+
+        for (const auto& subdir : subdirs)
+        {
+            CHECK(subdir.valid_cache_found());
+        }
+
+        subdirs = std::array{
+            SubdirIndexLoader::create(params, channel_context, channel, "linux-64", caches).value(),
+            SubdirIndexLoader::create(params, channel_context, channel, "noarch", caches).value(),
+        };
+        for (const auto& subdir : subdirs)
+        {
+            CHECK_FALSE(subdir.valid_cache_found());
+        }
+    }
+}

--- a/libmamba/tests/src/core/test_subdir_index.cpp
+++ b/libmamba/tests/src/core/test_subdir_index.cpp
@@ -103,7 +103,6 @@ TEST_CASE("SubdirIndexLoader", "[mamba::core][mamba::core::SubdirIndexLoader]")
         const auto params = SubdirParams{
             /* .local_repodata_ttl */ 1000000,
             /* .offline */ false,
-            /* .use_index_cache */ true,
             /* .repodata_use_zst */ true,
         };
         auto subdirs = std::array{
@@ -134,7 +133,6 @@ TEST_CASE("SubdirIndexLoader", "[mamba::core][mamba::core::SubdirIndexLoader]")
         const auto params = SubdirParams{
             /* .local_repodata_ttl */ 1000000,
             /* .offline */ true,
-            /* .use_index_cache */ true,
             /* .repodata_use_zst */ true,
         };
         auto subdirs = std::array{
@@ -183,7 +181,6 @@ TEST_CASE("SubdirIndexLoader", "[mamba::core][mamba::core::SubdirIndexLoader]")
         const auto params = SubdirParams{
             /* .local_repodata_ttl */ 0,
             /* .offline */ false,
-            /* .use_index_cache */ false,
             /* .repodata_use_zst */ true,
         };
         auto subdirs = std::array{

--- a/libmamba/tests/src/core/test_subdir_index.cpp
+++ b/libmamba/tests/src/core/test_subdir_index.cpp
@@ -170,13 +170,9 @@ TEST_CASE("SubdirIndexLoader", "[mamba::core][mamba::core::SubdirIndexLoader]")
         auto result = SubdirIndexLoader::download_required_indexes(subdirs, params, {}, mirrors, {}, {});
         REQUIRE(result.has_value());
 
-        const auto cache_dir = tmp_dir.path() / "cache";
         CHECK_FALSE(subdirs[0].valid_cache_found());
         CHECK(subdirs[1].valid_cache_found());
         CHECK(subdirs[1].valid_json_cache_path().has_value());
-        // TODO Local path are copied!
-        // CHECK(is_in_directory(local_repo_path / "noarch",
-        // subdirs[1].valid_json_cache_path().value()));
     }
 
     SECTION("Download indexes repodata ttl")

--- a/libmamba/tests/src/solver/test_problems_graph.cpp
+++ b/libmamba/tests/src/solver/test_problems_graph.cpp
@@ -17,7 +17,7 @@
 #include "mamba/core/channel_context.hpp"
 #include "mamba/core/package_database_loader.hpp"
 #include "mamba/core/prefix_data.hpp"
-#include "mamba/core/subdirdata.hpp"
+#include "mamba/core/subdir_index.hpp"
 #include "mamba/core/util.hpp"
 #include "mamba/fs/filesystem.hpp"
 #include "mamba/solver/libsolv/database.hpp"
@@ -334,7 +334,7 @@ namespace
         std::vector<std::string>&& channels
     )
     {
-        auto sub_dirs = std::vector<SubdirData>();
+        auto sub_dirs = std::vector<SubdirIndexLoader>();
         for (const auto& location : channels)
         {
             for (const auto& chan : channel_context.make_channel(location))
@@ -342,7 +342,7 @@ namespace
                 create_mirrors(ctx, chan);
                 for (const auto& platform : chan.platforms())
                 {
-                    auto sub_dir = SubdirData::create(
+                    auto sub_dir = SubdirIndexLoader::create(
                                        ctx.subdir_params(),
                                        channel_context,
                                        chan,
@@ -355,7 +355,7 @@ namespace
             }
         }
 
-        const auto result = SubdirData::download_required_indexes(
+        const auto result = SubdirIndexLoader::download_required_indexes(
             sub_dirs,
             mambatests::context().subdir_params(),
             mambatests::context().authentication_info(),

--- a/libmamba/tests/src/solver/test_problems_graph.cpp
+++ b/libmamba/tests/src/solver/test_problems_graph.cpp
@@ -342,13 +342,7 @@ namespace
                 create_mirrors(ctx, chan);
                 for (const auto& platform : chan.platforms())
                 {
-                    auto sub_dir = SubdirIndexLoader::create(
-                                       ctx.subdir_params(),
-                                       channel_context,
-                                       chan,
-                                       platform,
-                                       cache
-                    )
+                    auto sub_dir = SubdirIndexLoader::create(ctx.subdir_params(), chan, platform, cache)
                                        .value();
                     sub_dirs.push_back(std::move(sub_dir));
                 }

--- a/libmamba/tests/src/solver/test_problems_graph.cpp
+++ b/libmamba/tests/src/solver/test_problems_graph.cpp
@@ -351,7 +351,7 @@ namespace
 
         const auto result = SubdirIndexLoader::download_required_indexes(
             sub_dirs,
-            mambatests::context().subdir_params(),
+            mambatests::context().subdir_download_params(),
             mambatests::context().authentication_info(),
             mambatests::context().mirrors,
             mambatests::context().download_options(),

--- a/libmambapy/src/libmambapy/bindings/legacy.cpp
+++ b/libmambapy/src/libmambapy/bindings/legacy.cpp
@@ -163,14 +163,11 @@ namespace mambapy
         )
         {
             using namespace mamba;
-            m_subdirs.push_back(extract(SubdirIndexLoader::create(
-                ctx.subdir_params(),
-                channel_context,
-                channel,
-                platform,
-                caches,
-                repodata_fn
-            )));
+            auto subdir_params = ctx.subdir_params();
+            subdir_params.repodata_force_use_zst = channel_context.has_zst(channel);
+            m_subdirs.push_back(extract(
+                SubdirIndexLoader::create(ctx.subdir_params(), channel, platform, caches, repodata_fn)
+            ));
             m_entries.push_back({ nullptr, platform, &channel, url });
             for (size_t i = 0; i < m_subdirs.size(); ++i)
             {
@@ -560,7 +557,8 @@ bind_submodule_impl(pybind11::module_ m)
     py::class_<SubdirParams>(m, "SubdirParams")
         .def_readwrite("local_repodata_ttl_s", &SubdirParams::local_repodata_ttl_s)
         .def_readwrite("offline", &SubdirParams::offline)
-        .def_readwrite("repodata_check_zst", &SubdirParams::repodata_check_zst);
+        .def_readwrite("repodata_check_zst", &SubdirParams::repodata_check_zst)
+        .def_readwrite("repodata_force_use_zst", &SubdirParams::repodata_force_use_zst);
 
     auto subdir_metadata = py::class_<SubdirMetadata>(m, "SubdirMetadata");
 
@@ -589,7 +587,6 @@ bind_submodule_impl(pybind11::module_ m)
             "create",
             SubdirIndexLoader::create,
             py::arg("params"),
-            py::arg("channel_context"),
             py::arg("channel"),
             py::arg("platform"),
             py::arg("caches"),

--- a/libmambapy/src/libmambapy/bindings/legacy.cpp
+++ b/libmambapy/src/libmambapy/bindings/legacy.cpp
@@ -558,7 +558,7 @@ bind_submodule_impl(pybind11::module_ m)
         .def_static("depends", &Query::depends);
 
     py::class_<SubdirParams>(m, "SubdirParams")
-        .def_readwrite("local_repodata_ttl", &SubdirParams::local_repodata_ttl)
+        .def_readwrite("local_repodata_ttl_s", &SubdirParams::local_repodata_ttl_s)
         .def_readwrite("offline", &SubdirParams::offline)
         .def_readwrite("use_index_cache", &SubdirParams::use_index_cache)
         .def_readwrite("repodata_use_zst", &SubdirParams::repodata_use_zst);

--- a/libmambapy/src/libmambapy/bindings/legacy.cpp
+++ b/libmambapy/src/libmambapy/bindings/legacy.cpp
@@ -187,7 +187,7 @@ namespace mambapy
                 SubdirIndexMonitor index_monitor;
                 download_res = SubdirIndexLoader::download_required_indexes(
                     m_subdirs,
-                    ctx.subdir_params(),
+                    ctx.subdir_download_params(),
                     ctx.authentication_info(),
                     ctx.mirrors,
                     ctx.download_options(),
@@ -200,7 +200,7 @@ namespace mambapy
             {
                 download_res = SubdirIndexLoader::download_required_indexes(
                     m_subdirs,
-                    ctx.subdir_params(),
+                    ctx.subdir_download_params(),
                     ctx.authentication_info(),
                     ctx.mirrors,
                     ctx.download_options(),
@@ -557,8 +557,11 @@ bind_submodule_impl(pybind11::module_ m)
     py::class_<SubdirParams>(m, "SubdirParams")
         .def_readwrite("local_repodata_ttl_s", &SubdirParams::local_repodata_ttl_s)
         .def_readwrite("offline", &SubdirParams::offline)
-        .def_readwrite("repodata_check_zst", &SubdirParams::repodata_check_zst)
         .def_readwrite("repodata_force_use_zst", &SubdirParams::repodata_force_use_zst);
+
+    py::class_<SubdirDownloadParams>(m, "SubdirDownloadParams")
+        .def_readwrite("offline", &SubdirDownloadParams::offline)
+        .def_readwrite("repodata_check_zst", &SubdirDownloadParams::repodata_check_zst);
 
     auto subdir_metadata = py::class_<SubdirMetadata>(m, "SubdirMetadata");
 
@@ -595,7 +598,7 @@ bind_submodule_impl(pybind11::module_ m)
         .def_static(
             "download_required_indexes",
             [](py::iterable py_subdirs,
-               const SubdirParams& subdir_params,
+               const SubdirDownloadParams& subdir_download_params,
                const specs::AuthenticationDataBase& auth_info,
                const download::mirror_map& mirrors,
                const download::Options& download_options,
@@ -610,7 +613,7 @@ bind_submodule_impl(pybind11::module_ m)
                 }
                 return SubdirIndexLoader::download_required_indexes(
                     subdirs,
-                    subdir_params,
+                    subdir_download_params,
                     auth_info,
                     mirrors,
                     download_options,

--- a/libmambapy/src/libmambapy/bindings/legacy.cpp
+++ b/libmambapy/src/libmambapy/bindings/legacy.cpp
@@ -560,7 +560,6 @@ bind_submodule_impl(pybind11::module_ m)
     py::class_<SubdirParams>(m, "SubdirParams")
         .def_readwrite("local_repodata_ttl_s", &SubdirParams::local_repodata_ttl_s)
         .def_readwrite("offline", &SubdirParams::offline)
-        .def_readwrite("use_index_cache", &SubdirParams::use_index_cache)
         .def_readwrite("repodata_use_zst", &SubdirParams::repodata_use_zst);
 
     auto subdir_metadata = py::class_<SubdirMetadata>(m, "SubdirMetadata");

--- a/libmambapy/src/libmambapy/bindings/legacy.cpp
+++ b/libmambapy/src/libmambapy/bindings/legacy.cpp
@@ -166,7 +166,7 @@ namespace mambapy
             auto subdir_params = ctx.subdir_params();
             subdir_params.repodata_force_use_zst = channel_context.has_zst(channel);
             m_subdirs.push_back(extract(
-                SubdirIndexLoader::create(ctx.subdir_params(), channel, platform, caches, repodata_fn)
+                SubdirIndexLoader::create(subdir_params, channel, platform, caches, repodata_fn)
             ));
             m_entries.push_back({ nullptr, platform, &channel, url });
             for (size_t i = 0; i < m_subdirs.size(); ++i)

--- a/libmambapy/src/libmambapy/bindings/legacy.cpp
+++ b/libmambapy/src/libmambapy/bindings/legacy.cpp
@@ -606,11 +606,11 @@ bind_submodule_impl(pybind11::module_ m)
                const download::RemoteFetchParams& remote_fetch_params)
             {
                 // TODO(C++23): Pass range to SubdirIndexLoader::create
-                auto subdirs = std::vector<SubdirIndexLoader>();
+                auto subdirs = std::vector<SubdirIndexLoader*>();
                 subdirs.reserve(py::len_hint(py_subdirs));
                 for (py::handle item : py_subdirs)
                 {
-                    subdirs.push_back(py::cast<SubdirIndexLoader>(item));
+                    subdirs.push_back(py::cast<SubdirIndexLoader*>(item));
                 }
                 return SubdirIndexLoader::download_required_indexes(
                     subdirs,

--- a/libmambapy/src/libmambapy/bindings/legacy.cpp
+++ b/libmambapy/src/libmambapy/bindings/legacy.cpp
@@ -560,7 +560,7 @@ bind_submodule_impl(pybind11::module_ m)
     py::class_<SubdirParams>(m, "SubdirParams")
         .def_readwrite("local_repodata_ttl_s", &SubdirParams::local_repodata_ttl_s)
         .def_readwrite("offline", &SubdirParams::offline)
-        .def_readwrite("repodata_use_zst", &SubdirParams::repodata_use_zst);
+        .def_readwrite("repodata_check_zst", &SubdirParams::repodata_check_zst);
 
     auto subdir_metadata = py::class_<SubdirMetadata>(m, "SubdirMetadata");
 

--- a/libmambapy/src/libmambapy/bindings/legacy.cpp
+++ b/libmambapy/src/libmambapy/bindings/legacy.cpp
@@ -640,7 +640,7 @@ bind_submodule_impl(pybind11::module_ m)
         .def("valid_libsolv_cache_path", &SubdirIndexLoader::valid_libsolv_cache_path)
         .def("writable_libsolv_cache_path", &SubdirIndexLoader::writable_libsolv_cache_path)
         .def("valid_json_cache_path", &SubdirIndexLoader::valid_json_cache_path)
-        .def("clear_cache_files", &SubdirIndexLoader::clear_cache_files);
+        .def("clear_valid_cache_files", &SubdirIndexLoader::clear_valid_cache_files);
 
     // Deprecated, replaced by SubdirIndexLoader in 2.3.0
     struct SubdirDataMigrator

--- a/micromamba/src/constructor.cpp
+++ b/micromamba/src/constructor.cpp
@@ -10,7 +10,7 @@
 #include "mamba/api/configuration.hpp"
 #include "mamba/api/install.hpp"
 #include "mamba/core/package_handling.hpp"
-#include "mamba/core/subdirdata.hpp"
+#include "mamba/core/subdir_index.hpp"
 #include "mamba/core/util.hpp"
 #include "mamba/util/string.hpp"
 


### PR DESCRIPTION
This finishes the current refactoring of `SubdirData`.
- First a rename `SubdirData` > `SubdirIndexLoader`,
- Necessary work on the Python bindings to keep the current ones backward compatible,
- Adding new bindings for the new interface,
- Adding tests,
- A few more fixes here and there, and moving `ChannelContext` and `Console::stream()` (which fails when not used with external initialization).