### PR TITLE
feat: Support `track_features` for `ShardRecord`

### DIFF
--- a/libmamba/include/mamba/core/shard_types.hpp
+++ b/libmamba/include/mamba/core/shard_types.hpp
@@ -78,6 +78,7 @@ namespace mamba
         std::optional<std::string> md5;
         std::vector<std::string> depends;
         std::vector<std::string> constrains;
+        std::vector<std::string> track_features;
         std::optional<std::string> noarch;
         std::size_t size = 0;
         std::optional<std::string> license;

--- a/libmamba/src/core/shard_types.cpp
+++ b/libmamba/src/core/shard_types.cpp
@@ -52,7 +52,7 @@ namespace mamba
                                        .platform = {},
                                        .depends = record.depends,
                                        .constrains = record.constrains,
-                                       .track_features = {},
+                                       .track_features = record.track_features,
                                        .features = {},
                                        .noarch = noarch_value,
                                        .license = record.license,
@@ -88,6 +88,7 @@ namespace mamba
                                    .md5 = record.md5,
                                    .depends = record.depends,
                                    .constrains = record.constrains,
+                                   .track_features = record.track_features,
                                    .noarch = noarch_value,
                                    .size = record.size.value_or(0),
                                    .license = record.license,
@@ -164,6 +165,7 @@ namespace mamba
         pkg_info.sha256 = record.sha256.value_or("");
         pkg_info.dependencies = record.depends;
         pkg_info.constrains = record.constrains;
+        pkg_info.track_features = record.track_features;
         pkg_info.noarch = noarch_value;
         pkg_info.size = record.size;
         pkg_info.timestamp = record.timestamp.value_or(0);

--- a/libmamba/src/core/shards.cpp
+++ b/libmamba/src/core/shards.cpp
@@ -292,6 +292,23 @@ namespace mamba
                                       << static_cast<int>(val_obj.type);
                         }
                     }
+                    else if (key == "track_features")
+                    {
+                        // Track features may be stored as a string (e.g. "feat_a,feat_b")
+                        // or as an array of strings; normalize to a vector of strings.
+                        if (val_obj.type == MSGPACK_OBJECT_ARRAY)
+                        {
+                            record.track_features = msgpack_object_to_string_array(val_obj);
+                        }
+                        else
+                        {
+                            const auto features_str = msgpack_object_to_string(val_obj);
+                            if (!features_str.empty())
+                            {
+                                record.track_features = util::split(features_str, ", ");
+                            }
+                        }
+                    }
                     else if (key == "noarch")
                     {
                         if (val_obj.type == MSGPACK_OBJECT_NIL)
@@ -1180,6 +1197,15 @@ namespace mamba
             if (record_a.version != record_b.version)
             {
                 return record_b.version < record_a.version;  // Descending order
+            }
+
+            // Prefer packages with fewer track features when version is equal.
+            const auto track_count_a = record_a.track_features.size();
+            const auto track_count_b = record_b.track_features.size();
+            if (track_count_a != track_count_b)
+            {
+                // Smaller number of track features first.
+                return track_count_a < track_count_b;
             }
 
             // Finally compare by build number (descending - highest first)

--- a/libmamba/tests/include/test_shard_utils.hpp
+++ b/libmamba/tests/include/test_shard_utils.hpp
@@ -165,7 +165,8 @@ namespace mambatests
             const std::vector<std::string>& constrains = {},
             const std::optional<std::string>& noarch = std::nullopt,
             HashFormat sha256_format = HashFormat::String,
-            HashFormat md5_format = HashFormat::String
+            HashFormat md5_format = HashFormat::String,
+            const std::vector<std::string>& track_features = {}
         ) -> std::vector<std::uint8_t>;
     }
 }

--- a/libmamba/tests/src/core/test_shard_utils.cpp
+++ b/libmamba/tests/src/core/test_shard_utils.cpp
@@ -324,7 +324,8 @@ namespace mambatests
             const std::vector<std::string>& constrains,
             const std::optional<std::string>& noarch,
             HashFormat sha256_format,
-            HashFormat md5_format
+            HashFormat md5_format,
+            const std::vector<std::string>& track_features
         ) -> std::vector<std::uint8_t>
         {
             msgpack_sbuffer sbuf;
@@ -351,6 +352,10 @@ namespace mambatests
                 field_count++;
             }
             if (noarch.has_value())
