### PR TITLE
Constexpr fmt::formatter::parse for C++20

### DIFF
--- a/libmamba/include/mamba/specs/build_number_spec.hpp
+++ b/libmamba/include/mamba/specs/build_number_spec.hpp
@@ -15,7 +15,6 @@
 #include <fmt/format.h>
 
 #include "mamba/specs/error.hpp"
-#include "mamba/util/tuple_hash.hpp"
 
 namespace mamba::specs
 {
@@ -152,28 +151,41 @@ namespace mamba::specs
 template <>
 struct fmt::formatter<mamba::specs::BuildNumberPredicate>
 {
-    auto parse(format_parse_context& ctx) -> decltype(ctx.begin());
+    constexpr auto parse(format_parse_context& ctx) -> format_parse_context::iterator
+    {
+        // make sure that range is empty
+        if (ctx.begin() != ctx.end() && *ctx.begin() != '}')
+        {
+            throw format_error("invalid format");
+        }
+        return ctx.begin();
+    }
 
     auto format(const ::mamba::specs::BuildNumberPredicate& pred, format_context& ctx) const
-        -> decltype(ctx.out());
+        -> format_context::iterator;
 };
 
 template <>
 struct fmt::formatter<mamba::specs::BuildNumberSpec>
 {
-    auto parse(format_parse_context& ctx) -> decltype(ctx.begin());
+    constexpr auto parse(format_parse_context& ctx) -> format_parse_context::iterator
+    {
+        // make sure that range is empty
+        if (ctx.begin() != ctx.end() && *ctx.begin() != '}')
+        {
+            throw format_error("invalid format");
+        }
+        return ctx.begin();
+    }
 
     auto format(const ::mamba::specs::BuildNumberSpec& spec, format_context& ctx) const
-        -> decltype(ctx.out());
+        -> format_context::iterator;
 };
 
 template <>
 struct std::hash<mamba::specs::BuildNumberSpec>
 {
-    auto operator()(const mamba::specs::BuildNumberSpec& spec) const -> std::size_t
-    {
-        return mamba::util::hash_vals(spec.to_string());
-    }
+    auto operator()(const mamba::specs::BuildNumberSpec& spec) const -> std::size_t;
 };
 
 #endif

--- a/libmamba/include/mamba/specs/chimera_string_spec.hpp
+++ b/libmamba/include/mamba/specs/chimera_string_spec.hpp
@@ -15,7 +15,6 @@
 #include "mamba/specs/error.hpp"
 #include "mamba/specs/glob_spec.hpp"
 #include "mamba/specs/regex_spec.hpp"
-#include "mamba/util/tuple_hash.hpp"
 
 namespace mamba::specs
 {
@@ -72,19 +71,24 @@ namespace mamba::specs
 template <>
 struct fmt::formatter<mamba::specs::ChimeraStringSpec>
 {
-    auto parse(format_parse_context& ctx) -> decltype(ctx.begin());
+    constexpr auto parse(format_parse_context& ctx) -> format_parse_context::iterator
+    {
+        // make sure that range is empty
+        if (ctx.begin() != ctx.end() && *ctx.begin() != '}')
+        {
+            throw fmt::format_error("Invalid format");
+        }
+        return ctx.begin();
+    }
 
     auto format(const ::mamba::specs::ChimeraStringSpec& spec, format_context& ctx) const
-        -> decltype(ctx.out());
+        -> format_context::iterator;
 };
 
 template <>
 struct std::hash<mamba::specs::ChimeraStringSpec>
 {
-    auto operator()(const mamba::specs::ChimeraStringSpec& spec) const -> std::size_t
-    {
-        return mamba::util::hash_vals(spec.to_string());
-    }
+    auto operator()(const mamba::specs::ChimeraStringSpec& spec) const -> std::size_t;
 };
 
 #endif

--- a/libmamba/include/mamba/specs/glob_spec.hpp
+++ b/libmamba/include/mamba/specs/glob_spec.hpp
@@ -63,19 +63,24 @@ namespace mamba::specs
 template <>
 struct fmt::formatter<mamba::specs::GlobSpec>
 {
-    auto parse(format_parse_context& ctx) -> decltype(ctx.begin());
+    constexpr auto parse(format_parse_context& ctx) -> format_parse_context::iterator
+    {
+        // make sure that range is empty
+        if (ctx.begin() != ctx.end() && *ctx.begin() != '}')
+        {
+            throw fmt::format_error("Invalid format");
+        }
+        return ctx.begin();
+    }
 
     auto format(const ::mamba::specs::GlobSpec& spec, format_context& ctx) const
-        -> decltype(ctx.out());
+        -> format_context::iterator;
 };
 
 template <>
 struct std::hash<mamba::specs::GlobSpec>
 {
-    auto operator()(const mamba::specs::GlobSpec& spec) const -> std::size_t
-    {
-        return std::hash<std::string>{}(spec.to_string());
-    }
+    auto operator()(const mamba::specs::GlobSpec& spec) const -> std::size_t;
 };
 
 #endif

--- a/libmamba/include/mamba/specs/match_spec.hpp
+++ b/libmamba/include/mamba/specs/match_spec.hpp
@@ -229,10 +229,30 @@ namespace mamba::specs
 template <>
 struct fmt::formatter<::mamba::specs::MatchSpec>
 {
-    auto parse(format_parse_context& ctx) -> decltype(ctx.begin());
+    constexpr auto parse(format_parse_context& ctx) -> format_parse_context::iterator
+    {
+        // make sure that range is empty
+        if (ctx.begin() != ctx.end() && *ctx.begin() != '}')
+        {
+            throw fmt::format_error("Invalid format");
+        }
+        return ctx.begin();
+    }
 
     auto format(const ::mamba::specs::MatchSpec& spec, format_context& ctx) const
-        -> decltype(ctx.out());
+        -> format_context::iterator;
+};
+
+template <>
+struct std::hash<mamba::specs::MatchSpec>
+{
+    auto operator()(const mamba::specs::MatchSpec& spec) const -> std::size_t;
+};
+
+template <>
+struct std::hash<mamba::specs::MatchSpec::ExtraMembers>
+{
+    auto operator()(const mamba::specs::MatchSpec::ExtraMembers& extra) const -> std::size_t;
 };
 
 /*********************************
@@ -303,41 +323,5 @@ namespace mamba::specs
         return true;
     }
 }
-
-template <>
-struct std::hash<mamba::specs::MatchSpec>
-{
-    auto operator()(const mamba::specs::MatchSpec& spec) const -> std::size_t
-    {
-        return mamba::util::hash_vals(
-            spec.channel(),
-            spec.version(),
-            spec.name(),
-            spec.build_string(),
-            spec.name_space(),
-            spec.build_number(),
-            spec.extra_members_hash()
-        );
-    }
-};
-
-template <>
-struct std::hash<mamba::specs::MatchSpec::ExtraMembers>
-{
-    auto operator()(const mamba::specs::MatchSpec::ExtraMembers& extra) const -> std::size_t
-    {
-        return mamba::util::hash_vals(
-            extra.filename,
-            extra.subdirs,
-            extra.md5,
-            extra.sha256,
-            extra.license,
-            extra.license_family,
-            extra.features,
-            extra.track_features,
-            extra.optional
-        );
-    }
-};
 
 #endif

--- a/libmamba/include/mamba/specs/regex_spec.hpp
+++ b/libmamba/include/mamba/specs/regex_spec.hpp
@@ -69,19 +69,24 @@ namespace mamba::specs
 template <>
 struct fmt::formatter<mamba::specs::RegexSpec>
 {
-    auto parse(format_parse_context& ctx) -> decltype(ctx.begin());
+    constexpr auto parse(format_parse_context& ctx) -> format_parse_context::iterator
+    {
+        // make sure that range is empty
+        if (ctx.begin() != ctx.end() && *ctx.begin() != '}')
+        {
+            throw fmt::format_error("Invalid format");
+        }
+        return ctx.begin();
+    }
 
     auto format(const ::mamba::specs::RegexSpec& spec, format_context& ctx) const
-        -> decltype(ctx.out());
+        -> format_context::iterator;
 };
 
 template <>
 struct std::hash<mamba::specs::RegexSpec>
 {
-    auto operator()(const mamba::specs::RegexSpec& spec) const -> std::size_t
-    {
-        return std::hash<std::string>{}(spec.to_string());
-    }
+    auto operator()(const mamba::specs::RegexSpec& spec) const -> std::size_t;
 };
 
 #endif

--- a/libmamba/include/mamba/specs/version.hpp
+++ b/libmamba/include/mamba/specs/version.hpp
@@ -214,19 +214,35 @@ namespace mamba::specs
 template <>
 struct fmt::formatter<mamba::specs::VersionPartAtom>
 {
-    auto parse(format_parse_context& ctx) -> decltype(ctx.begin());
+    constexpr auto parse(format_parse_context& ctx) -> format_parse_context::iterator
+    {
+        // make sure that range is empty
+        if (ctx.begin() != ctx.end() && *ctx.begin() != '}')
+        {
+            throw fmt::format_error("Invalid format");
+        }
+        return ctx.begin();
+    }
 
     auto format(const ::mamba::specs::VersionPartAtom atom, format_context& ctx) const
-        -> decltype(ctx.out());
+        -> format_context::iterator;
 };
 
 template <>
 struct fmt::formatter<mamba::specs::VersionPart>
 {
-    auto parse(format_parse_context& ctx) -> decltype(ctx.begin());
+    constexpr auto parse(format_parse_context& ctx) -> format_parse_context::iterator
+    {
+        // make sure that range is empty
+        if (ctx.begin() != ctx.end() && *ctx.begin() != '}')
+        {
+            throw fmt::format_error("Invalid format");
+        }
+        return ctx.begin();
+    }
 
     auto format(const ::mamba::specs::VersionPart atom, format_context& ctx) const
-        -> decltype(ctx.out());
+        -> format_context::iterator;
 };
 
 template <>

--- a/libmamba/include/mamba/specs/version_spec.hpp
+++ b/libmamba/include/mamba/specs/version_spec.hpp
@@ -17,7 +17,6 @@
 #include "mamba/specs/error.hpp"
 #include "mamba/specs/version.hpp"
 #include "mamba/util/flat_bool_expr_tree.hpp"
-#include "mamba/util/tuple_hash.hpp"
 
 namespace mamba::specs
 {
@@ -265,10 +264,18 @@ struct fmt::formatter<mamba::specs::VersionPredicate>
      */
     bool conda_build_form = false;
 
-    auto parse(format_parse_context& ctx) -> decltype(ctx.begin());
+    constexpr auto parse(format_parse_context& ctx) -> format_parse_context::iterator
+    {
+        if (auto it = std::find(ctx.begin(), ctx.end(), 'b'); it < ctx.end())
+        {
+            conda_build_form = true;
+            return ++it;
+        }
+        return ctx.begin();
+    }
 
     auto format(const ::mamba::specs::VersionPredicate& pred, format_context& ctx) const
-        -> decltype(ctx.out());
+        -> format_context::iterator;
 };
 
 template <>
@@ -279,28 +286,30 @@ struct fmt::formatter<mamba::specs::VersionSpec>
      */
     bool conda_build_form = false;
 
-    auto parse(format_parse_context& ctx) -> decltype(ctx.begin());
+    constexpr auto parse(format_parse_context& ctx) -> format_parse_context::iterator
+    {
+        if (auto it = std::find(ctx.begin(), ctx.end(), 'b'); it < ctx.end())
+        {
+            conda_build_form = true;
+            return ++it;
+        }
+        return ctx.begin();
+    }
 
     auto format(const ::mamba::specs::VersionSpec& spec, format_context& ctx) const
-        -> decltype(ctx.out());
+        -> format_context::iterator;
 };
 
 template <>
 struct std::hash<mamba::specs::VersionPredicate>
 {
-    auto operator()(const mamba::specs::VersionPredicate& pred) const -> std::size_t
-    {
-        return mamba::util::hash_vals(pred.to_string());
-    }
+    auto operator()(const mamba::specs::VersionPredicate& pred) const -> std::size_t;
 };
 
 template <>
 struct std::hash<mamba::specs::VersionSpec>
 {
-    auto operator()(const mamba::specs::VersionSpec& spec) const -> std::size_t
-    {
-        return mamba::util::hash_vals(spec.to_string());
-    }
+    auto operator()(const mamba::specs::VersionSpec& spec) const -> std::size_t;
 };
 
 #endif

