### PR TITLE
fix: list dependencies pulled with uv

### DIFF
--- a/libmamba/src/core/prefix_data.cpp
+++ b/libmamba/src/core/prefix_data.cpp
@@ -304,7 +304,8 @@ namespace mamba
             for (const auto& package : j["installed"])
             {
                 // Get the package metadata, if installed with `pip`
-                if (package.contains("installer") && package["installer"] == "pip")
+                if (package.contains("installer")
+                    && (package["installer"] == "pip" || package["installer"] == "uv"))
                 {
                     if (package.contains("metadata"))
                     {

--- a/micromamba/tests/test_list.py
+++ b/micromamba/tests/test_list.py
@@ -203,6 +203,48 @@ def test_list_with_pip(tmp_home, tmp_root_prefix, tmp_path, no_pip_flag):
         assert all(package["name"] != "numpy" for package in res)
 
 
+env_yaml_content_to_install_numpy_with_uv = """
+channels:
+- conda-forge
+dependencies:
+- uv
+- pip:
+  - pandas==2.2.3
+"""
+
+
+@pytest.mark.parametrize("shared_pkgs_dirs", [True], indirect=True)
+def test_list_with_uv(tmp_home, tmp_root_prefix, tmp_path):
+    env_name = "env-list_with_uv"
+    tmp_root_prefix / "envs" / env_name
+
+    env_file_yml = tmp_path / "test_env_yaml_content_to_install_numpy_with_uv.yaml"
+    env_file_yml.write_text(env_yaml_content_to_install_numpy_with_uv)
+
+    helpers.create("-n", env_name, "python=3.12", "--json", no_dry_run=True)
+    helpers.install("-n", env_name, "-f", env_file_yml, "--json", no_dry_run=True)
+
+    res = helpers.umamba_list("-n", env_name, "--json")
+    assert any(
+        package["name"] == "pandas"
+        and package["version"] == "2.2.3"
+        and package["base_url"] == "https://pypi.org/"
+        and package["build_string"] == "pypi_0"
+        and package["channel"] == "pypi"
+        and package["platform"] == sys.platform + "-" + platform.machine()
+        for package in res
+    )
+    # Check that dependencies are listed
+    assert any(
+        package["name"] == "numpy"
+        and package["base_url"] == "https://pypi.org/"
+        and package["build_string"] == "pypi_0"
+        and package["channel"] == "pypi"
+        and package["platform"] == sys.platform + "-" + platform.machine()
+        for package in res
+    )
+
+
 @pytest.mark.parametrize("env_selector", ["name", "prefix"])
 @pytest.mark.parametrize("shared_pkgs_dirs", [True], indirect=True)
 def test_not_existing(tmp_home, tmp_root_prefix, tmp_xtensor_env, env_selector):


### PR DESCRIPTION
# Description

The equivalent of https://github.com/mamba-org/mamba/pull/3963 for when uv is used by mamba to install dependencies.

Fixes https://github.com/mamba-org/mamba/issues/4013

## Type of Change

<!-- Please skip this part if you are already using conventional commit keywords in the PR title. -->

- [x] Bugfix
- [ ] Feature / enhancement
- [ ] CI / Documentation
- [ ] Maintenance

## Checklist

- [x] My code follows the general style and conventions of the codebase, ensuring consistency
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have run `pre-commit run --all` locally in the source folder and confirmed that there are no linter errors.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
