### PR TITLE
maint: Replace `ShardPackageRecord` with `RepoDataPackage`

### DIFF
--- a/libmamba/include/mamba/core/shard_types.hpp
+++ b/libmamba/include/mamba/core/shard_types.hpp
@@ -18,101 +18,25 @@
 namespace mamba
 {
     /**
-     * Package record dictionary for shard data.
-     *
-     * This is a simplified representation of package metadata used in shards.
-     * It exists separately from other package types for several reasons:
-     *
-     * **Comparison with specs::RepoDataPackage:**
-     * - Uses primitive types (string for version, string for noarch) instead of
-     *   complex types (Version object, NoArchType enum), making direct msgpack
-     *   deserialization faster and more straightforward.
-     * - Contains only fields needed for dependency traversal, reducing memory usage
-     *   when processing many shards.
-     * - Conversion to RepoDataPackage happens lazily when building repodata for
-     *   the solver, deferring parsing costs until actually needed.
-     *
-     * **Comparison with specs::PackageInfo:**
-     * - PackageInfo is the runtime representation used for installed packages,
-     *   transactions, and queries. It uses string for version (like ShardPackageRecord)
-     *   but NoArchType enum (like RepoDataPackage), and includes runtime-specific
-     *   fields like channel, package_url, platform, filename, signatures, etc.
-     * - ShardPackageRecord is purely for parsing msgpack shards and contains only
-     *   the minimal fields needed for dependency traversal.
-     * - PackageInfo is created from RepoDataPackage when packages are added to the
-     *   solver database, not directly from ShardPackageRecord.
-     *
-     * **Key design decisions:**
-     *
-     * 1. **Simpler msgpack parsing**: The msgpack format from Python shards uses simple
-     *    types that map directly to primitives, avoiding complex type parsing during
-     *    deserialization.
-     *
-     * 2. **Minimal storage**: Only fields needed for dependency traversal (name, version,
-     *    build, dependencies, constraints). Fields like license, timestamp, track_features
-     *    are not needed during traversal.
-     *
-     * 3. **Lazy conversion**: Conversion to specs::RepoDataPackage happens only when
-     *    building repodata for the solver (via to_repo_data_package()), deferring
-     *    Version/NoArchType parsing costs until actually needed.
-     *
-     * 4. **Flexible msgpack handling**: Custom parsing handles various msgpack types
-     *    for sha256/md5 (strings, bytes, EXT types), easier with a dedicated structure.
-     *
-     * This structure supports all fields defined in the shard format specification.
-     * See https://conda.org/learn/ceps/cep-0016 for the complete shard format specification.
-     *
-     * @see specs::RepoDataPackage The canonical package record type used for repodata.json
-     * @see specs::PackageInfo The runtime package representation used throughout the codebase
-     * @see to_repo_data_package() Conversion function to RepoDataPackage
-     * @see from_repo_data_package() Conversion function from RepoDataPackage
-     * @see https://conda.org/learn/ceps/cep-0016 CEP 16 - Sharded Repodata specification
-     */
-    struct ShardPackageRecord
-    {
-        std::string name;
-        std::string version;
-        std::string build;
-        std::size_t build_number = 0;
-        std::size_t size = 0;
-        std::vector<std::string> depends;
-        std::vector<std::string> constrains;
-        std::vector<std::string> track_features;
-
-        std::optional<std::string> sha256;
-        std::optional<std::string> md5;
-        /** Optional path to the site-packages directory for Python packages. */
-        std::optional<std::string> python_site_packages_path;
-        /** Deprecated md5 hash for legacy .tar.bz2 archives. */
-        std::optional<std::string> legacy_bz2_md5;
-        /** Deprecated size for legacy .tar.bz2 archives. */
-        std::optional<std::size_t> legacy_bz2_size;
-        /** Optional architecture string. */
-        std::optional<std::string> arch;
-        /** Optional platform string. */
-        std::optional<std::string> platform;
-        /** Deprecated features string. */
-        std::optional<std::string> features;
-        std::optional<std::string> noarch;
-        std::optional<std::string> license;
-        std::optional<std::string> license_family;
-        std::optional<std::string> subdir;
-        std::optional<std::size_t> timestamp;
-    };
-
-    /**
      * A shard dictionary containing packages for a single package name.
      *
      * Maps to the Python ShardDict type. Contains all versions of a package
      * in both .tar.bz2 and .conda formats.
+     *
+     * Shards use a msgpack format; parsing is handled in `shards.cpp`.
+     * We store entries as `specs::RepoDataPackage` directly, which is the canonical
+     * record type used across libmamba.
+     *
+     * @see specs::RepoDataPackage The canonical package record type used for repodata.json
+     * @see https://conda.org/learn/ceps/cep-0016 CEP 16 - Sharded Repodata specification
      */
     struct ShardDict
     {
         /** Packages in .tar.bz2 format, keyed by filename. */
-        std::map<std::string, ShardPackageRecord> packages;
+        std::map<std::string, specs::RepoDataPackage> packages;
 
         /** Packages in .conda format, keyed by filename. */
-        std::map<std::string, ShardPackageRecord> conda_packages;
+        std::map<std::string, specs::RepoDataPackage> conda_packages;
     };
 
     /**
@@ -172,20 +96,6 @@ namespace mamba
     };
 
     /**
-     * Convert ShardPackageRecord to specs::RepoDataPackage.
-     *
-     * This conversion is used when building repodata for the solver.
-     */
-    specs::RepoDataPackage to_repo_data_package(const ShardPackageRecord& record);
-
-    /**
-     * Convert specs::RepoDataPackage to ShardPackageRecord.
-     *
-     * This conversion is used when treating monolithic repodata as shards.
-     */
-    ShardPackageRecord from_repo_data_package(const specs::RepoDataPackage& record);
-
-    /**
      * Convert RepodataDict to specs::RepoData.
      *
      * This conversion is used when building repodata for the solver from shards.
@@ -193,11 +103,11 @@ namespace mamba
     specs::RepoData to_repo_data(const RepodataDict& repodata);
 
     /**
-     * Convert ShardPackageRecord to specs::PackageInfo.
+     * Convert `specs::RepoDataPackage` to `specs::PackageInfo`.
      *
      * This conversion is used when loading packages from shards into the package database.
      * Requires additional metadata (filename, channel, platform, base_url) that is not
-     * present in ShardPackageRecord but needed for PackageInfo.
+     * present in the record itself but needed for PackageInfo.
      *
      * @param record The shard package record to convert
      * @param filename The package filename (e.g., "package-1.0.0-h123_0.tar.bz2")
@@ -207,7 +117,7 @@ namespace mamba
      * @return PackageInfo object with all fields populated
      */
     specs::PackageInfo to_package_info(
-        const ShardPackageRecord& record,
+        const specs::RepoDataPackage& record,
         const std::string& filename,
         const std::string& channel_id,
         const specs::DynamicPlatform& platform,

--- a/libmamba/src/core/shard_traversal.cpp
+++ b/libmamba/src/core/shard_traversal.cpp
@@ -57,7 +57,7 @@ namespace mamba
             }
         }
 