--- a/libmamba/src/specs/build_number_spec.cpp
+++ b/libmamba/src/specs/build_number_spec.cpp
@@ -6,12 +6,12 @@
 
 #include <algorithm>
 #include <charconv>
-#include <stdexcept>
 
 #include <fmt/format.h>
 
 #include "mamba/specs/build_number_spec.hpp"
 #include "mamba/util/string.hpp"
+#include "mamba/util/tuple_hash.hpp"
 
 namespace mamba::specs
 {
@@ -98,22 +98,10 @@ namespace mamba::specs
 }
 
 auto
-fmt::formatter<mamba::specs::BuildNumberPredicate>::parse(format_parse_context& ctx)
-    -> decltype(ctx.begin())
-{
-    // make sure that range is empty
-    if (ctx.begin() != ctx.end() && *ctx.begin() != '}')
-    {
-        throw format_error("invalid format");
-    }
-    return ctx.begin();
-}
-
-auto
 fmt::formatter<mamba::specs::BuildNumberPredicate>::format(
     const ::mamba::specs::BuildNumberPredicate& pred,
     format_context& ctx
-) const -> decltype(ctx.out())
+) const -> format_context::iterator
 {
     using BuildNumberPredicate = typename mamba::specs::BuildNumberPredicate;
     using BuildNumber = typename BuildNumberPredicate::BuildNumber;
@@ -253,22 +241,17 @@ namespace mamba::specs
 }
 
 auto
