### PR TITLE
ci: Temporarily pin catch2 <=3.8

### DIFF
--- a/dev/environment-dev.yml
+++ b/dev/environment-dev.yml
@@ -28,7 +28,10 @@ dependencies:
   - yaml-cpp >=0.8.0
   - sel(win): winreg
   # libmamba test dependencies
-  - catch2
+  # Catch2 3.9 changed the execution order of tests to random,
+  # changing assumptions of the test suite design.
+  # TODO: use the "decl" execution order again in catch2>=3.9.
+  - catch2 <=3.8
   # micromamba dependencies
   - cli11 >=2.2
   # micromamba test dependencies


### PR DESCRIPTION
# Description

Catch2 3.9 changed the execution order of tests to random, changing assumptions of the test suite design.

## Type of Change

<!-- Please skip this part if you are already using conventional commit keywords in the PR title. -->

- [ ] Bugfix
- [ ] Feature / enhancement
- [x] CI / Documentation
- [ ] Maintenance

## Checklist

- [x] My code follows the general style and conventions of the codebase, ensuring consistency
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have run `pre-commit run --all` locally in the source folder and confirmed that there are no linter errors.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
