### PR TITLE
fix: Only call `get_all_running_processes_info` when needed

### DIFF
--- a/libmamba/src/core/run.cpp
+++ b/libmamba/src/core/run.cpp
@@ -320,7 +320,10 @@ namespace mamba
             LOG_WARNING << "Could not create proc dir: " << proc_dir() << " (" << ec.message() << ")";
         }
 
-        LOG_DEBUG << "Currently running processes: " << get_all_running_processes_info();
+        if (logging::get_log_level() < log_level::info)
+        {
+            LOG_DEBUG << "Currently running processes: " << get_all_running_processes_info();
+        }
         fmt::print(LOG_DEBUG, "Remaining args to run as command: {}", fmt::join(command, " "));
 
         // replace the wrapping bash with new process entirely


### PR DESCRIPTION
Do not call `get_all_running_processes_info()` unless the log level requires printing debug logs.

When running micromamba in a specific production environment, we keep getting `Segmentation fault (core dumped)` and, by adding more logs in the code, I was able to narrow it down to this particular log entry, where it tries to print the currently running processes. I can confirm that the crash doesn't occur in `get_all_running_processes_info()` and it is something in the `MessageLogger` implementation, but I have a hard time narrowing it down since I don't have access to run gdb in that environment or collect core dumps. I believe it is something to do with the length of the resulting string, but I've not been able to get it to reproduce reliably in a unit test. However, we don't use debug logs and, in this case, I think the code should skip this log clause completely, which should unblock us.

# Description

<!-- Please include a summary of the changes and the related issue. -->

## Type of Change

<!-- Please skip this part if you are already using conventional commit keywords in the PR title. -->

- [x] Bugfix
- [ ] Feature / enhancement
- [ ] CI / Documentation
- [ ] Maintenance

## Checklist

- [x] My code follows the general style and conventions of the codebase, ensuring consistency
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have run `pre-commit run --all` locally in the source folder and confirmed that there are no linter errors.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
