### PR TITLE
Fix empty depends/constrains when installing explicit spec files

### DIFF
--- a/libmamba/src/core/package_fetcher.cpp
+++ b/libmamba/src/core/package_fetcher.cpp
@@ -438,14 +438,13 @@ namespace mamba
 
         // For explicit spec files (URLs), m_package_info has empty depends/constrains arrays
         // that would overwrite the correct values from index.json. Remove these empty fields.
-        auto depends_it = repodata_record.find("depends");
-        auto constrains_it = repodata_record.find("constrains");
-
-        if (depends_it != repodata_record.end() && depends_it->empty())
+        if (auto depends_it = repodata_record.find("depends");
+            depends_it != repodata_record.end() && depends_it->empty())
         {
             repodata_record.erase("depends");
         }
-        if (constrains_it != repodata_record.end() && constrains_it->empty())
+        if (auto constrains_it = repodata_record.find("constrains");
+            constrains_it != repodata_record.end() && constrains_it->empty())
         {
             repodata_record.erase("constrains");
         }

--- a/libmamba/src/core/package_fetcher.cpp
+++ b/libmamba/src/core/package_fetcher.cpp
@@ -436,6 +436,20 @@ namespace mamba
 
         nlohmann::json repodata_record = m_package_info;
 
+        // For explicit spec files (URLs), m_package_info has empty depends/constrains arrays
+        // that would overwrite the correct values from index.json. Remove these empty fields.
+        auto depends_it = repodata_record.find("depends");
+        auto constrains_it = repodata_record.find("constrains");
+
+        if (depends_it != repodata_record.end() && depends_it->empty())
+        {
+            repodata_record.erase("depends");
+        }
+        if (constrains_it != repodata_record.end() && constrains_it->empty())
+        {
+            repodata_record.erase("constrains");
+        }
+
         // To take correction of packages metadata (e.g. made using repodata patches) into account,
         // we insert the index into the repodata record to only add new fields from the index
         // while keeping the existing fields from the repodata record.

