### PR TITLE
maint: Increase timeout of `test_env_logging_overhead_regression` to 1 minute

### DIFF
--- a/micromamba/tests/test_create.py
+++ b/micromamba/tests/test_create.py
@@ -918,7 +918,7 @@ def test_clone_environment_with_many_packages(tmp_home, tmp_root_prefix, tmp_pat
 
 # Only run this test on Linux, as it is the only platform where xeus-cling
 # (which is part of the environment) is available.
-@pytest.mark.timeout(30)
+@pytest.mark.timeout(60)
 @pytest.mark.skipif(platform.system() != "Linux", reason="Test only available on Linux")
 @pytest.mark.parametrize("shared_pkgs_dirs", [True], indirect=True)
 def test_env_logging_overhead_regression(tmp_home, tmp_root_prefix, tmp_path):


### PR DESCRIPTION
# Description

Continues https://github.com/mamba-org/mamba/pull/4173/.

Time out have been observed in https://github.com/mamba-org/mamba/pull/4201 see [those logs](https://github.com/mamba-org/mamba/actions/runs/23650476610/job/68894025555?pr=4201).

## Type of Change

<!-- Please skip this part if you are already using conventional commit keywords in the PR title. -->

- [ ] Bugfix
- [ ] Feature / enhancement
- [ ] CI / Documentation
- [x] Maintenance

## Checklist

- [x] My code follows the general style and conventions of the codebase, ensuring consistency
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have run `pre-commit run --all` locally in the source folder and confirmed that there are no linter errors.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
