### PR TITLE
fix: Omit `--detach` option for run subcommand on Windows

### DIFF
--- a/micromamba/tests/test_run.py
+++ b/micromamba/tests/test_run.py
@@ -10,6 +10,12 @@ import pytest
 from .helpers import create, random_string, subprocess_run, umamba_run
 
 common_simple_flags = ["", "-d", "--detach", "--clean-env"]
+# -d/--detach are not available on Windows (see run.cpp)
+common_simple_flags_for_help = (
+    [f for f in common_simple_flags if f not in ("-d", "--detach")]
+    if platform == "win32"
+    else common_simple_flags
+)
 possible_characters_for_process_names = (
     "-_" + string.ascii_uppercase + string.digits + string.ascii_lowercase
 )
@@ -53,7 +59,7 @@ class TestRun:
         else:
             assert fails is True
 
-    @pytest.mark.parametrize("option_flag", common_simple_flags)
+    @pytest.mark.parametrize("option_flag", common_simple_flags_for_help)
     # @pytest.mark.parametrize("label_flags", naming_flags()) # TODO: reactivate after fixing help flag not disactivating the run
     @pytest.mark.parametrize("help_flag", ["-h", "--help"])
     @pytest.mark.parametrize("command", ["", simple_short_program()])


### PR DESCRIPTION
# Description

The `-d` / `--detach` flags are not defined on Windows in `run.cpp`:
https://github.com/mamba-org/mamba/blob/19407613cf92fb6431001ae60315ce9d52c23d64/micromamba/src/run.cpp#L160-L163

This makes some tests like `TestRun.test_help_succeeds[--h--d]` fail on Windows.

## Type of Change

<!-- Please skip this part if you are already using conventional commit keywords in the PR title. -->

- [x] Bugfix
- [ ] Feature / enhancement
- [ ] CI / Documentation
- [ ] Maintenance

## Checklist

- [x] My code follows the general style and conventions of the codebase, ensuring consistency
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have run `pre-commit run --all` locally in the source folder and confirmed that there are no linter errors.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
