### PR TITLE
Context dependency reduction

### DIFF
--- a/libmamba/CMakeLists.txt
+++ b/libmamba/CMakeLists.txt
@@ -365,6 +365,7 @@ set(
     # Core API (low-level)
     ${LIBMAMBA_INCLUDE_DIR}/mamba/core/activation.hpp
     ${LIBMAMBA_INCLUDE_DIR}/mamba/core/channel_context.hpp
+    ${LIBMAMBA_INCLUDE_DIR}/mamba/core/command_params.hpp
     ${LIBMAMBA_INCLUDE_DIR}/mamba/core/common_types.hpp
     ${LIBMAMBA_INCLUDE_DIR}/mamba/core/context.hpp
     ${LIBMAMBA_INCLUDE_DIR}/mamba/core/download_progress_bar.hpp

--- a/libmamba/CMakeLists.txt
+++ b/libmamba/CMakeLists.txt
@@ -365,9 +365,9 @@ set(
     # Core API (low-level)
     ${LIBMAMBA_INCLUDE_DIR}/mamba/core/activation.hpp
     ${LIBMAMBA_INCLUDE_DIR}/mamba/core/channel_context.hpp
-    ${LIBMAMBA_INCLUDE_DIR}/mamba/core/command_params.hpp
     ${LIBMAMBA_INCLUDE_DIR}/mamba/core/common_types.hpp
     ${LIBMAMBA_INCLUDE_DIR}/mamba/core/context.hpp
+    ${LIBMAMBA_INCLUDE_DIR}/mamba/core/context_params.hpp
     ${LIBMAMBA_INCLUDE_DIR}/mamba/core/download_progress_bar.hpp
     ${LIBMAMBA_INCLUDE_DIR}/mamba/core/env_lockfile.hpp
     ${LIBMAMBA_INCLUDE_DIR}/mamba/core/environments_manager.hpp

--- a/libmamba/include/mamba/core/command_params.hpp
+++ b/libmamba/include/mamba/core/command_params.hpp
@@ -1,0 +1,25 @@
+// Copyright (c) 2019, QuantStack and Mamba Contributors
+//
+// Distributed under the terms of the BSD 3-Clause License.
+//
+// The full license is in the file LICENSE, distributed with this software.
+
+#pragma once
+
+#include <string>
+
+// TODO: having a file for this single structure is a bit of
+// overkill; this should be refactored when we have more structures
+// like this (i.e. parameters structures with no dependency on other
+// parts of mamba)
+namespace mamba
+{
+    struct CommandParams
+    {
+        std::string caller_version{ "" };
+        std::string conda_version{ "3.8.0" };
+        std::string current_command{ "mamba" };
+        /** Is the Context used in a mamba or mamba executable (instead of a lib). */
+        bool is_mamba_exe{ false };
+    };
+}

--- a/libmamba/include/mamba/core/context.hpp
+++ b/libmamba/include/mamba/core/context.hpp
@@ -12,8 +12,8 @@
 #include <string>
 #include <vector>
 
-#include "mamba/core/command_params.hpp"
 #include "mamba/core/common_types.hpp"
+#include "mamba/core/context_params.hpp"
 #include "mamba/core/palette.hpp"
 #include "mamba/core/subdir_parameters.hpp"
 #include "mamba/core/tasksync.hpp"
@@ -108,14 +108,6 @@ namespace mamba
         {
             std::size_t download_threads{ 5 };
             int extract_threads{ 0 };
-        };
-
-        struct PrefixParams
-        {
-            fs::u8path target_prefix;
-            fs::u8path root_prefix;
-            fs::u8path conda_prefix;
-            fs::u8path relocate_prefix;
         };
 
         // Configurable

--- a/libmamba/include/mamba/core/context.hpp
+++ b/libmamba/include/mamba/core/context.hpp
@@ -12,6 +12,7 @@
 #include <string>
 #include <vector>
 
+#include "mamba/core/command_params.hpp"
 #include "mamba/core/common_types.hpp"
 #include "mamba/core/palette.hpp"
 #include "mamba/core/subdir_parameters.hpp"
@@ -101,15 +102,6 @@ namespace mamba
         {
             bool no_rc{ false };
             bool no_env{ false };
-        };
-
-        struct CommandParams
-        {
-            std::string caller_version{ "" };
-            std::string conda_version{ "3.8.0" };
-            std::string current_command{ "mamba" };
-            /** Is the Context used in a mamba or mamba executable (instead of a lib). */
-            bool is_mamba_exe{ false };
         };
 
         struct ThreadsParams

--- a/libmamba/include/mamba/core/context_params.hpp
+++ b/libmamba/include/mamba/core/context_params.hpp
@@ -8,6 +8,8 @@
 
 #include <string>
 
+#include "mamba/fs/filesystem.hpp"
+
 // TODO: having a file for this single structure is a bit of
 // overkill; this should be refactored when we have more structures
 // like this (i.e. parameters structures with no dependency on other
@@ -21,5 +23,13 @@ namespace mamba
         std::string current_command{ "mamba" };
         /** Is the Context used in a mamba or mamba executable (instead of a lib). */
         bool is_mamba_exe{ false };
+    };
+
+    struct PrefixParams
+    {
+        fs::u8path target_prefix;
+        fs::u8path root_prefix;
+        fs::u8path conda_prefix;
+        fs::u8path relocate_prefix;
     };
 }

