### PR TITLE
maint: Handle environment vars in micromamba/tests with monkeypatch

### DIFF
--- a/micromamba/tests/test_env.py
+++ b/micromamba/tests/test_env.py
@@ -1,4 +1,3 @@
-import os
 import re
 import shutil
 
@@ -22,7 +21,7 @@ def test_env_list(tmp_home, tmp_root_prefix, tmp_empty_env):
     assert str(tmp_empty_env) in env_json["envs"]
 
 
-def test_env_list_table(tmp_home, tmp_root_prefix, tmp_prefix):
+def test_env_list_table(tmp_home, tmp_root_prefix, tmp_prefix, monkeypatch):
     res = helpers.run_env("list")
 
     assert "Name" in res
@@ -34,8 +33,6 @@ def test_env_list_table(tmp_home, tmp_root_prefix, tmp_prefix):
         if "*" in line:
             active_env_l = line
     assert str(tmp_root_prefix) in active_env_l
-
-    os.environ["CONDA_PREFIX"] = str(tmp_prefix)
 
     res = helpers.run_env("list")
 
@@ -470,10 +467,10 @@ dependencies:
 
 
 @pytest.mark.parametrize("shared_pkgs_dirs", [True], indirect=True)
-def test_env_update_empty_base(tmp_home, tmp_root_prefix, tmp_path):
+def test_env_update_empty_base(tmp_home, tmp_root_prefix, tmp_path, monkeypatch):
     env_prefix = tmp_path / "env-update-empty-base"
 
-    os.environ["MAMBA_ROOT_PREFIX"] = str(env_prefix)
+    monkeypatch.setenv("MAMBA_ROOT_PREFIX", str(env_prefix))
 
     env_file_yml = tmp_path / "test_env_empty_base.yaml"
     env_file_yml.write_text(env_yaml_content_to_update_empty_base)

--- a/micromamba/tests/test_info.py
+++ b/micromamba/tests/test_info.py
@@ -40,7 +40,7 @@ def test_env(tmp_home, tmp_root_prefix, tmp_env_name, tmp_prefix, prefix_selecti
 
 @pytest.mark.parametrize("existing_prefix", [False, True])
 @pytest.mark.parametrize("prefix_selection", [None, "env_var", "prefix", "name"])
-def test_not_env(tmp_home, tmp_root_prefix, prefix_selection, existing_prefix):
+def test_not_env(tmp_home, tmp_root_prefix, prefix_selection, existing_prefix, monkeypatch):
     name = "not_an_env"
     prefix = tmp_root_prefix / "envs" / name
 
@@ -52,10 +52,9 @@ def test_not_env(tmp_home, tmp_root_prefix, prefix_selection, existing_prefix):
     elif prefix_selection == "name":
         infos = helpers.info("-n", name)
     elif prefix_selection == "env_var":
-        os.environ["CONDA_PREFIX"] = str(prefix)
+        monkeypatch.setenv("CONDA_PREFIX", str(prefix))
         infos = helpers.info()
     else:
-        os.environ.pop("CONDA_PREFIX", "")
         infos = helpers.info()
 
     if prefix_selection is None:
@@ -131,11 +130,7 @@ def flags_test(tmp_root_prefix, infos, base_flag, envs_flag, json_flag):
 @pytest.mark.parametrize("envs_flag", ["", "-e", "--envs"])
 @pytest.mark.parametrize("json_flag", ["", "--json"])
 @pytest.mark.parametrize("prefix_selection", [None, "prefix", "name"])
-def test_base_flags(
-    tmp_home, tmp_root_prefix, prefix_selection, base_flag, envs_flag, json_flag, monkeypatch
-):
-    monkeypatch.setenv("CONDA_PREFIX", str(tmp_root_prefix))
-
+def test_base_flags(tmp_home, tmp_root_prefix, prefix_selection, base_flag, envs_flag, json_flag):
     if prefix_selection == "prefix":
         infos = helpers.info("-p", tmp_root_prefix, base_flag, envs_flag, json_flag)
     elif prefix_selection == "name":

--- a/micromamba/tests/test_menuinst.py
+++ b/micromamba/tests/test_menuinst.py
@@ -59,9 +59,9 @@ class TestMenuinst:
         not sys.platform.startswith("win"),
         reason="skipping windows-only tests",
     )
