### PR TITLE
fix: Solve bug when changing permissions with no modification right

### DIFF
--- a/libmamba/include/mamba/core/util.hpp
+++ b/libmamba/include/mamba/core/util.hpp
@@ -62,10 +62,10 @@ namespace mamba
 
     inline void make_executable(const fs::u8path& p)
     {
-        fs::permissions(
-            p,
-            fs::perms::owner_all | fs::perms::group_all | fs::perms::others_read | fs::perms::others_exec
-        );
+        const auto permissions = fs::perms::owner_all | fs::perms::group_all |
+          fs::perms::others_read | fs::perms::others_exec;
+        if (! fs::has_permissions(p, permissions))
+          fs::permissions(p, permissions);
     }
 
     // @return `true` if `TemporaryFile` will not delete files once destroy.

--- a/libmamba/include/mamba/core/util.hpp
+++ b/libmamba/include/mamba/core/util.hpp
@@ -62,10 +62,12 @@ namespace mamba
 
     inline void make_executable(const fs::u8path& p)
     {
-        const auto permissions = fs::perms::owner_all | fs::perms::group_all |
-          fs::perms::others_read | fs::perms::others_exec;
-        if (! fs::has_permissions(p, permissions))
-          fs::permissions(p, permissions);
+        const auto permissions = fs::perms::owner_all | fs::perms::group_all
+                                 | fs::perms::others_read | fs::perms::others_exec;
+        if (!fs::has_permissions(p, permissions))
+        {
+            fs::permissions(p, permissions);
+        }
     }
 
     // @return `true` if `TemporaryFile` will not delete files once destroy.

--- a/libmamba/include/mamba/fs/filesystem.hpp
+++ b/libmamba/include/mamba/fs/filesystem.hpp
@@ -1140,7 +1140,7 @@ namespace mamba::fs
     }
 
     // Check if we have modification rights on a path
-    bool has_permissions(const u8path&, fs::perms const&);
+    bool has_permissions(const u8path&, const fs::perms&);
 
     // void permissions(const path& p, perms prms, perm_options opts = perm_options::replace);
     // void permissions(const path& p, perms prms, error_code& ec) noexcept;

--- a/libmamba/include/mamba/fs/filesystem.hpp
+++ b/libmamba/include/mamba/fs/filesystem.hpp
@@ -1140,7 +1140,7 @@ namespace mamba::fs
     }
 
     // Check if we have modification rights on a path
-    bool has_modification_rights_on(const u8path& path);
+    bool has_permissions(const u8path&, fs::perms const&);
 
     // void permissions(const path& p, perms prms, perm_options opts = perm_options::replace);
     // void permissions(const path& p, perms prms, error_code& ec) noexcept;

--- a/libmamba/include/mamba/fs/filesystem.hpp
+++ b/libmamba/include/mamba/fs/filesystem.hpp
@@ -1139,6 +1139,9 @@ namespace mamba::fs
         return std::filesystem::last_write_time(path, new_time, std::forward<OtherArgs>(args)...);
     }
 
+    // Check if we have modification rights on a path
+    bool has_modification_rights_on(const u8path& path);
+
     // void permissions(const path& p, perms prms, perm_options opts = perm_options::replace);
     // void permissions(const path& p, perms prms, error_code& ec) noexcept;
     // void permissions(const path& p, perms prms, perm_options opts, error_code& ec);

--- a/libmamba/include/mamba/fs/filesystem.hpp
+++ b/libmamba/include/mamba/fs/filesystem.hpp
@@ -1139,7 +1139,12 @@ namespace mamba::fs
         return std::filesystem::last_write_time(path, new_time, std::forward<OtherArgs>(args)...);
     }
 
-    // Check if we have modification rights on a path
+    /* Check if we have modification rights on a path.
+     * This function is not a wrapping on a of std::filesystem function, but it
+     * uses std::filesystem::status().
+     * Exceptions may be thrown by std::filesystem::status() if the path is not
+     * valid.
+     */
     bool has_permissions(const u8path&, const fs::perms&);
 
     // void permissions(const path& p, perms prms, perm_options opts = perm_options::replace);

--- a/libmamba/src/core/subdir_index.cpp
+++ b/libmamba/src/core/subdir_index.cpp
@@ -1122,7 +1122,10 @@ namespace mamba
     auto create_cache_dir(const fs::u8path& cache_path) -> std::string
     {
         const auto cache_dir = cache_path / "cache";
-        fs::create_directories(cache_dir);
+        if (!std::filesystem::is_directory(cache_dir))
+        {
+            fs::create_directories(cache_dir);
+        }
 
         // Some filesystems don't support special permissions such as setgid on directories (e.g.
         // NFS). and fail if we try to set the setgid bit on the cache directory.
@@ -1141,17 +1144,21 @@ namespace mamba
             LOG_TRACE << "Set permissions on cache directory " << cache_dir << " to 'rwxrwxr-x'";
         }
 
