### PR TITLE
feat: Optimize `PackageInfo` descending sorts

### DIFF
--- a/libmamba/include/mamba/specs/package_info.hpp
+++ b/libmamba/include/mamba/specs/package_info.hpp
@@ -95,10 +95,12 @@ namespace mamba::specs
     void from_json(const nlohmann::json& j, PackageInfo& pkg);
 
     /**
-     * Compare two packages by version first, then by build number.
-     * Returns true if lhs should come before rhs (lhs < rhs).
+     * Sort packages by version (descending), then by build number (descending).
+     *
+     * This function precomputes parsed versions once per package to avoid repeatedly
+     * calling `Version::parse` in sort comparator hot paths.
      */
-    bool compare_packages_by_version_and_build(const PackageInfo& lhs, const PackageInfo& rhs);
+    void sort_packages_by_version_and_build_desc(std::vector<PackageInfo>& packages);
 }
 
 template <>

--- a/libmamba/src/api/channel_loader.cpp
+++ b/libmamba/src/api/channel_loader.cpp
@@ -580,15 +580,7 @@ namespace mamba
                 loaded_subdirs_with_shards.insert(repo_name);
 
                 auto sorted_pkgs = pkgs;
-                std::sort(
-                    sorted_pkgs.begin(),
-                    sorted_pkgs.end(),
-                    [](const specs::PackageInfo& lhs, const specs::PackageInfo& rhs)
-                    {
-                        // Compare in reverse order for descending sort (newer versions first)
-                        return specs::compare_packages_by_version_and_build(rhs, lhs);
-                    }
-                );
+                specs::sort_packages_by_version_and_build_desc(sorted_pkgs);
                 auto repo = database.add_repo_from_packages(
                     sorted_pkgs,
                     repo_name,

--- a/libmamba/src/core/query.cpp
+++ b/libmamba/src/core/query.cpp
@@ -926,15 +926,7 @@ namespace mamba
                 }
             }
             // Sort by version (descending), then by build number (descending)
-            std::sort(
-                sorted_packages.begin(),
-                sorted_packages.end(),
-                [](const specs::PackageInfo& lhs, const specs::PackageInfo& rhs)
-                {
-                    // Compare in reverse order for descending sort
-                    return specs::compare_packages_by_version_and_build(rhs, lhs);
-                }
-            );
+            sort_packages_by_version_and_build_desc(sorted_packages);
 
             for (const auto& package : sorted_packages)
             {
@@ -1004,15 +996,7 @@ namespace mamba
             {
                 // Sort packages by version (descending) and build number (descending)
                 // so that the latest version is first
-                std::sort(
-                    entry.second.begin(),
-                    entry.second.end(),
-                    [](const specs::PackageInfo& lhs, const specs::PackageInfo& rhs)
-                    {
-                        // Compare in reverse order for descending sort (newest first)
-                        return specs::compare_packages_by_version_and_build(rhs, lhs);
-                    }
-                );
+                sort_packages_by_version_and_build_desc(entry.second);
 
                 print_solvable(
                     out,

--- a/libmamba/src/specs/package_info.cpp
+++ b/libmamba/src/specs/package_info.cpp
@@ -593,20 +593,46 @@ namespace mamba::specs
         return fmt::format("{}/{}", channel_mirror_platform_url, filename);
     }
 
-    bool compare_packages_by_version_and_build(const PackageInfo& lhs, const PackageInfo& rhs)
+    void sort_packages_by_version_and_build_desc(std::vector<PackageInfo>& packages)
     {
-        // First compare by version
-        auto lhs_version = Version::parse(lhs.version).value_or(Version());
-        auto rhs_version = Version::parse(rhs.version).value_or(Version());
-        if (lhs_version < rhs_version)
+        struct VersionBuildSortKey
         {
-            return true;
-        }
-        if (rhs_version < lhs_version)
+            std::size_t idx;
+            Version version;
+            std::size_t build_number;
+        };
+
+        std::vector<VersionBuildSortKey> sort_keys;
+        sort_keys.reserve(packages.size());
+        for (std::size_t i = 0; i < packages.size(); ++i)
         {
-            return false;
+            auto version = Version::parse(packages[i].version).value_or(Version());
+            sort_keys.push_back(VersionBuildSortKey{ i, std::move(version), packages[i].build_number });
         }
-        // Versions are equal, compare by build number
-        return lhs.build_number < rhs.build_number;
+
+        std::sort(
+            sort_keys.begin(),
+            sort_keys.end(),
+            [](const VersionBuildSortKey& lhs, const VersionBuildSortKey& rhs)
+            {
+                if (rhs.version < lhs.version)
+                {
+                    return true;
+                }
+                if (lhs.version < rhs.version)
+                {
+                    return false;
+                }
+                return lhs.build_number > rhs.build_number;
+            }
+        );
+
+        std::vector<PackageInfo> sorted_packages;
+        sorted_packages.reserve(packages.size());
+        for (const auto& key : sort_keys)
+        {
+            sorted_packages.push_back(std::move(packages[key.idx]));
+        }
+        packages = std::move(sorted_packages);
     }
 }


### PR DESCRIPTION
# Description

Cache `Versions` to avoid the significant overhead of `Version::parse` when sorting `PackageInfo` descendingly.

## Type of Change

<!-- Please skip this part if you are already using conventional commit keywords in the PR title. -->

- [ ] Bugfix
- [x] Feature / enhancement
- [ ] CI / Documentation
- [ ] Maintenance

## Checklist

- [x] My code follows the general style and conventions of the codebase, ensuring consistency
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have run `pre-commit run --all` locally in the source folder and confirmed that there are no linter errors.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