--- a/libmamba/tests/src/core/test_package_fetcher.cpp
+++ b/libmamba/tests/src/core/test_package_fetcher.cpp
@@ -96,6 +96,9 @@ namespace
     TEST_CASE("extract_creates_repodata_record_with_dependencies")
     {
         // Test that PackageFetcher.extract() preserves dependencies in repodata_record.json
+#ifdef _WIN32
+        SKIP("Test not supported on Windows");
+#endif
 
         auto& ctx = mambatests::context();
         TemporaryDirectory temp_dir;

--- a/libmamba/tests/src/core/test_package_fetcher.cpp
+++ b/libmamba/tests/src/core/test_package_fetcher.cpp
@@ -4,10 +4,16 @@
 //
 // The full license is in the file LICENSE, distributed with this software.
 
+#include <fstream>
+
 #include <catch2/catch_all.hpp>
 
 #include "mamba/core/context.hpp"
 #include "mamba/core/package_fetcher.hpp"
+#include "mamba/core/util.hpp"
+#include "mamba/fs/filesystem.hpp"
+
+#include "mambatests.hpp"
 
 namespace
 {
@@ -85,5 +91,103 @@ namespace
             // Should correspond to PackageFetcher::url_path()
             REQUIRE(req.url_path == "linux-64/xtensor-0.25.0-h00ab1b0_0.conda");
         }
+    }
+
+    TEST_CASE("extract_creates_repodata_record_with_dependencies")
+    {
+        // Test that PackageFetcher.extract() preserves dependencies in repodata_record.json
+        // This test FAILS when the bug is present, PASSES when fixed
+
+        auto& ctx = mambatests::context();
+        TemporaryDirectory temp_dir;
+        MultiPackageCache package_caches{ { temp_dir.path() / "pkgs" }, ctx.validation_params };
+
+        // Create PackageInfo from URL (exhibits the problematic empty dependencies)
+        static constexpr std::string_view url = "https://conda.anaconda.org/conda-forge/linux-64/zeromq-4.3.5-h59595ed_1.conda";
+        auto pkg_info = specs::PackageInfo::from_url(url).value();
+
+        // Verify precondition: PackageInfo from URL has empty dependencies
+        REQUIRE(pkg_info.dependencies.empty());
+        REQUIRE(pkg_info.constrains.empty());
+
+        // Create a minimal but valid conda package structure
+        auto pkg_extract_dir = temp_dir.path() / "pkgs"
+                               / (pkg_info.filename.substr(0, pkg_info.filename.size() - 6));
+        auto info_dir = pkg_extract_dir / "info";
+        fs::create_directories(info_dir);
+
+        // Create index.json with dependencies (what real packages contain)
+        nlohmann::json index_json;
+        index_json["name"] = pkg_info.name;
+        index_json["version"] = pkg_info.version;
+        index_json["build"] = pkg_info.build_string;
+        index_json["depends"] = nlohmann::json::array({ "libgcc-ng >=12",
+                                                        "libsodium >=1.0.18,<1.0.19.0a0" });
+        index_json["constrains"] = nlohmann::json::array();
+        index_json["size"] = 123456;
+
+        std::ofstream index_file(info_dir / "index.json");
+        index_file << index_json.dump(2);
+        index_file.close();
+
+        // Create minimal required metadata files for a valid conda package
+        std::ofstream paths_file(info_dir / "paths.json");
+        paths_file << R"({"paths": [], "paths_version": 1})";
+        paths_file.close();
+
+        // Create a simple tar.bz2 archive that contains our info directory
+        // A .conda file is a zip archive, but let's use .tar.bz2 format for simplicity
+        auto tarball_path = temp_dir.path() / "pkgs"
+                            / (pkg_info.filename.substr(0, pkg_info.filename.size() - 6) + ".tar.bz2");
+
+        // Use system tar to create a valid tar.bz2 archive
+        std::string tar_cmd = "cd " + pkg_extract_dir.string() + " && tar -cjf "
+                              + tarball_path.string() + " info/";
+        int result = std::system(tar_cmd.c_str());
+        REQUIRE(result == 0);
+        REQUIRE(fs::exists(tarball_path));
+
+        // Update pkg_info to use .tar.bz2 format instead of .conda
+        auto modified_pkg_info = pkg_info;
+        modified_pkg_info.filename = pkg_info.filename.substr(0, pkg_info.filename.size() - 6)
+                                     + ".tar.bz2";
+
+        // Clean up the extracted directory so PackageFetcher can extract fresh
+        fs::remove_all(pkg_extract_dir);
+
+        // Create PackageFetcher with modified package info
+        PackageFetcher pkg_fetcher{ modified_pkg_info, package_caches };
+
+        // Set up extract options
+        ExtractOptions options;
+        options.sparse = false;
+        options.subproc_mode = extract_subproc_mode::mamba_package;
+
+        // Call extract - this is the actual method we're testing
+        bool extract_success = pkg_fetcher.extract(options);
+        REQUIRE(extract_success);
+
+        // Verify that repodata_record.json was created with correct dependencies
+        auto repodata_record_path = pkg_extract_dir / "info" / "repodata_record.json";
+        REQUIRE(fs::exists(repodata_record_path));
+
+        // Read and parse the created repodata_record.json
+        std::ifstream repodata_file(repodata_record_path);
+        nlohmann::json repodata_record;
+        repodata_file >> repodata_record;
+
+        // THE TEST: Dependencies should be preserved from index.json, not empty
+        // This will FAIL with the bug (empty arrays preserved)
+        // This will PASS with the fix (dependencies from index.json preserved)
+        REQUIRE(repodata_record.contains("depends"));
+        REQUIRE(repodata_record["depends"].is_array());
+        REQUIRE(repodata_record["depends"].size() == 2);
+        REQUIRE(repodata_record["depends"][0] == "libgcc-ng >=12");
+        REQUIRE(repodata_record["depends"][1] == "libsodium >=1.0.18,<1.0.19.0a0");
+
+        // Also verify constrains is handled correctly
+        REQUIRE(repodata_record.contains("constrains"));
+        REQUIRE(repodata_record["constrains"].is_array());
+        REQUIRE(repodata_record["constrains"].empty());
     }
 }

--- a/libmamba/tests/src/core/test_package_fetcher.cpp
+++ b/libmamba/tests/src/core/test_package_fetcher.cpp
@@ -10,6 +10,7 @@
 
 #include "mamba/core/context.hpp"
 #include "mamba/core/package_fetcher.hpp"
+#include "mamba/core/package_handling.hpp"
 #include "mamba/core/util.hpp"
 #include "mamba/fs/filesystem.hpp"
 
@@ -142,11 +143,15 @@ namespace
         // A .conda file is a zip archive, but let's use .tar.bz2 format for simplicity
         auto tarball_path = temp_dir.path() / "pkgs" / (pkg_basename + ".tar.bz2");
 
