### PR TITLE
Update README to remove QuantStack Zulip link

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,8 +174,7 @@ Only `mamba` and `micromamba` 2.0 and later are supported and are actively devel
 
 The `1.x` branch is only maintained for addressing security issues such as CVEs.
 
-For questions, you can also join us on the [QuantStack Zulip](https://quantstack.zulipchat.com/)
-or on the [Conda Zulip](https://conda.zulipchat.com/#narrow/channel/457607-general) (note that this project is not officially affiliated with `conda` or Anaconda Inc.).
+For questions, you can also join us on the [Conda Zulip](https://conda.zulipchat.com/#narrow/channel/457607-general) (note that this project is not officially affiliated with `conda` or Anaconda Inc.).
 
 ## License
 


### PR DESCRIPTION
# Description

Removed mention of QuantStack Zulip from README.

Follow-up to #4103 since the QuantStack Zulip is invite-only as found out in #4104.

<!-- Please include a summary of the changes and the related issue. -->

## Type of Change

<!-- Please skip this part if you are already using conventional commit keywords in the PR title. -->

- [ ] Bugfix
- [ ] Feature / enhancement
- [x] CI / Documentation
- [ ] Maintenance

## Checklist

- [ ] My code follows the general style and conventions of the codebase, ensuring consistency
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have run `pre-commit run --all` locally in the source folder and confirmed that there are no linter errors.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
