### PR TITLE
ci: Ensure that `conda-content-trust` tests run inside `build_env`

### DIFF
--- a/.github/workflows/unix_impl.yml
+++ b/.github/workflows/unix_impl.yml
@@ -329,6 +329,9 @@ jobs:
           export MAMBA_ROOT_PREFIX="${HOME}/micromamba"
           unset CONDARC  # Interferes with tests
 
+          # Sanity check: ensure `securesystemslib` is importable in `build_env`
+          micromamba run -n build_env python -c "import securesystemslib; print('securesystemslib import OK:', securesystemslib.__version__)"
+
           # Ensure that `conda-content-trust` tests run inside `build_env`
           micromamba run -n build_env bash -lc '
             set -euo pipefail -x


### PR DESCRIPTION
# Description

<!-- Please include a summary of the changes and the related issue. -->

## Type of Change

<!-- Please skip this part if you are already using conventional commit keywords in the PR title. -->

- [ ] Bugfix
- [ ] Feature / enhancement
- [x] CI / Documentation
- [ ] Maintenance

## Checklist

- [x] My code follows the general style and conventions of the codebase, ensuring consistency
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have run `pre-commit run --all` locally in the source folder and confirmed that there are no linter errors.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
