### PR TITLE
fix: proxy both micromamba and mamba with fish function

### DIFF
--- a/libmamba/data/mamba.fish
+++ b/libmamba/data/mamba.fish
@@ -54,7 +54,6 @@ if not set -q MAMBA_NO_PROMPT
 end
 
 
-function micromamba --inherit-variable MAMBA_EXE
   if test (count $argv) -lt 1 || contains -- --help $argv
     $MAMBA_EXE $argv
   else
@@ -72,7 +71,13 @@ function micromamba --inherit-variable MAMBA_EXE
   end
 end
 
+function mamba --inherit-variable MAMBA_EXE
+  __fish_mamba_wrapper
+end
 
+function micromamba --inherit-variable MAMBA_EXE
+  __fish_mamba_wrapper
+end
 
 # Autocompletions below
 


### PR DESCRIPTION
# Description

<!-- Please include a summary of the changes and the related issue. -->

Abstracted the logic of `mamba` cli wrapper fish function, and proxy both `micromamba` and `mamba` usage through it.

This PR will fix #3847.

## Type of Change

<!-- Please skip this part if you are already using conventional commit keywords in the PR title. -->

- [x] Bugfix
- [ ] Feature / enhancement
- [ ] CI / Documentation
- [ ] Maintenance

## Checklist

- [x] My code follows the general style and conventions of the codebase, ensuring consistency
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have run `pre-commit run --all` locally in the source folder and confirmed that there are no linter errors.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
