### PR TITLE
fixed test "load_file_specs" too strict

### DIFF
--- a/libmamba/tests/src/core/test_configuration.cpp
+++ b/libmamba/tests/src/core/test_configuration.cpp
@@ -325,10 +325,9 @@ namespace mamba
                 util::set_env("SOME_OTHER_PRIVATE_KEY", "kqf458r1h127de9");
                 load_file_specs_config(file_specs);
                 const auto src = util::shrink_home(tempfile_ptr->path().string());
-                REQUIRE(
-                    config.dump().starts_with(
-                    "channels:\n  - https://private.cloud/t/hdfd5256h6degd5/get/channel\n  - https://private.cloud/t/kqf458r1h127de9/get/channel\n  - https://private.cloud/t/SOME_TOKEN/get/channel\n  - conda-forge")
-                );
+                REQUIRE(config.dump().starts_with(
+                    "channels:\n  - https://private.cloud/t/hdfd5256h6degd5/get/channel\n  - https://private.cloud/t/kqf458r1h127de9/get/channel\n  - https://private.cloud/t/SOME_TOKEN/get/channel\n  - conda-forge"
+                ));
             }
 
             TEST_CASE_METHOD(Configuration, "dump")


### PR DESCRIPTION
# Description

This test fails because the expected output apparently changed:
```
test_libmamba is a Catch2 v3.8.0 host application.
Run with -? for options

-------------------------------------------------------------------------------
load_file_specs
-------------------------------------------------------------------------------
/home/joel/quantstack/mamba/libmamba/tests/src/core/test_configuration.cpp:313
...............................................................................

/home/joel/quantstack/mamba/libmamba/tests/src/core/test_configuration.cpp:328: FAILED:
  REQUIRE( config.dump() == "channels:\n  - https://private.cloud/t/hdfd5256h6degd5/get/channel\n  - https://private.cloud/t/kqf458r1h127de9/get/channel\n  - https://private.cloud/t/SOME_TOKEN/get/channel\n  - conda-forge" )
with expansion:
  "channels:
    - https://private.cloud/t/hdfd5256h6degd5/get/channel
    - https://private.cloud/t/kqf458r1h127de9/get/channel
    - https://private.cloud/t/SOME_TOKEN/get/channel
    - conda-forge
    - nodefaults
  channel_priority: strict"
  ==
  "channels:
    - https://private.cloud/t/hdfd5256h6degd5/get/channel
    - https://private.cloud/t/kqf458r1h127de9/get/channel
    - https://private.cloud/t/SOME_TOKEN/get/channel
    - conda-forge"

===============================================================================
test cases: 1 | 1 failed
assertions: 1 | 1 failed
```

This pr should fix this while preserving the intent of the test.

## Type of Change

<!-- Please skip this part if you are already using conventional commit keywords in the PR title. -->

- [ ] Bugfix
- [ ] Feature / enhancement
- [ ] CI / Documentation
- [x] Maintenance

## Checklist

- [x] My code follows the general style and conventions of the codebase, ensuring consistency
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have run `pre-commit run --all` locally in the source folder and confirmed that there are no linter errors.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
