### PR TITLE
maint: Make spdlog a private dependency

### DIFF
--- a/libmamba/CMakeLists.txt
+++ b/libmamba/CMakeLists.txt
@@ -472,8 +472,9 @@ macro(libmamba_create_target target_name linkage output_name)
 
         target_link_libraries(
             ${target_name}
-            PUBLIC fmt::fmt-header-only spdlog::spdlog_header_only yaml-cpp::yaml-cpp
+            PUBLIC fmt::fmt-header-only yaml-cpp::yaml-cpp
             PRIVATE
+                spdlog::spdlog_header_only
                 reproc
                 reproc++
                 simdjson::simdjson_static
@@ -605,16 +606,12 @@ macro(libmamba_create_target target_name linkage output_name)
 
         target_link_libraries(
             ${target_name}
-            PUBLIC
-                ${LIBSOLV_LIBRARIES}
-                ${LIBSOLVEXT_LIBRARIES}
-                yaml-cpp::yaml-cpp
-                fmt::fmt
+            PUBLIC ${LIBSOLV_LIBRARIES} ${LIBSOLVEXT_LIBRARIES} yaml-cpp::yaml-cpp fmt::fmt
+            PRIVATE
                 # Since conda-forge spdlog is built with a bundled version of fmt we use the header
                 # only version to avoid chasing after the correct fmt version matching the one used
                 # in the bundle
                 spdlog::spdlog_header_only
-            PRIVATE
                 ${LibArchive_LIBRARIES}
                 ${CURL_LIBRARIES}
                 ${OPENSSL_LIBRARIES}

--- a/libmamba/libmambaConfig.cmake.in
+++ b/libmamba/libmambaConfig.cmake.in
@@ -23,7 +23,6 @@ set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR};${CMAKE_MODULE_PATH}")
 
 include(CMakeFindDependencyMacro)
 find_dependency(fmt)
-find_dependency(spdlog)
 find_dependency(tl-expected)
 find_dependency(nlohmann_json)
 find_dependency(yaml-cpp)


### PR DESCRIPTION
Fix https://github.com/mamba-org/mamba/issues/3925.

:warning: The run-export on `spdlog` will need to be removed then.