### PR TITLE
fix: Adapt bindings for `UnresolvedChannel`'s readonly properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@ Bug fixes:
 - [micromamba, libmamba] Graceful handling of download cancel/interruption by @Klaim in <https://github.com/mamba-org/mamba/pull/4146>
 - [micromamba, libmamba] fix: Do not show activation message for dry runs by @jjerphan in <https://github.com/mamba-org/mamba/pull/4140>
 - [libmamba] fix: Only call `get_all_running_processes_info` when needed by @mihaitodor in <https://github.com/mamba-org/mamba/pull/4135>
-- [libmamba] Add #include <functional> for std::ref by @opoplawski in <https://github.com/mamba-org/mamba/pull/4132>
+- [libmamba] Add `#include <functional>` for std::ref by @opoplawski in <https://github.com/mamba-org/mamba/pull/4132>
 
 CI fixes and doc:
 

--- a/libmamba/CHANGELOG.md
+++ b/libmamba/CHANGELOG.md
@@ -38,7 +38,7 @@ Bug fixes:
 - Graceful handling of download cancel/interruption by @Klaim in <https://github.com/mamba-org/mamba/pull/4146>
 - fix: Do not show activation message for dry runs by @jjerphan in <https://github.com/mamba-org/mamba/pull/4140>
 - fix: Only call `get_all_running_processes_info` when needed by @mihaitodor in <https://github.com/mamba-org/mamba/pull/4135>
-- Add #include <functional> for std::ref by @opoplawski in <https://github.com/mamba-org/mamba/pull/4132>
+- Add `#include <functional>` for std::ref by @opoplawski in <https://github.com/mamba-org/mamba/pull/4132>
 
 CI fixes and doc:
 

--- a/libmambapy/bindings/specs.cpp
+++ b/libmambapy/bindings/specs.cpp
@@ -345,8 +345,15 @@ namespace mambapy
             .def("__copy__", &copy<UnresolvedChannel>)
             .def("__deepcopy__", &deepcopy<UnresolvedChannel>, py::arg("memo"))
             .def_property_readonly("type", &UnresolvedChannel::type)
