### PR TITLE
Fix install of /etc/profile.d/mamba.sh when `--prefix` is set

### DIFF
--- a/micromamba/CMakeLists.txt
+++ b/micromamba/CMakeLists.txt
@@ -5,9 +5,6 @@
 # The full license is in the file LICENSE, distributed with this software.
 
 cmake_minimum_required(VERSION 3.16...4.1)
-cmake_policy(SET CMP0025 NEW) # Introduced in cmake 3.0
-cmake_policy(SET CMP0077 NEW) # Introduced in cmake 3.13
-cmake_policy(SET CMP0192 NEW) # Introduced in cmake 4.1
 project(micromamba)
 
 include(GNUInstallDirs)


### PR DESCRIPTION
Fixes #4055

TODO: Is updating `cmake_minimum_required` correct or is there a way for people to get that policy active with lower versions?