-        std::error_code ec;
-        fs::permissions(cache_dir, fs::perms::set_gid, fs::perm_options::add, ec);
+        const auto setgid_perms = fs::perms::set_gid;
+        if (!fs::has_permissions(cache_dir, setgid_perms))
+        {
+            std::error_code ec;
+            fs::permissions(cache_dir, setgid_perms, fs::perm_options::add, ec);
 
-        if (!ec)
-        {
-            LOG_TRACE << "Set setgid bit on cache directory " << cache_dir;
-        }
-        else
-        {
-            LOG_TRACE << "Could not set setgid bit on cache directory " << cache_dir
-                      << "\nReason:" << ec.message() << "; ignoring and continuing";
+            if (!ec)
+            {
+                LOG_TRACE << "Set setgid bit on cache directory " << cache_dir;
+            }
+            else
+            {
+                LOG_TRACE << "Could not set setgid bit on cache directory " << cache_dir
+                          << "\nReason:" << ec.message() << "; ignoring and continuing";
+            }
         }
 
         return cache_dir.string();

--- a/libmamba/src/core/subdir_index.cpp
+++ b/libmamba/src/core/subdir_index.cpp
@@ -1135,8 +1135,11 @@ namespace mamba
 
         const auto permissions = fs::perms::owner_all | fs::perms::group_all
                                  | fs::perms::others_read | fs::perms::others_exec;
-        fs::permissions(cache_dir, permissions, fs::perm_options::replace);
-        LOG_TRACE << "Set permissions on cache directory " << cache_dir << " to 'rwxrwxr-x'";
+        if (! fs::has_permissions(cache_dir, permissions)) {
+            fs::permissions(cache_dir, permissions, fs::perm_options::replace);
+            LOG_TRACE << "Set permissions on cache directory " << cache_dir
+                << " to 'rwxrwxr-x'";
+        }
 
         std::error_code ec;
         fs::permissions(cache_dir, fs::perms::set_gid, fs::perm_options::add, ec);

--- a/libmamba/src/core/subdir_index.cpp
+++ b/libmamba/src/core/subdir_index.cpp
@@ -1135,10 +1135,10 @@ namespace mamba
 
         const auto permissions = fs::perms::owner_all | fs::perms::group_all
                                  | fs::perms::others_read | fs::perms::others_exec;
-        if (! fs::has_permissions(cache_dir, permissions)) {
+        if (!fs::has_permissions(cache_dir, permissions))
+        {
             fs::permissions(cache_dir, permissions, fs::perm_options::replace);
-            LOG_TRACE << "Set permissions on cache directory " << cache_dir
-                << " to 'rwxrwxr-x'";
+            LOG_TRACE << "Set permissions on cache directory " << cache_dir << " to 'rwxrwxr-x'";
         }
 
         std::error_code ec;

--- a/libmamba/src/fs/filesystem.cpp
+++ b/libmamba/src/fs/filesystem.cpp
@@ -12,7 +12,6 @@
 
 #ifndef _WIN32
 #include <fcntl.h>
-#include <grp.h>
 #include <pwd.h>
 #include <sys/stat.h>
 #include <unistd.h>

--- a/libmamba/src/fs/filesystem.cpp
+++ b/libmamba/src/fs/filesystem.cpp
@@ -12,7 +12,10 @@
 
 #ifndef _WIN32
 #include <fcntl.h>
+#include <grp.h>
+#include <pwd.h>
 #include <sys/stat.h>
+#include <unistd.h>
 // We can use the presence of UTIME_OMIT to detect platforms that provide
 // utimensat.
 #if defined(UTIME_OMIT)
@@ -77,6 +80,76 @@ namespace mamba::fs
 #else
         auto new_time = fs::file_time_type::clock::now();
         std::filesystem::last_write_time(path, new_time, ec);
+#endif
+    }
+
+
+    bool has_modification_rights_on(const u8path& path) {
+
+#if defined(_WIN32) // All Windows platforms
+        return true;
+
+#else // UNIX-like platforms
+
+        using std::filesystem::perms;
+
+        // Get permissions
+        auto perm = std::filesystem::status(path).permissions();
+
+        // Everybody can modify
+        if (perms::none != (perm & perms::others_write))
+            return true;
+
+        // Check user and/or group
+        if (perms::none != (perm & (perms::owner_write | perms::group_write))) {
+
+            // Get path status
+            struct stat info;
+            if (stat(path.string().c_str(), &info))
+                throw std::runtime_error("Unable to get status information for"
+                                         " path " + path.string() + ": "
+                                         + strerror(errno));
+
+            // Check user rights
+            if (perms::none != (perm & perms::owner_write)
+                && info.st_uid == geteuid())
+                return true;
+
+            // Check group rights
+            if (perms::none != (perm & perms::group_write)) {
+
+                // Check main group
+                if (info.st_gid == getegid())
+                    return true;
+
+                // Get user name
+                auto pwd = getpwuid(geteuid());
+                if (! pwd)
+                    throw std::runtime_error("Unable to get user name from user"
+                                             " ID "
+                                             + std::to_string(info.st_uid)
+                                             + ": " + strerror(errno));
+
+                // Get first group IDs
+                std::vector<gid_t> groups(16);
+                int ngroups = groups.size();
+                int n = getgrouplist(pwd->pw_name, info.st_gid,
+                                     groups.data(), &ngroups);
+                if (n < 0) {
+                    groups.resize(static_cast<size_t>(n));
+                    static_cast<void>(getgrouplist(pwd->pw_name, info.st_gid,
+                                                   groups.data(), &ngroups));
+                }
+                else
+                    groups.resize(static_cast<size_t>(ngroups));
+
+                // Find if file group is in list
+                auto it = std::find(groups.begin(), groups.end(), info.st_uid);
+                if (it != groups.end()) 
+                    return true;
+          }
+        }
+        return false;
 #endif
     }
 }

