### PR TITLE
ci: use VS2022 instead of VS2019

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,7 +36,7 @@ jobs:
     name: Windows
     strategy:
       matrix:
-        os: [windows-2019]
+        os: [windows-2022]
         build_type: [release]
       fail-fast: true
     uses: ./.github/workflows/windows_impl.yml


### PR DESCRIPTION
# Description

This changes the CI so that it uses windows with VS2022.

We were using VS2019 to build and test on Windows (except the static (micro)mamba apparently), but since we use C++20 now we might hit bugs from that toolchain as it is old and dont have the fixes from VS2022.
Also windows with VS2019 images are deprecated by github.

## Type of Change

<!-- Please skip this part if you are already using conventional commit keywords in the PR title. -->

- [ ] Bugfix
- [ ] Feature / enhancement
- [x] CI / Documentation
- [ ] Maintenance

## Checklist

- [x] My code follows the general style and conventions of the codebase, ensuring consistency
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have run `pre-commit run --all` locally in the source folder and confirmed that there are no linter errors.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