--- a/libmamba/include/mamba/core/history.hpp
+++ b/libmamba/include/mamba/core/history.hpp
@@ -11,8 +11,8 @@
 #include <unordered_map>
 #include <vector>
 
-#include "mamba/core/command_params.hpp"
 #include "mamba/core/channel_context.hpp"
+#include "mamba/core/context_params.hpp"
 #include "mamba/fs/filesystem.hpp"
 #include "mamba/specs/match_spec.hpp"
 #include "mamba/specs/package_info.hpp"

--- a/libmamba/include/mamba/core/history.hpp
+++ b/libmamba/include/mamba/core/history.hpp
@@ -11,6 +11,7 @@
 #include <unordered_map>
 #include <vector>
 
+#include "mamba/core/command_params.hpp"
 #include "mamba/core/channel_context.hpp"
 #include "mamba/fs/filesystem.hpp"
 #include "mamba/specs/match_spec.hpp"
@@ -18,8 +19,6 @@
 
 namespace mamba
 {
-    class Context;
-
     class History
     {
     public:
@@ -35,7 +34,7 @@ namespace mamba
 
         struct UserRequest
         {
-            static UserRequest prefilled(const Context& context);
+            static UserRequest prefilled(const CommandParams& command_params);
 
             std::string date;
             std::size_t revision_num = 0;

--- a/libmamba/include/mamba/core/shell_init.hpp
+++ b/libmamba/include/mamba/core/shell_init.hpp
@@ -66,7 +66,7 @@ namespace mamba
     );
 
     // we need this function during linking...
-    void init_root_prefix_cmdexe(const Context& context, const fs::u8path& root_prefix);
+    void init_root_prefix_cmdexe(const fs::u8path& root_prefix);
     void deinit_root_prefix_cmdexe(const Context& context, const fs::u8path& root_prefix);
     void init_root_prefix(Context& context, const std::string& shell, const fs::u8path& root_prefix);
     void

--- a/libmamba/include/mamba/core/util.hpp
+++ b/libmamba/include/mamba/core/util.hpp
@@ -16,6 +16,7 @@
 #include <string_view>
 #include <vector>
 
+#include "mamba/core/context_params.hpp"
 #include "mamba/core/error_handling.hpp"
 #include "mamba/fs/filesystem.hpp"
 
@@ -373,7 +374,6 @@ namespace mamba
     };
 
     std::unique_ptr<TemporaryFile> wrap_call(
-        const Context& context,
         const fs::u8path& root_prefix,
         const fs::u8path& prefix,
         const std::vector<std::string>& arguments,  // TODO: c++20 replace by std::span
@@ -387,9 +387,9 @@ namespace mamba
     };
 
     PreparedWrappedCall prepare_wrapped_call(
-        const Context& context,
-        const fs::u8path& prefix,
-        const std::vector<std::string>& cmd
+        const PrefixParams& prefix_params,
+        const std::vector<std::string>& cmd,
+        WrappedCallOptions options
     );
 
     /// Returns `true` if the filename matches names of files which should be interpreted as YAML.

--- a/libmamba/src/api/utils.cpp
+++ b/libmamba/src/api/utils.cpp
@@ -173,9 +173,9 @@ namespace mamba
         }();
 
         auto [wrapped_command, tmpfile] = prepare_wrapped_call(
-            ctx,
-            ctx.prefix_params.target_prefix,
-            command
+            ctx.prefix_params,
+            command,
+            WrappedCallOptions::from_context(ctx)
         );
 
         reproc::options options;

--- a/libmamba/src/core/history.cpp
+++ b/libmamba/src/core/history.cpp
@@ -8,7 +8,6 @@
 #include <regex>
 
 #include "mamba/core/channel_context.hpp"
