### PR TITLE
feat: Do not warn for missing channels index

### DIFF
--- a/libmamba/src/api/channel_loader.cpp
+++ b/libmamba/src/api/channel_loader.cpp
@@ -255,8 +255,8 @@ namespace mamba
                     // Shards failed and no cache - try to fetch and load flat repodata.
                     if (!ctx.offline)
                     {
-                        LOG_WARNING << "Shard loading failed for " << subdir.name()
-                                    << ". Falling back to full repodata.json download.";
+                        LOG_DEBUG << "Shard loading failed for " << subdir.name()
+                                  << ". Falling back to full repodata.json download.";
                         std::vector<SubdirIndexLoader*> fallback_subdirs = { &subdir };
                         auto fetch_res = SubdirIndexLoader::download_requests(
                             SubdirIndexLoader::build_all_index_requests(
@@ -723,7 +723,7 @@ namespace mamba
             LOG_INFO << "Loaded subdir with shards: " << subdir.name();
             return std::move(*result_repo);
         }
-        LOG_WARNING << "No packages loaded from shards for " << subdir.name();
+        LOG_DEBUG << "No packages loaded from shards for " << subdir.name();
         return tl::unexpected(
             mamba_error("No packages for " + subdir.name(), mamba_error_code::subdirdata_not_loaded)
         );

--- a/libmamba/src/core/subdir_index.cpp
+++ b/libmamba/src/core/subdir_index.cpp
@@ -604,7 +604,7 @@ namespace mamba
                 // Don't log if it's a user interruption.
                 if (!result.has_value() and not result.error().is_stop)
                 {
-                    LOG_WARNING << "Failed to load subdir: " << result.error().message;
+                    LOG_DEBUG << "Failed to load subdir: " << result.error().message;
                 }
             }
         }
@@ -883,13 +883,13 @@ namespace mamba
         {
             if (error.transfer.has_value())
             {
-                LOG_WARNING << "Unable to retrieve repodata (response: "
-                            << error.transfer.value().http_status << ") for '"
-                            << error.transfer.value().effective_url << "'";
+                LOG_DEBUG << "Unable to retrieve repodata (response: "
+                          << error.transfer.value().http_status << ") for '"
+                          << error.transfer.value().effective_url << "'";
             }
             else
             {
-                LOG_WARNING << error.message;
+                LOG_DEBUG << error.message;
             }
             if (error.retry_wait_seconds.has_value())
             {

--- a/micromamba/tests/test_create.py
+++ b/micromamba/tests/test_create.py
@@ -2352,6 +2352,47 @@ def test_create_from_mirror(tmp_home, tmp_root_prefix):
     )
 
 
+def test_create_from_mirror_with_prefix(tmp_home, tmp_root_prefix, tmp_path):
+    """
+    Non-regression test for create with prefix path and sharded repodata.
+    Covers: emscripten-forge-dev channel, shard loading, priorities handling.
+    Verifies no warnings are emitted to stdout/stderr.
+    """
+    prefix = tmp_path / "cpp-env"
+
+    umamba = helpers.get_umamba()
+    cmd = [
+        umamba,
+        "create",
+        "cpp-tabulate",
+        "-p",
+        str(prefix),
+        "-c",
+        "https://repo.prefix.dev/emscripten-forge-dev",
+        "--platform=emscripten-wasm32",
+        "--json",
+        "-y",
+        "--no-rc",
+    ]
+    result = subprocess.run(cmd, capture_output=True, text=True, check=True)
+
+    res = json.loads(result.stdout)
+    assert res["success"]
+
+    assert any(
+        package["name"] == "cpp-tabulate"
+        and package["channel"] == "https://repo.prefix.dev/emscripten-forge-dev"
+        and package["subdir"] == "emscripten-wasm32"
+        for package in res["actions"]["LINK"]
+    )
+
+    # Verify no warnings in output
+    combined_output = result.stdout + result.stderr
+    assert "warning" not in combined_output.lower(), (
+        f"Unexpected warning in output:\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
+
+
 @pytest.mark.parametrize("shared_pkgs_dirs", [True], indirect=True)
 def test_create_with_multiple_files(tmp_home, tmp_root_prefix, tmpdir):
     env_name = "myenv"


### PR DESCRIPTION
# Description

Requalify this kind of warnings for debug logs:

```
./build/micromamba/micromamba create -p /tmp/cpp cpp-tabulate -c https://repo.prefix.dev/emscripten-forge-dev --platform=emscripten-wasm32                                                  
warning  libmamba Failed to load subdir: Transfer finalized, status: 404 [https://prefix.dev/conda-forge/emscripten-wasm32/repodata.json.zst] 0 bytes                                          
warning  libmamba Failed to load subdir: Transfer finalized, status: 404 [https://prefix.dev/conda-forge/emscripten-wasm32/repodata_shards.msgpack.zst] 0 bytes                                
[+] 0.0s                                                                                                                                                                                       
warning  libmamba Unable to retrieve repodata (response: 404) for 'https://prefix.dev/conda-forge/emscripten-wasm32/repodata.json'                                                             
warning  libmamba Failed to load subdir: Transfer finalized, status: 404 [https://prefix.dev/conda-forge/emscripten-wasm32/repodata.json] 23 bytes                                             
Fetch Shards' Index for https://repo.prefix.dev/emscripten-forge-dev/emscripten-wa...               ✔ Done
Fetch Shards' Index for https://repo.prefix.dev/emscripten-forge-dev/noarch                         ✔ Done
Fetching and Parsing Packages' Shards                                                           ⧖ Starting
Fetching and Parsing Packages' Shards                                                               ✔ Done
Fetch Shards' Index for https://prefix.dev/conda-forge/noarch                                       ✔ Done
Fetching and Parsing Packages' Shards                                                           ⧖ Starting
Fetching and Parsing Packages' Shards                                                               ✔ Done
warning  libmamba No packages loaded from shards for https://prefix.dev/conda-forge/noarch
warning  libmamba Shard loading failed for https://prefix.dev/conda-forge/noarch. Falling back to full repodata.json download.
```

## Type of Change

<!-- Please skip this part if you are already using conventional commit keywords in the PR title. -->

- [ ] Bugfix
- [x] Feature / enhancement
- [ ] CI / Documentation
- [ ] Maintenance

## Checklist

- [x] My code follows the general style and conventions of the codebase, ensuring consistency
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have run `pre-commit run --all` locally in the source folder and confirmed that there are no linter errors.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
