### PR TITLE
fix: Pass priorities in `load_single_subdir`

### DIFF
--- a/libmamba/src/api/channel_loader.cpp
+++ b/libmamba/src/api/channel_loader.cpp
@@ -225,7 +225,8 @@ namespace mamba
             std::vector<SubdirIndexLoader>& subdirs,
             std::size_t subdir_idx,
             std::set<std::string>& loaded_subdirs_with_shards,
-            const SubdirDownloadParams& subdir_params
+            const SubdirDownloadParams& subdir_params,
+            const std::vector<solver::libsolv::Priorities>& priorities
         )
         {
             auto& subdir = subdirs[subdir_idx];
@@ -243,7 +244,7 @@ namespace mamba
                     subdirs,
                     subdir_idx,
                     loaded_subdirs_with_shards,
-                    {}  // priorities are set by the caller after loading
+                    priorities
                 );
 
                 if (!res)
@@ -456,7 +457,8 @@ namespace mamba
                     subdirs,
                     i,
                     loaded_subdirs_with_shards,
-                    subdir_params
+                    subdir_params,
+                    priorities
                 );
 
                 if (result)


### PR DESCRIPTION
# Description

Follow-up of #4178.

Extracted from https://github.com/mamba-org/mamba/pull/4187.

## Type of Change

<!-- Please skip this part if you are already using conventional commit keywords in the PR title. -->

- [x] Bugfix
- [ ] Feature / enhancement
- [ ] CI / Documentation
- [ ] Maintenance

## Checklist

- [x] My code follows the general style and conventions of the codebase, ensuring consistency
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have run `pre-commit run --all` locally in the source folder and confirmed that there are no linter errors.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
