### PR TITLE
feat: Cache mentioned packages by each `Node` during traversal

### DIFF
--- a/libmamba/include/mamba/core/shard_traversal.hpp
+++ b/libmamba/include/mamba/core/shard_traversal.hpp
@@ -52,14 +52,6 @@ namespace mamba
     using ShardsByUrl = std::map<std::string, std::size_t>;
 
     /**
-     * Extracts package names from dependency specs in a shard.
-     *
-     * Parses depends and constrains via specs::MatchSpec, returning the
-     * package names for dependency traversal.
-     */
-    [[nodiscard]] auto shard_mentioned_packages(const ShardDict& shard) -> std::vector<std::string>;
-
-    /**
      * Traverses sharded repodata to find reachable packages from root packages.
      *
      * Uses BFS or pipelined strategy to explore dependencies across shards.
@@ -94,6 +86,13 @@ namespace mamba
         std::vector<Shards> m_shards;
 
         NodeMap m_nodes;
+
+        // Cache of dependency names mentioned in a Node's ShardDict, computed on first visit.
+        // Keyed by NodeId to re-iterating on the package records.
+        std::map<NodeId, std::vector<std::string>> m_mentioned_packages;
+
+        const std::vector<std::string>&
+        mentioned_packages(const NodeId& node_id, const ShardDict& shard);
 
         void reachable_bfs(
             const std::vector<std::string>& root_packages,

--- a/libmamba/src/core/shard_traversal.cpp
+++ b/libmamba/src/core/shard_traversal.cpp
@@ -5,7 +5,8 @@
 // The full license is in the file LICENSE, distributed with this software.
 
 #include <algorithm>
-#include <set>
+#include <cctype>
+#include <optional>
 #include <vector>
 
 #include <fmt/format.h>
@@ -41,9 +42,10 @@ namespace mamba
         return NodeId{ package, channel, shard_url };
     }
 
-    namespace
+    namespace detail
     {
-        void add_names_from_specs(const std::vector<std::string>& specs, std::set<std::string>& names)
+        void
+        add_names_from_specs(const std::vector<std::string>& specs, std::vector<std::string>& names)
         {
             for (const auto& spec : specs)
             {
@@ -53,13 +55,13 @@ namespace mamba
                     auto name = parsed->name().to_string();
                     if (!name.empty() && !parsed->name().is_free())
                     {
-                        names.insert(std::move(name));
+                        names.push_back(std::move(name));
                     }
                 }
             }
         }
 
-        void add_names_from_record(const ShardPackageRecord& record, std::set<std::string>& names)
+        void add_names_from_record(const ShardPackageRecord& record, std::vector<std::string>& names)
         {
             add_names_from_specs(record.depends, names);
             add_names_from_specs(record.constrains, names);
@@ -67,7 +69,13 @@ namespace mamba
 
         std::vector<std::string> extract_dependencies_impl(const ShardDict& shard)
         {
-            std::set<std::string> names;
+            // We collect dependency names in a flat vector, then sort + unique.
+            // This is typically faster than inserting into a std::set one-by-one:
+            // it minimizes per-insert allocator traffic and takes advantage of
+            // contiguous storage and cache locality, while still producing a
+            // deterministically ordered, deduplicated list of names.
+            std::vector<std::string> names;
+            names.reserve(shard.packages.size() + shard.conda_packages.size());
             for (const auto& [_, record] : shard.packages)
             {
                 add_names_from_record(record, names);
@@ -76,14 +84,11 @@ namespace mamba
             {
                 add_names_from_record(record, names);
             }
-            return std::vector<std::string>(names.begin(), names.end());
+            std::sort(names.begin(), names.end());
+            names.erase(std::unique(names.begin(), names.end()), names.end());
+            return names;
         }
     }  // namespace
-
-    std::vector<std::string> shard_mentioned_packages(const ShardDict& shard)
-    {
-        return extract_dependencies_impl(shard);
-    }
 
     /******************
      * RepodataSubset *
@@ -227,18 +232,49 @@ namespace mamba
         {
             auto& node = m_nodes[id];
             node.visited = true;
-            for (const auto& neighbor_id : neighbors(id))
+
+            auto shards_it = std::find_if(
+                m_shards.begin(),
+                m_shards.end(),
+                [&id](const Shards& s) { return s.url() == id.channel; }
+            );
+            if (shards_it == m_shards.end())
             {
-                if (!m_nodes.contains(neighbor_id))
+                continue;
+            }
+
+            ShardDict shard;
+            try
+            {
+                shard = shards_it->visit_package(id.package);
+            }
+            catch (const std::exception& e)
+            {
+                LOG_WARNING << "Could not visit shard for " << id.package << ": " << e.what();
+                continue;
+            }
+
+            for (const std::string& dep : mentioned_packages(id, shard))
+            {
+                for (auto& dep_shards : m_shards)
                 {
-                    m_nodes[neighbor_id] = Node{
-                        node.distance + 1,
-                        neighbor_id.package,
-                        neighbor_id.channel,
-                        neighbor_id.shard_url,
-                        false,
-                    };
-                    pending.push_back(neighbor_id);
+                    const std::string url = dep_shards.url();
+                    if (!dep_shards.contains(dep))
+                    {
+                        continue;
+                    }
+                    NodeId neighbor_id{ dep, url, dep_shards.shard_url(dep) };
+                    if (!m_nodes.contains(neighbor_id))
+                    {
+                        m_nodes[neighbor_id] = Node{
+                            node.distance + 1,
+                            neighbor_id.package,
+                            neighbor_id.channel,
+                            neighbor_id.shard_url,
+                            false,
+                        };
+                        pending.push_back(neighbor_id);
+                    }
                 }
             }
         }
@@ -303,18 +339,9 @@ namespace mamba
         auto& node = m_nodes[node_id];
         node.visited = true;
 
-        ShardDict shard;
-        try
-        {
-            shard = shards.visit_package(node_id.package);
-        }
-        catch (const std::exception& e)
-        {
-            LOG_WARNING << "Could not visit shard for " << node_id.package << ": " << e.what();
-            return;
-        }
+        ShardDict shard = shards.visit_package(node_id.package);
 
-        for (const auto& dep : extract_dependencies_impl(shard))
+        for (const std::string& dep : mentioned_packages(node_id, shard))
         {
             for (auto& dep_shards : m_shards)
             {
@@ -348,6 +375,17 @@ namespace mamba
         }
     }
 
+    const std::vector<std::string>&
+    RepodataSubset::mentioned_packages(const NodeId& node_id, const ShardDict& shard)
+    {
+        auto [it, inserted] = m_mentioned_packages.emplace(node_id, std::vector<std::string>{});
+        if (inserted)
+        {
+            it->second = detail::extract_dependencies_impl(shard);
+        }
+        return it->second;
+    }
+
     std::vector<NodeId> RepodataSubset::neighbors(const NodeId& node_id)
     {
         auto shards_it = std::find_if(
@@ -366,18 +404,10 @@ namespace mamba
             return {};
         }
 
-        ShardDict shard;
-        try
-        {
-            shard = shards.visit_package(node_id.package);
-        }
-        catch (const std::exception&)
-        {
-            return {};
-        }
+        ShardDict shard = shards.visit_package(node_id.package);
 
         std::vector<NodeId> result;
-        for (const auto& dep : extract_dependencies_impl(shard))
+        for (const std::string& dep : mentioned_packages(node_id, shard))
         {
             for (auto& dep_shards : m_shards)
             {

--- a/libmamba/tests/src/core/test_shard_traversal.cpp
+++ b/libmamba/tests/src/core/test_shard_traversal.cpp
@@ -22,6 +22,12 @@
 
 using namespace mamba;
 
+// Internal helper declared in shard_traversal.cpp for testing.
+namespace mamba::detail
+{
+    std::vector<std::string> extract_dependencies_impl(const ShardDict& shard);
+}
+
 namespace
 {
     auto make_simple_channel(std::string_view chan) -> specs::Channel
@@ -129,7 +135,7 @@ TEST_CASE("Node to_id", "[mamba::core][mamba::core::shard_traversal]")
     REQUIRE(id.shard_url == "url");
 }
 
-TEST_CASE("shard_mentioned_packages", "[mamba::core][mamba::core::shard_traversal]")
+TEST_CASE("extract_dependencies_impl", "[mamba::core][mamba::core::shard_traversal]")
 {
     SECTION("Extract from depends")
     {
@@ -141,7 +147,7 @@ TEST_CASE("shard_mentioned_packages", "[mamba::core][mamba::core::shard_traversa
         record.depends = { "libffi", "libzstd>=1.4" };
         shard.packages["python-3.11-0.conda"] = record;
 
-        auto packages = shard_mentioned_packages(shard);
+        auto packages = mamba::detail::extract_dependencies_impl(shard);
         REQUIRE(packages.size() >= 2);
         REQUIRE(std::find(packages.begin(), packages.end(), "libffi") != packages.end());
         REQUIRE(std::find(packages.begin(), packages.end(), "libzstd") != packages.end());
@@ -157,7 +163,7 @@ TEST_CASE("shard_mentioned_packages", "[mamba::core][mamba::core::shard_traversa
         record.constrains = { "python>=3.9" };
         shard.conda_packages["numpy-1.24-0.conda"] = record;
 
-        auto packages = shard_mentioned_packages(shard);
+        auto packages = mamba::detail::extract_dependencies_impl(shard);
         REQUIRE(packages.size() >= 1);
         REQUIRE(std::find(packages.begin(), packages.end(), "python") != packages.end());
     }
@@ -175,7 +181,7 @@ TEST_CASE("shard_mentioned_packages", "[mamba::core][mamba::core::shard_traversa
         rec2.depends = { "dep_b" };
         shard.conda_packages["pkg2-1.0.conda"] = rec2;
 
-        auto packages = shard_mentioned_packages(shard);
+        auto packages = mamba::detail::extract_dependencies_impl(shard);
         REQUIRE(packages.size() >= 2);
         REQUIRE(std::find(packages.begin(), packages.end(), "dep_a") != packages.end());
         REQUIRE(std::find(packages.begin(), packages.end(), "dep_b") != packages.end());
@@ -194,7 +200,7 @@ TEST_CASE("shard_mentioned_packages", "[mamba::core][mamba::core::shard_traversa
         rec2.depends = { "common_dep" };
         shard.packages["pkg2-1.0.tar.bz2"] = rec2;
 
-        auto packages = shard_mentioned_packages(shard);
+        auto packages = mamba::detail::extract_dependencies_impl(shard);
         REQUIRE(std::count(packages.begin(), packages.end(), "common_dep") == 1);
     }
 
@@ -206,7 +212,7 @@ TEST_CASE("shard_mentioned_packages", "[mamba::core][mamba::core::shard_traversa
         record.depends = { "valid>=1.0", "!!!invalid!!!", "another_valid" };
         shard.packages["pkg-1.0.conda"] = record;
 
-        auto packages = shard_mentioned_packages(shard);
+        auto packages = mamba::detail::extract_dependencies_impl(shard);
         REQUIRE(std::find(packages.begin(), packages.end(), "valid") != packages.end());
         REQUIRE(std::find(packages.begin(), packages.end(), "another_valid") != packages.end());
     }
@@ -219,7 +225,7 @@ TEST_CASE("shard_mentioned_packages", "[mamba::core][mamba::core::shard_traversa
         record.depends = { "normal_pkg", "*" };
         shard.packages["pkg-1.0.conda"] = record;
 
-        auto packages = shard_mentioned_packages(shard);
+        auto packages = mamba::detail::extract_dependencies_impl(shard);
         REQUIRE(std::find(packages.begin(), packages.end(), "normal_pkg") != packages.end());
         REQUIRE(std::find(packages.begin(), packages.end(), "*") == packages.end());
     }
@@ -227,7 +233,7 @@ TEST_CASE("shard_mentioned_packages", "[mamba::core][mamba::core::shard_traversa
     SECTION("Empty shard")
     {
         ShardDict shard;
-        auto packages = shard_mentioned_packages(shard);
+        auto packages = mamba::detail::extract_dependencies_impl(shard);
         REQUIRE(packages.empty());
     }
 
@@ -240,7 +246,7 @@ TEST_CASE("shard_mentioned_packages", "[mamba::core][mamba::core::shard_traversa
         record.constrains = {};
         shard.packages["pkg-1.0.conda"] = record;
 
-        auto packages = shard_mentioned_packages(shard);
+        auto packages = mamba::detail::extract_dependencies_impl(shard);
         REQUIRE(packages.empty());
     }
 }


### PR DESCRIPTION
# Description

This avoids calling `extract_dependencies_impl` repeatedly.

`shard_mentioned_packages` was removed as not used anymore, and its tests have been adapted for `extract_dependencies_impl`.

## Type of Change

<!-- Please skip this part if you are already using conventional commit keywords in the PR title. -->

- [ ] Bugfix
- [x] Feature / enhancement
- [ ] CI / Documentation
- [ ] Maintenance

## Checklist

- [x] My code follows the general style and conventions of the codebase, ensuring consistency
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have run `pre-commit run --all` locally in the source folder and confirmed that there are no linter errors.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
