### PR TITLE
Handle removed `is_rgb` from `fmt 11.2.0`

### DIFF
--- a/libmambapy/src/libmambapy/bindings/utils.cpp
+++ b/libmambapy/src/libmambapy/bindings/utils.cpp
@@ -17,6 +17,20 @@
 
 namespace mambapy
 {
+    // NOTE: These fmt "internals" are for internal use only.
+    // External users should not use them in their projects.
+    // Instead, rely on the public API or appropriate abstractions.
+    // (not sure if they exist at the moment for this specific use case though)
+    // cf. https://github.com/fmtlib/fmt/issues/4466
+    bool fmt_is_rgb(const fmt::detail::color_type& color_type)
+    {
+#if FMT_VERSION >= 110200
+        return !color_type.is_terminal_color();
+#else
+        return color_type.is_rgb;
+#endif
+    }
+
     void bind_submodule_utils(pybind11::module_ m)
     {
         namespace py = pybind11;
@@ -110,7 +124,7 @@ namespace mambapy
                         return std::nullopt;
                     }
                     const auto fg = style.get_foreground();
-                    if (fg.is_rgb)
+                    if (fmt_is_rgb(fg))
                     {
                         return { { fmt::rgb(fg.value.rgb_color) } };
                     }
@@ -126,7 +140,7 @@ namespace mambapy
                         return std::nullopt;
                     }
                     const auto bg = style.get_background();
-                    if (bg.is_rgb)
+                    if (fmt_is_rgb(bg))
                     {
                         return { { fmt::rgb(bg.value.rgb_color) } };
                     }


### PR DESCRIPTION
# Description

Fix #3958 

## Type of Change

<!-- Please skip this part if you are already using conventional commit keywords in the PR title. -->

- [ ] Bugfix
- [ ] Feature / enhancement
- [ ] CI / Documentation
- [x] Maintenance

## Checklist

- [x] My code follows the general style and conventions of the codebase, ensuring consistency
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have run `pre-commit run --all` locally in the source folder and confirmed that there are no linter errors.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
