### PR TITLE
Handle environment variables from `yaml` file

### DIFF
--- a/libmamba/include/mamba/api/install.hpp
+++ b/libmamba/include/mamba/api/install.hpp
@@ -8,6 +8,7 @@
 #define MAMBA_API_INSTALL_HPP
 
 #include <iosfwd>
+#include <map>
 #include <string>
 #include <vector>
 
@@ -80,7 +81,18 @@ namespace mamba
     {
         void create_target_directory(const Context& context, const fs::u8path prefix);
 
-        void create_empty_target(const Context& context, const fs::u8path& prefix);
+        void create_empty_target(
+            const Context& context,
+            const fs::u8path& prefix,
+            const std::map<std::string, std::string>& env_vars,
+            bool no_env
+        );
+
+        void populate_state_file(
+            const fs::u8path& prefix,
+            const std::map<std::string, std::string>& env_vars,
+            bool no_env
+        );
 
         void file_specs_hook(Configuration& config, std::vector<std::string>& file_specs);
 
@@ -102,6 +114,7 @@ namespace mamba
         {
             std::string name;
             std::vector<std::string> dependencies, channels;
+            std::map<std::string, std::string> variables;
             std::vector<other_pkg_mgr_spec> others_pkg_mgrs_specs;
         };
 

--- a/libmamba/src/api/configuration.cpp
+++ b/libmamba/src/api/configuration.cpp
@@ -1395,6 +1395,12 @@ namespace mamba
                    .set_post_merge_hook(detail::file_spec_env_name_hook)
                    .description("Name of the target prefix, specified in a YAML spec file"));
 
+        insert(Configurable("spec_file_env_vars", std::map<std::string, std::string>({}))
+                   .group("Basic")
+                   .needs({ "file_specs" })
+                   .set_single_op_lifetime()
+                   .description("Environment variables specified in a YAML spec file"));
+
         insert(Configurable("specs", std::vector<std::string>({}))
                    .group("Basic")
                    .needs({ "file_specs" })  // explicit file specs overwrite current specs

--- a/libmamba/src/api/create.cpp
+++ b/libmamba/src/api/create.cpp
@@ -32,6 +32,8 @@ namespace mamba
         auto& create_specs = config.at("specs").value<std::vector<std::string>>();
         auto& use_explicit = config.at("explicit_install").value<bool>();
         auto& json_format = config.at("json").get_cli_config<bool>();
+        auto& env_vars = config.at("spec_file_env_vars").value<std::map<std::string, std::string>>();
+        auto& no_env = config.at("no_env").value<bool>();
 
         auto channel_context = ChannelContext::make_conda_compatible(ctx);
 
@@ -82,7 +84,7 @@ namespace mamba
             }
             if (create_specs.empty())
             {
-                detail::create_empty_target(ctx, ctx.prefix_params.target_prefix);
+                detail::create_empty_target(ctx, ctx.prefix_params.target_prefix, env_vars, no_env);
             }
 
             if (config.at("platform").configured() && !config.at("platform").rc_configured())

--- a/micromamba/tests/test_create.py
+++ b/micromamba/tests/test_create.py
@@ -430,9 +430,9 @@ def test_spec_file_env_vars(tmp_home, tmp_root_prefix, tmp_path, env_vars, no_en
         "dependencies: [numpy]",
     ]
     if env_vars:
-        file_content.append(
-            "variables: {'MY_ENV_VAR': 'My Value', 'MY_OTHER_ENV_VAR': 'Another Value'}",
-        )
+        variables_dict = {"MY_ENV_VAR": "My Value", "MY_OTHER_ENV_VAR": "Another Value"}
+        yaml_str = yaml.dump({"variables": variables_dict}, default_flow_style=False)
+        file_content.append(yaml_str)
 
     with open(spec_file, "w") as f:
         f.write("\n".join(file_content))

--- a/micromamba/tests/test_create.py
+++ b/micromamba/tests/test_create.py
@@ -420,6 +420,49 @@ def test_channels(tmp_home, tmp_root_prefix, tmp_path, cli, yaml, env_var, rc_fi
 
 
 @pytest.mark.parametrize("shared_pkgs_dirs", [True], indirect=True)
+@pytest.mark.parametrize("env_vars", (False, True))
+@pytest.mark.parametrize("no_env", (False, True))
+def test_spec_file_env_vars(tmp_home, tmp_root_prefix, tmp_path, env_vars, no_env):
+    env_name = "env-check-env-vars"
+
+    spec_file = tmp_path / "env-check-env-vars.yaml"
+    file_content = [
+        "dependencies: [numpy]",
+    ]
+    if env_vars:
+        file_content.append(
+            "variables: {'MY_ENV_VAR': 'My Value', 'MY_OTHER_ENV_VAR': 'Another Value'}",
+        )
+
+    with open(spec_file, "w") as f:
+        f.write("\n".join(file_content))
+
+    cmd = ["-n", env_name, "-f", spec_file, "--json"]
+    if no_env:
+        cmd += ["--no-env"]
+
+    res = helpers.create(*cmd)
+    assert res["success"]
+
+    packages = helpers.umamba_list("-n", env_name, "--json")
+    assert any(package["name"] == "numpy" for package in packages)
+
+    state_file_path = tmp_root_prefix / "envs" / env_name / "conda-meta" / "state"
+
+    if env_vars and not no_env:
+        assert state_file_path.exists()
+
+        with open(state_file_path) as f:
+            state_content = f.read()
+        assert (
+            '"env_vars":{"MY_ENV_VAR":"My Value","MY_OTHER_ENV_VAR":"Another Value"}'
+            in state_content
+        )
+    else:
+        assert not state_file_path.exists()
+
+
+@pytest.mark.parametrize("shared_pkgs_dirs", [True], indirect=True)
 @pytest.mark.parametrize("type", ("yaml", "classic", "explicit"))
 def test_multiple_spec_files(tmp_home, tmp_root_prefix, tmp_path, type):
     env_prefix = tmp_path / "myenv"


### PR DESCRIPTION
Fix #3884 

As specified in the [CEP](https://github.com/conda/ceps/blob/main/cep-0024.md):

- The `prefix` is often ignored (it's the case in `conda` as well)
- `platforms` and `category` are optional and are mostly used by tools that generate lockfiles.

Therefore, those are not considered in `mamba`.

This PR handles the missing key `variables` corresponding to the environment variables to be set upon environment activation (through `state` file).