-        void add_names_from_record(const ShardPackageRecord& record, std::set<std::string>& names)
+        void add_names_from_record(const specs::RepoDataPackage& record, std::set<std::string>& names)
         {
             add_names_from_specs(record.depends, names);
             add_names_from_specs(record.constrains, names);

--- a/libmamba/src/core/shard_types.cpp
+++ b/libmamba/src/core/shard_types.cpp
@@ -13,98 +13,6 @@
 
 namespace mamba
 {
-    specs::RepoDataPackage to_repo_data_package(const ShardPackageRecord& record)
-    {
-        // Parse version string to Version object
-        auto version = specs::Version::parse(record.version);
-        auto parsed_version = version ? version.value() : specs::Version(0, { { { 0 } } });
-
-        // Parse noarch string to NoArchType
-        std::optional<specs::NoArchType> noarch_value = std::nullopt;
-        if (record.noarch)
-        {
-            const auto& noarch_str = *record.noarch;
-            if (noarch_str == "python")
-            {
-                noarch_value = specs::NoArchType::Python;
-            }
-            else if (noarch_str == "generic")
-            {
-                noarch_value = specs::NoArchType::Generic;
-            }
-            // If noarch_str doesn't match known values, leave as nullopt
-        }
-
-        return specs::RepoDataPackage{
-            .name = record.name,
-            .version = parsed_version,
-            .build_string = record.build,
-            .build_number = record.build_number,
-            .subdir = record.subdir,
-            .md5 = record.md5,
-            .sha256 = record.sha256,
-            .python_site_packages_path = record.python_site_packages_path,
-            .legacy_bz2_md5 = record.legacy_bz2_md5,
-            .legacy_bz2_size = record.legacy_bz2_size,
-            .size = record.size > 0 ? std::optional<std::size_t>(record.size) : std::nullopt,
-            .arch = record.arch,
-            .platform = record.platform,
-            .depends = record.depends,
-            .constrains = record.constrains,
-            .track_features = record.track_features,
-            .features = record.features,
-            .noarch = noarch_value,
-            .license = record.license,
-            .license_family = record.license_family,
-            .timestamp = record.timestamp,
-        };
-    }
-
-    ShardPackageRecord from_repo_data_package(const specs::RepoDataPackage& record)
-    {
-        std::optional<std::string> noarch_value = std::nullopt;
-        if (record.noarch)
-        {
-            switch (*record.noarch)
-            {
-                case specs::NoArchType::Generic:
-                    noarch_value = "generic";
-                    break;
-                case specs::NoArchType::Python:
-                    noarch_value = "python";
-                    break;
-                case specs::NoArchType::No:
-                default:
-                    // No noarch type
-                    break;
-            }
-        }
-
-        return ShardPackageRecord{
-            .name = record.name,
-            .version = record.version.to_string(),
-            .build = record.build_string,
-            .build_number = record.build_number,
-            .size = record.size.value_or(0),
-            .depends = record.depends,
-            .constrains = record.constrains,
-            .track_features = record.track_features,
-            .sha256 = record.sha256,
-            .md5 = record.md5,
-            .python_site_packages_path = record.python_site_packages_path,
-            .legacy_bz2_md5 = record.legacy_bz2_md5,
-            .legacy_bz2_size = record.legacy_bz2_size,
-            .arch = record.arch,
-            .platform = record.platform,
-            .features = record.features,
-            .noarch = noarch_value,
-            .license = record.license,
-            .license_family = record.license_family,
-            .subdir = record.subdir,
-            .timestamp = record.timestamp,
-        };
-    }
-
     specs::RepoData to_repo_data(const RepodataDict& repodata)
     {
         // Convert info section
@@ -118,51 +26,26 @@ namespace mamba
             }
         }
 
-        // Convert packages
-        std::map<std::string, specs::RepoDataPackage> packages;
-        for (const auto& [filename, record] : repodata.shard_dict.packages)
-        {
-            packages[filename] = to_repo_data_package(record);
-        }
-
-        // Convert conda packages
-        std::map<std::string, specs::RepoDataPackage> conda_packages;
-        for (const auto& [filename, record] : repodata.shard_dict.conda_packages)
-        {
-            conda_packages[filename] = to_repo_data_package(record);
-        }
-
         return specs::RepoData{ .version = repodata.repodata_version,
                                 .info = info_value,
-                                .packages = std::move(packages),
-                                .conda_packages = std::move(conda_packages) };
+                                .packages = repodata.shard_dict.packages,
+                                .conda_packages = repodata.shard_dict.conda_packages };
     }
 
     specs::PackageInfo to_package_info(
-        const ShardPackageRecord& record,
+        const specs::RepoDataPackage& record,
         const std::string& filename,
         const std::string& channel_id,
         const specs::DynamicPlatform& platform,
         const std::string& base_url
     )
     {
-        specs::NoArchType noarch_value = specs::NoArchType::No;
-        if (record.noarch)
-        {
-            if (*record.noarch == "python")
-            {
-                noarch_value = specs::NoArchType::Python;
-            }
-            else if (*record.noarch == "generic")
-            {
-                noarch_value = specs::NoArchType::Generic;
-            }
-        }
+        const specs::NoArchType noarch_value = record.noarch.value_or(specs::NoArchType::No);
 
         specs::PackageInfo pkg_info;
         pkg_info.name = record.name;
-        pkg_info.version = record.version;
-        pkg_info.build_string = record.build;
+        pkg_info.version = record.version.to_string();
+        pkg_info.build_string = record.build_string;
         pkg_info.build_number = record.build_number;
         pkg_info.channel = channel_id;
         pkg_info.package_url = util::url_concat(base_url, "/", filename);
@@ -175,7 +58,7 @@ namespace mamba
         pkg_info.constrains = record.constrains;
         pkg_info.track_features = record.track_features;
         pkg_info.noarch = noarch_value;
-        pkg_info.size = record.size;
+        pkg_info.size = record.size.value_or(0);
         pkg_info.timestamp = record.timestamp.value_or(0);
         return pkg_info;
     }

--- a/libmamba/src/core/shards.cpp
+++ b/libmamba/src/core/shards.cpp
@@ -178,18 +178,18 @@ namespace mamba
         }
 
         /**
-         * Manually parse a ShardPackageRecord from msgpack object.
+         * Manually parse a `specs::RepoDataPackage` from msgpack object.
          *
          * This handles the case where sha256 and md5 can be either strings or bytes
          * (as per Python TypedDict: NotRequired[str | bytes]).
          */
-        auto parse_shard_package_record(const msgpack_object& obj) -> ShardPackageRecord
+        auto parse_shard_package_record(const msgpack_object& obj) -> specs::RepoDataPackage
         {
-            ShardPackageRecord record;
+            specs::RepoDataPackage record;
 
             if (obj.type != MSGPACK_OBJECT_MAP)
             {
-                throw std::runtime_error("Expected MAP type for ShardPackageRecord");
+                throw std::runtime_error("Expected MAP type for shard package record");
             }
 
             for (std::uint32_t i = 0; i < obj.via.map.size; ++i)
@@ -221,11 +221,13 @@ namespace mamba
                     }
                     else if (key == "version")
                     {
-                        record.version = msgpack_object_to_string(val_obj);
+                        const auto version_str = msgpack_object_to_string(val_obj);
+                        auto parsed = specs::Version::parse(version_str);
+                        record.version = parsed ? parsed.value() : specs::Version(0, { { { 0 } } });
                     }
                     else if (key == "build")
                     {
-                        record.build = msgpack_object_to_string(val_obj);
+                        record.build_string = msgpack_object_to_string(val_obj);
                     }
                     else if (key == "build_number")
                     {
@@ -309,7 +311,19 @@ namespace mamba
                         }
                         else
                         {
-                            record.noarch = msgpack_object_to_string(val_obj);
+                            const auto noarch_str = msgpack_object_to_string(val_obj);
+                            if (noarch_str == "python")
+                            {
+                                record.noarch = specs::NoArchType::Python;
+                            }
+                            else if (noarch_str == "generic")
+                            {
+                                record.noarch = specs::NoArchType::Generic;
+                            }
+                            else
+                            {
+                                record.noarch = std::nullopt;
+                            }
                         }
                     }
                     else if (key == "size")
