### PR TITLE
fix: fix automatic pretty printing with "mamba search"

### DIFF
--- a/micromamba/src/repoquery.cpp
+++ b/micromamba/src/repoquery.cpp
@@ -69,7 +69,7 @@ namespace
         // show the pretty single package view.
         if (query == mamba::QueryType::Search
             && (options.pretty_print
-                || specs_has_wildcard(options.specs.cbegin(), options.specs.cend())))
+                || !specs_has_wildcard(options.specs.cbegin(), options.specs.cend())))
         {
             format = mamba::QueryResultFormat::Pretty;
         }


### PR DESCRIPTION
# Description

`mamba search` without wildcards is supposed to auto-enable pretty printing. (with package info)  
`mamba search` **with** wildcards should just print everything as a table.

Currently, it does the opposite, spamming the terminal with lots of package details when a wildcard is used. (see below for an example with the `opencv` package)

This PR fixes the issue and makes it work the way it should.

## Type of Change

- [x] Bugfix
- [ ] Feature / enhancement
- [ ] CI / Documentation
- [ ] Maintenance

## Checklist

- [x] My code follows the general style and conventions of the codebase, ensuring consistency
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have run `pre-commit run --all` locally in the source folder and confirmed that there are no linter errors.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes

## Other

current output:

```
$ mamba search "opencv"
Getting repodata from channels...

conda-forge/linux-64                                        Using cache
conda-forge/noarch                                          Using cache
 Name   Version  Build                                          Channel     Subdir  
─────────────────────────────────────────────────────────────────────────────────────
 opencv 4.9.0    headless_py310h18fe71b_12       (+ 161 builds) conda-forge linux-64
 opencv 4.8.1    py310h60d20e8_4                 (+  44 builds) conda-forge linux-64
 opencv 4.8.0    py310hff52083_0                 (+  26 builds) conda-forge linux-64
 opencv 4.7.0    py310hff52083_0                 (+  41 builds) conda-forge linux-64
 opencv 4.6.0    py310hff52083_7                 (+  59 builds) conda-forge linux-64
 opencv 4.5.5    py310hff52083_10                (+  63 builds) conda-forge linux-64
 opencv 4.5.3    py310hff52083_8                 (+  27 builds) conda-forge linux-64
 opencv 4.5.2    py36h5fab9bb_0                  (+   8 builds) conda-forge linux-64
 opencv 4.5.1    py36h5fab9bb_0                  (+   9 builds) conda-forge linux-64
 opencv 4.5.0    py36_0                          (+  30 builds) conda-forge linux-64
 opencv 4.4.0    py36_2                          (+   6 builds) conda-forge linux-64
 opencv 4.3.0    py36_0                          (+   8 builds) conda-forge linux-64
 opencv 4.2.0    py27_0                          (+  26 builds) conda-forge linux-64
 opencv 4.12.0   headless_py310h89e5e42_0        (+  45 builds) conda-forge linux-64
 opencv 4.11.0   headless_py310h1766cdc_0        (+  99 builds) conda-forge linux-64
 opencv 4.10.0   headless_py310h1766cdc_14       (+ 275 builds) conda-forge linux-64
 opencv 4.1.2    0                               (+   5 builds) conda-forge linux-64
 opencv 4.1.1    3                               (+  10 builds) conda-forge linux-64
 opencv 4.1.0    py27h3aa1047_5                  (+  20 builds) conda-forge linux-64
 opencv 4.0.1    py27_blas_openblash26fe798_200  (+   4 builds) conda-forge linux-64
 opencv 4.0.0    py27_blas_openblash26fe798_200  (+   2 builds) conda-forge linux-64
 opencv 3.4.9    py27_1                          (+   7 builds) conda-forge linux-64
 opencv 3.4.8    py27_7                          (+   3 builds) conda-forge linux-64
 opencv 3.4.7    4                               (+  29 builds) conda-forge linux-64
 opencv 3.4.4    py27_blas_openblash26fe798_1204 (+  21 builds) conda-forge linux-64
 opencv 3.4.3    py27_blas_openblash1006a3a_201  (+   4 builds) conda-forge linux-64
 opencv 3.4.1    py27_blas_openblas_200          (+   8 builds) conda-forge linux-64
 opencv 3.3.0    py27_blas_openblas_200          (+  14 builds) conda-forge linux-64
 opencv 3.2.0    np111py27_blas_openblas_200     (+  32 builds) conda-forge linux-64
 opencv 3.1.0    np110py27_0                     (+  15 builds) conda-forge linux-64
 opencv 2.4.13.4 py27_blas_openblas_0            (+   1 builds) conda-forge linux-64
 opencv 2.4.13   np111py27_0                     (+   4 builds) conda-forge linux-64
 opencv 2.4.12   np110py27_0                     (+   6 builds) conda-forge linux-64
$ mamba search "opencv*"
Getting repodata from channels...

conda-forge/linux-64                                        Using cache
conda-forge/noarch                                          Using cache
opencv 4.10.0 headless_py310h1766cdc_14 (+ 275 builds)
──────────────────────────────────────────────────────

 Name            opencv
 Version         4.10.0
 Build           headless_py310h1766cdc_14
 Size            26 kB
 License         Apache-2.0
 Subdir          linux-64
 File Name       opencv-4.10.0-headless_py310h1766cdc_14.conda
 URL             https://conda.anaconda.org/conda-forge/linux-64/opencv-4.10.0-headless_py310h1766cdc_14.conda
 MD5             33bd9dbaf91cb1e5b765e795bef71267
 SHA256          edf4c40c9b78437ce847b490041ebc6413acd2379a5735cd05d65b21173700c9

 Dependencies:
  - hdf5 >=1.14.3,<1.14.4.0a0
  - libopencv 4.10.0 headless_py310h83326b1_14
  - libprotobuf >=5.28.3,<5.28.4.0a0
  - py-opencv 4.10.0 headless_py310h17dd4f5_14
  - python_abi 3.10.* *_cp310

 Other Versions (32):

  Version Build                                   
 ──────────────────────────────────────────────────
  4.9.0   headless_py310h18fe71b_12 (+ 161 builds)
  4.8.1   py310h60d20e8_4           (+  44 builds)
  ...     (28 hidden versions)                 ...
  2.4.13  np111py27_0               (+   4 builds)
  2.4.12  np110py27_0               (+   6 builds)

opencv-cuda 4.10.0 qt5_py310h89e78a7_709
────────────────────────────────────────

 Name            opencv-cuda
 Version         4.10.0
 Build           qt5_py310h89e78a7_709
 Size            25 kB
 License         Apache-2.0
 Subdir          linux-64
 File Name       opencv-cuda-4.10.0-qt5_py310h89e78a7_709.tar.bz2
 URL             https://conda.linkworks.io/t/*****/get/link-developers/linux-64/opencv-cuda-4.10.0-qt5_py310h89e78a7_709.tar.bz2
 MD5             af89704dc2a3e6d79643b8833316131c
 SHA256          947abc88156c52d879bf5fa0112909c01ecfbe7441c72b204fc7872c1f90a722

 Dependencies:
  - libopencv-cuda 4.10.0 qt5_py310h83c7aba_709
  - libprotobuf >=5.27.5,<5.27.6.0a0
  - py-opencv-cuda 4.10.0 qt5_py310h99a4758_709
  - python_abi 3.10.* *_cp310
```