### PR TITLE
Add Findzstd.cmake

### DIFF
--- a/cmake/modules/Findzstd.cmake
+++ b/cmake/modules/Findzstd.cmake
@@ -1,0 +1,12 @@
+find_path(ZSTD_INCLUDE_DIR zstd.h)
+find_library(ZSTD_LIBRARY NAMES zstd)
+
+if(ZSTD_INCLUDE_DIR AND ZSTD_LIBRARY)
+  set(zstd_FOUND TRUE)
+  if(NOT TARGET zstd::libzstd_shared)
+    add_library(zstd::libzstd_shared UNKNOWN IMPORTED)
+    set_target_properties(zstd::libzstd_shared PROPERTIES
+      IMPORTED_LOCATION \"${ZSTD_LIBRARY}\"
+      INTERFACE_INCLUDE_DIRECTORIES \"${ZSTD_INCLUDE_DIR}\")
+  endif()
+endif()


### PR DESCRIPTION
* Add Findzstd.cmake

# Description

This makes mamba find zstd when that zstd was built using their `Makefile` rather than their `cmake` (and hence their `zstdConfig.cmake` is not installed).

A logical cmake target `zstd::libzstd_shared` is created, referring to either a shared or a static library `zstd` (not specified which of static or shared to make it more general).

No `zstdConfig.cmake` in `libzstd-dev` in the following distributions:
   * Ubuntu 20.04 LTS (`libzstd-dev`)
   * Ubuntu 22.04 LTS (`libzstd-dev`)
   * CentOS 8 / RHEL 8 (`libzstd-devel`)
   * Debian 11 (Bullseye)
   * Fedora 43
   * Guix

A `zstdConfig.cmake` is in `libzstd-dev` in the following distributions:
   * Arch Linux
   * Debian 12 (Bookworm)

## Type of Change

<!-- Please skip this part if you are already using conventional commit keywords in the PR title. -->

- [X] Bugfix
- [ ] Feature / enhancement
- [ ] CI / Documentation
- [ ] Maintenance

## Checklist

- [X] My code follows the general style and conventions of the codebase, ensuring consistency
- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [ ] I have run `pre-commit run --all` locally in the source folder and confirmed that there are no linter errors.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
