### PR TITLE
Fix fmt headers includes

### DIFF
--- a/libmamba/include/mamba/specs/chimera_string_spec.hpp
+++ b/libmamba/include/mamba/specs/chimera_string_spec.hpp
@@ -11,6 +11,7 @@
 #include <variant>
 
 #include <fmt/core.h>
+#include <fmt/format.h>
 
 #include "mamba/specs/error.hpp"
 #include "mamba/specs/glob_spec.hpp"

--- a/libmamba/include/mamba/specs/glob_spec.hpp
+++ b/libmamba/include/mamba/specs/glob_spec.hpp
@@ -11,6 +11,7 @@
 #include <string_view>
 
 #include <fmt/core.h>
+#include <fmt/format.h>
 
 namespace mamba::specs
 {

--- a/libmamba/include/mamba/specs/match_spec.hpp
+++ b/libmamba/include/mamba/specs/match_spec.hpp
@@ -13,6 +13,7 @@
 #include <string_view>
 
 #include <fmt/core.h>
+#include <fmt/format.h>
 
 #include "mamba/specs/build_number_spec.hpp"
 #include "mamba/specs/chimera_string_spec.hpp"

--- a/libmamba/include/mamba/specs/regex_spec.hpp
+++ b/libmamba/include/mamba/specs/regex_spec.hpp
@@ -12,6 +12,7 @@
 #include <string_view>
 
 #include <fmt/core.h>
+#include <fmt/format.h>
 
 #include "mamba/specs/error.hpp"
 

--- a/libmamba/src/specs/chimera_string_spec.cpp
+++ b/libmamba/src/specs/chimera_string_spec.cpp
@@ -8,8 +8,6 @@
 #include <cassert>
 #include <type_traits>
 
-#include <fmt/format.h>
-
 #include "mamba/specs/chimera_string_spec.hpp"
 #include "mamba/specs/regex_spec.hpp"
 #include "mamba/util/string.hpp"

--- a/libmamba/src/specs/glob_spec.cpp
+++ b/libmamba/src/specs/glob_spec.cpp
@@ -4,8 +4,6 @@
 //
 // The full license is in the file LICENSE, distributed with this software.
 
-#include <fmt/format.h>
-
 #include "mamba/specs/glob_spec.hpp"
 #include "mamba/util/parsers.hpp"
 #include "mamba/util/string.hpp"

--- a/libmamba/src/specs/match_spec.cpp
+++ b/libmamba/src/specs/match_spec.cpp
@@ -8,7 +8,6 @@
 #include <string_view>
 #include <tuple>
 
-#include <fmt/format.h>
 #include <fmt/ranges.h>
 
 #include "mamba/specs/archive.hpp"

--- a/libmamba/src/specs/regex_spec.cpp
+++ b/libmamba/src/specs/regex_spec.cpp
@@ -8,8 +8,6 @@
 #include <cassert>
 #include <sstream>
 
-#include <fmt/format.h>
-
 #include "mamba/specs/regex_spec.hpp"
 #include "mamba/util/string.hpp"
 


### PR DESCRIPTION
I don't know how this is building on the CI without failures but it's not the case on my machine.
`#include <fmt/format.h>` should have been moved alongside `fmt::format_error` in https://github.com/mamba-org/mamba/pull/3942