### PR TITLE
ci: Disable `mamba-content-trust and auth tests`

### DIFF
--- a/.github/workflows/unix_impl.yml
+++ b/.github/workflows/unix_impl.yml
@@ -287,7 +287,7 @@ jobs:
     name: mamba-content-trust and auth tests
     needs: ["build_shared_unix"]
     runs-on: ${{ inputs.os }}
-    if: startsWith(inputs.os, 'ubuntu')
+    if: false # Disabled for now
     steps:
       - name: Disk Space Before Clean Up
         run: |


### PR DESCRIPTION
# Description

As proposed by @JohanMabille.

## Type of Change

<!-- Please skip this part if you are already using conventional commit keywords in the PR title. -->

- [ ] Bugfix
- [ ] Feature / enhancement
- [x] CI / Documentation
- [ ] Maintenance

## Checklist

- [x] My code follows the general style and conventions of the codebase, ensuring consistency
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have run `pre-commit run --all` locally in the source folder and confirmed that there are no linter errors.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
