### PR TITLE
fix: Exclude Installed Packages from Root Packages

### DIFF
--- a/libmamba/src/api/install.cpp
+++ b/libmamba/src/api/install.cpp
@@ -549,14 +549,6 @@ namespace mamba
 
     namespace
     {
-        std::vector<std::string>
-        build_sharded_root_packages(const std::vector<std::string>& raw_specs)
-        {
-            std::vector<std::string> root_packages = extract_package_names_from_specs(raw_specs);
-            add_pip_if_python(root_packages);
-            return root_packages;
-        }
-
         void print_activation_message(const Context& ctx)
         {
             // Check that the target prefix is not active before printing the activation message

--- a/libmamba/src/api/update.cpp
+++ b/libmamba/src/api/update.cpp
@@ -176,15 +176,9 @@ namespace mamba
 
         MultiPackageCache package_caches(ctx.pkgs_dirs, ctx.validation_params);
 
-        auto root_packages = extract_package_names_from_specs(raw_update_specs);
-
-        // When updating python with sharded repodata, also include pip in root packages.
-        // This also avoids pulling old versions of python (1.x) which do not depend on
-        // other packages, which is a choice the solver can make.
-        if (ctx.repodata_use_shards)
-        {
-            add_pip_if_python(root_packages);
-        }
+        std::vector<std::string> root_packages = ctx.repodata_use_shards
+                                                     ? build_sharded_root_packages(raw_update_specs)
+                                                     : std::vector<std::string>{};
 
         auto exp_loaded = load_channels(ctx, channel_context, db, package_caches, root_packages);
         if (!exp_loaded)

--- a/libmamba/src/api/utils.cpp
+++ b/libmamba/src/api/utils.cpp
@@ -278,4 +278,11 @@ namespace mamba
             root_packages.push_back("pip");
         }
     }
+
+    std::vector<std::string> build_sharded_root_packages(const std::vector<std::string>& raw_specs)
+    {
+        std::vector<std::string> root_packages = extract_package_names_from_specs(raw_specs);
+        add_pip_if_python(root_packages);
+        return root_packages;
+    }
 }

--- a/libmamba/src/api/utils.hpp
+++ b/libmamba/src/api/utils.hpp
@@ -56,6 +56,13 @@ namespace mamba
      */
     void add_pip_if_python(std::vector<std::string>& root_packages);
 
+    /**
+     * Build root packages for sharded repodata loading.
+     *
+     * Starts from requested specs and adds ``pip`` when ``python`` is present.
+     */
+    std::vector<std::string> build_sharded_root_packages(const std::vector<std::string>& raw_specs);
+
 }
 
 #endif  // MAMBA_UTILS_HPP


### PR DESCRIPTION
# Description

We do not need to include installed packages as part of the root packages when installing new packages.

## Type of Change

- [x] Bugfix
- [ ] Feature / enhancement
- [ ] CI / Documentation
- [ ] Maintenance

## Checklist

- [x] My code follows the general style and conventions of the codebase, ensuring consistency
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have run `pre-commit run --all` locally in the source folder and confirmed that there are no linter errors.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
