### PR TITLE
Adapt label check to bot

### DIFF
--- a/.github/workflows/label_check.yml
+++ b/.github/workflows/label_check.yml
@@ -6,6 +6,7 @@ on:
       - synchronize
       - opened
       - reopened
+      - edited
       - labeled
       - unlabeled
 
@@ -16,16 +17,29 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Wait for bot to set label
+        run: sleep 10
+
       - name: Check labels
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          NUMBER_OF_LABELS=$(jq '.pull_request.labels | length' "$GITHUB_EVENT_PATH")
+          # Get PR number and repo name from event payload
+          PR_NUMBER=$(jq -r .pull_request.number "$GITHUB_EVENT_PATH")
+          REPO_FULL_NAME=$(jq -r .repository.full_name "$GITHUB_EVENT_PATH")
+
+          # Fetch fresh PR data from GitHub API
+          PR_DATA=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
+            "https://api.github.com/repos/$REPO_FULL_NAME/issues/$PR_NUMBER")
+
+          NUMBER_OF_LABELS=$(echo "$PR_DATA" | jq -r '.labels')
           if [ $NUMBER_OF_LABELS -eq 0 ]; then
             echo "PR has no labels. Please add at least one label of release type."
             exit 1
           fi
 
           RELEASE_LABELS=("release::enhancements" "release::bug_fixes" "release::ci_docs" "release::maintenance")
-          PR_LABELS=$(jq -r '.pull_request.labels[].name' "$GITHUB_EVENT_PATH")
+          PR_LABELS=$(echo "$PR_DATA" | jq -r '.labels[].name')
           NB_RELEASE_LABELS=0
 
           for LABEL in $PR_LABELS; do

--- a/.github/workflows/label_check.yml
+++ b/.github/workflows/label_check.yml
@@ -32,7 +32,7 @@ jobs:
           PR_DATA=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
             "https://api.github.com/repos/$REPO_FULL_NAME/issues/$PR_NUMBER")
 
-          NUMBER_OF_LABELS=$(echo "$PR_DATA" | jq -r '.labels')
+          NUMBER_OF_LABELS=$(echo "$PR_DATA" | jq '.labels | length')
           if [ $NUMBER_OF_LABELS -eq 0 ]; then
             echo "PR has no labels. Please add at least one label of release type."
             exit 1


### PR DESCRIPTION
# Description

- Since the bot uses `GITHUB_TOKEN` when adding a label, the `labeled` event is not triggered and the `label_check` workflow not re-run.
- As a consequence, `GITHUB_EVENT_PATH` is outdated (still corresponds to `opened` even after labeling) and so is its payload. We are now fetching fresh data (PR labels set by the bot through `set_pr_label` workflow) directly from GH API instead.
- Additionally, there is a race condition between opening the PR, labeling with the bot and running the `label_check` workflow, a delay of 10s has been added to mitigate this.

## Type of Change

- [ ] Bugfix
- [x] Feature / enhancement
- [ ] CI / Documentation
- [ ] Maintenance

## Checklist

- [x] My code follows the general style and conventions of the codebase, ensuring consistency
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have run `pre-commit run --all` locally in the source folder and confirmed that there are no linter errors.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