+            {
+                field_count++;
+            }
+            if (!track_features.empty())
             {
                 field_count++;
             }
@@ -519,6 +524,19 @@ namespace mambatests
                 msgpack_pack_str_body(&pk, "noarch", 6);
                 msgpack_pack_str(&pk, noarch->size());
                 msgpack_pack_str_body(&pk, noarch->c_str(), noarch->size());
+            }
+
+            // track_features (optional)
+            if (!track_features.empty())
+            {
+                msgpack_pack_str(&pk, 13);
+                msgpack_pack_str_body(&pk, "track_features", 13);
+                msgpack_pack_array(&pk, track_features.size());
+                for (const auto& feat : track_features)
+                {
+                    msgpack_pack_str(&pk, feat.size());
+                    msgpack_pack_str_body(&pk, feat.c_str(), feat.size());
+                }
             }
 
             std::vector<std::uint8_t> result(

--- a/libmamba/tests/src/core/test_sharded_repodata_integration.cpp
+++ b/libmamba/tests/src/core/test_sharded_repodata_integration.cpp
@@ -492,7 +492,7 @@ TEST_CASE("Sharded repodata - solver results consistency", "[mamba::core][sharde
     }
 }
 
-TEST_CASE("Sharded repodata - environment consistency", "[mamba::core][sharded][.integration][!mayfail]")
+TEST_CASE("Sharded repodata - environment consistency", "[mamba::core][sharded][.integration]")
 {
     auto& ctx = mambatests::context();
     ctx.channels = { "https://prefix.dev/conda-forge" };
@@ -536,7 +536,7 @@ TEST_CASE("Sharded repodata - environment consistency", "[mamba::core][sharded][
     }
 }
 