--- a/libmamba/src/fs/filesystem.cpp
+++ b/libmamba/src/fs/filesystem.cpp
@@ -84,72 +84,12 @@ namespace mamba::fs
     }
 
 
-    bool has_modification_rights_on(const u8path& path) {
+    bool has_permissions(const u8path& path, fs::perms const& perm) {
 
-#if defined(_WIN32) // All Windows platforms
-        return true;
+        // Get path permissions
+        auto p = std::filesystem::status(path).permissions();
 
-#else // UNIX-like platforms
-
-        using std::filesystem::perms;
-
-        // Get permissions
-        auto perm = std::filesystem::status(path).permissions();
-
-        // Everybody can modify
-        if (perms::none != (perm & perms::others_write))
-            return true;
-
-        // Check user and/or group
-        if (perms::none != (perm & (perms::owner_write | perms::group_write))) {
-
-            // Get path status
-            struct stat info;
-            if (stat(path.string().c_str(), &info))
-                throw std::runtime_error("Unable to get status information for"
-                                         " path " + path.string() + ": "
-                                         + strerror(errno));
-
-            // Check user rights
-            if (perms::none != (perm & perms::owner_write)
-                && info.st_uid == geteuid())
-                return true;
-
-            // Check group rights
-            if (perms::none != (perm & perms::group_write)) {
-
-                // Check main group
-                if (info.st_gid == getegid())
-                    return true;
-
-                // Get user name
-                auto pwd = getpwuid(geteuid());
-                if (! pwd)
-                    throw std::runtime_error("Unable to get user name from user"
-                                             " ID "
-                                             + std::to_string(info.st_uid)
-                                             + ": " + strerror(errno));
-
-                // Get first group IDs
-                std::vector<gid_t> groups(16);
-                int ngroups = groups.size();
-                int n = getgrouplist(pwd->pw_name, info.st_gid,
-                                     groups.data(), &ngroups);
-                if (n < 0) {
-                    groups.resize(static_cast<size_t>(n));
-                    static_cast<void>(getgrouplist(pwd->pw_name, info.st_gid,
-                                                   groups.data(), &ngroups));
-                }
-                else
-                    groups.resize(static_cast<size_t>(ngroups));
-
-                // Find if file group is in list
-                auto it = std::find(groups.begin(), groups.end(), info.st_uid);
-                if (it != groups.end()) 
-                    return true;
-          }
-        }
-        return false;
-#endif
+        // Path perms must include wanted perms
+        return perm == (p & perm);
     }
 }

--- a/libmamba/src/fs/filesystem.cpp
+++ b/libmamba/src/fs/filesystem.cpp
@@ -83,9 +83,8 @@ namespace mamba::fs
 #endif
     }
 
-
-    bool has_permissions(const u8path& path, fs::perms const& perm) {
-
+    bool has_permissions(const u8path& path, const fs::perms& perm)
+    {
         // Get path permissions
         auto p = std::filesystem::status(path).permissions();
 

--- a/libmamba/tests/src/core/test_filesystem.cpp
+++ b/libmamba/tests/src/core/test_filesystem.cpp
@@ -293,6 +293,91 @@ namespace mamba
         }
     }
 
