### PR TITLE
fix: Treat sibling-subdir shard loads as successful

### DIFF
--- a/libmamba/src/api/channel_loader.cpp
+++ b/libmamba/src/api/channel_loader.cpp
@@ -463,7 +463,12 @@ namespace mamba
 
                 if (result)
                 {
-                    database.set_repo_priority(std::move(result).value(), priorities[i]);
+                    // `load_subdir_with_shards` already sets priorities for all repos it adds.
+                    // Avoid overriding another repo when this subdir has no direct match.
+                    if (!use_shards)
+                    {
+                        database.set_repo_priority(std::move(result).value(), priorities[i]);
+                    }
                 }
                 else if (is_retry)
                 {
@@ -596,7 +601,7 @@ namespace mamba
                 );
                 std::size_t idx = url_to_subdir_idx.at(channel_url);
                 database.set_repo_priority(repo, priorities[idx]);
-                if (channel_url == current_repodata_url)
+                if (!result_repo.has_value() || channel_url == current_repodata_url)
                 {
                     result_repo = std::move(repo);
                 }

--- a/libmamba/tests/src/core/test_sharded_repodata_integration.cpp
+++ b/libmamba/tests/src/core/test_sharded_repodata_integration.cpp
@@ -418,6 +418,45 @@ TEST_CASE(
     REQUIRE(result.has_value());
 }
 
+TEST_CASE(
+    "Sharded repodata - noarch-only root package is installable",
+    "[mamba::core][sharded][.integration][!mayfail]"
+)
+{
+    auto& ctx = mambatests::context();
+    ctx.channels = { "https://prefix.dev/conda-forge" };
+    ctx.offline = false;
+
+    const TemporaryDirectory tmp_dir;
+    const fs::u8path cache_dir = tmp_dir.path() / "cache";
+    fs::create_directories(cache_dir);
+
+    ChannelContext channel_context = ChannelContext::make_conda_compatible(ctx);
+    init_channels(ctx, channel_context);
+
+    // `tzdata` is a noarch package with no dependencies; this exercises the edge case where
+    // the root package is resolved from a sibling subdir while iterating platform subdirs.
+    const std::vector<std::string> specs = { "tzdata" };
+
+    auto flat_solution = solve_environment(ctx, channel_context, specs, false, cache_dir);
+    REQUIRE(flat_solution.has_value());
+
+    auto sharded_solution = solve_environment(ctx, channel_context, specs, true, cache_dir);
+    REQUIRE(sharded_solution.has_value());
+    REQUIRE(flat_solution.value() == sharded_solution.value());
+
+    bool tzdata_found = false;
+    for (const auto& pkg : sharded_solution->packages_to_install())
+    {
+        if (pkg.name == "tzdata")
+        {
+            tzdata_found = true;
+            break;
+        }
+    }
+    REQUIRE(tzdata_found);
+}
+
 TEST_CASE("Sharded repodata - solver results consistency", "[mamba::core][sharded][.integration][!mayfail]")
 {
     auto& ctx = mambatests::context();


### PR DESCRIPTION
# Description

Sharded repodata loading could incorrectly report failure when the reachable subset contained only packages from a sibling subdir (for example, a noarch root package while iterating linux-64). In that case repos were added, but no repo handle matched the current subdir URL, which triggered a fallback to full repodata and made shard loading look unsuccessful.

Return a fallback repo handle when at least one repo was loaded from shards, while still preferring the current subdir URL when present. Also avoid reapplying per-subdir priority in the generic caller for shard paths, since shard loading already applies priority per loaded channel URL. This keeps `noarch`-only roots like `tzdata` installable via shards without spurious fallback behavior.

## Type of Change

<!-- Please skip this part if you are already using conventional commit keywords in the PR title. -->

- [x] Bugfix
- [ ] Feature / enhancement
- [ ] CI / Documentation
- [ ] Maintenance

## Checklist

- [x] My code follows the general style and conventions of the codebase, ensuring consistency
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have run `pre-commit run --all` locally in the source folder and confirmed that there are no linter errors.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