-fmt::formatter<mamba::specs::BuildNumberSpec>::parse(format_parse_context& ctx)
-    -> decltype(ctx.begin())
-{
-    // make sure that range is empty
-    if (ctx.begin() != ctx.end() && *ctx.begin() != '}')
-    {
-        throw format_error("invalid format");
-    }
-    return ctx.begin();
-}
-
-auto
 fmt::formatter<mamba::specs::BuildNumberSpec>::format(
     const ::mamba::specs::BuildNumberSpec& spec,
     format_context& ctx
 ) const -> decltype(ctx.out())
 {
     return fmt::format_to(ctx.out(), "{}", spec.m_predicate);
+}
+
+auto
+std::hash<mamba::specs::BuildNumberSpec>::operator()(const mamba::specs::BuildNumberSpec& spec) const
+    -> std::size_t
+{
+    return mamba::util::hash_vals(spec.to_string());
 }

--- a/libmamba/src/specs/chimera_string_spec.cpp
+++ b/libmamba/src/specs/chimera_string_spec.cpp
@@ -13,6 +13,7 @@
 #include "mamba/specs/chimera_string_spec.hpp"
 #include "mamba/specs/regex_spec.hpp"
 #include "mamba/util/string.hpp"
+#include "mamba/util/tuple_hash.hpp"
 
 namespace mamba::specs
 {
@@ -126,22 +127,17 @@ namespace mamba::specs
 }
 
 auto