-TEST_CASE("Sharded repodata - cross-subdir dependencies", "[mamba::core][sharded][.integration][!mayfail]")
+TEST_CASE("Sharded repodata - cross-subdir dependencies", "[mamba::core][sharded][.integration]")
 {
     auto& ctx = mambatests::context();
     ctx.channels = { "https://prefix.dev/conda-forge" };
@@ -592,7 +592,7 @@ TEST_CASE("Sharded repodata - cross-subdir dependencies", "[mamba::core][sharded
     // which is verified by the successful loading and solving.
 }
 
-TEST_CASE("Sharded repodata - update scenarios", "[mamba::core][sharded][.integration][!mayfail]")
+TEST_CASE("Sharded repodata - update scenarios", "[mamba::core][sharded][.integration]")
 {
     auto& ctx = mambatests::context();
     ctx.channels = { "https://prefix.dev/conda-forge" };
@@ -718,7 +718,7 @@ TEST_CASE("Sharded repodata - update scenarios", "[mamba::core][sharded][.integr
     REQUIRE(solution_traditional == solution_sharded);
 }
 
-TEST_CASE("Sharded repodata - remove scenarios", "[mamba::core][sharded][.integration][!mayfail]")
+TEST_CASE("Sharded repodata - remove scenarios", "[mamba::core][sharded][.integration]")
 {
     auto& ctx = mambatests::context();
     ctx.channels = { "https://prefix.dev/conda-forge" };
@@ -867,7 +867,7 @@ TEST_CASE("Sharded repodata - remove scenarios", "[mamba::core][sharded][.integr
 
 TEST_CASE(
     "Sharded repodata - python install includes pip and version >= 3.14",
-    "[mamba::core][sharded][.integration][!mayfail]"
+    "[mamba::core][sharded][.integration]"
 )
 {
     auto& ctx = mambatests::context();
@@ -918,4 +918,40 @@ TEST_CASE(
     auto min_version = specs::Version::parse("3.14");
     REQUIRE(min_version.has_value());
     REQUIRE(python_version_obj.value() >= min_version.value());
+}
+
+TEST_CASE("Sharded repodata - libblas implementation preference", "[mamba::core][sharded][.integration]")
+{
+    auto& ctx = mambatests::context();
+    ctx.channels = { "https://prefix.dev/conda-forge" };
+    ctx.offline = false;
+
+    const auto tmp_dir = TemporaryDirectory();
+    const auto cache_dir = tmp_dir.path() / "cache";
+    fs::create_directories(cache_dir);
+
+    auto channel_context = ChannelContext::make_conda_compatible(ctx);
+    init_channels(ctx, channel_context);
+
+    std::vector<std::string> install_specs = { "libblas" };
+
+    const bool use_shards = true;
+    expected_t<Solution>
+        solution = solve_environment(ctx, channel_context, install_specs, use_shards, cache_dir);
+    REQUIRE(solution.has_value());
+
+    bool libblas_found = false;
+    for (const auto& pkg : solution.value().packages())
+    {
+        if (pkg.name == "libblas")
+        {
+            libblas_found = true;
+            // OpenBLAS builds do not carry BLAS track_features, whereas
+            // netlib / MKL / BLIS variants do. Ensuring an empty
+            // track_features set corresponds to selecting the openblas
+            // implementation from the available libblas builds.
+            REQUIRE(pkg.track_features.empty());
+        }
+    }
+    REQUIRE(libblas_found);
 }

--- a/libmamba/tests/src/core/test_shards.cpp
+++ b/libmamba/tests/src/core/test_shards.cpp
@@ -67,7 +67,8 @@ namespace
         const std::string& package_name,
         const std::string& version,
         const std::string& build,
-        const std::vector<std::string>& depends = {}
+        const std::vector<std::string>& depends = {},
+        const std::vector<std::string>& track_features = {}
     ) -> std::vector<std::uint8_t>
     {
         // Create package record with checksum
@@ -82,7 +83,8 @@ namespace
             {},
             std::nullopt,
             HashFormat::String,
-            HashFormat::String
+            HashFormat::String,
+            track_features
         );
 
         // Wrap in shard structure: {"packages": {filename: record}}
@@ -844,6 +846,49 @@ TEST_CASE("Shards - build_repodata")
         }
         REQUIRE(found_1_0);
         REQUIRE(found_2_0);
+    }
+
+    SECTION("Track-features ordering prefers fewer features for same version")
+    {
+        ShardDict shard;
+
+        // libblas 3.11.0 netlib variant with track_features
+        ShardPackageRecord netlib;
+        netlib.name = "libblas";
+        netlib.version = "3.11.0";
+        netlib.build = "7_hc00574d_netlib";
+        netlib.build_number = 7;
+        netlib.track_features = { "blas_netlib", "blas_netlib_2" };
+        shard.packages["libblas-3.11.0-7_hc00574d_netlib.conda"] = netlib;
+
+        // libblas 3.11.0 openblas variant without track_features
+        ShardPackageRecord openblas;
+        openblas.name = "libblas";
+        openblas.version = "3.11.0";
+        openblas.build = "5_h4a7cf45_openblas";
+        openblas.build_number = 5;
+        openblas.track_features = {};
+        shard.packages["libblas-3.11.0-5_h4a7cf45_openblas.conda"] = openblas;
+
+        shards.process_fetched_shard("libblas", shard);
+
+        auto repodata = shards.build_repodata();
+
+        // Collect libblas entries in the order seen after sorting.
+        std::vector<std::string> keys;
+        for (const auto& [filename, record] : repodata.shard_dict.packages)
+        {
+            if (record.name == "libblas" && record.version == "3.11.0")
+            {
+                keys.push_back(filename);
+            }
+        }
+
+        REQUIRE(keys.size() == 2);
+        // The first entry must be the openblas build (no track_features),
+        // followed by the netlib build (with track_features).
+        REQUIRE(keys[0].find("5_h4a7cf45_openblas") != std::string::npos);
+        REQUIRE(keys[1].find("7_hc00574d_netlib") != std::string::npos);
     }
 
     SECTION("Build repodata with conda packages")


### PR DESCRIPTION
# Description

[`track_features`](https://docs.conda.io/projects/conda/en/stable/user-guide/concepts/packages.html#track-features) are present for some packages only and are used to weight them.

Their handling was missing in the code parsing the `ShardRecords`. This PR introduces it.

## Type of Change

<!-- Please skip this part if you are already using conventional commit keywords in the PR title. -->

- [ ] Bugfix
- [x] Feature / enhancement
- [ ] CI / Documentation
- [ ] Maintenance

## Checklist

- [x] My code follows the general style and conventions of the codebase, ensuring consistency
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have run `pre-commit run --all` locally in the source folder and confirmed that there are no linter errors.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