@@ -329,13 +343,29 @@ namespace mamba
                     {
                         record.features = msgpack_object_to_string(val_obj);
                     }
+                    else if (key == "license")
+                    {
+                        record.license = msgpack_object_to_string(val_obj);
+                    }
+                    else if (key == "license_family")
+                    {
+                        record.license_family = msgpack_object_to_string(val_obj);
+                    }
+                    else if (key == "subdir")
+                    {
+                        record.subdir = msgpack_object_to_string(val_obj);
+                    }
+                    else if (key == "timestamp")
+                    {
+                        record.timestamp = msgpack_object_to_uint64(val_obj);
+                    }
                     // Ignore unknown fields (they might be present in the data but not needed)
                 }
                 catch (const std::exception& e)
                 {
                     LOG_WARNING << "Failed to parse field '" << key
                                 << "' (type=" << static_cast<int>(val_obj.type)
-                                << ") in ShardPackageRecord: " << e.what();
+                                << ") in shard package record: " << e.what();
                     // Continue parsing other fields
                 }
             }
@@ -868,7 +898,7 @@ namespace mamba
             ShardDict shard;
 
             auto parse_package_records = [](const msgpack_object& map_obj,
-                                            std::map<std::string, ShardPackageRecord>& target_map,
+                                            std::map<std::string, specs::RepoDataPackage>& target_map,
                                             const std::string& map_name)
             {
                 for (std::uint32_t k = 0; k < map_obj.via.map.size; ++k)
@@ -876,7 +906,7 @@ namespace mamba
                     try
                     {
                         std::string pkg_filename = msgpack_object_to_string(map_obj.via.map.ptr[k].key);
-                        ShardPackageRecord record = parse_shard_package_record(
+                        specs::RepoDataPackage record = parse_shard_package_record(
                             map_obj.via.map.ptr[k].val
                         );
                         target_map[pkg_filename] = record;
@@ -1130,8 +1160,8 @@ namespace mamba
         // Collect all packages first, then sort by version and build number
         // This ensures that when libsolv processes packages, it sees them in
         // the correct order (highest version/build first)
-        std::vector<std::pair<std::string, ShardPackageRecord>> all_packages;
-        std::vector<std::pair<std::string, ShardPackageRecord>> all_conda_packages;
+        std::vector<std::pair<std::string, specs::RepoDataPackage>> all_packages;
+        std::vector<std::pair<std::string, specs::RepoDataPackage>> all_conda_packages;
 
         for (const auto& [package, shard] : m_visited)
         {
@@ -1162,25 +1192,6 @@ namespace mamba
             }
 
             // Then compare by version (descending - highest first)
-            // Parse versions for comparison
-            auto version_a = specs::Version::parse(record_a.version);
-            auto version_b = specs::Version::parse(record_b.version);
-
-            if (version_a.has_value() && version_b.has_value())
-            {
-                if (version_a.value() != version_b.value())
-                {
-                    return version_b.value() < version_a.value();  // Descending order
-                }
-            }
-
-            // If only one can be parsed, prefer the parsed one
-            if (version_a.has_value() || version_b.has_value())
-            {
-                return !version_a.has_value();
-            }
-
-            // Fallback to string comparison if parsing fails
             if (record_a.version != record_b.version)
             {
                 return record_b.version < record_a.version;  // Descending order
@@ -1202,7 +1213,7 @@ namespace mamba
             }
 
             // If everything else is equal, compare by build string
-            return record_b.build < record_a.build;  // Descending order
+            return record_b.build_string < record_a.build_string;  // Descending order
         };
 
         std::sort(all_packages.begin(), all_packages.end(), compare_packages);

--- a/libmamba/tests/src/core/test_shard_index_loader.cpp
+++ b/libmamba/tests/src/core/test_shard_index_loader.cpp
@@ -326,8 +326,8 @@ TEST_CASE("ShardIndexLoader::parse_shard_index - Download and parse numpy shard"
                     {
                         found_numpy = true;
                         // Verify the record has required fields
-                        REQUIRE(!record.version.empty());
-                        REQUIRE(!record.build.empty());
+                        REQUIRE(!record.version.to_string().empty());
+                        REQUIRE(!record.build_string.empty());
                         break;
                     }
                 }
@@ -336,8 +336,8 @@ TEST_CASE("ShardIndexLoader::parse_shard_index - Download and parse numpy shard"
                     if (record.name == "numpy")
                     {
                         found_numpy = true;
-                        REQUIRE(!record.version.empty());
-                        REQUIRE(!record.build.empty());
+                        REQUIRE(!record.version.to_string().empty());
+                        REQUIRE(!record.build_string.empty());
                         break;
                     }
                 }

--- a/libmamba/tests/src/core/test_shard_traversal.cpp
+++ b/libmamba/tests/src/core/test_shard_traversal.cpp
@@ -134,10 +134,10 @@ TEST_CASE("shard_mentioned_packages", "[mamba::core][mamba::core::shard_traversa
     SECTION("Extract from depends")
     {
         ShardDict shard;
-        ShardPackageRecord record;
+        specs::RepoDataPackage record;
         record.name = "python";
-        record.version = "3.11";
-        record.build = "0";
+        record.version = specs::Version::parse("3.11").value();
+        record.build_string = "0";
         record.depends = { "libffi", "libzstd>=1.4" };
         shard.packages["python-3.11-0.conda"] = record;
 
@@ -150,10 +150,10 @@ TEST_CASE("shard_mentioned_packages", "[mamba::core][mamba::core::shard_traversa
     SECTION("Extract from constrains")
     {
         ShardDict shard;
-        ShardPackageRecord record;
+        specs::RepoDataPackage record;
         record.name = "numpy";
-        record.version = "1.24";
-        record.build = "0";
+        record.version = specs::Version::parse("1.24").value();
+        record.build_string = "0";
         record.constrains = { "python>=3.9" };
         shard.conda_packages["numpy-1.24-0.conda"] = record;
 
@@ -165,12 +165,12 @@ TEST_CASE("shard_mentioned_packages", "[mamba::core][mamba::core::shard_traversa
     SECTION("Extract from both packages and conda_packages")
     {
         ShardDict shard;
-        ShardPackageRecord rec1;
+        specs::RepoDataPackage rec1;
         rec1.name = "pkg1";
         rec1.depends = { "dep_a" };
         shard.packages["pkg1-1.0.tar.bz2"] = rec1;
 
-        ShardPackageRecord rec2;
+        specs::RepoDataPackage rec2;
         rec2.name = "pkg2";
         rec2.depends = { "dep_b" };
         shard.conda_packages["pkg2-1.0.conda"] = rec2;
@@ -184,12 +184,12 @@ TEST_CASE("shard_mentioned_packages", "[mamba::core][mamba::core::shard_traversa
     SECTION("Deduplicate across multiple records")
     {
         ShardDict shard;
-        ShardPackageRecord rec1;
+        specs::RepoDataPackage rec1;
         rec1.name = "pkg1";
         rec1.depends = { "common_dep" };
         shard.packages["pkg1-1.0.tar.bz2"] = rec1;
 
-        ShardPackageRecord rec2;
+        specs::RepoDataPackage rec2;
         rec2.name = "pkg2";
         rec2.depends = { "common_dep" };
         shard.packages["pkg2-1.0.tar.bz2"] = rec2;
@@ -201,7 +201,7 @@ TEST_CASE("shard_mentioned_packages", "[mamba::core][mamba::core::shard_traversa
     SECTION("Skip invalid specs")
     {
         ShardDict shard;
-        ShardPackageRecord record;
+        specs::RepoDataPackage record;
         record.name = "pkg";
         record.depends = { "valid>=1.0", "!!!invalid!!!", "another_valid" };
         shard.packages["pkg-1.0.conda"] = record;
@@ -214,7 +214,7 @@ TEST_CASE("shard_mentioned_packages", "[mamba::core][mamba::core::shard_traversa
     SECTION("Skip free name specs")
     {
         ShardDict shard;
-        ShardPackageRecord record;
+        specs::RepoDataPackage record;
         record.name = "pkg";
         record.depends = { "normal_pkg", "*" };
         shard.packages["pkg-1.0.conda"] = record;
@@ -234,7 +234,7 @@ TEST_CASE("shard_mentioned_packages", "[mamba::core][mamba::core::shard_traversa
     SECTION("Shard with empty depends and constrains")
     {
         ShardDict shard;
-        ShardPackageRecord record;
+        specs::RepoDataPackage record;
         record.name = "pkg";
         record.depends = {};
         record.constrains = {};
@@ -294,19 +294,19 @@ TEST_CASE("RepodataSubset reachable empty", "[mamba::core][mamba::core::shard_tr
 TEST_CASE("RepodataSubset reachable pipelined", "[mamba::core][mamba::core::shard_traversal]")
 {
     ShardDict python_shard;
-    ShardPackageRecord python_rec;
+    specs::RepoDataPackage python_rec;
     python_rec.name = "python";
     python_rec.depends = { "numpy" };
     python_shard.packages["python-3.11-0.conda"] = python_rec;
 
     ShardDict numpy_shard;
-    ShardPackageRecord numpy_rec;
+    specs::RepoDataPackage numpy_rec;
     numpy_rec.name = "numpy";
     numpy_rec.depends = { "libffi" };
     numpy_shard.packages["numpy-1.24-0.conda"] = numpy_rec;
 
     ShardDict libffi_shard;
-    ShardPackageRecord libffi_rec;
+    specs::RepoDataPackage libffi_rec;
     libffi_rec.name = "libffi";
     libffi_rec.depends = {};
     libffi_shard.packages["libffi-1.0-0.conda"] = libffi_rec;
@@ -343,19 +343,19 @@ TEST_CASE("RepodataSubset reachable pipelined", "[mamba::core][mamba::core::shar
 TEST_CASE("RepodataSubset reachable bfs", "[mamba::core][mamba::core::shard_traversal]")
 {
     ShardDict python_shard;
-    ShardPackageRecord python_rec;
+    specs::RepoDataPackage python_rec;
     python_rec.name = "python";
     python_rec.depends = { "numpy" };
     python_shard.packages["python-3.11-0.conda"] = python_rec;
 
     ShardDict numpy_shard;
-    ShardPackageRecord numpy_rec;
+    specs::RepoDataPackage numpy_rec;
     numpy_rec.name = "numpy";
     numpy_rec.depends = { "libffi" };
     numpy_shard.packages["numpy-1.24-0.conda"] = numpy_rec;
 
     ShardDict libffi_shard;
-    ShardPackageRecord libffi_rec;
+    specs::RepoDataPackage libffi_rec;
     libffi_rec.name = "libffi";
     libffi_rec.depends = {};
     libffi_shard.packages["libffi-1.0-0.conda"] = libffi_rec;
@@ -392,7 +392,7 @@ TEST_CASE("RepodataSubset reachable bfs", "[mamba::core][mamba::core::shard_trav
 TEST_CASE("RepodataSubset reachable with root_shards filter", "[mamba::core][mamba::core::shard_traversal]")
 {
     ShardDict python_shard;
-    ShardPackageRecord python_rec;
+    specs::RepoDataPackage python_rec;
     python_rec.name = "python";
     python_rec.depends = {};
     python_shard.packages["python-3.11-0.conda"] = python_rec;
@@ -415,7 +415,7 @@ TEST_CASE(
 )
 {
     ShardDict python_shard;
-    ShardPackageRecord python_rec;
+    specs::RepoDataPackage python_rec;
     python_rec.name = "python";
     python_rec.depends = {};
     python_shard.packages["python-3.11-0.conda"] = python_rec;
@@ -435,7 +435,7 @@ TEST_CASE(
 TEST_CASE("RepodataSubset multiple channels", "[mamba::core][mamba::core::shard_traversal]")
 {
     ShardDict python_shard;
-    ShardPackageRecord python_rec;
+    specs::RepoDataPackage python_rec;
     python_rec.name = "python";
     python_rec.depends = {};
     python_shard.packages["python-3.11-0.conda"] = python_rec;
@@ -459,7 +459,7 @@ TEST_CASE("RepodataSubset multiple channels", "[mamba::core][mamba::core::shard_
 TEST_CASE("RepodataSubset package not in any shard", "[mamba::core][mamba::core::shard_traversal]")
 {
     ShardDict python_shard;
-    ShardPackageRecord python_rec;
+    specs::RepoDataPackage python_rec;
     python_rec.name = "python";
     python_rec.depends = {};
     python_shard.packages["python-3.11-0.conda"] = python_rec;
@@ -478,7 +478,7 @@ TEST_CASE("RepodataSubset package not in any shard", "[mamba::core][mamba::core:
 TEST_CASE("RepodataSubset default strategy is bfs", "[mamba::core][mamba::core::shard_traversal]")
 {
     ShardDict python_shard;
-    ShardPackageRecord python_rec;
+    specs::RepoDataPackage python_rec;
     python_rec.name = "python";
     python_rec.depends = {};
     python_shard.packages["python-3.11-0.conda"] = python_rec;

--- a/libmamba/tests/src/core/test_shard_types.cpp
+++ b/libmamba/tests/src/core/test_shard_types.cpp
@@ -12,77 +12,6 @@
 
 using namespace mamba;
 
-TEST_CASE("ShardPackageRecord conversion", "[mamba::core][mamba::core::shard_types]")
-{
-    SECTION("Convert RepoDataPackage to ShardPackageRecord")
-    {
-        specs::RepoDataPackage pkg;
-        pkg.name = "test-package";
-        pkg.version = specs::Version::parse("1.2.3").value();
-        pkg.build_string = "build123";
-        pkg.build_number = 42;
-        pkg.sha256 = "abc123";
-        pkg.md5 = "def456";
-        pkg.depends = { "dep1", "dep2" };
-        pkg.constrains = { "constraint1" };
-        pkg.noarch = specs::NoArchType::Generic;
-        pkg.license = "MIT";
-        pkg.license_family = "MIT";
-        pkg.subdir = "linux-64";
-        pkg.timestamp = 1234567890;
-        pkg.size = 98765;
-
-        ShardPackageRecord shard_record = from_repo_data_package(pkg);
-
-        REQUIRE(shard_record.name == "test-package");
-        REQUIRE(shard_record.version == "1.2.3");
-        REQUIRE(shard_record.build == "build123");
-        REQUIRE(shard_record.build_number == 42);
-        REQUIRE(shard_record.sha256 == "abc123");
-        REQUIRE(shard_record.md5 == "def456");
-        REQUIRE(shard_record.depends.size() == 2);
-        REQUIRE(shard_record.constrains.size() == 1);
-        REQUIRE(shard_record.noarch == "generic");
-        REQUIRE(shard_record.license == "MIT");
-        REQUIRE(shard_record.license_family == "MIT");
-        REQUIRE(shard_record.subdir == "linux-64");
-        REQUIRE(shard_record.timestamp == 1234567890);
-        REQUIRE(shard_record.size == 98765);
-    }
-
-    SECTION("Convert ShardPackageRecord to RepoDataPackage")
-    {
-        ShardPackageRecord shard_record;
-        shard_record.name = "test-package";
-        shard_record.version = "2.3.4";
-        shard_record.build = "build456";
-        shard_record.build_number = 100;
-        shard_record.sha256 = "xyz789";
-        shard_record.depends = { "dep3" };
-        shard_record.noarch = "python";
-        shard_record.license = "BSD";
-        shard_record.license_family = "BSD";
-        shard_record.subdir = "noarch";
-        shard_record.timestamp = 9876543210;
-        shard_record.size = 54321;
-
-        specs::RepoDataPackage pkg = to_repo_data_package(shard_record);
-
-        REQUIRE(pkg.name == "test-package");
-        REQUIRE(pkg.version.to_string() == "2.3.4");
-        REQUIRE(pkg.build_string == "build456");
-        REQUIRE(pkg.build_number == 100);
-        REQUIRE(pkg.sha256 == "xyz789");
-        REQUIRE(pkg.depends.size() == 1);
-        REQUIRE(pkg.noarch == specs::NoArchType::Python);
-        REQUIRE(pkg.license == "BSD");
-        REQUIRE(pkg.license_family == "BSD");
-        REQUIRE(pkg.subdir == "noarch");
-        REQUIRE(pkg.timestamp == 9876543210);
-        REQUIRE(pkg.size == 54321);
-    }
-}
-
 TEST_CASE("RepodataDict to RepoData conversion", "[mamba::core][mamba::core::shard_types]")
 {
     RepodataDict repodata_dict;
@@ -91,9 +20,9 @@ TEST_CASE("RepodataDict to RepoData conversion", "[mamba::core][mamba::core::sha
     repodata_dict.info.subdir = "linux-64";
     repodata_dict.repodata_version = 2;
 
-    ShardPackageRecord record;
+    specs::RepoDataPackage record;
     record.name = "test-pkg";
-    record.version = "1.0.0";
+    record.version = specs::Version::parse("1.0.0").value();
     repodata_dict.shard_dict.packages["test-pkg-1.0.0.tar.bz2"] = record;
 
     specs::RepoData repo_data = to_repo_data(repodata_dict);
@@ -103,146 +32,20 @@ TEST_CASE("RepodataDict to RepoData conversion", "[mamba::core][mamba::core::sha
     REQUIRE(repo_data.packages.begin()->second.name == "test-pkg");
 }
 
-TEST_CASE("ShardPackageRecord round-trip conversion", "[mamba::core][mamba::core::shard_types]")
-{
-    SECTION("ShardPackageRecord -> RepoDataPackage -> ShardPackageRecord")
-    {
-        ShardPackageRecord original;
-        original.name = "roundtrip-package";
-        original.version = "3.2.1";
-        original.build = "py39_0";
-        original.build_number = 5;
-        original.sha256 = "abcdef1234567890";
-        original.md5 = "1234567890abcdef";
-        original.depends = { "python >=3.9", "numpy" };
-        original.constrains = { "scipy <2.0" };
-        original.noarch = "python";
-        original.size = 12345;
-        original.license = "Apache-2.0";
-        original.license_family = "Apache";
-        original.subdir = "linux-64";
-        original.timestamp = 1609459200;
-
-        // Convert to RepoDataPackage and back
-        specs::RepoDataPackage repo_pkg = to_repo_data_package(original);
-        ShardPackageRecord roundtripped = from_repo_data_package(repo_pkg);
-
-        // Verify all fields are preserved
-        REQUIRE(roundtripped.name == original.name);
-        REQUIRE(roundtripped.version == original.version);
-        REQUIRE(roundtripped.build == original.build);
-        REQUIRE(roundtripped.build_number == original.build_number);
-        REQUIRE(roundtripped.sha256 == original.sha256);
-        REQUIRE(roundtripped.md5 == original.md5);
-        REQUIRE(roundtripped.depends == original.depends);
-        REQUIRE(roundtripped.constrains == original.constrains);
-        REQUIRE(roundtripped.noarch == original.noarch);
-        REQUIRE(roundtripped.size == original.size);
-        REQUIRE(roundtripped.license == original.license);
-        REQUIRE(roundtripped.license_family == original.license_family);
-        REQUIRE(roundtripped.subdir == original.subdir);
-        REQUIRE(roundtripped.timestamp == original.timestamp);
-    }
-
-    SECTION("RepoDataPackage -> ShardPackageRecord -> RepoDataPackage")
-    {
-        specs::RepoDataPackage original;
-        original.name = "roundtrip-pkg";
-        original.version = specs::Version::parse("4.5.6").value();
-        original.build_string = "h123abc_1";
-        original.build_number = 10;
-        original.sha256 = "sha256hash";
-        original.md5 = "md5hash";
-        original.depends = { "libstdcxx-ng >=7.5.0", "openssl >=1.1.1" };
-        original.constrains = { "some-constraint >=1.0" };
-        original.noarch = specs::NoArchType::Generic;
-        original.license = "GPL-3.0";
-        original.license_family = "GPL";
-        original.subdir = "osx-64";
-        original.timestamp = 1704067200;
-        original.size = 45678;
-
-        // Convert to ShardPackageRecord and back
-        ShardPackageRecord shard_rec = from_repo_data_package(original);
-        specs::RepoDataPackage roundtripped = to_repo_data_package(shard_rec);
-
-        // Verify all fields are preserved
-        REQUIRE(roundtripped.name == original.name);
-        REQUIRE(roundtripped.version.to_string() == original.version.to_string());
-        REQUIRE(roundtripped.build_string == original.build_string);
-        REQUIRE(roundtripped.build_number == original.build_number);
-        REQUIRE(roundtripped.sha256 == original.sha256);
-        REQUIRE(roundtripped.md5 == original.md5);
-        REQUIRE(roundtripped.depends == original.depends);
-        REQUIRE(roundtripped.constrains == original.constrains);
-        REQUIRE(roundtripped.noarch == original.noarch);
-        REQUIRE(roundtripped.license == original.license);
-        REQUIRE(roundtripped.license_family == original.license_family);
-        REQUIRE(roundtripped.subdir == original.subdir);
-        REQUIRE(roundtripped.timestamp == original.timestamp);
-        REQUIRE(roundtripped.size == original.size);
-    }
-
-    SECTION("Round-trip with no noarch")
-    {
-        ShardPackageRecord original;
-        original.name = "no-noarch-pkg";
-        original.version = "1.0.0";
-        original.build = "build_0";
-        // noarch is not set (nullopt)
-
-        specs::RepoDataPackage repo_pkg = to_repo_data_package(original);
-        ShardPackageRecord roundtripped = from_repo_data_package(repo_pkg);
-
-        REQUIRE_FALSE(roundtripped.noarch.has_value());
-    }
-
-    SECTION("Round-trip with generic noarch")
-    {
-        ShardPackageRecord original;
-        original.name = "generic-noarch-pkg";
-        original.version = "2.0.0";
-        original.build = "build_1";
-        original.noarch = "generic";
-
-        specs::RepoDataPackage repo_pkg = to_repo_data_package(original);
-        ShardPackageRecord roundtripped = from_repo_data_package(repo_pkg);
-
-        REQUIRE(roundtripped.noarch == "generic");
-    }
-
-    SECTION("Round-trip without optional metadata fields")
-    {
-        ShardPackageRecord original;
-        original.name = "minimal-metadata-pkg";
-        original.version = "1.0.0";
-        original.build = "0";
-        // license, license_family, subdir, timestamp are not set
-
-        specs::RepoDataPackage repo_pkg = to_repo_data_package(original);
-        ShardPackageRecord roundtripped = from_repo_data_package(repo_pkg);
-
-        REQUIRE_FALSE(roundtripped.license.has_value());
-        REQUIRE_FALSE(roundtripped.license_family.has_value());
-        REQUIRE_FALSE(roundtripped.subdir.has_value());
-        REQUIRE_FALSE(roundtripped.timestamp.has_value());
-    }
-}
-
 TEST_CASE("to_package_info conversion", "[mamba::core][mamba::core::shard_types]")
 {
     SECTION("Basic conversion with all fields")
     {
-        ShardPackageRecord record;
+        specs::RepoDataPackage record;
         record.name = "test-package";
-        record.version = "1.2.3";
-        record.build = "py310_0";
+        record.version = specs::Version::parse("1.2.3").value();
+        record.build_string = "py310_0";
         record.build_number = 42;
         record.sha256 = "abc123sha256";
         record.md5 = "def456md5";
         record.depends = { "python >=3.10", "numpy >=1.20" };
         record.constrains = { "scipy <2.0" };
-        record.noarch = "python";
+        record.noarch = specs::NoArchType::Python;
         record.size = 98765;
         record.license = "MIT";
         record.license_family = "MIT";
@@ -279,11 +82,11 @@ TEST_CASE("to_package_info conversion", "[mamba::core][mamba::core::shard_types]
 
     SECTION("Conversion with generic noarch")
     {
-        ShardPackageRecord record;
+        specs::RepoDataPackage record;
         record.name = "generic-pkg";
-        record.version = "1.0.0";
-        record.build = "0";
-        record.noarch = "generic";
+        record.version = specs::Version::parse("1.0.0").value();
+        record.build_string = "0";
+        record.noarch = specs::NoArchType::Generic;
 
         specs::PackageInfo pkg_info = to_package_info(
             record,
@@ -298,10 +101,10 @@ TEST_CASE("to_package_info conversion", "[mamba::core][mamba::core::shard_types]
 
     SECTION("Conversion without noarch")
     {
-        ShardPackageRecord record;
+        specs::RepoDataPackage record;
         record.name = "native-pkg";
-        record.version = "2.0.0";
-        record.build = "h123_1";
+        record.version = specs::Version::parse("2.0.0").value();
+        record.build_string = "h123_1";
         // noarch is not set
 
         specs::PackageInfo pkg_info = to_package_info(
@@ -317,10 +120,10 @@ TEST_CASE("to_package_info conversion", "[mamba::core][mamba::core::shard_types]
 
     SECTION("Conversion without optional hashes")
     {
-        ShardPackageRecord record;
+        specs::RepoDataPackage record;
         record.name = "no-hash-pkg";
-        record.version = "3.0.0";
-        record.build = "0";
+        record.version = specs::Version::parse("3.0.0").value();
+        record.build_string = "0";
         // sha256 and md5 are not set
 
         specs::PackageInfo pkg_info = to_package_info(
@@ -337,10 +140,10 @@ TEST_CASE("to_package_info conversion", "[mamba::core][mamba::core::shard_types]
 
     SECTION("Conversion with optional metadata fields")
     {
-        ShardPackageRecord record;
+        specs::RepoDataPackage record;
         record.name = "metadata-pkg";
-        record.version = "1.0.0";
-        record.build = "0";
+        record.version = specs::Version::parse("1.0.0").value();
+        record.build_string = "0";
         record.license = "BSD-3-Clause";
         record.license_family = "BSD";
         record.subdir = "linux-64";
@@ -360,10 +163,10 @@ TEST_CASE("to_package_info conversion", "[mamba::core][mamba::core::shard_types]
 
     SECTION("Conversion without optional metadata fields")
     {
-        ShardPackageRecord record;
+        specs::RepoDataPackage record;
         record.name = "minimal-pkg";
-        record.version = "1.0.0";
-        record.build = "0";
+        record.version = specs::Version::parse("1.0.0").value();
+        record.build_string = "0";
         // license, license_family, subdir, timestamp are not set
 
         specs::PackageInfo pkg_info = to_package_info(
@@ -380,10 +183,10 @@ TEST_CASE("to_package_info conversion", "[mamba::core][mamba::core::shard_types]
 
     SECTION("URL construction with trailing slash in base_url")
     {
-        ShardPackageRecord record;
+        specs::RepoDataPackage record;
         record.name = "url-test-pkg";
-        record.version = "1.0.0";
-        record.build = "0";
+        record.version = specs::Version::parse("1.0.0").value();
+        record.build_string = "0";
 
         // Base URL with trailing slash
         specs::PackageInfo pkg_info = to_package_info(
@@ -402,10 +205,10 @@ TEST_CASE("to_package_info conversion", "[mamba::core][mamba::core::shard_types]
 
     SECTION("Conversion with empty dependencies and constrains")
     {
-        ShardPackageRecord record;
+        specs::RepoDataPackage record;
         record.name = "no-deps-pkg";
-        record.version = "1.0.0";
-        record.build = "0";
+        record.version = specs::Version::parse("1.0.0").value();
+        record.build_string = "0";
         // depends and constrains are empty by default
 
         specs::PackageInfo pkg_info = to_package_info(

--- a/libmamba/tests/src/core/test_shards.cpp
+++ b/libmamba/tests/src/core/test_shards.cpp
@@ -212,31 +212,31 @@ TEST_CASE("Shards package ordering")
         ShardDict shard;
 
         // Add packages in random order
-        ShardPackageRecord pkg1;
+        specs::RepoDataPackage pkg1;
         pkg1.name = "test-pkg";
-        pkg1.version = "1.0.0";
-        pkg1.build = "0";
+        pkg1.version = specs::Version::parse("1.0.0").value();
+        pkg1.build_string = "0";
         pkg1.build_number = 0;
         shard.packages["test-pkg-1.0.0-0.tar.bz2"] = pkg1;
 
-        ShardPackageRecord pkg2;
+        specs::RepoDataPackage pkg2;
         pkg2.name = "test-pkg";
-        pkg2.version = "2.0.0";
-        pkg2.build = "0";
+        pkg2.version = specs::Version::parse("2.0.0").value();
+        pkg2.build_string = "0";
         pkg2.build_number = 0;
         shard.packages["test-pkg-2.0.0-0.tar.bz2"] = pkg2;
 
-        ShardPackageRecord pkg3;
+        specs::RepoDataPackage pkg3;
         pkg3.name = "test-pkg";
-        pkg3.version = "1.5.0";
-        pkg3.build = "0";
+        pkg3.version = specs::Version::parse("1.5.0").value();
+        pkg3.build_string = "0";
         pkg3.build_number = 0;
         shard.packages["test-pkg-1.5.0-0.tar.bz2"] = pkg3;
 
-        ShardPackageRecord pkg4;
+        specs::RepoDataPackage pkg4;
         pkg4.name = "test-pkg";
-        pkg4.version = "2.0.0";
-        pkg4.build = "1";
+        pkg4.version = specs::Version::parse("2.0.0").value();
+        pkg4.build_string = "1";
         pkg4.build_number = 1;
         shard.packages["test-pkg-2.0.0-1.tar.bz2"] = pkg4;
 
@@ -665,7 +665,7 @@ TEST_CASE("Shard parsing - ShardDict parsing")
         msgpack_pack_str_body(&pk, filename.c_str(), filename.size());
 
         // Pack the package record directly using the packer
-        // We need to manually pack the fields from ShardPackageRecord
+        // We need to manually pack the fields from the shard package record format
         msgpack_pack_map(&pk, 3);  // name, version, build
 
         // name
@@ -779,9 +779,9 @@ TEST_CASE("Shards - Basic operations")
     SECTION("process_fetched_shard and visit_package")
     {
         ShardDict shard1;
-        ShardPackageRecord record1;
+        specs::RepoDataPackage record1;
         record1.name = "pkg1";
-        record1.version = "1.0.0";
+        record1.version = specs::Version::parse("1.0.0").value();
         shard1.packages["pkg1-1.0.0.tar.bz2"] = record1;
 
         shards.process_fetched_shard("pkg1", shard1);
@@ -843,10 +843,10 @@ TEST_CASE("Shards - build_repodata")
     SECTION("Build repodata with packages")
     {
         ShardDict shard1;
-        ShardPackageRecord pkg1;
+        specs::RepoDataPackage pkg1;
         pkg1.name = "test-pkg";
-        pkg1.version = "1.0.0";
-        pkg1.build = "0";
+        pkg1.version = specs::Version::parse("1.0.0").value();
+        pkg1.build_string = "0";
         pkg1.build_number = 0;
         pkg1.python_site_packages_path = "lib/python3.11/site-packages";
         pkg1.legacy_bz2_md5 = "legacy-md5";
@@ -857,10 +857,10 @@ TEST_CASE("Shards - build_repodata")
         pkg1.features = "feature_a";
         shard1.packages["test-pkg-1.0.0-0.tar.bz2"] = pkg1;
 
-        ShardPackageRecord pkg2;
+        specs::RepoDataPackage pkg2;
         pkg2.name = "test-pkg";
-        pkg2.version = "2.0.0";
-        pkg2.build = "0";
+        pkg2.version = specs::Version::parse("2.0.0").value();
+        pkg2.build_string = "0";
         pkg2.build_number = 0;
         shard1.packages["test-pkg-2.0.0-0.tar.bz2"] = pkg2;
 
@@ -872,7 +872,7 @@ TEST_CASE("Shards - build_repodata")
         bool found_2_0 = false;
         for (const auto& [filename, record] : repodata.shard_dict.packages)
         {
-            if (record.version == "1.0.0")
+            if (record.version.to_string() == "1.0.0")
             {
                 found_1_0 = true;
                 REQUIRE(
@@ -881,12 +881,12 @@ TEST_CASE("Shards - build_repodata")
                 );
                 REQUIRE(record.legacy_bz2_md5 == std::optional<std::string>("legacy-md5"));
                 REQUIRE(record.legacy_bz2_size == std::optional<std::size_t>(1111));
-                REQUIRE(record.size == 2222);
+                REQUIRE(record.size == std::optional<std::size_t>(2222));
                 REQUIRE(record.arch == std::optional<std::string>("x86_64"));
                 REQUIRE(record.platform == std::optional<std::string>("linux-64"));
                 REQUIRE(record.features == std::optional<std::string>("feature_a"));
             }
-            if (record.version == "2.0.0")
+            if (record.version.to_string() == "2.0.0")
             {
                 found_2_0 = true;
             }
@@ -900,19 +900,19 @@ TEST_CASE("Shards - build_repodata")
         ShardDict shard;
 
         // libblas 3.11.0 netlib variant with track_features
-        ShardPackageRecord netlib;
+        specs::RepoDataPackage netlib;
         netlib.name = "libblas";
-        netlib.version = "3.11.0";
-        netlib.build = "7_hc00574d_netlib";
+        netlib.version = specs::Version::parse("3.11.0").value();
+        netlib.build_string = "7_hc00574d_netlib";
         netlib.build_number = 7;
         netlib.track_features = { "blas_netlib", "blas_netlib_2" };
         shard.packages["libblas-3.11.0-7_hc00574d_netlib.conda"] = netlib;
 
         // libblas 3.11.0 openblas variant without track_features
-        ShardPackageRecord openblas;
+        specs::RepoDataPackage openblas;
         openblas.name = "libblas";
-        openblas.version = "3.11.0";
-        openblas.build = "5_h4a7cf45_openblas";
+        openblas.version = specs::Version::parse("3.11.0").value();
+        openblas.build_string = "5_h4a7cf45_openblas";
         openblas.build_number = 5;
         openblas.track_features = {};
         shard.packages["libblas-3.11.0-5_h4a7cf45_openblas.conda"] = openblas;
@@ -925,7 +925,7 @@ TEST_CASE("Shards - build_repodata")
         std::vector<std::string> keys;
         for (const auto& [filename, record] : repodata.shard_dict.packages)
         {
-            if (record.name == "libblas" && record.version == "3.11.0")
+            if (record.name == "libblas" && record.version.to_string() == "3.11.0")
             {
                 keys.push_back(filename);
             }
@@ -941,10 +941,10 @@ TEST_CASE("Shards - build_repodata")
     SECTION("Build repodata with conda packages")
     {
         ShardDict shard1;
-        ShardPackageRecord pkg1;
+        specs::RepoDataPackage pkg1;
         pkg1.name = "test-pkg";
-        pkg1.version = "1.0.0";
-        pkg1.build = "0";
+        pkg1.version = specs::Version::parse("1.0.0").value();
+        pkg1.build_string = "0";
         shard1.conda_packages["test-pkg-1.0.0-0.conda"] = pkg1;
 
         shards.process_fetched_shard("pkg1", shard1);
@@ -957,15 +957,15 @@ TEST_CASE("Shards - build_repodata")
     SECTION("Build repodata with multiple shards")
     {
         ShardDict shard1;
-        ShardPackageRecord pkg1;
+        specs::RepoDataPackage pkg1;
         pkg1.name = "pkg1";
-        pkg1.version = "1.0.0";
+        pkg1.version = specs::Version::parse("1.0.0").value();
         shard1.packages["pkg1-1.0.0.tar.bz2"] = pkg1;
 
         ShardDict shard2;
-        ShardPackageRecord pkg2;
+        specs::RepoDataPackage pkg2;
         pkg2.name = "pkg2";
-        pkg2.version = "1.0.0";
+        pkg2.version = specs::Version::parse("1.0.0").value();
         shard2.packages["pkg2-1.0.0.tar.bz2"] = pkg2;
 
         shards.process_fetched_shard("pkg1", shard1);
@@ -1036,9 +1036,9 @@ TEST_CASE("Shards - fetch_shards with visited cache")
     SECTION("fetch_shards returns already visited shards")
     {
         ShardDict shard1;
-        ShardPackageRecord pkg1;
+        specs::RepoDataPackage pkg1;
         pkg1.name = "pkg1";
-        pkg1.version = "1.0.0";
+        pkg1.version = specs::Version::parse("1.0.0").value();
         shard1.packages["pkg1-1.0.0.tar.bz2"] = pkg1;
 
         shards.process_fetched_shard("pkg1", shard1);
@@ -1141,17 +1141,17 @@ TEST_CASE("Shards - build_repodata sorting")
     SECTION("Sort by build number")
     {
         ShardDict shard1;
-        ShardPackageRecord pkg1;
+        specs::RepoDataPackage pkg1;
         pkg1.name = "test-pkg";
-        pkg1.version = "1.0.0";
-        pkg1.build = "0";
+        pkg1.version = specs::Version::parse("1.0.0").value();
+        pkg1.build_string = "0";
         pkg1.build_number = 0;
         shard1.packages["test-pkg-1.0.0-0.tar.bz2"] = pkg1;
 
-        ShardPackageRecord pkg2;
+        specs::RepoDataPackage pkg2;
         pkg2.name = "test-pkg";
-        pkg2.version = "1.0.0";
-        pkg2.build = "1";
+        pkg2.version = specs::Version::parse("1.0.0").value();
+        pkg2.build_string = "1";
         pkg2.build_number = 1;
         shard1.packages["test-pkg-1.0.0-1.tar.bz2"] = pkg2;
 
@@ -1180,17 +1180,17 @@ TEST_CASE("Shards - build_repodata sorting")
     SECTION("Sort by build string when build numbers equal")
     {
         ShardDict shard1;
-        ShardPackageRecord pkg1;
+        specs::RepoDataPackage pkg1;
         pkg1.name = "test-pkg";
-        pkg1.version = "1.0.0";
-        pkg1.build = "a";
+        pkg1.version = specs::Version::parse("1.0.0").value();
+        pkg1.build_string = "a";
         pkg1.build_number = 0;
         shard1.packages["test-pkg-1.0.0-a.tar.bz2"] = pkg1;
 
-        ShardPackageRecord pkg2;
+        specs::RepoDataPackage pkg2;
         pkg2.name = "test-pkg";
-        pkg2.version = "1.0.0";
-        pkg2.build = "b";
+        pkg2.version = specs::Version::parse("1.0.0").value();
+        pkg2.build_string = "b";
         pkg2.build_number = 0;
         shard1.packages["test-pkg-1.0.0-b.tar.bz2"] = pkg2;
 
@@ -1203,11 +1203,11 @@ TEST_CASE("Shards - build_repodata sorting")
         bool found_build_b = false;
         for (const auto& [filename, record] : repodata.shard_dict.packages)
         {
-            if (record.build == "a")
+            if (record.build_string == "a")
             {
                 found_build_a = true;
             }
-            if (record.build == "b")
+            if (record.build_string == "b")
             {
                 found_build_b = true;
             }
@@ -1491,10 +1491,10 @@ TEST_CASE("Shard parsing - Hash format edge cases")
         // When sha256 array contains negative integers, parsing should return empty string
         // md5 should still be present to allow the record to be valid
         ShardDict shard_dict;
-        ShardPackageRecord record;
+        specs::RepoDataPackage record;
         record.name = "test-pkg";
-        record.version = "1.0.0";
-        record.build = "0";
+        record.version = specs::Version::parse("1.0.0").value();
+        record.build_string = "0";
         record.md5 = "12345678901234567890123456789012";
         // sha256 should be empty (not set) because negative integers cause parsing to fail
         // This simulates what happens when parse_shard_package_record encounters negative integers
@@ -1656,10 +1656,10 @@ TEST_CASE("Shard parsing - Hash format edge cases")
         // Test parsing indirectly through process_fetched_shard
         // Create a ShardDict manually with the parsed data
         ShardDict shard_dict;
-        ShardPackageRecord record;
+        specs::RepoDataPackage record;
         record.name = "test-pkg";
-        record.version = "1.0.0";
-        record.build = "0";
+        record.version = specs::Version::parse("1.0.0").value();
+        record.build_string = "0";
         record.md5 = "12345678901234567890123456789012";
         // sha256 will be empty due to invalid element types, but md5 is present
         shard_dict.packages["test-pkg-1.0.0-0.tar.bz2"] = record;
@@ -1804,10 +1804,10 @@ TEST_CASE("Shard parsing - Hash format edge cases")
         // Test parsing indirectly through process_fetched_shard
         // Create a ShardDict manually with the parsed data
         ShardDict shard_dict;
-        ShardPackageRecord record;
+        specs::RepoDataPackage record;
         record.name = "test-pkg";
-        record.version = "1.0.0";
-        record.build = "0";
+        record.version = specs::Version::parse("1.0.0").value();
+        record.build_string = "0";
         record.md5 = "12345678901234567890123456789012";
         // sha256 will be empty due to empty array, but md5 is present
         shard_dict.packages["test-pkg-1.0.0-0.tar.bz2"] = record;
@@ -1924,10 +1924,10 @@ TEST_CASE("Shard parsing - Package record error handling")
         // We can't directly test parse_shard_msgpack, but we can verify
         // that process_fetched_shard requires valid records
         ShardDict shard_dict;
-        ShardPackageRecord record;
+        specs::RepoDataPackage record;
         record.name = "test-pkg";
-        record.version = "1.0.0";
-        record.build = "0";
+        record.version = specs::Version::parse("1.0.0").value();
+        record.build_string = "0";
         // No checksums - this should be invalid
         // But process_fetched_shard doesn't validate, so we just verify
         // the structure can be created
@@ -2096,10 +2096,10 @@ TEST_CASE("Shard parsing - Package record error handling")
         // Test that a shard with nil name can be processed
         // We test indirectly through process_fetched_shard
         ShardDict shard_dict;
-        ShardPackageRecord record;
+        specs::RepoDataPackage record;
         record.name = "";  // Empty name (nil was skipped)
-        record.version = "1.0.0";
-        record.build = "0";
+        record.version = specs::Version::parse("1.0.0").value();
+        record.build_string = "0";
         record.sha256 = "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890";
         shard_dict.packages["test-pkg-1.0.0-0.tar.bz2"] = record;
 
@@ -2236,10 +2236,10 @@ TEST_CASE("Shard parsing - Package record error handling")
         // Test that size field is handled correctly
         // We test indirectly through process_fetched_shard
         ShardDict shard_dict;
-        ShardPackageRecord record;
+        specs::RepoDataPackage record;
         record.name = "test-pkg";
-        record.version = "1.0.0";
-        record.build = "0";
+        record.version = specs::Version::parse("1.0.0").value();
+        record.build_string = "0";
         record.sha256 = "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890";
         record.size = 12345;
         shard_dict.packages["test-pkg-1.0.0-0.tar.bz2"] = record;
@@ -2249,7 +2249,7 @@ TEST_CASE("Shard parsing - Package record error handling")
 
         auto visited = shards.visit_package("test-pkg");
         REQUIRE(visited.packages.size() == 1);
-        REQUIRE(visited.packages.begin()->second.size == 12345);
+        REQUIRE(visited.packages.begin()->second.size == std::optional<std::size_t>(12345));
 
         msgpack_zone_destroy(unpacked.zone);
     }
@@ -2428,7 +2428,7 @@ TEST_CASE("Shards - Disk caching")
         );
         const auto& record = result.value().packages.at("test-pkg-1.0.0-0.tar.bz2");
         REQUIRE(record.name == "test-pkg");
-        REQUIRE(record.version == "1.0.0");
+        REQUIRE(record.version.to_string() == "1.0.0");
     }
 
     SECTION("Cache miss - shard not in cache")
@@ -2658,8 +2658,8 @@ TEST_CASE("Shards - process_downloaded_shard")
         );
         const auto& record = result.value().packages.at("test-pkg-1.0.0-0.tar.bz2");
         REQUIRE(record.name == "test-pkg");
-        REQUIRE(record.version == "1.0.0");
-        REQUIRE(record.build == "0");
+        REQUIRE(record.version.to_string() == "1.0.0");
+        REQUIRE(record.build_string == "0");
         REQUIRE(record.depends == std::vector<std::string>{ "dep1" });
     }
 
@@ -2684,8 +2684,8 @@ TEST_CASE("Shards - process_downloaded_shard")
         );
         const auto& record = result.value().packages.at("test-pkg-2.0.0-1.tar.bz2");
         REQUIRE(record.name == "test-pkg");
-        REQUIRE(record.version == "2.0.0");
-        REQUIRE(record.build == "1");
+        REQUIRE(record.version.to_string() == "2.0.0");
+        REQUIRE(record.build_string == "1");
         REQUIRE(record.depends == std::vector<std::string>{ "dep-a", "dep-b" });
     }
 


### PR DESCRIPTION
# Description

The benefit of using a dedicated structure for shards' records is not clear since it seems that we have to parse all fields anyway. We can simply use `RepoDataPackage`.

## Type of Change

<!-- Please skip this part if you are already using conventional commit keywords in the PR title. -->

- [ ] Bugfix
- [ ] Feature / enhancement
- [ ] CI / Documentation
- [x] Maintenance

## Checklist

- [x] My code follows the general style and conventions of the codebase, ensuring consistency
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have run `pre-commit run --all` locally in the source folder and confirmed that there are no linter errors.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