-fmt::formatter<mamba::specs::ChimeraStringSpec>::parse(format_parse_context& ctx)
-    -> decltype(ctx.begin())
-{
-    // make sure that range is empty
-    if (ctx.begin() != ctx.end() && *ctx.begin() != '}')
-    {
-        throw fmt::format_error("Invalid format");
-    }
-    return ctx.begin();
-}
-
-auto
 fmt::formatter<mamba::specs::ChimeraStringSpec>::format(
     const ::mamba::specs::ChimeraStringSpec& spec,
     format_context& ctx
 ) const -> decltype(ctx.out())
 {
     return fmt::format_to(ctx.out(), "{}", spec.to_string());
+}
+
+auto
+std::hash<mamba::specs::ChimeraStringSpec>::operator()(const mamba::specs::ChimeraStringSpec& spec
+) const -> std::size_t
+{
+    return mamba::util::hash_vals(spec.to_string());
 }

--- a/libmamba/src/specs/glob_spec.cpp
+++ b/libmamba/src/specs/glob_spec.cpp
@@ -45,19 +45,14 @@ namespace mamba::specs
 }
 
 auto
-fmt::formatter<mamba::specs::GlobSpec>::parse(format_parse_context& ctx) -> decltype(ctx.begin())
+fmt::formatter<mamba::specs::GlobSpec>::format(const ::mamba::specs::GlobSpec& spec, format_context& ctx) const
+    -> format_context::iterator
 {
-    // make sure that range is empty
-    if (ctx.begin() != ctx.end() && *ctx.begin() != '}')
-    {
-        throw fmt::format_error("Invalid format");
-    }
-    return ctx.begin();
+    return fmt::format_to(ctx.out(), "{}", spec.to_string());
 }
 
 auto
