### PR TITLE
ci: Free disk space for linux workflows

### DIFF
--- a/.github/workflows/unix_impl.yml
+++ b/.github/workflows/unix_impl.yml
@@ -20,6 +20,30 @@ jobs:
     name: Build binaries
     runs-on: ${{ inputs.os }}
     steps:
+      - name: Disk Space Before Clean Up
+        if: startsWith(inputs.os, 'ubuntu')
+        run: |
+          df -h
+      - name: Free Disk Space (Base Runner)
+        if: startsWith(inputs.os, 'ubuntu')
+        uses: jlumbroso/free-disk-space@v1.3.1
+        with:
+          tool-cache: false
+          large-packages: false
+          docker-images: false
+      - name: Free Disk Space (Container)
+        if: startsWith(inputs.os, 'ubuntu')
+        run: |
+          rm -rf /mnt/usr/local/lib/android
+          rm -rf /mnt/usr/share/dotnet
+          rm -rf /mnt/usr/local/share/boost
+          rm -rf /mnt/opt/ghc
+          rm -rf /mnt/opt/hostedtoolcache/CodeQL
+          rm -rf /mnt/usr/local/lib/node_modules
+      - name: Disk Space After Clean Up
+        if: startsWith(inputs.os, 'ubuntu')
+        run: |
+          df -h
       - name: Checkout mamba repository
         uses: actions/checkout@v6
       - name: Create build environment


### PR DESCRIPTION
# Description

Some tests are failing on the CI due to lack of disk space.

Disk space before:
```
Filesystem      Size  Used Avail Use% Mounted on
/dev/root        72G   54G   18G  76% /
tmpfs           7.9G   84K  7.9G   1% /dev/shm
tmpfs           3.2G  1.2M  3.2G   1% /run
tmpfs           5.0M     0  5.0M   0% /run/lock
/dev/sdb16      881M   62M  758M   8% /boot
/dev/sdb15      105M  6.2M   99M   6% /boot/efi
/dev/sda1        74G  4.1G   66G   6% /mnt
tmpfs           1.6G   12K  1.6G   1% /run/user/1001
```

Disk space after:
```
Filesystem      Size  Used Avail Use% Mounted on
/dev/root        72G   31G   41G  44% /
tmpfs           7.9G   84K  7.9G   1% /dev/shm
tmpfs           3.2G  1.2M  3.2G   1% /run
tmpfs           5.0M     0  5.0M   0% /run/lock
/dev/sdb16      881M   62M  758M   8% /boot
/dev/sdb15      105M  6.2M   99M   6% /boot/efi
/dev/sda1        74G   28K   70G   1% /mnt
tmpfs           1.6G   12K  1.6G   1% /run/user/1001
```

## Type of Change

<!-- Please skip this part if you are already using conventional commit keywords in the PR title. -->

- [ ] Bugfix
- [ ] Feature / enhancement
- [x] CI / Documentation
- [ ] Maintenance

## Checklist

- [x] My code follows the general style and conventions of the codebase, ensuring consistency
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have run `pre-commit run --all` locally in the source folder and confirmed that there are no linter errors.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
