### PR TITLE
Add #include <functional> for std::ref

### DIFF
--- a/libmamba/include/mamba/util/random.hpp
+++ b/libmamba/include/mamba/util/random.hpp
@@ -10,6 +10,7 @@
 #include <algorithm>
 #include <array>
 #include <cstring>
+#include <functional>
 #include <limits>
 #include <random>
 #include <string>


### PR DESCRIPTION
# Description

Fedora rawhide has updated to gcc 16.  We are now seeing:
```
In file included from /builddir/build/BUILD/libmamba-2.4.0-build/mamba-2.4.0/libmamba/src/util/random.cpp:7:
/builddir/build/BUILD/libmamba-2.4.0-build/mamba-2.4.0/libmamba/include/mamba/util/random.hpp: In function ‘Generator mamba::util::random_generator()’:
/builddir/build/BUILD/libmamba-2.4.0-build/mamba-2.4.0/libmamba/include/mamba/util/random.hpp:50:53: error: ‘ref’ is not a member of ‘std’; did you mean ‘erf’? [-Wtemplate-body]
   50 |         std::generate_n(begin(seed), seed_len, std::ref(dev));
      |                                                     ^~~
      |                                                     erf
```

std::ref is defined in <functional> so it needs to be included.

## Type of Change

<!-- Please skip this part if you are already using conventional commit keywords in the PR title. -->

- [x] Bugfix
- [ ] Feature / enhancement
- [ ] CI / Documentation
- [ ] Maintenance

## Checklist

- [x] My code follows the general style and conventions of the codebase, ensuring consistency
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have run `pre-commit run --all` locally in the source folder and confirmed that there are no linter errors.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
