### PR TITLE
maint: upgrade usage of deprecated posix API functions

### DIFF
--- a/libmamba/src/core/run.cpp
+++ b/libmamba/src/core/run.cpp
@@ -199,7 +199,7 @@ namespace mamba
         const std::vector<std::string>& command,
         LockFile proc_dir_lock [[maybe_unused]]
     )
-        : location{ proc_dir() / fmt::format("{}.json", getpid()) }
+        : location{ proc_dir() / fmt::format("{}.json", _getpid()) }
     {
         // Lock must be hold for the duraction of this constructor.
         if (is_file_locking_allowed())

--- a/libmamba/src/core/util.cpp
+++ b/libmamba/src/core/util.cpp
@@ -892,7 +892,7 @@ namespace mamba
         int ret = 0;
         if (m_fd > -1)
         {
-            ret = close(m_fd);
+            ret = _close(m_fd);
             m_fd = -1;
         }
         return ret;


### PR DESCRIPTION
# Description

We get build warnings about usage of posix api that are officially deprecated, this replaces the functions calls to their upgraded versions.

## Type of Change

<!-- Please skip this part if you are already using conventional commit keywords in the PR title. -->

- [ ] Bugfix
- [ ] Feature / enhancement
- [ ] CI / Documentation
- [ ] Maintenance

## Checklist

- [ ] My code follows the general style and conventions of the codebase, ensuring consistency
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have run `pre-commit run --all` locally in the source folder and confirmed that there are no linter errors.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