-fmt::formatter<mamba::specs::GlobSpec>::format(const ::mamba::specs::GlobSpec& spec, format_context& ctx) const
-    -> decltype(ctx.out())
+std::hash<mamba::specs::GlobSpec>::operator()(const mamba::specs::GlobSpec& spec) const -> std::size_t
 {
-    return fmt::format_to(ctx.out(), "{}", spec.to_string());
+    return std::hash<std::string>{}(spec.to_string());
 }

--- a/libmamba/src/specs/match_spec.cpp
+++ b/libmamba/src/specs/match_spec.cpp
@@ -16,6 +16,7 @@
 #include "mamba/specs/package_info.hpp"
 #include "mamba/util/parsers.hpp"
 #include "mamba/util/string.hpp"
+#include "mamba/util/tuple_hash.hpp"
 
 namespace mamba::specs
 {
@@ -1112,21 +1113,10 @@ namespace mamba::specs
 }
 
 auto
-fmt::formatter<::mamba::specs::MatchSpec>::parse(format_parse_context& ctx) -> decltype(ctx.begin())
-{
-    // make sure that range is empty
-    if (ctx.begin() != ctx.end() && *ctx.begin() != '}')
-    {
-        throw fmt::format_error("Invalid format");
-    }
-    return ctx.begin();
-}
-
-auto
 fmt::formatter<::mamba::specs::MatchSpec>::format(
     const ::mamba::specs::MatchSpec& spec,
     format_context& ctx
-) const -> decltype(ctx.out())
+) const -> format_context::iterator
 {
     using MatchSpec = ::mamba::specs::MatchSpec;
 
@@ -1265,4 +1255,37 @@ fmt::formatter<::mamba::specs::MatchSpec>::format(
     ensure_bracket_close();
 
     return out;
+}
+
+auto
+std::hash<mamba::specs::MatchSpec>::operator()(const mamba::specs::MatchSpec& spec) const
+    -> std::size_t
+{
+    return mamba::util::hash_vals(
+        spec.channel(),
+        spec.version(),
+        spec.name(),
+        spec.build_string(),
+        spec.name_space(),
+        spec.build_number(),
+        spec.extra_members_hash()
+    );
+}
+
+auto
+std::hash<mamba::specs::MatchSpec::ExtraMembers>::operator()(
+    const mamba::specs::MatchSpec::ExtraMembers& extra
+) const -> std::size_t
+{
+    return mamba::util::hash_vals(
+        extra.filename,
+        extra.subdirs,
+        extra.md5,
+        extra.sha256,
+        extra.license,
+        extra.license_family,
+        extra.features,
+        extra.track_features,
+        extra.optional
+    );
 }

--- a/libmamba/src/specs/regex_spec.cpp
+++ b/libmamba/src/specs/regex_spec.cpp
@@ -128,21 +128,17 @@ namespace mamba::specs
 }
 
 auto
-fmt::formatter<mamba::specs::RegexSpec>::parse(format_parse_context& ctx) -> decltype(ctx.begin())
-{
-    // make sure that range is empty
-    if (ctx.begin() != ctx.end() && *ctx.begin() != '}')
-    {
-        throw fmt::format_error("Invalid format");
-    }
-    return ctx.begin();
-}
-
-auto
 fmt::formatter<mamba::specs::RegexSpec>::format(
     const ::mamba::specs::RegexSpec& spec,
     format_context& ctx
-) const -> decltype(ctx.out())
+) const -> format_context::iterator
 {
     return fmt::format_to(ctx.out(), "{}", spec.to_string());
+}
+
+auto
+std::hash<mamba::specs::RegexSpec>::operator()(const mamba::specs::RegexSpec& spec) const
+    -> std::size_t
+{
+    return std::hash<std::string>{}(spec.to_string());
 }

