### PR TITLE
feat: Add support for a new architecture loongarch

### DIFF
--- a/libmamba/include/mamba/specs/platform.hpp
+++ b/libmamba/include/mamba/specs/platform.hpp
@@ -35,6 +35,7 @@ namespace mamba::specs
         linux_s390x,
         linux_riscv32,
         linux_riscv64,
+        linux_loongarch64,
         osx_64,
         osx_arm64,
         win_32,
@@ -190,6 +191,8 @@ namespace mamba::specs
                 return "linux-riscv32";
             case KnownPlatform::linux_riscv64:
                 return "linux-riscv64";
+            case KnownPlatform::linux_loongarch64:
+                return "linux-loongarch64";
             case KnownPlatform::osx_64:
                 return "osx-64";
             case KnownPlatform::osx_arm64:

--- a/libmamba/src/specs/platform.cpp
+++ b/libmamba/src/specs/platform.cpp
@@ -38,7 +38,8 @@ namespace mamba::specs
                || (plat == KnownPlatform::linux_ppc64)    //
                || (plat == KnownPlatform::linux_s390x)    //
                || (plat == KnownPlatform::linux_riscv32)  //
-               || (plat == KnownPlatform::linux_riscv64);
+               || (plat == KnownPlatform::linux_riscv64)  //
+               || (plat == KnownPlatform::linux_loongarch64);
     }
 
     auto platform_is_linux(DynamicPlatform plat) -> bool
@@ -119,6 +120,8 @@ namespace mamba::specs
         return KnownPlatform::linux_riscv32;
 #elif defined(__riscv) && defined(__riscv_xlen) && (__riscv_xlen == 64)
         return KnownPlatform::linux_riscv64;
+#elif defined(__loongarch64)
+        return KnownPlatform::linux_loongarch64;
 #else
 #error "Unknown Linux platform"
 #endif

--- a/libmamba/tests/src/specs/test_platform.cpp
+++ b/libmamba/tests/src/specs/test_platform.cpp
@@ -17,6 +17,7 @@ namespace
         SECTION("name")
         {
             REQUIRE(platform_name(KnownPlatform::linux_riscv32) == "linux-riscv32");
+            REQUIRE(platform_name(KnownPlatform::linux_loongarch64) == "linux-loongarch64");
             REQUIRE(platform_name(KnownPlatform::osx_arm64) == "osx-arm64");
             REQUIRE(platform_name(KnownPlatform::win_64) == "win-64");
         }
@@ -24,6 +25,7 @@ namespace
         SECTION("parse")
         {
             REQUIRE(platform_parse("linux-armv6l") == KnownPlatform::linux_armv6l);
+            REQUIRE(platform_parse("linux-loongarch64") == KnownPlatform::linux_loongarch64);
             REQUIRE(platform_parse(" win-32 ") == KnownPlatform::win_32);
             REQUIRE(platform_parse(" OSX-64") == KnownPlatform::osx_64);
             REQUIRE(platform_parse("linus-46") == std::nullopt);
@@ -32,10 +34,11 @@ namespace
         SECTION("known_platform")
         {
             static constexpr decltype(known_platform_names()) expected{
-                "noarch",        "linux-32",      "linux-64",    "linux-armv6l", "linux-armv7l",
-                "linux-aarch64", "linux-ppc64le", "linux-ppc64", "linux-s390x",  "linux-riscv32",
-                "linux-riscv64", "osx-64",        "osx-arm64",   "win-32",       "win-64",
-                "win-arm64",     "zos-z",
+                "noarch",       "linux-32",      "linux-64",      "linux-armv6l",
+                "linux-armv7l", "linux-aarch64", "linux-ppc64le", "linux-ppc64",
+                "linux-s390x",  "linux-riscv32", "linux-riscv64", "linux-loongarch64",
+                "osx-64",       "osx-arm64",     "win-32",        "win-64",
+                "win-arm64",    "zos-z",
 
             };
             REQUIRE(expected == known_platform_names());

--- a/libmambapy/src/libmambapy/bindings/specs.cpp
+++ b/libmambapy/src/libmambapy/bindings/specs.cpp
@@ -75,6 +75,7 @@ namespace mambapy
             .value("linux_s390x", KnownPlatform::linux_s390x)
             .value("linux_riscv32", KnownPlatform::linux_riscv32)
             .value("linux_riscv64", KnownPlatform::linux_riscv64)
+            .value("linux_loongarch64", KnownPlatform::linux_loongarch64)
             .value("osx_64", KnownPlatform::osx_64)
             .value("osx_arm64", KnownPlatform::osx_arm64)
             .value("win_32", KnownPlatform::win_32)

--- a/libmambapy/tests/test_specs.py
+++ b/libmambapy/tests/test_specs.py
@@ -47,6 +47,7 @@ def test_KnownPlatform():
     assert KnownPlatform.linux_s390x.name == "linux_s390x"
     assert KnownPlatform.linux_riscv32.name == "linux_riscv32"
     assert KnownPlatform.linux_riscv64.name == "linux_riscv64"
+    assert KnownPlatform.linux_loongarch64.name == "linux_loongarch64"
     assert KnownPlatform.osx_64.name == "osx_64"
     assert KnownPlatform.osx_arm64.name == "osx_arm64"
     assert KnownPlatform.win_32.name == "win_32"


### PR DESCRIPTION
# Description

In this commit, support for a new architecture Loongarch is added to mamba. LoongArch is a new RISC ISA, which is a bit like MIPS or RISC-V. Loongarch has been added to Debian port since August 2023. So supporting this new architecture is necessary for conda/mamba users on Loongarch.
[https://wiki.debian.org/LoongArch](https://github.com/mamba-org/mamba/pull/url)
[https://lists.debian.org/debian-devel-announce/2023/08/msg00000.html](https://github.com/mamba-org/mamba/pull/url)
[https://www.kernel.org/doc/html/v6.1//loongarch/introduction.html](https://github.com/mamba-org/mamba/pull/url)
## Type of Change

<!-- Please skip this part if you are already using conventional commit keywords in the PR title. -->

- [ ] Bugfix
- [x] Feature / enhancement
- [ ] CI / Documentation
- [ ] Maintenance

## Checklist

- [x] My code follows the general style and conventions of the codebase, ensuring consistency
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x ] My changes generate no new warnings
- [x] I have run `pre-commit run --all` locally in the source folder and confirmed that there are no linter errors.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
