### PR TITLE
Fix wrong use of deprecation macro

### DIFF
--- a/libmamba/include/mamba/util/deprecation.hpp
+++ b/libmamba/include/mamba/util/deprecation.hpp
@@ -10,13 +10,13 @@
 #if __cplusplus >= 202002L
 #define MAMBA_DEPRECATED_CXX20 [[deprecated("Use C++20 functions with the same name")]]
 #else
-#define MAMBA_DEPRECATED_CXX20
+#define MAMBA_DEPRECATED_CXX20 [[]]
 #endif
 
 #if __cplusplus >= 202302L
 #define MAMBA_DEPRECATED_CXX23 [[deprecated("Use C++23 functions with the same name")]]
 #else
-#define MAMBA_DEPRECATED_CXX23
+#define MAMBA_DEPRECATED_CXX23 [[]]
 #endif
 
 #endif

--- a/libmamba/include/mamba/util/deprecation.hpp
+++ b/libmamba/include/mamba/util/deprecation.hpp
@@ -8,13 +8,13 @@
 #define MAMBA_UTIL_DEPRECATION_HPP
 
 #if __cplusplus >= 202002L
-#define MAMBA_UTIL_COMPARE_DEPRECATED [[deprecated("Use C++20 functions with the same name")]]
+#define MAMBA_DEPRECATED_CXX20 [[deprecated("Use C++20 functions with the same name")]]
 #else
 #define MAMBA_DEPRECATED_CXX20
 #endif
 
 #if __cplusplus >= 202302L
-#define MAMBA_UTIL_COMPARE_DEPRECATED [[deprecated("Use C++23 functions with the same name")]]
+#define MAMBA_DEPRECATED_CXX23 [[deprecated("Use C++23 functions with the same name")]]
 #else
 #define MAMBA_DEPRECATED_CXX23
 #endif

--- a/libmamba/include/mamba/util/functional.hpp
+++ b/libmamba/include/mamba/util/functional.hpp
@@ -13,7 +13,7 @@
 
 namespace mamba::util
 {
-    MAMBA_DEPRECATED_CXX20 struct identity
+    struct MAMBA_DEPRECATED_CXX20 identity
     {
         template <typename T>
         constexpr auto operator()(T&& t) const noexcept -> T&&;


### PR DESCRIPTION
It was misused but did not make an error because it resolved to nothing.