-        // Use system tar to create a valid tar.bz2 archive
-        std::string tar_cmd = "cd \"" + pkg_extract_dir.string() + "\" && tar -cjf \""
-                              + tarball_path.string() + "\" info/";
-        int result = std::system(tar_cmd.c_str());
-        REQUIRE(result == 0);
+        // Use mamba's create_archive function to create a cross-platform tar.bz2 archive
+        create_archive(
+            pkg_extract_dir,
+            tarball_path,
+            compression_algorithm::bzip2,
+            /* compression_level= */ 1,
+            /* compression_threads= */ 1,
+            /* filter= */ nullptr
+        );
         REQUIRE(fs::exists(tarball_path));
 
         // Update pkg_info to use .tar.bz2 format instead of .conda

--- a/libmamba/tests/src/core/test_package_fetcher.cpp
+++ b/libmamba/tests/src/core/test_package_fetcher.cpp
@@ -125,12 +125,12 @@ namespace
         index_json["constrains"] = nlohmann::json::array();
         index_json["size"] = 123456;
 
-        std::ofstream index_file(info_dir / "index.json");
+        std::ofstream index_file((info_dir / "index.json").string());
         index_file << index_json.dump(2);
         index_file.close();
 
         // Create minimal required metadata files for a valid conda package
-        std::ofstream paths_file(info_dir / "paths.json");
+        std::ofstream paths_file((info_dir / "paths.json").string());
         paths_file << R"({"paths": [], "paths_version": 1})";
         paths_file.close();
 
@@ -171,7 +171,7 @@ namespace
         REQUIRE(fs::exists(repodata_record_path));
 
         // Read and parse the created repodata_record.json
-        std::ifstream repodata_file(repodata_record_path);
+        std::ifstream repodata_file(repodata_record_path.string());
         nlohmann::json repodata_record;
         repodata_file >> repodata_record;
 

--- a/libmamba/tests/src/core/test_package_fetcher.cpp
+++ b/libmamba/tests/src/core/test_package_fetcher.cpp
@@ -125,7 +125,7 @@ namespace
         index_json["version"] = pkg_info.version;
         index_json["build"] = pkg_info.build_string;
         index_json["depends"] = nlohmann::json::array({ "python >=3.7" });
-        index_json["constrains"] = nlohmann::json::array();
+        index_json["constrains"] = nlohmann::json::array({ "pytz" });
         index_json["size"] = 123456;
 
         {
@@ -190,6 +190,7 @@ namespace
         // Also verify constrains is handled correctly
         REQUIRE(repodata_record.contains("constrains"));
         REQUIRE(repodata_record["constrains"].is_array());
-        REQUIRE(repodata_record["constrains"].empty());
+        REQUIRE(repodata_record["constrains"].size() == 1);
+        REQUIRE(repodata_record["constrains"][0] == "pytz");
     }
 }

--- a/libmamba/tests/src/core/test_package_fetcher.cpp
+++ b/libmamba/tests/src/core/test_package_fetcher.cpp
@@ -96,7 +96,6 @@ namespace
     TEST_CASE("extract_creates_repodata_record_with_dependencies")
     {
         // Test that PackageFetcher.extract() preserves dependencies in repodata_record.json
-        // This test FAILS when the bug is present, PASSES when fixed
 
         auto& ctx = mambatests::context();
         TemporaryDirectory temp_dir;
@@ -176,9 +175,6 @@ namespace
         nlohmann::json repodata_record;
         repodata_file >> repodata_record;
 
-        // THE TEST: Dependencies should be preserved from index.json, not empty
-        // This will FAIL with the bug (empty arrays preserved)
-        // This will PASS with the fix (dependencies from index.json preserved)
         REQUIRE(repodata_record.contains("depends"));
         REQUIRE(repodata_record["depends"].is_array());
         REQUIRE(repodata_record["depends"].size() == 2);


### PR DESCRIPTION
# Description

This PR fixes a bug where empty dependencies and constraints were not properly handled when installing packages from explicit spec files. This fixes #4070 and #4052 

## Type of Change

<!-- Please skip this part if you are already using conventional commit keywords in the PR title. -->

- [x] Bugfix
- [ ] Feature / enhancement
- [ ] CI / Documentation
- [ ] Maintenance

## Checklist

- [x] My code follows the general style and conventions of the codebase, ensuring consistency
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have run `pre-commit run --all` locally in the source folder and confirmed that there are no linter errors.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