-#include "mamba/core/context.hpp"
 #include "mamba/core/fsutil.hpp"
 #include "mamba/core/history.hpp"
 #include "mamba/core/output.hpp"
@@ -24,7 +23,7 @@ namespace mamba
     {
     }
 
-    History::UserRequest History::UserRequest::prefilled(const Context& context)
+    History::UserRequest History::UserRequest::prefilled(const CommandParams& command_params)
     {
         UserRequest ur;
         std::time_t t = std::time(nullptr);
@@ -33,8 +32,8 @@ namespace mamba
         {
             ur.date = mbstr;
         }
-        ur.cmd = context.command_params.current_command;
-        ur.conda_version = context.command_params.conda_version;
+        ur.cmd = command_params.current_command;
+        ur.conda_version = command_params.conda_version;
         return ur;
     }
 

--- a/libmamba/src/core/link.cpp
+++ b/libmamba/src/core/link.cpp
@@ -369,7 +369,6 @@ namespace mamba
             if (activate)
             {
                 script_file = wrap_call(
-                    context,
                     context.prefix_params.root_prefix,
                     prefix,
                     { "@CALL", path.string() },
@@ -397,7 +396,6 @@ namespace mamba
             {
                 // std::string caller
                 script_file = wrap_call(
-                    context,
                     context.prefix_params.root_prefix.string(),
                     prefix,
                     { ".", path.string() },

--- a/libmamba/src/core/run.cpp
+++ b/libmamba/src/core/run.cpp
@@ -332,7 +332,11 @@ namespace mamba
         }
 #endif
 
-        auto [wrapped_command, script_file] = prepare_wrapped_call(context, prefix, command);
+        auto [wrapped_command, script_file] = prepare_wrapped_call(
+            context.prefix_params,
+            command,
+            WrappedCallOptions::from_context(context)
+        );
 
         fmt::print(LOG_DEBUG, "Running wrapped script: {}", fmt::join(command, " "));
 

--- a/libmamba/src/core/shell_init.cpp
+++ b/libmamba/src/core/shell_init.cpp
@@ -756,7 +756,7 @@ namespace mamba
         }
         else if (shell == "cmd.exe")
         {
-            init_root_prefix_cmdexe(context, context.prefix_params.root_prefix);
+            init_root_prefix_cmdexe(context.prefix_params.root_prefix);
             LOG_WARNING << "Hook installed, now 'manually' execute:";
             LOG_WARNING
                 << "       CALL "
@@ -779,7 +779,7 @@ namespace mamba
         return "";
     }
 
-    void init_root_prefix_cmdexe(const Context&, const fs::u8path& root_prefix)
+    void init_root_prefix_cmdexe(const fs::u8path& root_prefix)
     {
         const ShellInitPathsWindowsCmd paths{ root_prefix };
 
@@ -989,7 +989,7 @@ namespace mamba
         }
         else if (shell == "cmd.exe")
         {
-            init_root_prefix_cmdexe(context, root_prefix);
+            init_root_prefix_cmdexe(root_prefix);
         }
         else if (shell == "powershell")
         {

--- a/libmamba/src/core/transaction.cpp
+++ b/libmamba/src/core/transaction.cpp
@@ -163,7 +163,7 @@ namespace mamba
 
     MTransaction::MTransaction(const Context& ctx, MultiPackageCache& caches)
         : m_multi_cache(caches)
-        , m_history_entry(History::UserRequest::prefilled(ctx))
+        , m_history_entry(History::UserRequest::prefilled(ctx.command_params))
     {
     }
 

--- a/libmamba/src/core/transaction_context.cpp
+++ b/libmamba/src/core/transaction_context.cpp
@@ -238,7 +238,11 @@ namespace mamba
         const std::string cwd = target_prefix.string();
         options.working_directory = cwd.c_str();
 
-        auto [wrapped_command, script_file] = prepare_wrapped_call(ctx, target_prefix, command);
+        auto [wrapped_command, script_file] = prepare_wrapped_call(
+            context().prefix_params,
+            command,
+            WrappedCallOptions::from_context(ctx)
+        );
         m_pyc_script_file = std::move(script_file);
 
         LOG_INFO << "Running wrapped python compilation command " << util::join(" ", command);

--- a/libmamba/src/core/util.cpp
+++ b/libmamba/src/core/util.cpp
@@ -1557,9 +1557,9 @@ namespace mamba
     }
 
     PreparedWrappedCall prepare_wrapped_call(
-        const Context& context,
-        const fs::u8path& prefix,
-        const std::vector<std::string>& cmd
+        const PrefixParams& prefix_params,
+        const std::vector<std::string>& cmd,
+        WrappedCallOptions options
     )
     {
         std::vector<std::string> command_args;
@@ -1576,12 +1576,7 @@ namespace mamba
                 );
             }
 
-            script_file = wrap_call(
-                context.prefix_params.root_prefix,
-                prefix,
-                cmd,
-                WrappedCallOptions::from_context(context)
-            );
+            script_file = wrap_call(prefix_params.root_prefix, prefix_params.target_prefix, cmd, options);
 
             command_args = { comspec.value(), "/D", "/C", script_file->path().string() };
         }