--- a/libmamba/src/specs/version.cpp
+++ b/libmamba/src/specs/version.cpp
@@ -264,22 +264,10 @@ namespace mamba::specs
 }
 
 auto
-fmt::formatter<mamba::specs::VersionPartAtom>::parse(format_parse_context& ctx)
-    -> decltype(ctx.begin())
-{
-    // make sure that range is empty
-    if (ctx.begin() != ctx.end() && *ctx.begin() != '}')
-    {
-        throw fmt::format_error("Invalid format");
-    }
-    return ctx.begin();
-}
-
-auto
 fmt::formatter<mamba::specs::VersionPartAtom>::format(
     const ::mamba::specs::VersionPartAtom atom,
     format_context& ctx
-) const -> decltype(ctx.out())
+) const -> format_context::iterator
 {
     return fmt::format_to(ctx.out(), "{}{}", atom.numeral(), atom.literal());
 }
@@ -361,21 +349,10 @@ namespace mamba::specs
 }
 
 auto
-fmt::formatter<mamba::specs::VersionPart>::parse(format_parse_context& ctx) -> decltype(ctx.begin())
-{
-    // make sure that range is empty
-    if (ctx.begin() != ctx.end() && *ctx.begin() != '}')
-    {
-        throw fmt::format_error("Invalid format");
-    }
-    return ctx.begin();
-}
-
-auto
 fmt::formatter<mamba::specs::VersionPart>::format(
     const ::mamba::specs::VersionPart part,
     format_context& ctx
-) const -> decltype(ctx.out())
+) const -> format_context::iterator
 {
     auto out = ctx.out();
     if (part.atoms.empty())

--- a/libmamba/src/specs/version_spec.cpp
+++ b/libmamba/src/specs/version_spec.cpp
@@ -14,6 +14,7 @@
 
 #include "mamba/specs/version_spec.hpp"
 #include "mamba/util/string.hpp"
+#include "mamba/util/tuple_hash.hpp"
 
 #include "specs/version_spec_impl.hpp"
 
@@ -308,22 +309,10 @@ namespace mamba::specs
 }
 
 auto
-fmt::formatter<mamba::specs::VersionPredicate>::parse(format_parse_context& ctx)
-    -> decltype(ctx.begin())
-{
-    if (auto it = std::find(ctx.begin(), ctx.end(), 'b'); it < ctx.end())
-    {
-        conda_build_form = true;
-        return ++it;
-    }
-    return ctx.begin();
-}
-
-auto
 fmt::formatter<mamba::specs::VersionPredicate>::format(
     const ::mamba::specs::VersionPredicate& pred,
     format_context& ctx
-) const -> decltype(ctx.out())
+) const -> format_context::iterator
 {
     using VersionPredicate = typename mamba::specs::VersionPredicate;
     using VersionSpec = typename mamba::specs::VersionSpec;
@@ -780,21 +769,10 @@ namespace mamba::specs
 }
 
 auto
-fmt::formatter<mamba::specs::VersionSpec>::parse(format_parse_context& ctx) -> decltype(ctx.begin())
-{
-    if (auto it = std::find(ctx.begin(), ctx.end(), 'b'); it < ctx.end())
-    {
-        conda_build_form = true;
-        return ++it;
-    }
-    return ctx.begin();
-}
-
-auto
 fmt::formatter<mamba::specs::VersionSpec>::format(
     const ::mamba::specs::VersionSpec& spec,
     format_context& ctx
-) const -> decltype(ctx.out())
+) const -> format_context::iterator
 {
     using VersionSpec = typename mamba::specs::VersionSpec;
 
@@ -834,4 +812,18 @@ fmt::formatter<mamba::specs::VersionSpec>::format(
         }
     );
     return out;
+}
+
+auto
+std::hash<mamba::specs::VersionPredicate>::operator()(const mamba::specs::VersionPredicate& pred) const
+    -> std::size_t
+{
+    return mamba::util::hash_vals(pred.to_string());
+}
+
+auto
+std::hash<mamba::specs::VersionSpec>::operator()(const mamba::specs::VersionSpec& spec) const
+    -> std::size_t
+{
+    return mamba::util::hash_vals(spec.to_string());
 }


### PR DESCRIPTION
Move some code to make ``fmt::formatter::parse``, which will be required for C++20.
