### PR TITLE
maint: use `synchronized_value` where we use a mutex to protect data

### DIFF
--- a/libmamba/include/mamba/core/execution.hpp
+++ b/libmamba/include/mamba/core/execution.hpp
@@ -144,8 +144,10 @@ namespace mamba
     private:
 
         std::atomic<bool> is_open{ true };
-        util::synchronized_value<std::vector<std::thread>> threads;
-        util::synchronized_value<std::vector<on_close_handler>> close_handlers;
+        using Threads = std::vector<std::thread>;
+        using CloseHandlers = std::vector<on_close_handler>;
+        util::synchronized_value<Threads, std::recursive_mutex> threads;
+        util::synchronized_value<CloseHandlers, std::recursive_mutex> close_handlers;
 
         void invoke_close_handlers();
     };

--- a/libmamba/include/mamba/core/thread_utils.hpp
+++ b/libmamba/include/mamba/core/thread_utils.hpp
@@ -194,7 +194,7 @@ namespace mamba
     inline void counting_semaphore::unlock()
     {
         {
-            std::lock_guard lock{ m_access_mutex };
+            std::unique_lock lock{ m_access_mutex };
             if (++m_value <= 0)
             {
                 return;

--- a/libmamba/include/mamba/core/thread_utils.hpp
+++ b/libmamba/include/mamba/core/thread_utils.hpp
@@ -186,7 +186,7 @@ namespace mamba
 
     inline void counting_semaphore::lock()
     {
-        std::unique_lock<std::mutex> lock(m_access_mutex);
+        std::unique_lock lock{ m_access_mutex };
         m_cv.wait(lock, [&]() { return m_value > 0; });
         --m_value;
     }
@@ -194,7 +194,7 @@ namespace mamba
     inline void counting_semaphore::unlock()
     {
         {
-            std::lock_guard<std::mutex> lock(m_access_mutex);
+            std::lock_guard lock{ m_access_mutex };
             if (++m_value <= 0)
             {
                 return;

--- a/libmamba/include/mamba/download/mirror.hpp
+++ b/libmamba/include/mamba/download/mirror.hpp
@@ -17,6 +17,7 @@
 #include <fmt/core.h>
 
 #include "mamba/download/request.hpp"
+#include "mamba/util/synchronized_value.hpp"
 
 namespace mamba::download
 {
@@ -109,13 +110,17 @@ namespace mamba::download
         MirrorID m_id;
         size_t m_max_retries;
 
-        // TODO: use synchronized value
-        std::mutex m_stats_mutex;
-        std::optional<std::size_t> m_allowed_connections = std::nullopt;
-        std::size_t m_max_tried_connections = 0;
-        std::size_t m_running_transfers = 0;
-        std::size_t m_successful_transfers = 0;
-        std::size_t m_failed_transfers = 0;
+        struct Stats
+        {
+            std::optional<std::size_t> allowed_connections = std::nullopt;
+            std::size_t max_tried_connections = 0;
+            std::size_t running_transfers = 0;
+            std::size_t successful_transfers = 0;
+            std::size_t failed_transfers = 0;
+        };
+
+        util::synchronized_value<Stats> m_stats;
+
     };
 
     std::unique_ptr<Mirror> make_mirror(std::string url);

--- a/libmamba/include/mamba/download/mirror.hpp
+++ b/libmamba/include/mamba/download/mirror.hpp
@@ -9,7 +9,6 @@
 
 #include <functional>
 #include <memory>
-#include <mutex>
 #include <optional>
 #include <string>
 #include <vector>

--- a/libmamba/include/mamba/download/mirror.hpp
+++ b/libmamba/include/mamba/download/mirror.hpp
@@ -67,6 +67,15 @@ namespace mamba::download
         MirrorRequest& operator=(MirrorRequest&&) = default;
     };
 
+    struct MirrorStats // Moved out of Mirror internals because of compilers not agreeing: https://godbolt.org/z/GcjWhrb9W
+    {
+        std::optional<std::size_t> allowed_connections = std::nullopt;
+        std::size_t max_tried_connections = 0;
+        std::size_t running_transfers = 0;
+        std::size_t successful_transfers = 0;
+        std::size_t failed_transfers = 0;
+    };
+
     // A Mirror represents a location from where an asset can be downloaded.
     // It handles the generation of required requests to get the asset, and
     // provides some statistics about its usage.
@@ -110,24 +119,9 @@ namespace mamba::download
         MirrorID m_id;
         size_t m_max_retries;
 
-        struct Stats
-        {
-            Stats() = default;
-            Stats(const Stats&) = default;
-            Stats(Stats&&) noexcept = default;
-            Stats& operator=(const Stats&) = default;
-            Stats& operator=(Stats&&) noexcept = default;
+        static_assert(std::default_initializable<MirrorStats>);
 
-            std::optional<std::size_t> allowed_connections = std::nullopt;
-            std::size_t max_tried_connections = 0;
-            std::size_t running_transfers = 0;
-            std::size_t successful_transfers = 0;
-            std::size_t failed_transfers = 0;
-        };
-
-        static_assert(std::default_initializable<Stats>);
-
-        util::synchronized_value<Stats> m_stats;
+        util::synchronized_value<MirrorStats> m_stats;
 
     };
 

--- a/libmamba/include/mamba/download/mirror.hpp
+++ b/libmamba/include/mamba/download/mirror.hpp
@@ -66,7 +66,8 @@ namespace mamba::download
         MirrorRequest& operator=(MirrorRequest&&) = default;
     };
 
-    struct MirrorStats // Moved out of Mirror internals because of compilers not agreeing: https://godbolt.org/z/GcjWhrb9W
+    struct MirrorStats  // Moved out of Mirror internals because of compilers not agreeing:
+                        // https://godbolt.org/z/GcjWhrb9W
     {
         std::optional<std::size_t> allowed_connections = std::nullopt;
         std::size_t max_tried_connections = 0;
@@ -121,7 +122,6 @@ namespace mamba::download
         static_assert(std::default_initializable<MirrorStats>);
 
         util::synchronized_value<MirrorStats> m_stats;
-
     };
 
     std::unique_ptr<Mirror> make_mirror(std::string url);

--- a/libmamba/include/mamba/download/mirror.hpp
+++ b/libmamba/include/mamba/download/mirror.hpp
@@ -112,6 +112,12 @@ namespace mamba::download
 
         struct Stats
         {
+            Stats() = default;
+            Stats(const Stats&) = default;
+            Stats(Stats&&) noexcept = default;
+            Stats& operator=(const Stats&) = default;
+            Stats& operator=(Stats&&) noexcept = default;
+
             std::optional<std::size_t> allowed_connections = std::nullopt;
             std::size_t max_tried_connections = 0;
             std::size_t running_transfers = 0;
@@ -119,11 +125,14 @@ namespace mamba::download
             std::size_t failed_transfers = 0;
         };
 
+        static_assert(std::default_initializable<Stats>);
+
         util::synchronized_value<Stats> m_stats;
 
     };
 
     std::unique_ptr<Mirror> make_mirror(std::string url);
+
 }
 
 #endif

--- a/libmamba/include/mamba/util/synchronized_value.hpp
+++ b/libmamba/include/mamba/util/synchronized_value.hpp
@@ -8,10 +8,10 @@
 #define MAMBA_UTIL_SYNCHRONIZED_VALUE_HPP
 
 #include <concepts>
+#include <functional>
 #include <mutex>
 #include <shared_mutex>
 #include <tuple>
-#include <functional>
 #include <utility>
 
 namespace mamba::util

--- a/libmamba/include/mamba/util/synchronized_value.hpp
+++ b/libmamba/include/mamba/util/synchronized_value.hpp
@@ -308,7 +308,7 @@ namespace mamba::util
             The lock is released before the end of the call.
         */
         // NOTE: this is redundant with the generic impl, but required to workaround
-        // apple-clang failing to properly constrain the generic impl.
+        // apple-clang failing to properly
         auto operator=(const T& value) noexcept -> synchronized_value&;
 
         /** Locks and return the value of the current object.

--- a/libmamba/include/mamba/util/synchronized_value.hpp
+++ b/libmamba/include/mamba/util/synchronized_value.hpp
@@ -40,7 +40,7 @@ namespace mamba::util
     /// `true` if the instances of two provided types can be compared with operator==.
     /// Notice that this concept is less restrictive than `std::equality_comparable_with`,
     /// which requires the existence of a common reference type for T and U. This additional
-    /// restriction makes it impossible to use it in the context here (orginally of sparrow), where
+    /// restriction makes it impossible to use it in the context here (originally of sparrow), where
     /// we want to compare objects that are logically similar while being "physically" different.
     // Source:
     // https://github.com/man-group/sparrow/blob/66f70418cf1b00cc294c99bbbe04b5b4d2f83c98/include/sparrow/utils/mp_utils.hpp#L604-L619

--- a/libmamba/include/mamba/util/synchronized_value.hpp
+++ b/libmamba/include/mamba/util/synchronized_value.hpp
@@ -11,6 +11,8 @@
 #include <mutex>
 #include <shared_mutex>
 #include <tuple>
+#include <functional>
+#include <utility>
 
 namespace mamba::util
 {

--- a/libmamba/include/mamba/util/synchronized_value.hpp
+++ b/libmamba/include/mamba/util/synchronized_value.hpp
@@ -258,8 +258,9 @@ namespace mamba::util
 
         /// Constructs with a provided value as initializer for the stored object.
         template <typename V>
-            requires(not std::same_as<T, std::decay_t<V>>) and std::assignable_from<T&, V>
+            requires(not std::same_as<T, std::decay_t<V>>)
                     and (not std::same_as<this_type, std::decay_t<V>>)
+                    and std::assignable_from<T&, V>
         synchronized_value(V&& value) noexcept
             : m_value(std::forward<V>(value))
         {
@@ -270,6 +271,8 @@ namespace mamba::util
         }
 
         /// Constructs with a provided value as initializer for the stored object.
+        // NOTE: this is redundant with the generic impl, but required to workaround
+        // apple-clang failing to properly constrain the generic impl.
         synchronized_value(T value) noexcept;
 
         /// Constructs with a provided initializer list used to initialize the stored object.
@@ -297,8 +300,9 @@ namespace mamba::util
             The lock is released before the end of the call.
         */
         template <typename V>
-            requires(not std::same_as<T, std::decay_t<V>>) and std::assignable_from<T&, V>
+            requires(not std::same_as<T, std::decay_t<V>>)
                     and (not std::same_as<this_type, std::decay_t<V>>)
+                    and std::assignable_from<T&, V>
         auto operator=(V&& value) noexcept -> synchronized_value&
         {
             // NOTE: when moving the definition outside the class,

--- a/libmamba/src/core/execution.cpp
+++ b/libmamba/src/core/execution.cpp
@@ -8,8 +8,8 @@ namespace mamba
 
     void MainExecutor::invoke_close_handlers()
     {
-        std::scoped_lock lock{ handlers_mutex };
-        for (auto&& handler : close_handlers)
+        auto synched_handlers = close_handlers.synchronize();
+        for (auto&& handler : *synched_handlers)
         {
             const auto result = safe_invoke(handler);
             if (!result)

--- a/libmamba/src/core/output.cpp
+++ b/libmamba/src/core/output.cpp
@@ -25,9 +25,9 @@
 #include "mamba/core/tasksync.hpp"
 #include "mamba/core/thread_utils.hpp"
 #include "mamba/core/util.hpp"
-#include "mamba/util/synchronized_value.hpp"
 #include "mamba/specs/conda_url.hpp"
 #include "mamba/util/string.hpp"
+#include "mamba/util/synchronized_value.hpp"
 #include "mamba/util/url_manip.hpp"
 
 #include "progress_bar_impl.hpp"
@@ -276,7 +276,6 @@ namespace mamba
 
     using ConsoleBuffer = std::vector<std::string>;
 
-
     class ConsoleData
     {
     public:
@@ -305,6 +304,7 @@ namespace mamba
             std::unique_ptr<ProgressBarManager> progress_bar_manager;
             ConsoleBuffer buffer;
         };
+
         util::synchronized_value<Data> m_synched_data;
 
         TaskSynchronizer m_tasksync;
@@ -450,7 +450,7 @@ namespace mamba
                 name,
                 {
                     .graphics = context().graphics_params,
-                    .ascii_only =  context().ascii_only,
+                    .ascii_only = context().ascii_only,
                 },
                 expected_total
             );

--- a/libmamba/src/core/output.cpp
+++ b/libmamba/src/core/output.cpp
@@ -276,11 +276,6 @@ namespace mamba
 
     using ConsoleBuffer = std::vector<std::string>;
 
-    struct ConsoleSynchedData
-    {
-        std::unique_ptr<ProgressBarManager> progress_bar_manager;
-        ConsoleBuffer buffer;
-    };
 
     class ConsoleData
     {
@@ -297,6 +292,7 @@ namespace mamba
         ConsoleData(ConsoleData&&) noexcept = delete;
         ConsoleData& operator=(ConsoleData&&) noexcept = delete;
 
+
         const Context& m_context;
 
         std::string json_hier;
@@ -304,8 +300,12 @@ namespace mamba
         nlohmann::json json_log;
         bool is_json_print_cancelled = false;
 
-
-        util::synchronized_value<ConsoleSynchedData> m_synched_data;
+        struct Data
+        {
+            std::unique_ptr<ProgressBarManager> progress_bar_manager;
+            ConsoleBuffer buffer;
+        };
+        util::synchronized_value<Data> m_synched_data;
 
         TaskSynchronizer m_tasksync;
     };

--- a/libmamba/src/core/output.cpp
+++ b/libmamba/src/core/output.cpp
@@ -291,11 +291,16 @@ namespace mamba
         {
         }
 
+        ConsoleData(const ConsoleData&) = delete;
+        ConsoleData& operator=(const ConsoleData&) = delete;
+
+        ConsoleData(ConsoleData&&) noexcept = delete;
+        ConsoleData& operator=(ConsoleData&&) noexcept = delete;
+
         const Context& m_context;
 
-
         std::string json_hier;
-        unsigned int json_index;
+        unsigned int json_index = 0;
         nlohmann::json json_log;
         bool is_json_print_cancelled = false;
 
@@ -306,7 +311,7 @@ namespace mamba
     };
 
     Console::Console(const Context& context)
-        : p_data(new ConsoleData{ context })
+        : p_data(std::make_unique<ConsoleData>(context))
     {
         set_singleton(*this);
 

--- a/libmamba/src/core/output.cpp
+++ b/libmamba/src/core/output.cpp
@@ -25,6 +25,7 @@
 #include "mamba/core/tasksync.hpp"
 #include "mamba/core/thread_utils.hpp"
 #include "mamba/core/util.hpp"
+#include "mamba/util/synchronized_value.hpp"
 #include "mamba/specs/conda_url.hpp"
 #include "mamba/util/string.hpp"
 #include "mamba/util/url_manip.hpp"
@@ -283,15 +284,21 @@ namespace mamba
 
         const Context& m_context;
 
-        std::mutex m_mutex;
-        std::unique_ptr<ProgressBarManager> p_progress_bar_manager;
 
         std::string json_hier;
         unsigned int json_index;
         nlohmann::json json_log;
         bool is_json_print_cancelled = false;
 
-        std::vector<std::string> m_buffer;
+        using Buffer = std::vector<std::string>;
+
+        struct Data
+        {
+            std::unique_ptr<ProgressBarManager> progress_bar_manager;
+            Buffer buffer;
+        };
+
+        util::synchronized_value<Data> m_synched_data;
 
         TaskSynchronizer m_tasksync;
     };
@@ -346,11 +353,11 @@ namespace mamba
     {
         if (force_print || !(context().output_params.quiet || context().output_params.json))
         {
-            const std::lock_guard<std::mutex> lock(p_data->m_mutex);
+            auto synched_data = p_data->m_synched_data.synchronize();
 
-            if (p_data->p_progress_bar_manager && p_data->p_progress_bar_manager->started())
+            if (synched_data->progress_bar_manager && synched_data->progress_bar_manager->started())
             {
-                p_data->m_buffer.push_back(hide_secrets(str));
+                synched_data->buffer.push_back(hide_secrets(str));
             }
             else
             {
@@ -362,12 +369,8 @@ namespace mamba
     void Console::print_buffer(std::ostream& ostream)
     {
         auto& data = instance().p_data;
-        decltype(data->m_buffer) tmp;
-
-        {
-            const std::lock_guard<std::mutex> lock(data->m_mutex);
-            data->m_buffer.swap(tmp);
-        }
+        ConsoleData::Buffer tmp;
+        data->m_synched_data->buffer.swap(tmp);
 
         for (const auto& message : tmp)
         {
@@ -436,7 +439,7 @@ namespace mamba
         }
         else
         {
-            return p_data->p_progress_bar_manager->add_progress_bar(
+            return p_data->m_synched_data->progress_bar_manager->add_progress_bar(
                 name,
                 {
                     /* .graphics = */ context().graphics_params,
@@ -449,31 +452,35 @@ namespace mamba
 
     void Console::clear_progress_bars()
     {
-        return p_data->p_progress_bar_manager->clear_progress_bars();
+        return p_data->m_synched_data->progress_bar_manager->clear_progress_bars();
     }
 
     ProgressBarManager& Console::init_progress_bar_manager(ProgressBarMode mode)
     {
-        p_data->p_progress_bar_manager = make_progress_bar_manager(mode);
-        p_data->p_progress_bar_manager->register_print_hook(Console::print_buffer);
-        p_data->p_progress_bar_manager->register_print_hook(MessageLogger::print_buffer);
-        p_data->p_progress_bar_manager->register_pre_start_hook(MessageLogger::activate_buffer);
-        p_data->p_progress_bar_manager->register_post_stop_hook(MessageLogger::deactivate_buffer);
+        auto new_progress_bar_manager = make_progress_bar_manager(mode);
+        new_progress_bar_manager->register_print_hook(Console::print_buffer);
+        new_progress_bar_manager->register_print_hook(MessageLogger::print_buffer);
+        new_progress_bar_manager->register_pre_start_hook(MessageLogger::activate_buffer);
+        new_progress_bar_manager->register_post_stop_hook(MessageLogger::deactivate_buffer);
 
-        return *(p_data->p_progress_bar_manager);
+        auto synched_data = p_data->m_synched_data.synchronize();
+        synched_data->progress_bar_manager = std::move(new_progress_bar_manager);
+
+        return *(synched_data->progress_bar_manager);  // unsafe!
     }
 
     void Console::terminate_progress_bar_manager()
     {
-        if (p_data->p_progress_bar_manager)
+        auto synched_data = p_data->m_synched_data.synchronize();
+        if (synched_data->progress_bar_manager)
         {
-            p_data->p_progress_bar_manager->terminate();
+            synched_data->progress_bar_manager->terminate();
         }
     }
 
     ProgressBarManager& Console::progress_bar_manager()
     {
-        return *(p_data->p_progress_bar_manager);
+        return *(p_data->m_synched_data->progress_bar_manager);
     }
 
     void Console::json_print()
@@ -543,12 +550,10 @@ namespace mamba
      * MessageLogger *
      *****************/
 
-    struct MessageLoggerData
-    {
-        static std::mutex m_mutex;
-        static bool use_buffer;
-        static std::vector<std::pair<std::string, log_level>> m_buffer;
-    };
+    static std::atomic<bool> message_logger_use_buffer;
+
+    using MessageLoggerBuffer = std::vector<std::pair<std::string, log_level>>;
+    static util::synchronized_value<MessageLoggerBuffer> message_logger_buffer;
 
     MessageLogger::MessageLogger(log_level level)
         : m_level(level)
@@ -558,14 +563,13 @@ namespace mamba
 
     MessageLogger::~MessageLogger()
     {
-        if (!MessageLoggerData::use_buffer && Console::is_available())
+        if (!message_logger_use_buffer && Console::is_available())
         {
             emit(m_stream.str(), m_level);
         }
         else
         {
-            const std::lock_guard<std::mutex> lock(MessageLoggerData::m_mutex);
-            MessageLoggerData::m_buffer.push_back({ m_stream.str(), m_level });
+            message_logger_buffer->push_back({ m_stream.str(), m_level });
         }
     }
 
@@ -608,22 +612,18 @@ namespace mamba
 
     void MessageLogger::activate_buffer()
     {
-        MessageLoggerData::use_buffer = true;
+        message_logger_use_buffer = true;
     }
 
     void MessageLogger::deactivate_buffer()
     {
-        MessageLoggerData::use_buffer = false;
+        message_logger_use_buffer = false;
     }
 
     void MessageLogger::print_buffer(std::ostream& /*ostream*/)
     {
-        decltype(MessageLoggerData::m_buffer) tmp;
-
-        {
-            const std::lock_guard<std::mutex> lock(MessageLoggerData::m_mutex);
-            MessageLoggerData::m_buffer.swap(tmp);
-        }
+        MessageLoggerBuffer tmp;
+        message_logger_buffer->swap(tmp);
 
         for (const auto& [msg, level] : tmp)
         {

--- a/libmamba/src/core/output.cpp
+++ b/libmamba/src/core/output.cpp
@@ -273,6 +273,15 @@ namespace mamba
      * Console *
      ***********/
 
+
+    using ConsoleBuffer = std::vector<std::string>;
+
+    struct ConsoleSynchedData
+    {
+        std::unique_ptr<ProgressBarManager> progress_bar_manager;
+        ConsoleBuffer buffer;
+    };
+
     class ConsoleData
     {
     public:
@@ -290,15 +299,8 @@ namespace mamba
         nlohmann::json json_log;
         bool is_json_print_cancelled = false;
 
-        using Buffer = std::vector<std::string>;
 
-        struct Data
-        {
-            std::unique_ptr<ProgressBarManager> progress_bar_manager;
-            Buffer buffer;
-        };
-
-        util::synchronized_value<Data> m_synched_data;
+        util::synchronized_value<ConsoleSynchedData> m_synched_data;
 
         TaskSynchronizer m_tasksync;
     };
@@ -369,7 +371,7 @@ namespace mamba
     void Console::print_buffer(std::ostream& ostream)
     {
         auto& data = instance().p_data;
-        ConsoleData::Buffer tmp;
+        ConsoleBuffer tmp;
         data->m_synched_data->buffer.swap(tmp);
 
         for (const auto& message : tmp)
@@ -442,8 +444,8 @@ namespace mamba
             return p_data->m_synched_data->progress_bar_manager->add_progress_bar(
                 name,
                 {
-                    /* .graphics = */ context().graphics_params,
-                    /* .ascii_only =  */ context().ascii_only,
+                    .graphics = context().graphics_params,
+                    .ascii_only =  context().ascii_only,
                 },
                 expected_total
             );

--- a/libmamba/src/core/package_fetcher.cpp
+++ b/libmamba/src/core/package_fetcher.cpp
@@ -458,7 +458,7 @@ namespace mamba
     void PackageFetcher::update_urls_txt() const
     {
         // TODO: check if this lock is really required
-        std::lock_guard<std::mutex> lock(urls_txt_mutex);
+        std::unique_lock lock{ urls_txt_mutex };
         const auto urls_file_path = m_cache_path / "urls.txt";
         std::ofstream urls_txt(urls_file_path.std_path(), std::ios::app);
         urls_txt << url() << std::endl;

--- a/libmamba/src/core/package_handling.cpp
+++ b/libmamba/src/core/package_handling.cpp
@@ -740,7 +740,7 @@ namespace mamba
     void extract(const fs::u8path& file, const fs::u8path& dest, const ExtractOptions& options)
     {
         static std::mutex extract_mutex;
-        std::lock_guard<std::mutex> lock(extract_mutex);
+        std::unique_lock lock{ extract_mutex };
 
         if (util::ends_with(file.string(), ".tar.bz2"))
         {

--- a/libmamba/src/core/util.cpp
+++ b/libmamba/src/core/util.cpp
@@ -1066,7 +1066,7 @@ namespace mamba
 #endif
 
         struct LockedFilesRegistry_Data  // made public to workaround CWG2335, should be private
-                                            // otherwise
+                                         // otherwise
         {
             // TODO: replace by something like boost::multiindex or equivalent to avoid having
             // to handle 2 hashmaps

--- a/libmamba/src/core/util.cpp
+++ b/libmamba/src/core/util.cpp
@@ -1065,26 +1065,7 @@ namespace mamba
 #pragma GCC diagnostic pop
 #endif
 
-        struct LockedFilesData
-        {
-            // TODO: replace by something like boost::multiindex or equivalent to avoid having to
-            // handle 2 hashmaps
-            std::unordered_map<fs::u8path, std::weak_ptr<LockFileOwner>> locked_files;  // TODO:
-                                                                                        // consider
-                                                                                        // replacing
-                                                                                        // by real
-                                                                                        // concurrent
-                                                                                        // set to
-                                                                                        // avoid
-                                                                                        // having to
-                                                                                        // lock the
-                                                                                        // whole
-                                                                                        // container
 
-            std::unordered_map<int, fs::u8path> fd_to_locked_path;  // this is a workaround the
-                                                                    // usage of file descriptors on
-                                                                    // linux instead of paths
-        };
 
         class LockedFilesRegistry
         {
@@ -1188,7 +1169,31 @@ namespace mamba
             std::atomic_bool m_is_file_locking_allowed{ true };
             std::atomic<std::chrono::seconds> m_default_lock_timeout{ std::chrono::seconds::zero() };
 
-            util::synchronized_value<LockedFilesData, std::recursive_mutex> m_data;
+            struct Data
+            {
+                // TODO: replace by something like boost::multiindex or equivalent to avoid having
+                // to handle 2 hashmaps
+                std::unordered_map<fs::u8path, std::weak_ptr<LockFileOwner>> locked_files;  // TODO:
+                                                                                            // consider
+                                                                                            // replacing
+                                                                                            // by
+                                                                                            // real
+                                                                                            // concurrent
+                                                                                            // set
+                                                                                            // to
+                                                                                            // avoid
+                                                                                            // having
+                                                                                            // to
+                                                                                            // lock
+                                                                                            // the
+                                                                                            // whole
+                                                                                            // container
+
+                std::unordered_map<int, fs::u8path> fd_to_locked_path;  // this is a workaround the
+                                                                        // usage of file descriptors
+                                                                        // on linux instead of paths
+            };
+            util::synchronized_value<Data, std::recursive_mutex> m_data;
         };
 
         static LockedFilesRegistry files_locked_by_this_process;

--- a/libmamba/src/core/util.cpp
+++ b/libmamba/src/core/util.cpp
@@ -1065,7 +1065,34 @@ namespace mamba
 #pragma GCC diagnostic pop
 #endif
 
+        namespace
+        {
+            struct LockedFilesRegistry_Data  // made public to workaround CWG2335, should be private
+                                             // otherwise
+            {
+                // TODO: replace by something like boost::multiindex or equivalent to avoid having
+                // to handle 2 hashmaps
+                std::unordered_map<fs::u8path, std::weak_ptr<LockFileOwner>> locked_files;  // TODO:
+                                                                                            // consider
+                                                                                            // replacing
+                                                                                            // by
+                                                                                            // real
+                                                                                            // concurrent
+                                                                                            // set
+                                                                                            // to
+                                                                                            // avoid
+                                                                                            // having
+                                                                                            // to
+                                                                                            // lock
+                                                                                            // the
+                                                                                            // whole
+                                                                                            // container
 
+                std::unordered_map<int, fs::u8path> fd_to_locked_path;  // this is a workaround the
+                                                                        // usage of file descriptors
+                                                                        // on linux instead of paths
+            };
+        }
 
         class LockedFilesRegistry
         {
@@ -1164,41 +1191,12 @@ namespace mamba
                 }
             }
 
+
         private:
 
             std::atomic_bool m_is_file_locking_allowed{ true };
             std::atomic<std::chrono::seconds> m_default_lock_timeout{ std::chrono::seconds::zero() };
-
-            struct Data
-            {
-                Data()
-                {
-                    // this user-defined constructor is a workaround for CWG2335 and related compiler issues
-                }
-
-                // TODO: replace by something like boost::multiindex or equivalent to avoid having
-                // to handle 2 hashmaps
-                std::unordered_map<fs::u8path, std::weak_ptr<LockFileOwner>> locked_files;  // TODO:
-                                                                                            // consider
-                                                                                            // replacing
-                                                                                            // by
-                                                                                            // real
-                                                                                            // concurrent
-                                                                                            // set
-                                                                                            // to
-                                                                                            // avoid
-                                                                                            // having
-                                                                                            // to
-                                                                                            // lock
-                                                                                            // the
-                                                                                            // whole
-                                                                                            // container
-
-                std::unordered_map<int, fs::u8path> fd_to_locked_path;  // this is a workaround the
-                                                                        // usage of file descriptors
-                                                                        // on linux instead of paths
-            };
-            util::synchronized_value<Data, std::recursive_mutex> m_data;
+            util::synchronized_value<LockedFilesRegistry_Data, std::recursive_mutex> m_data;
         };
 
         static LockedFilesRegistry files_locked_by_this_process;

--- a/libmamba/src/core/util.cpp
+++ b/libmamba/src/core/util.cpp
@@ -1065,34 +1065,31 @@ namespace mamba
 #pragma GCC diagnostic pop
 #endif
 
-        namespace
+        struct LockedFilesRegistry_Data  // made public to workaround CWG2335, should be private
+                                            // otherwise
         {
-            struct LockedFilesRegistry_Data  // made public to workaround CWG2335, should be private
-                                             // otherwise
-            {
-                // TODO: replace by something like boost::multiindex or equivalent to avoid having
-                // to handle 2 hashmaps
-                std::unordered_map<fs::u8path, std::weak_ptr<LockFileOwner>> locked_files;  // TODO:
-                                                                                            // consider
-                                                                                            // replacing
-                                                                                            // by
-                                                                                            // real
-                                                                                            // concurrent
-                                                                                            // set
-                                                                                            // to
-                                                                                            // avoid
-                                                                                            // having
-                                                                                            // to
-                                                                                            // lock
-                                                                                            // the
-                                                                                            // whole
-                                                                                            // container
+            // TODO: replace by something like boost::multiindex or equivalent to avoid having
+            // to handle 2 hashmaps
+            std::unordered_map<fs::u8path, std::weak_ptr<LockFileOwner>> locked_files;  // TODO:
+                                                                                        // consider
+                                                                                        // replacing
+                                                                                        // by
+                                                                                        // real
+                                                                                        // concurrent
+                                                                                        // set
+                                                                                        // to
+                                                                                        // avoid
+                                                                                        // having
+                                                                                        // to
+                                                                                        // lock
+                                                                                        // the
+                                                                                        // whole
+                                                                                        // container
 
-                std::unordered_map<int, fs::u8path> fd_to_locked_path;  // this is a workaround the
-                                                                        // usage of file descriptors
-                                                                        // on linux instead of paths
-            };
-        }
+            std::unordered_map<int, fs::u8path> fd_to_locked_path;  // this is a workaround the
+                                                                    // usage of file descriptors
+                                                                    // on linux instead of paths
+        };
 
         class LockedFilesRegistry
         {

--- a/libmamba/src/core/util.cpp
+++ b/libmamba/src/core/util.cpp
@@ -1171,6 +1171,11 @@ namespace mamba
 
             struct Data
             {
+                Data()
+                {
+                    // this user-defined constructor is a workaround for CWG2335 and related compiler issues
+                }
+
                 // TODO: replace by something like boost::multiindex or equivalent to avoid having
                 // to handle 2 hashmaps
                 std::unordered_map<fs::u8path, std::weak_ptr<LockFileOwner>> locked_files;  // TODO:

--- a/libmamba/tests/src/util/test_synchronized_value.cpp
+++ b/libmamba/tests/src/util/test_synchronized_value.cpp
@@ -103,7 +103,6 @@ namespace
         {
             return { i };
         }
-
     };
 
     struct ComparableToValueType
@@ -115,7 +114,6 @@ namespace
     {
         return left.x == right.j;
     }
-
 
     // NOTE: We do not use TEMPLATE_TEST_CASE or TEMPLATE_LIST_TEST_CASE here because code coverage
     // tools (such as gcov/lcov) do not properly attribute coverage to tests instantiated via
@@ -147,9 +145,8 @@ namespace
             synchronized_value a;
             ComparableToValueType x{ a->x };
             REQUIRE(a == x);
-            ComparableToValueType y{ a->x +1 };
+            ComparableToValueType y{ a->x + 1 };
             REQUIRE(a != y);
-
         }
 
         static constexpr auto initial_value = ValueType{ 42 };

--- a/libmamba/tests/src/util/test_synchronized_value.cpp
+++ b/libmamba/tests/src/util/test_synchronized_value.cpp
@@ -95,6 +95,28 @@ namespace
         auto operator<=>(const ValueType&) const noexcept = default;
     };
 
+    struct ConvertibleToValueType
+    {
+        int i = 0;
+
+        operator ValueType() const
+        {
+            return { i };
+        }
+
+    };
+
+    struct ComparableToValueType
+    {
+        int j = 0;
+    };
+
+    bool operator==(const ValueType& left, const ComparableToValueType& right)
+    {
+        return left.x == right.j;
+    }
+
+
     // NOTE: We do not use TEMPLATE_TEST_CASE or TEMPLATE_LIST_TEST_CASE here because code coverage
     // tools (such as gcov/lcov) do not properly attribute coverage to tests instantiated via
     // template test cases. Instead, we use individual TEST_CASEs for each mutex type, and factorize
@@ -111,6 +133,23 @@ namespace
         SECTION("default constructible")
         {
             synchronized_value a;
+        }
+
+        SECTION("compatible value assignation")
+        {
+            synchronized_value a;
+            a = ConvertibleToValueType{ 1234 };
+            REQUIRE(a->x == 1234);
+        }
+
+        SECTION("compatible comparison")
+        {
+            synchronized_value a;
+            ComparableToValueType x{ a->x };
+            REQUIRE(a == x);
+            ComparableToValueType y{ a->x +1 };
+            REQUIRE(a != y);
+
         }
 
         static constexpr auto initial_value = ValueType{ 42 };


### PR DESCRIPTION
# Description

Replaces manual usage of a mutex to protect data by usage of `synchronized_value`.
This also reveals some cases where data were used unprotected, so it also fixes these cases.
I also updated the locks types as `std::unique_lock` and `std::scoped_lock` are upgrades compared to  `std::lock_guard`.

## Type of Change

<!-- Please skip this part if you are already using conventional commit keywords in the PR title. -->

- [ ] Bugfix
- [ ] Feature / enhancement
- [ ] CI / Documentation
- [x] Maintenance

## Checklist

- [x] My code follows the general style and conventions of the codebase, ensuring consistency
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have run `pre-commit run --all` locally in the source folder and confirmed that there are no linter errors.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