@@ -1599,12 +1594,7 @@ namespace mamba
                 shell_path = "sh";
             }
 
-            script_file = wrap_call(
-                context.prefix_params.root_prefix,
-                prefix,
-                cmd,
-                WrappedCallOptions::from_context(context)
-            );
+            script_file = wrap_call(prefix_params.root_prefix, prefix_params.target_prefix, cmd, options);
             command_args.push_back(shell_path.string());
             command_args.push_back(script_file->path().string());
         }

--- a/libmamba/src/core/util.cpp
+++ b/libmamba/src/core/util.cpp
@@ -1405,7 +1405,6 @@ namespace mamba
     }
 
     std::unique_ptr<TemporaryFile> wrap_call(
-        const Context& context [[maybe_unused]],
         const fs::u8path& root_prefix,
         const fs::u8path& prefix,
         const std::vector<std::string>& arguments,
@@ -1436,7 +1435,7 @@ namespace mamba
         if (!fs::exists(conda_bat) && options.is_mamba_exe)
         {
             // this adds in the needed .bat files for activation
-            init_root_prefix_cmdexe(context, root_prefix);
+            init_root_prefix_cmdexe(root_prefix);
         }
 
         auto tf = std::make_unique<TemporaryFile>("mamba_bat_", ".bat");
@@ -1578,7 +1577,6 @@ namespace mamba
             }
 
             script_file = wrap_call(
-                context,
                 context.prefix_params.root_prefix,
                 prefix,
                 cmd,
@@ -1602,7 +1600,6 @@ namespace mamba
             }
 
             script_file = wrap_call(
-                context,
                 context.prefix_params.root_prefix,
                 prefix,
                 cmd,

--- a/libmamba/tests/src/core/test_cpp.cpp
+++ b/libmamba/tests/src/core/test_cpp.cpp
@@ -50,7 +50,7 @@ namespace mamba
     {
         TEST_CASE("user_request")
         {
-            auto u = History::UserRequest::prefilled(mambatests::context());
+            auto u = History::UserRequest::prefilled(mambatests::context().command_params);
             // update in 100 years!
             REQUIRE(u.date[0] == '2');
             REQUIRE(u.date[1] == '0');

--- a/libmambapy/src/libmambapy/bindings/legacy.cpp
+++ b/libmambapy/src/libmambapy/bindings/legacy.cpp
@@ -20,6 +20,7 @@
 #include "mamba/api/repoquery.hpp"
 #include "mamba/core/channel_context.hpp"
 #include "mamba/core/context.hpp"
+#include "mamba/core/context_params.hpp"
 #include "mamba/core/download_progress_bar.hpp"
 #include "mamba/core/execution.hpp"
 #include "mamba/core/output.hpp"
@@ -933,11 +934,11 @@ bind_submodule_impl(pybind11::module_ m)
         .def_readwrite("download_threads", &Context::ThreadsParams::download_threads)
         .def_readwrite("extract_threads", &Context::ThreadsParams::extract_threads);
 
-    py::class_<Context::PrefixParams>(ctx, "PrefixParams")
+    py::class_<PrefixParams>(ctx, "PrefixParams")
         .def(py::init<>())
-        .def_readwrite("target_prefix", &Context::PrefixParams::target_prefix)
-        .def_readwrite("conda_prefix", &Context::PrefixParams::conda_prefix)
-        .def_readwrite("root_prefix", &Context::PrefixParams::root_prefix);
+        .def_readwrite("target_prefix", &PrefixParams::target_prefix)
+        .def_readwrite("conda_prefix", &PrefixParams::conda_prefix)
+        .def_readwrite("root_prefix", &PrefixParams::root_prefix);
 
     py::class_<ValidationParams>(ctx, "ValidationParams")
         .def(py::init<>())


### PR DESCRIPTION
Low level refactoring to reduce dependency on Context. The utilmate goal is to remove the Context from the Transaction class so that we can refactor its API and expose it more easily.