### PR TITLE
feat: Introduce `MatchSpec::extract_name`

### DIFF
--- a/libmamba/include/mamba/specs/match_spec.hpp
+++ b/libmamba/include/mamba/specs/match_spec.hpp
@@ -55,6 +55,14 @@ namespace mamba::specs
 
         [[nodiscard]] static auto parse(std::string_view spec) -> expected_parse_t<MatchSpec>;
 
+        /**
+         * Fast extraction of package name from a dependency spec.
+         *
+         * This function is much faster than `MatchSpec::parse`.
+         */
+        [[nodiscard]] static auto extract_name(std::string_view spec)
+            -> expected_parse_t<std::string>;
+
         [[nodiscard]] static auto parse_url(std::string_view spec) -> expected_parse_t<MatchSpec>;
 
         [[nodiscard]] auto channel() const -> const std::optional<UnresolvedChannel>&;

--- a/libmamba/src/core/shard_traversal.cpp
+++ b/libmamba/src/core/shard_traversal.cpp
@@ -47,13 +47,11 @@ namespace mamba
         {
             for (const auto& spec : specs)
             {
-                auto parsed = specs::MatchSpec::parse(spec);
-                if (parsed)
+                if (auto name = specs::MatchSpec::extract_name(spec); name.has_value())
                 {
-                    auto name = parsed->name().to_string();
-                    if (!name.empty() && !parsed->name().is_free())
+                    if (name.value() != "*")
                     {
-                        names.insert(std::move(name));
+                        names.insert(std::move(name).value());
                     }
                 }
             }

--- a/libmamba/src/specs/match_spec.cpp
+++ b/libmamba/src/specs/match_spec.cpp
@@ -4,6 +4,7 @@
 //
 // The full license is in the file LICENSE, distributed with this software.
 
+#include <cctype>
 #include <string>
 #include <string_view>
 #include <tuple>
@@ -19,6 +20,38 @@
 
 namespace mamba::specs
 {
+    auto MatchSpec::extract_name(std::string_view spec) -> expected_parse_t<std::string>
+    {
+        std::size_t i = 0;
+        while (i < spec.size() && std::isspace(static_cast<unsigned char>(spec[i])))
+        {
+            ++i;
+        }
+        if (i == spec.size())
+        {
+            return make_unexpected_parse("Empty package name.");
+        }
+
+        const std::size_t name_start = i;
+        constexpr std::string_view binary_ops = "<>=!~";
+        while (i < spec.size())
+        {
+            const char c = spec[i];
+            if (std::isspace(static_cast<unsigned char>(c))
+                || (binary_ops.find(c) != std::string_view::npos))
+            {
+                break;
+            }
+            ++i;
+        }
+
+        if (i == name_start)
+        {
+            return make_unexpected_parse("Empty package name.");
+        }
+        return { std::string(spec.substr(name_start, i - name_start)) };
+    }
+
     auto MatchSpec::parse_url(std::string_view spec) -> expected_parse_t<MatchSpec>
     {
         auto out = MatchSpec();

--- a/libmamba/tests/src/specs/test_match_spec.cpp
+++ b/libmamba/tests/src/specs/test_match_spec.cpp
@@ -758,6 +758,53 @@ namespace
         }
     }
 
+    TEST_CASE("MatchSpec::extract_name", "[mamba::specs][mamba::specs::MatchSpec]")
+    {
+        SECTION("extract plain name")
+        {
+            auto name = MatchSpec::extract_name("python");
+            REQUIRE(name.has_value());
+            REQUIRE(name.value() == "python");
+        }
+
+        SECTION("extract name before whitespace")
+        {
+            auto name = MatchSpec::extract_name("python >=3.11");
+            REQUIRE(name.has_value());
+            REQUIRE(name.value() == "python");
+        }
+
+        SECTION("extract name before binary operator")
+        {
+            auto name = MatchSpec::extract_name("numpy>=2");
+            REQUIRE(name.has_value());
+            REQUIRE(name.value() == "numpy");
+            name = MatchSpec::extract_name("python=3.12");
+            REQUIRE(name.has_value());
+            REQUIRE(name.value() == "python");
+            name = MatchSpec::extract_name("libzstd!=1.5");
+            REQUIRE(name.has_value());
+            REQUIRE(name.value() == "libzstd");
+            name = MatchSpec::extract_name("openssl~=3.0");
+            REQUIRE(name.has_value());
+            REQUIRE(name.value() == "openssl");
+        }
+
+        SECTION("skip leading whitespace")
+        {
+            auto name = MatchSpec::extract_name("   scipy >=1.11");
+            REQUIRE(name.has_value());
+            REQUIRE(name.value() == "scipy");
+        }
+
+        SECTION("empty and operator-only specs return empty")
+        {
+            REQUIRE_FALSE(MatchSpec::extract_name("").has_value());
+            REQUIRE_FALSE(MatchSpec::extract_name("   ").has_value());
+            REQUIRE_FALSE(MatchSpec::extract_name(">=1.0").has_value());
+        }
+    }
+
     TEST_CASE("Conda discrepancies", "[mamba::specs][mamba::specs::MatchSpec]")
     {
         SECTION("python=3.7=bld")


### PR DESCRIPTION
# Description

`MatchSpec::parse` currently accounts for nearly all of the time spent in the BFS traversal to extract names of packages.

This PR introduces `MatchSpec::extract_name`, a specialized static method, to reduce this overhead.


## Type of Change

<!-- Please skip this part if you are already using conventional commit keywords in the PR title. -->

- [ ] Bugfix
- [x] Feature / enhancement
- [ ] CI / Documentation
- [ ] Maintenance

## Checklist

- [x] My code follows the general style and conventions of the codebase, ensuring consistency
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have run `pre-commit run --all` locally in the source folder and confirmed that there are no linter errors.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