-    def test_shortcut_weird_env(self):
+    def test_shortcut_weird_env(self, monkeypatch):
         # note Umlauts do not work yet
-        os.environ["MAMBA_ROOT_PREFIX"] = str(Path("./compl i c ted").absolute())
+        monkeypatch.setenv("MAMBA_ROOT_PREFIX", str(Path("./compl i c ted").absolute()))
         root_prefix = os.environ["MAMBA_ROOT_PREFIX"]
 
         env_name = random_string()
@@ -97,7 +97,6 @@ class TestMenuinst:
         assert not os.path.exists(lnk)
 
         shutil.rmtree(root_prefix)
-        os.environ["MAMBA_ROOT_PREFIX"] = self.root_prefix
 
     # Testing a package (spyder) using menuinst v2 schema
     @pytest.mark.skipif(

--- a/micromamba/tests/test_remove.py
+++ b/micromamba/tests/test_remove.py
@@ -235,13 +235,15 @@ def test_remove_config_target_prefix(
     cli_env_name,
     env_var,
     current_target_prefix_fallback,
+    monkeypatch,
 ):
     (tmp_root_prefix / "conda-meta").mkdir(parents=True, exist_ok=True)
 
     cmd = []
 
     if use_root_prefix in (None, "cli"):
-        os.environ["MAMBA_DEFAULT_ROOT_PREFIX"] = os.environ.pop("MAMBA_ROOT_PREFIX")
+        monkeypatch.setenv("MAMBA_DEFAULT_ROOT_PREFIX", os.environ["MAMBA_ROOT_PREFIX"])
+        monkeypatch.delenv("MAMBA_ROOT_PREFIX")
 
     if use_root_prefix == "cli":
         cmd += ["-r", str(tmp_root_prefix)]
@@ -262,12 +264,12 @@ def test_remove_config_target_prefix(
         cmd += ["-n", n]
 
     if env_var:
-        os.environ["MAMBA_TARGET_PREFIX"] = p
+        monkeypatch.setenv("MAMBA_TARGET_PREFIX", p)
 
     if not current_target_prefix_fallback:
-        os.environ.pop("CONDA_PREFIX")
+        monkeypatch.delenv("CONDA_PREFIX")
     else:
-        os.environ["CONDA_PREFIX"] = p
+        monkeypatch.setenv("CONDA_PREFIX", p)
 
     if (cli_prefix and cli_env_name) or not (
         cli_prefix or cli_env_name or env_var or current_target_prefix_fallback

--- a/micromamba/tests/test_run.py
+++ b/micromamba/tests/test_run.py
@@ -28,9 +28,6 @@ def simple_short_program():
 
 
 class TestRun:
-    current_root_prefix = os.environ["MAMBA_ROOT_PREFIX"]
-    current_prefix = os.environ["CONDA_PREFIX"]
-
     @pytest.mark.parametrize("option_flag", common_simple_flags)
     @pytest.mark.parametrize("make_label_flags", next_label_flags)
     def test_fail_without_command(self, option_flag, make_label_flags):
@@ -100,22 +97,17 @@ class TestRun:
 
 
 @pytest.fixture()
-def temp_env_prefix():
-    previous_root_prefix = os.environ["MAMBA_ROOT_PREFIX"]
-    previous_prefix = os.environ["CONDA_PREFIX"]
-
+def temp_env_prefix(monkeypatch):
     env_name = random_string()
     root_prefix = os.path.expanduser(os.path.join("~", "tmproot" + random_string()))
     prefix = os.path.join(root_prefix, "envs", env_name)
 
-    os.environ["MAMBA_ROOT_PREFIX"] = root_prefix
+    monkeypatch.setenv("MAMBA_ROOT_PREFIX", root_prefix)
     create("-p", prefix, "python")
 
     yield prefix
 
     shutil.rmtree(prefix)
-    os.environ["MAMBA_ROOT_PREFIX"] = previous_root_prefix
-    os.environ["CONDA_PREFIX"] = previous_prefix
 
 
 class TestRunVenv:

--- a/micromamba/tests/test_update.py
+++ b/micromamba/tests/test_update.py
@@ -25,15 +25,13 @@ class TestUpdate:
     medium_old_version = "0.22"
 
     @staticmethod
-    @pytest.fixture(scope="class")
-    def root(existing_cache):
-        os.environ["MAMBA_ROOT_PREFIX"] = TestUpdate.root_prefix
-        os.environ["CONDA_PREFIX"] = TestUpdate.prefix
+    @pytest.fixture
+    def root(existing_cache, monkeypatch):
+        monkeypatch.setenv("MAMBA_ROOT_PREFIX", TestUpdate.root_prefix)
+        monkeypatch.setenv("CONDA_PREFIX", TestUpdate.prefix)
 
         yield
 
-        os.environ["MAMBA_ROOT_PREFIX"] = TestUpdate.current_root_prefix
-        os.environ["CONDA_PREFIX"] = TestUpdate.current_prefix
         shutil.rmtree(TestUpdate.root_prefix)
 
     @staticmethod
@@ -239,30 +237,25 @@ class TestUpdateConfig:
     prefix = os.path.join(root_prefix, "envs", env_name)
 
     @staticmethod
-    @pytest.fixture(scope="class")
-    def root(existing_cache):
-        os.environ["MAMBA_ROOT_PREFIX"] = TestUpdateConfig.root_prefix
-        os.environ["CONDA_PREFIX"] = TestUpdateConfig.prefix
+    @pytest.fixture
+    def root(existing_cache, monkeypatch):
+        monkeypatch.setenv("MAMBA_ROOT_PREFIX", TestUpdateConfig.root_prefix)
+        monkeypatch.setenv("CONDA_PREFIX", TestUpdateConfig.prefix)
+
         helpers.create("-n", "base", no_dry_run=True)
         helpers.create("-n", TestUpdateConfig.env_name, "--offline", no_dry_run=True)
 
         yield
 
-        os.environ["MAMBA_ROOT_PREFIX"] = TestUpdateConfig.current_root_prefix
-        os.environ["CONDA_PREFIX"] = TestUpdateConfig.current_prefix
         shutil.rmtree(TestUpdateConfig.root_prefix)
 
     @staticmethod
     @pytest.fixture
-    def env_created(root):
-        os.environ["MAMBA_ROOT_PREFIX"] = TestUpdateConfig.root_prefix
-        os.environ["CONDA_PREFIX"] = TestUpdateConfig.prefix
+    def env_created(root, monkeypatch):
+        monkeypatch.setenv("MAMBA_ROOT_PREFIX", TestUpdateConfig.root_prefix)
+        monkeypatch.setenv("CONDA_PREFIX", TestUpdateConfig.prefix)
 
         yield
-
-        for v in ("CONDA_CHANNELS", "MAMBA_TARGET_PREFIX"):
-            if v in os.environ:
-                os.environ.pop(v)
 
     @classmethod
     def config_tests(cls, res, root_prefix=root_prefix, target_prefix=prefix):
@@ -346,11 +339,13 @@ class TestUpdateConfig:
         env_var,
         current_target_prefix_fallback,
         env_created,
+        monkeypatch,
     ):
         cmd = []
 
         if root_prefix in (None, "cli"):
-            os.environ["MAMBA_DEFAULT_ROOT_PREFIX"] = os.environ.pop("MAMBA_ROOT_PREFIX")
+            monkeypatch.setenv("MAMBA_DEFAULT_ROOT_PREFIX", os.environ["MAMBA_ROOT_PREFIX"])
+            monkeypatch.delenv("MAMBA_ROOT_PREFIX")
 
         if root_prefix == "cli":
             cmd += ["-r", TestUpdateConfig.root_prefix]
@@ -393,13 +388,13 @@ class TestUpdateConfig:
             cmd += ["-f", spec_file]
 
         if env_var:
-            os.environ["MAMBA_TARGET_PREFIX"] = p
+            monkeypatch.setenv("MAMBA_TARGET_PREFIX", p)
 
         if not current_target_prefix_fallback:
-            os.environ.pop("CONDA_PREFIX")
-            os.environ.pop("CONDA_DEFAULT_ENV")
+            monkeypatch.delenv("CONDA_PREFIX")
+            monkeypatch.delenv("CONDA_DEFAULT_ENV")
         else:
-            os.environ["CONDA_PREFIX"] = p
+            monkeypatch.setenv("CONDA_PREFIX", p)
 
         if (cli_prefix and cli_env_name) or (yaml_name == "prefix"):
             with pytest.raises(helpers.subprocess.CalledProcessError):
@@ -417,14 +412,15 @@ class TestUpdateConfig:
     def test_target_prefix_with_no_settings(
         self,
         existing_cache,
+        monkeypatch,
     ):
         # Specify no arg
         cmd = []
 
         # Get the actual set MAMBA_ROOT_PREFIX when setting up `TestUpdateConfig` class
-        os.environ["MAMBA_DEFAULT_ROOT_PREFIX"] = os.environ.pop("MAMBA_ROOT_PREFIX")
-        os.environ.pop("CONDA_PREFIX")
-        os.environ.pop("CONDA_DEFAULT_ENV")
+        monkeypatch.setenv("MAMBA_DEFAULT_ROOT_PREFIX", os.environ["MAMBA_ROOT_PREFIX"])
+        for env_var in ("MAMBA_ROOT_PREFIX", "CONDA_PREFIX", "CONDA_DEFAULT_ENV"):
+            monkeypatch.delenv(env_var)
 
         # Fallback on root prefix
         res = helpers.install(*cmd, "--print-config-only")
@@ -441,13 +437,13 @@ class TestUpdateConfig:
     def test_target_prefix_with_no_settings_and_no_env_var(
         self,
         existing_cache,
+        monkeypatch,
     ):
         # Specify no arg
         cmd = []
 
-        os.environ.pop("MAMBA_ROOT_PREFIX")
-        os.environ.pop("CONDA_PREFIX")
-        os.environ.pop("CONDA_DEFAULT_ENV")
+        for env_var in ("MAMBA_ROOT_PREFIX", "CONDA_PREFIX", "CONDA_DEFAULT_ENV"):
+            monkeypatch.delenv(env_var)
 
         # Fallback on root prefix
         res = helpers.install(*cmd, "--print-config-only")
@@ -462,7 +458,7 @@ class TestUpdateConfig:
     @pytest.mark.parametrize("yaml", (False, True))
     @pytest.mark.parametrize("env_var", (False, True))
     @pytest.mark.parametrize("rc_file", (False, True))
-    def test_channels(self, cli, yaml, env_var, rc_file, env_created):
+    def test_channels(self, cli, yaml, env_var, rc_file, env_created, monkeypatch):
         cmd = []
         expected_channels = []
 
@@ -485,7 +481,7 @@ class TestUpdateConfig:
             expected_channels += ["yaml"]
 
         if env_var:
-            os.environ["CONDA_CHANNELS"] = "env_var"
+            monkeypatch.setenv("CONDA_CHANNELS", "env_var")
             expected_channels += ["env_var"]
 
         if rc_file:


### PR DESCRIPTION
# Description

Addresses #3830.

Nearly all of places where environment variables were set in the tests were needed, so I didn't change very much.

## Type of Change

<!-- Please skip this part if you are already using conventional commit keywords in the PR title. -->

- [ ] Bugfix
- [ ] Feature / enhancement
- [ ] CI / Documentation
- [X] Maintenance