+    namespace {
+        TEST_CASE("has_permissions()")
+        {
+            // Create temp folder
+            const auto tmp_dir = fs::temp_directory_path()
+                / "mamba-fs-has_permissions";
+            fs::create_directories(tmp_dir);
+
+            // Create file
+            const auto some_file = tmp_dir / "some_file";
+            {
+                std::ofstream ofs{ some_file.std_path(),
+                                   std::ofstream::binary
+                                       | std::ofstream::trunc };
+                ofs << "ABC" << std::endl;
+            }
+
+            // Set permissions
+            const auto perms = fs::perms::owner_read | fs::perms::owner_write
+                | fs::perms::group_read;
+            fs::permissions(some_file, perms, fs::perm_options::replace);
+
+            // Check permissions
+            REQUIRE(fs::has_permissions(some_file, perms));
+            REQUIRE(fs::has_permissions(some_file, fs::perms::owner_read));
+            REQUIRE(fs::has_permissions(some_file, fs::perms::owner_write));
+            REQUIRE(fs::has_permissions(some_file, fs::perms::group_read));
+            REQUIRE(fs::has_permissions(some_file, fs::perms::owner_read
+                                        | fs::perms::owner_write));
+            REQUIRE(fs::has_permissions(some_file, fs::perms::owner_read
+                                        | fs::perms::group_read));
+            REQUIRE(fs::has_permissions(some_file, fs::perms::owner_write
+                                        | fs::perms::group_read));
+            REQUIRE_FALSE(fs::has_permissions(some_file,
+                                              fs::perms::owner_exec));
+            REQUIRE_FALSE(fs::has_permissions(some_file,
+                                              fs::perms::group_write));
+            REQUIRE_FALSE(fs::has_permissions(some_file,
+                                              fs::perms::group_exec));
+            REQUIRE_FALSE(fs::has_permissions(some_file,
+                                              fs::perms::others_read));
+            REQUIRE_FALSE(fs::has_permissions(some_file,
+                                              fs::perms::others_write));
+            REQUIRE_FALSE(fs::has_permissions(some_file,
+                                              fs::perms::others_exec));
+            REQUIRE_FALSE(fs::has_permissions(some_file, fs::perms::owner_read
+                                        | fs::perms::owner_exec));
+
+            fs::remove_all(tmp_dir);
+        }
+
+        // 2025-11-27 make_executable() bug
+        TEST_CASE("Bug: failure when calling make_executable()"
+                  " on already executable file inside non-writable folder.")
+        {
+            // Create temp folder
+            const auto tmp_dir = fs::temp_directory_path()
+                / "mamba-fs-make_executable-2025-11-27-bug";
+            mamba::on_scope_exit _([&] { fs::remove_all(tmp_dir); });
+            const auto folder = tmp_dir / "some_folder";
+            fs::create_directories(folder);
+
+            // Create file
+            const auto some_file = tmp_dir / "some_file";
+            {
+                std::ofstream ofs{ some_file.std_path(),
+                                   std::ofstream::binary
+                                       | std::ofstream::trunc };
+                ofs << "ABC" << std::endl;
+            }
+
+            // Make executable
+            make_executable(some_file);
+
+            // Remove write permissions on folder
+            const auto perms = fs::perms::owner_read
+                | fs::perms::group_read | fs::perms::others_read;
+            fs::permissions(folder, perms, fs::perm_options::replace);
+
+            // Make executable (again!)
+            // This should not fail
+            make_executable(some_file);
+        }
+    }
+
     namespace
     {
         TEST_CASE("remove_readonly_file")


### PR DESCRIPTION
# Description

When trying to set execution mode for a file or setting permissions to cache directory, an error may occur if we have no modification right on the parent folder.
This error occurs regardless of the current permissions on the targeted file or folder.
Thus, even if we already have the required permissions on the targeted file or folder, the error occurs.

This pull request introduces a function `has_permissions()` that tests if we already have the wanted permissions on a file or folder.
This new function is used at the two places described above, in order to avoid a useless setting of permissions that would lead to an error.

## Type of Change

- [X] Bugfix
- [ ] Feature / enhancement
- [ ] CI / Documentation
- [ ] Maintenance

## Checklist

- [X] My code follows the general style and conventions of the codebase, ensuring consistency
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [X] I have run `pre-commit run --all` locally in the source folder and confirmed that there are no linter errors.
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing tests pass locally with my changes
