### PR TITLE
ci: Run micromamba's integration tests in two jobs

### DIFF
--- a/.github/workflows/unix_impl.yml
+++ b/.github/workflows/unix_impl.yml
@@ -183,7 +183,73 @@ jobs:
           export TEST_MAMBA_EXE=$(pwd)/build/micromamba/mamba
           unset CONDARC  # Interferes with tests
           # Only rerun flaky tests on the `main` branch
+          # Note: test_create.py and test_install.py are excluded here and run in a separate job
+          # (mamba_integration_tests_test_create_unix) to allow parallel execution and speed up CI,
+          # as these test files account for a significant portion of test runtime
           python -m pytest micromamba/tests/ \
+              --ignore=micromamba/tests/test_create.py \
+              --ignore=micromamba/tests/test_install.py \
+              ${{ runner.debug == 'true' && '-v --capture=tee-sys' || '--exitfirst' }} \
+              ${{ github.ref == 'refs/heads/main' && '--reruns 3' || '' }}
+
+  # Separate job for test_create.py and test_install.py to enable parallel execution with other tests.
+  # These test files account for a significant portion of the time spent running integration tests,
+  # so running them in parallel with the rest of the tests significantly speeds up CI.
+  mamba_integration_tests_test_create_unix:
+    name: mamba integration tests (test_create.py, test_install.py)
+    needs: ["build_shared_unix"]
+    runs-on: ${{ inputs.os }}
+    steps:
+      - name: Checkout mamba repository
+        uses: actions/checkout@v6
+      - name: Restore workspace
+        uses: ./.github/actions/workspace
+        with:
+          action: restore
+          path: build/
+          key_suffix: ${{ inputs.os }}-${{ inputs.build_type }}
+      - name: Create build environment
+        uses: mamba-org/setup-micromamba@v2
+        with:
+          environment-file: ./build/environment.lock
+          environment-name: build_env
+      - name: install zsh, xonsh, fish and tcsh in linux
+        if: startsWith(inputs.os, 'ubuntu')
+        run: |
+          sudo apt-get install zsh xonsh fish tcsh -y
+      - name: Install xonsh and fish in mac
+        if: startsWith(inputs.os, 'macos')
+        run: |
+          brew install fish xonsh
+      - name: Diagnose CURL/DNS issue
+        run: |
+          echo 'ping -c 3 conda.anaconda.org'
+          ping -c 3 conda.anaconda.org || echo 'FAILED'
+          echo '--------------------------------------------------'
+          echo 'ping -c 3 repo.mamba.pm'
+          ping -c 3 repo.mamba.pm || echo 'FAILED'
+          echo '--------------------------------------------------'
+          echo 'nslookup conda.anaconda.org'
+          nslookup conda.anaconda.org || echo 'FAILED'
+          echo '--------------------------------------------------'
+          echo 'nslookup repo.mamba.pm'
+          nslookup repo.mamba.pm || echo 'FAILED'
+          echo '--------------------------------------------------'
+          echo 'which curl'
+          which curl  || echo 'FAILED'
+          echo '--------------------------------------------------'
+          echo 'curl -I -vvvv https://conda.anaconda.org/conda-forge/noarch/repodata.json'
+          curl -I -vvv https://conda.anaconda.org/conda-forge/noarch/repodata.json || echo 'FAILED'
+          echo '--------------------------------------------------'
+          echo 'curl -I -vvvv https://repo.mamba.pm/conda-forge/noarch/repodata.json'
+          curl -I -vvv https://repo.mamba.pm/conda-forge/noarch/repodata.json || echo 'FAILED'
+
+      - name: mamba python based tests (test_create.py, test_install.py)
+        run: |
+          export TEST_MAMBA_EXE=$(pwd)/build/micromamba/mamba
+          unset CONDARC  # Interferes with tests
+          # Only rerun flaky tests on the `main` branch
+          python -m pytest micromamba/tests/test_create.py micromamba/tests/test_install.py \
               ${{ runner.debug == 'true' && '-v --capture=tee-sys' || '--exitfirst' }} \
               ${{ github.ref == 'refs/heads/main' && '--reruns 3' || '' }}
 

--- a/.github/workflows/windows_impl.yml
+++ b/.github/workflows/windows_impl.yml
@@ -165,6 +165,50 @@ jobs:
           $env:MAMBA_TEST_SHELL_TYPE='powershell'
           Remove-Item -Path "env:CONDARC"
           # Only rerun flaky tests on the `main` branch
+          # Note: test_create.py and test_install.py are excluded here and run in a separate job
+          # (mamba_integration_tests_test_create_install_win) to allow parallel execution and speed up CI,
+          # as these test files account for a significant portion of test runtime
           python -m pytest micromamba/tests/ `
+            --ignore=micromamba/tests/test_create.py `
+            --ignore=micromamba/tests/test_install.py `
+            ${{ runner.debug == 'true' && '-v --capture=tee-sys' || '--exitfirst' }} `
+            ${{ github.ref == 'refs/heads/main' && '--reruns 3' || '' }}
+
+  # Separate job for test_create.py and test_install.py to enable parallel execution with other tests.
+  # These test files account for a significant portion of the time spent running integration tests,
+  # so running them in parallel with the rest of the tests significantly speeds up CI.
+  mamba_integration_tests_test_create_install_win:
+    name: mamba integration tests (test_create.py, test_install.py)
+    needs: ["build_shared_win"]
+    runs-on: ${{ inputs.os }}
+    steps:
+      - name: Checkout mamba repository
+        uses: actions/checkout@v6
+      - name: Restore workspace
+        uses: ./.github/actions/workspace
+        with:
+          action: restore
+          path: build/
+          key_suffix: ${{ inputs.os }}-${{ inputs.build_type }}
+      - name: Create build environment
+        uses: mamba-org/setup-micromamba@v2
+        with:
+          environment-file: ./build/environment.lock
+          environment-name: build_env
+          init-shell: bash cmd.exe powershell
+      - name: Install mamba
+        shell: bash -elo pipefail {0}
+        run: |
+          cmake --install build/ --prefix local/
+      - name: mamba python based tests with pwsh (test_create.py, test_install.py)
+        shell: pwsh
+        run: |
+          $env:PYTHONIOENCODING='UTF-8'
+          $env:MAMBA_ROOT_PREFIX = Join-Path -Path $pwd -ChildPath 'mambaroot'
+          $env:TEST_MAMBA_EXE = Join-Path -Path $pwd -ChildPath 'local\bin\mamba.exe'
+          $env:MAMBA_TEST_SHELL_TYPE='powershell'
+          Remove-Item -Path "env:CONDARC"
+          # Only rerun flaky tests on the `main` branch
+          python -m pytest micromamba/tests/test_create.py micromamba/tests/test_install.py `
             ${{ runner.debug == 'true' && '-v --capture=tee-sys' || '--exitfirst' }} `
             ${{ github.ref == 'refs/heads/main' && '--reruns 3' || '' }}


### PR DESCRIPTION
# Description

Use two job for micromamba's integration tests suite so that both jobs account for approximately half the time spent running integration tests, speeding up CI time.

## Type of Change

<!-- Please skip this part if you are already using conventional commit keywords in the PR title. -->

- [ ] Bugfix
- [ ] Feature / enhancement
- [x] CI / Documentation
- [ ] Maintenance

## Checklist

- [x] My code follows the general style and conventions of the codebase, ensuring consistency
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have run `pre-commit run --all` locally in the source folder and confirmed that there are no linter errors.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
