### PR TITLE
fix CI issues related to moving dependencies

### DIFF
--- a/dev/CMakePresetsMamba.json
+++ b/dev/CMakePresetsMamba.json
@@ -23,7 +23,8 @@
     {
       "cacheVariables": {
         "BUILD_MICROMAMBA": "ON",
-        "BUILD_STATIC": "ON"
+        "BUILD_STATIC": "ON",
+        "ENABLE_WIN32_XMLLITE": "ON"
       },
       "hidden": true,
       "name": "mamba-static"

--- a/dev/environment-dev.yml
+++ b/dev/environment-dev.yml
@@ -47,7 +47,7 @@ dependencies:
   - scikit-build
   # libmambapy dependencies
   - python
-  - pybind11
+  - pybind11<3.0.0
   # libmambapy-stubs build dependencies
   - mypy # For stubgen
   - setuptools

--- a/libmamba/CMakeLists.txt
+++ b/libmamba/CMakeLists.txt
@@ -583,6 +583,7 @@ macro(libmamba_create_target target_name linkage output_name)
                 ${target_name}
                 PUBLIC
                     ${CRYPTO_LIBRARIES}
+                    XmlLite.lib
                     ${LibArchive_LIBRARY}
                     ${LIBXML2_LIBRARY}
                     ${ICONV_LIBRARY}

--- a/libmamba/CMakeLists.txt
+++ b/libmamba/CMakeLists.txt
@@ -562,7 +562,8 @@ macro(libmamba_create_target target_name linkage output_name)
         elseif(WIN32)
 
             set(CMAKE_PREFIX_PATH "$ENV{VCPKG_ROOT}/installed/x64-windows-static-md/")
-            set(ENABLE_WIN32_XMLLITE ON) # libarchive uses xmllite on windows if using libxml and not expat
+            set(ENABLE_WIN32_XMLLITE ON) # libarchive uses xmllite on windows if using libxml and
+                                         # not expat
 
             # For Windows we have a vcpkg based build system right now.
             find_package(LibArchive MODULE REQUIRED)

--- a/libmamba/CMakeLists.txt
+++ b/libmamba/CMakeLists.txt
@@ -583,7 +583,7 @@ macro(libmamba_create_target target_name linkage output_name)
                 ${target_name}
                 PUBLIC
                     ${CRYPTO_LIBRARIES}
-                    XmlLite.lib
+                    XmlLite.lib # required by libarchive
                     ${LibArchive_LIBRARY}
                     ${LIBXML2_LIBRARY}
                     ${ICONV_LIBRARY}

--- a/libmamba/CMakeLists.txt
+++ b/libmamba/CMakeLists.txt
@@ -562,8 +562,16 @@ macro(libmamba_create_target target_name linkage output_name)
         elseif(WIN32)
 
             set(CMAKE_PREFIX_PATH "$ENV{VCPKG_ROOT}/installed/x64-windows-static-md/")
-            set(ENABLE_WIN32_XMLLITE ON) # libarchive uses xmllite on windows if using libxml and
-                                         # not expat
+            
+            # TODO AND CONTEXT: We found a link error in libarchive which lacked a link to
+            # XmlLite which is provided by Windows. libarchive has cmake
+            # scripts doing the necessary work to link that library but for some
+            # reason we couldnt idenfity it is not linking in this specific case
+            # (it was before but the version changed apparently). As a workaround
+            # we manually link with that required library but a better solution
+            # would be to find why libarchive doesnt do it itself.
+            set(SYSTEM_PROVIDED_LIBRARIES XmlLite.lib) # required by libarchive
+            set(ENABLE_WIN32_XMLLITE ON)
 
             # For Windows we have a vcpkg based build system right now.
             find_package(LibArchive MODULE REQUIRED)
@@ -584,7 +592,7 @@ macro(libmamba_create_target target_name linkage output_name)
                 ${target_name}
                 PUBLIC
                     ${CRYPTO_LIBRARIES}
-                    XmlLite.lib # required by libarchive
+                    ${SYSTEM_PROVIDED_LIBRARIES}
                     ${LibArchive_LIBRARY}
                     ${LIBXML2_LIBRARY}
                     ${ICONV_LIBRARY}

--- a/libmamba/CMakeLists.txt
+++ b/libmamba/CMakeLists.txt
@@ -562,6 +562,7 @@ macro(libmamba_create_target target_name linkage output_name)
         elseif(WIN32)
 
             set(CMAKE_PREFIX_PATH "$ENV{VCPKG_ROOT}/installed/x64-windows-static-md/")
+            set(ENABLE_WIN32_XMLLITE ON) # libarchive uses xmllite on windows if using libxml and not expat
 
             # For Windows we have a vcpkg based build system right now.
             find_package(LibArchive MODULE REQUIRED)

--- a/libmamba/CMakeLists.txt
+++ b/libmamba/CMakeLists.txt
@@ -562,7 +562,7 @@ macro(libmamba_create_target target_name linkage output_name)
         elseif(WIN32)
 
             set(CMAKE_PREFIX_PATH "$ENV{VCPKG_ROOT}/installed/x64-windows-static-md/")
-            
+
             # TODO AND CONTEXT: We found a link error in libarchive which lacked a link to XmlLite
             # which is provided by Windows. libarchive has cmake scripts doing the necessary work to
             # link that library but for some reason we couldnt identify it is not linking in this

--- a/libmamba/CMakeLists.txt
+++ b/libmamba/CMakeLists.txt
@@ -563,13 +563,12 @@ macro(libmamba_create_target target_name linkage output_name)
 
             set(CMAKE_PREFIX_PATH "$ENV{VCPKG_ROOT}/installed/x64-windows-static-md/")
             
-            # TODO AND CONTEXT: We found a link error in libarchive which lacked a link to
-            # XmlLite which is provided by Windows. libarchive has cmake
-            # scripts doing the necessary work to link that library but for some
-            # reason we couldnt idenfity it is not linking in this specific case
-            # (it was before but the version changed apparently). As a workaround
-            # we manually link with that required library but a better solution
-            # would be to find why libarchive doesnt do it itself.
+            # TODO AND CONTEXT: We found a link error in libarchive which lacked a link to XmlLite
+            # which is provided by Windows. libarchive has cmake scripts doing the necessary work to
+            # link that library but for some reason we couldnt identify it is not linking in this
+            # specific case (it was before but the version changed apparently). As a workaround we
+            # manually link with that required library but a better solution would be to find why
+            # libarchive doesnt do it itself.
             set(SYSTEM_PROVIDED_LIBRARIES XmlLite.lib) # required by libarchive
             set(ENABLE_WIN32_XMLLITE ON)
 

--- a/libmamba/src/util/encoding.cpp
+++ b/libmamba/src/util/encoding.cpp
@@ -5,6 +5,7 @@
 // The full license is in the file LICENSE, distributed with this software.
 
 #include <array>
+#include <cassert>
 #include <cstdint>
 #include <cstring>
 #include <ranges>

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -3,8 +3,11 @@
   "dependencies": [
     "zstd",
     "curl",
-    "libxml2",
     "libiconv",
+    {
+      "features": ["iconv", "lzma", "zlib"],
+      "name": "libxml2"
+    },
     {
       "name": "winreg",
       "platform": "windows"

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -3,6 +3,8 @@
   "dependencies": [
     "zstd",
     "curl",
+    "libxml2",
+    "libiconv",
     {
       "name": "winreg",
       "platform": "windows"

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -10,7 +10,7 @@
       "platform": "windows"
     },
     {
-      "features": ["bzip2", "lz4", "lzma", "lzo", "crypto", "zstd"],
+      "features": ["bzip2", "lz4", "lzma", "lzo", "crypto", "zstd", "xar"],
       "name": "libarchive"
     },
     {

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -10,7 +10,7 @@
       "platform": "windows"
     },
     {
-      "features": ["bzip2", "lz4", "lzma", "lzo", "crypto", "zstd", "xar"],
+      "features": ["bzip2", "lz4", "lzma", "lzo", "crypto", "zstd"],
       "name": "libarchive"
     },
     {


### PR DESCRIPTION
# Description

API changes in pybind11 v3.0.0 breaks the CI. We didnt plan that change so we restrict mamba's build to use the previous versions.

## Type of Change

<!-- Please skip this part if you are already using conventional commit keywords in the PR title. -->

- [ ] Bugfix
- [ ] Feature / enhancement
- [ ] CI / Documentation
- [x] Maintenance

## Checklist

- [ ] My code follows the general style and conventions of the codebase, ensuring consistency
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have run `pre-commit run --all` locally in the source folder and confirmed that there are no linter errors.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