-            .def_property_readonly("location", &UnresolvedChannel::location)
-            .def_property_readonly("platform_filters", &UnresolvedChannel::platform_filters);
+            .def_property_readonly(
+                "location",
+                [](const UnresolvedChannel& self) -> std::string { return self.location(); }
+            )
+            .def_property_readonly(
+                "platform_filters",
+                [](const UnresolvedChannel& self) -> const UnresolvedChannel::platform_set&
+                { return self.platform_filters(); }
+            );
 
         py::class_<BasicHTTPAuthentication>(m, "BasicHTTPAuthentication")
             .def(


### PR DESCRIPTION
# Description

For some reasons, the previous state of the file fails when it is being compiled; this was first observed on the feedstock with https://github.com/conda-forge/mamba-feedstock/pull/376 although nothing changed in the code-base.

```cpp
 │ │   *** Building project with Default Generator...                                                                                                                                                                                                                   
 │ │   [1/7] Building CXX object CMakeFiles/bindings.dir/bindings/bindings.cpp.o                                                                                                                                                                                        
 │ │   [2/7] Building CXX object CMakeFiles/bindings.dir/bindings/utils.cpp.o                                                                                                                                                                                           
 │ │   [3/7] Building CXX object CMakeFiles/bindings.dir/bindings/solver_libsolv.cpp.o                                                                                                                                                                                  
 │ │   [4/7] Building CXX object CMakeFiles/bindings.dir/bindings/specs.cpp.o                                                                                                                                                                                           
 │ │   FAILED: [code=1] CMakeFiles/bindings.dir/bindings/specs.cpp.o                                                                                                                                                                                                    
 │ │   $BUILD_PREFIX/bin/x86_64-conda-linux-gnu-c++ -DFMT_SHARED -DMAMBA_USE_INSTALL_PREFIX_AS_BASE -DSPDLOG_FMT_EXTERNAL -DSPDLOG_FWRITE_UNLOCKED -Dbindings_EXPORTS -I$SRC_DIR/libmambapy/bindings -isystem $PREFIX/include/python3.10 -isystem $PREFIX/lib/python3.10
 │ │ /site-packages/pybind11/include -isystem $PREFIX/share -fvisibility-inlines-hidden -fmessage-length=0 -march=nocona -mtune=haswell -ftree-vectorize -fPIC -fstack-protector-strong -fno-plt -O2 -ffunction-sections -pipe -isystem $PREFIX/include -fdebug-prefix-m
 │ │ ap=$SRC_DIR=/usr/local/src/conda/libmambapy-2.6.0.rc0 -fdebug-prefix-map=$PREFIX=/usr/local/src/conda-prefix -D_LIBCPP_DISABLE_AVAILABILITY=1 -O3 -DNDEBUG -std=c++20 -fPIC -fvisibility=hidden -fdiagnostics-color=always -Wall -Wextra -Wshadow -Wnon-virtual-dto
 │ │ r -Wold-style-cast -Wcast-align -Wunused -Woverloaded-virtual -Wpedantic -Wconversion -Wsign-conversion -Wdouble-promotion -Wformat=2 -Wunreachable-code -Wuninitialized -Wmisleading-indentation -Wduplicated-cond -Wduplicated-branches -Wlogical-op -Wuseless-ca
 │ │ st -flto=auto -fno-fat-lto-objects -pthread -MD -MT CMakeFiles/bindings.dir/bindings/specs.cpp.o -MF CMakeFiles/bindings.dir/bindings/specs.cpp.o.d -o CMakeFiles/bindings.dir/bindings/specs.cpp.o -c $SRC_DIR/libmambapy/bindings/specs.cpp                      
 │ │   $SRC_DIR/libmambapy/bindings/specs.cpp: In function 'void mambapy::bind_submodule_specs(pybind11::module_)':                                                                                                                                                     
 │ │   $SRC_DIR/libmambapy/bindings/specs.cpp:348:48: error: conversion from '<unresolved overloaded function type>' to 'const pybind11::cpp_function' is ambiguous                                                                                                     
 │ │     348 |             .def_property_readonly("location", &UnresolvedChannel::location)                                                                                                                                                                             
 │ │         |                                                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~                                                                                                                                                                              
 │ │   In file included from $PREFIX/lib/python3.10/site-packages/pybind11/include/pybind11/operators.h:12,                                                                                                                                                             
 │ │                    from $SRC_DIR/libmambapy/bindings/specs.cpp:7:                                                                                                                                                                                                  
 │ │   $PREFIX/lib/python3.10/site-packages/pybind11/include/pybind11/pybind11.h:375:5: note: candidate: 'pybind11::cpp_function::cpp_function(Return (Class::*)(Arg ...) &&, const Extra& ...) [with Return = std::__cxx11::basic_string<char>; Class = mamba::specs::U
 │ │ nresolvedChannel; Arg = {}; Extra = {}]'                                                                                                                                                                                                                           
 │ │     375 |     cpp_function(Return (Class::*f)(Arg...) &&, const Extra &...extra) {                                                                                                                                                                                 
 │ │         |     ^~~~~~~~~~~~                                                                                                                                                                                                                                         
 │ │   $PREFIX/lib/python3.10/site-packages/pybind11/include/pybind11/pybind11.h:365:5: note: candidate: 'pybind11::cpp_function::cpp_function(Return (Class::*)(Arg ...) const &, const Extra& ...) [with Return = const std::__cxx11::basic_string<char>&; Class = mam
 │ │ ba::specs::UnresolvedChannel; Arg = {}; Extra = {}]'                                                                                                                                                                                                               
 │ │     365 |     cpp_function(Return (Class::*f)(Arg...) const &, const Extra &...extra) {                                                                                                                                                                            
 │ │         |     ^~~~~~~~~~~~                                                                                                                                                                                                                                         
 │ │   $PREFIX/lib/python3.10/site-packages/pybind11/include/pybind11/pybind11.h:2590:65: note:   initializing argument 2 of 'pybind11::class_<type_, options>& pybind11::class_<type_, options>::def_property_readonly(const char*, const pybind11::cpp_function&, cons
 │ │ t Extra& ...) [with Extra = {}; type_ = mamba::specs::UnresolvedChannel; options = {}]'
 │ │    2590 |     def_property_readonly(const char *name, const cpp_function &fget, const Extra &...extra) {
 │ │         |                                             ~~~~~~~~~~~~~~~~~~~~^~~~
 │ │   [5/7] Building CXX object CMakeFiles/bindings.dir/bindings/solver.cpp.o
 │ │   [6/7] Building CXX object CMakeFiles/bindings.dir/bindings/legacy.cpp.o
 │ │   ninja: build stopped: subcommand failed.
 │ │   
```

This PR upstreams the commit of the patch made there.

## Type of Change

<!-- Please skip this part if you are already using conventional commit keywords in the PR title. -->

- [x] Bugfix
- [ ] Feature / enhancement
- [ ] CI / Documentation
- [ ] Maintenance

## Checklist

- [x] My code follows the general style and conventions of the codebase, ensuring consistency
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have run `pre-commit run --all` locally in the source folder and confirmed that there are no linter errors.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
