### PR TITLE
feat: Support excluding recent builds using timestamp (`--exclude-newer`)

### DIFF
--- a/libmamba/include/mamba/solver/libsolv/database.hpp
+++ b/libmamba/include/mamba/solver/libsolv/database.hpp
@@ -7,6 +7,7 @@
 #ifndef MAMBA_SOLVER_LIBSOLV_DATABASE_HPP
 #define MAMBA_SOLVER_LIBSOLV_DATABASE_HPP
 
+#include <cstdint>
 #include <functional>
 #include <memory>
 #include <optional>
@@ -59,6 +60,7 @@ namespace mamba::solver::libsolv
         struct Settings
         {
             MatchSpecParser matchspec_parser = MatchSpecParser::Libsolv;
+            std::optional<std::uint64_t> exclude_newer_timestamp = std::nullopt;
         };
 
         using logger_type = std::function<void(LogLevel, std::string_view)>;

--- a/libmamba/include/mamba/solver/libsolv/database.hpp
+++ b/libmamba/include/mamba/solver/libsolv/database.hpp
@@ -8,6 +8,7 @@
 #define MAMBA_SOLVER_LIBSOLV_DATABASE_HPP
 
 #include <concepts>
+#include <cstdint>
 #include <functional>
 #include <iterator>
 #include <memory>
@@ -64,6 +65,7 @@ namespace mamba::solver::libsolv
         struct Settings
         {
             MatchSpecParser matchspec_parser = MatchSpecParser::Libsolv;
+            std::optional<std::uint64_t> exclude_newer_timestamp = std::nullopt;
         };
 
         using logger_type = std::function<void(LogLevel, std::string_view)>;

--- a/libmamba/src/solver/libsolv/database.cpp
+++ b/libmamba/src/solver/libsolv/database.cpp
@@ -181,7 +181,8 @@ namespace mamba::solver::libsolv
                     channel_id,
                     package_types,
                     settings().matchspec_parser,
-                    verify_artifacts
+                    verify_artifacts,
+                    settings().exclude_newer_timestamp
                 );
             }
 
@@ -259,6 +260,16 @@ namespace mamba::solver::libsolv
     void
     Database::add_repo_from_packages_impl_loop(const RepoInfo& repo, const specs::PackageInfo& pkg)
     {
+        if (const auto cutoff = settings().exclude_newer_timestamp)
+        {
+            const auto ts = (pkg.timestamp > MAX_CONDA_TIMESTAMP)
+                                ? (pkg.timestamp / 1000)
+                                : pkg.timestamp;
+            if (ts > *cutoff)
+            {
+                return;
+            }
+        }
         auto s_repo = solv::ObjRepoView(*repo.m_ptr);
         auto [id, solv] = s_repo.add_solvable();
         set_solvable(pool(), solv, pkg, settings().matchspec_parser);

--- a/libmamba/src/solver/libsolv/database.cpp
+++ b/libmamba/src/solver/libsolv/database.cpp
@@ -262,9 +262,8 @@ namespace mamba::solver::libsolv
     {
         if (const auto cutoff = settings().exclude_newer_timestamp)
         {
-            const auto ts = (pkg.timestamp > MAX_CONDA_TIMESTAMP)
-                                ? (pkg.timestamp / 1000)
-                                : pkg.timestamp;
+            const auto ts = (pkg.timestamp > MAX_CONDA_TIMESTAMP) ? (pkg.timestamp / 1000)
+                                                                  : pkg.timestamp;
             if (ts > *cutoff)
             {
                 return;

--- a/libmamba/src/solver/libsolv/database.cpp
+++ b/libmamba/src/solver/libsolv/database.cpp
@@ -264,9 +264,8 @@ namespace mamba::solver::libsolv
     {
         if (const auto cutoff = settings().exclude_newer_timestamp)
         {
-            const auto ts = (pkg.timestamp > MAX_CONDA_TIMESTAMP)
-                                ? (pkg.timestamp / 1000)
-                                : pkg.timestamp;
+            const auto ts = (pkg.timestamp > MAX_CONDA_TIMESTAMP) ? (pkg.timestamp / 1000)
+                                                                  : pkg.timestamp;
             if (ts > *cutoff)
             {
                 return;

--- a/libmamba/src/solver/libsolv/database.cpp
+++ b/libmamba/src/solver/libsolv/database.cpp
@@ -183,7 +183,8 @@ namespace mamba::solver::libsolv
                     channel_id,
                     package_types,
                     settings().matchspec_parser,
-                    verify_artifacts
+                    verify_artifacts,
+                    settings().exclude_newer_timestamp
                 );
             }
 
@@ -261,6 +262,16 @@ namespace mamba::solver::libsolv
     void
     Database::add_repo_from_packages_impl_loop(const RepoInfo& repo, const specs::PackageInfo& pkg)
     {
+        if (const auto cutoff = settings().exclude_newer_timestamp)
+        {
+            const auto ts = (pkg.timestamp > MAX_CONDA_TIMESTAMP)
+                                ? (pkg.timestamp / 1000)
+                                : pkg.timestamp;
+            if (ts > *cutoff)
+            {
+                return;
+            }
+        }
         auto s_repo = solv::ObjRepoView(*repo.m_ptr);
         auto [id, solv] = s_repo.add_solvable();
         set_solvable(pool(), solv, pkg, settings().matchspec_parser);

--- a/libmamba/src/solver/libsolv/database.cpp
+++ b/libmamba/src/solver/libsolv/database.cpp
@@ -264,9 +264,7 @@ namespace mamba::solver::libsolv
     {
         if (const auto cutoff = settings().exclude_newer_timestamp)
         {
-            const auto ts = (pkg.timestamp > MAX_CONDA_TIMESTAMP) ? (pkg.timestamp / 1000)
-                                                                  : pkg.timestamp;
-            if (ts > *cutoff)
+            if (normalize_conda_timestamp(pkg.timestamp) > *cutoff)
             {
                 return;
             }

--- a/libmamba/src/solver/libsolv/helpers.cpp
+++ b/libmamba/src/solver/libsolv/helpers.cpp
@@ -40,10 +40,6 @@
 
 namespace mamba::solver::libsolv
 {
-    // Beyond this value, the timestamp would be in milliseconds and therefore should be converted
-    // to seconds.
-    inline constexpr auto MAX_CONDA_TIMESTAMP = 253402300799ULL;
-
     void set_solvable(
         solv::ObjPool& pool,
         solv::ObjSolvableView solv,
@@ -419,7 +415,8 @@ namespace mamba::solver::libsolv
             const std::optional<nlohmann::json>& signatures,
             Filter&& filter,
             OnParsed&& on_parsed,
-            MatchSpecParser parser
+            MatchSpecParser parser,
+            std::optional<std::uint64_t> exclude_newer_timestamp = std::nullopt
         )
         {
             auto packages_as_object = packages.get_object();
@@ -442,7 +439,15 @@ namespace mamba::solver::libsolv
                     );
                     if (parsed)
                     {
-                        on_parsed(filename);
+                        if (exclude_newer_timestamp
+                            && solv.timestamp() > static_cast<std::int64_t>(*exclude_newer_timestamp))
+                        {
+                            repo.remove_solvable(id, /* reuse_id= */ true);
+                        }
+                        else
+                        {
+                            on_parsed(filename);
+                        }
                     }
                     else
                     {
@@ -462,7 +467,8 @@ namespace mamba::solver::libsolv
             const std::string& default_subdir,
             JSONObject& packages,
             const std::optional<nlohmann::json>& signatures,
-            MatchSpecParser parser
+            MatchSpecParser parser,
+            std::optional<std::uint64_t> exclude_newer_timestamp = std::nullopt
         )
         {
             return set_repo_solvables_impl(
@@ -475,7 +481,8 @@ namespace mamba::solver::libsolv
                 signatures,
                 /* filter= */ [](const auto&) { return true; },
                 /* on_parsed= */ [](const auto&) {},
-                parser
+                parser,
+                exclude_newer_timestamp
             );
         }
 
@@ -488,7 +495,8 @@ namespace mamba::solver::libsolv
             const std::string& default_subdir,
             JSONObject& packages,
             const std::optional<nlohmann::json>& signatures,
-            MatchSpecParser parser
+            MatchSpecParser parser,
+            std::optional<std::uint64_t> exclude_newer_timestamp = std::nullopt
         ) -> util::flat_set<std::string>
         {
             auto filenames = util::flat_set<std::string>();
@@ -504,7 +512,8 @@ namespace mamba::solver::libsolv
                 /* on_parsed= */
                 [&](const auto& fn)
                 { filenames.insert(std::string(specs::strip_archive_extension(fn))); },
-                parser
+                parser,
+                exclude_newer_timestamp
             );
             // Sort only once
             return filenames;
@@ -520,7 +529,8 @@ namespace mamba::solver::libsolv
             JSONObject& packages,
             const std::optional<nlohmann::json>& signatures,
             const SortedStringRange& added,
-            MatchSpecParser parser
+            MatchSpecParser parser,
+            std::optional<std::uint64_t> exclude_newer_timestamp = std::nullopt
         )
         {
             return set_repo_solvables_impl(
@@ -534,7 +544,8 @@ namespace mamba::solver::libsolv
                 /* filter= */
                 [&](const auto& fn) { return !added.contains(specs::strip_archive_extension(fn)); },
                 /* on_parsed= */ [&](const auto&) {},
-                parser
+                parser,
+                exclude_newer_timestamp
             );
         }
     }
@@ -599,7 +610,8 @@ namespace mamba::solver::libsolv
         const std::string& channel_id,
         PackageTypes package_types,
         MatchSpecParser ms_parser,
-        bool verify_artifacts
+        bool verify_artifacts,
+        std::optional<std::uint64_t> exclude_newer_timestamp
     ) -> expected_t<solv::ObjRepoView>
     {
         LOG_INFO << "Reading repodata.json file " << filename << " for repo " << repo.name()
@@ -715,7 +727,8 @@ namespace mamba::solver::libsolv
                     default_subdir,
                     pkgs,
                     json_signatures,
-                    ms_parser
+                    ms_parser,
+                    exclude_newer_timestamp
                 );
             }
             if (auto pkgs = repodata_doc["packages"]; !pkgs.error())
@@ -729,7 +742,8 @@ namespace mamba::solver::libsolv
                     pkgs,
                     json_signatures,
                     added,
-                    ms_parser
+                    ms_parser,
+                    exclude_newer_timestamp
                 );
             }
         }
@@ -746,7 +760,8 @@ namespace mamba::solver::libsolv
                     default_subdir,
                     pkgs,
                     json_signatures,
-                    ms_parser
+                    ms_parser,
+                    exclude_newer_timestamp
                 );
             }
 
@@ -761,7 +776,8 @@ namespace mamba::solver::libsolv
                     default_subdir,
                     pkgs,
                     json_signatures,
-                    ms_parser
+                    ms_parser,
+                    exclude_newer_timestamp
                 );
             }
         }

--- a/libmamba/src/solver/libsolv/helpers.cpp
+++ b/libmamba/src/solver/libsolv/helpers.cpp
@@ -1500,8 +1500,7 @@ namespace mamba::solver::libsolv
                             return true;
                         }
                     }
-                    if constexpr (std::is_same_v<Action, Solution::Reinstall>
-                                  || std::is_same_v<Action, Solution::Omit>)
+                    if constexpr (std::is_same_v<Action, Solution::Reinstall> || std::is_same_v<Action, Solution::Omit>)
                     {
                         if (action.what.name == pkg_name)
                         {

--- a/libmamba/src/solver/libsolv/helpers.cpp
+++ b/libmamba/src/solver/libsolv/helpers.cpp
@@ -195,16 +195,15 @@ namespace mamba::solver::libsolv
         template <class JSONObject>
         [[nodiscard]] auto set_solvable(
             solv::ObjPool& pool,
-            // const std::string& repo_url_str,
             const specs::CondaURL& repo_url,
             const std::string& channel_id,
             solv::ObjSolvableView solv,
-
             const std::string& filename,
             JSONObject&& pkg,
             const std::optional<nlohmann::json>& signatures,
             const std::string& default_subdir,
-            MatchSpecParser parser
+            MatchSpecParser parser,
+            std::uint64_t* out_timestamp = nullptr
         ) -> bool
         {
             // Not available from RepoDataPackage
@@ -319,7 +318,12 @@ namespace mamba::solver::libsolv
             if (auto timestamp = pkg["timestamp"]; !timestamp.error())
             {
                 const auto time = timestamp.get_uint64().value_unsafe();
-                solv.set_timestamp((time > MAX_CONDA_TIMESTAMP) ? (time / 1000) : time);
+                const auto normalized = (time > MAX_CONDA_TIMESTAMP) ? (time / 1000) : time;
+                solv.set_timestamp(normalized);
+                if (out_timestamp)
+                {
+                    *out_timestamp = normalized;
+                }
             }
 
             if (auto depends = pkg["depends"].get_array(); !depends.error())
@@ -426,6 +430,7 @@ namespace mamba::solver::libsolv
                 if (filter(filename))
                 {
                     auto [id, solv] = repo.add_solvable();
+                    std::uint64_t pkg_timestamp = 0;
                     const bool parsed = set_solvable(
                         pool,
                         repo_url,
@@ -435,12 +440,12 @@ namespace mamba::solver::libsolv
                         pkg_field.value(),
                         signatures,
                         default_subdir,
-                        parser
+                        parser,
+                        &pkg_timestamp
                     );
                     if (parsed)
                     {
-                        if (exclude_newer_timestamp
-                            && solv.timestamp() > static_cast<std::int64_t>(*exclude_newer_timestamp))
+                        if (exclude_newer_timestamp && pkg_timestamp > *exclude_newer_timestamp)
                         {
                             repo.remove_solvable(id, /* reuse_id= */ true);
                         }

--- a/libmamba/src/solver/libsolv/helpers.cpp
+++ b/libmamba/src/solver/libsolv/helpers.cpp
@@ -40,10 +40,6 @@
 
 namespace mamba::solver::libsolv
 {
-    // Beyond this value, the timestamp would be in milliseconds and therefore should be converted
-    // to seconds.
-    inline constexpr auto MAX_CONDA_TIMESTAMP = 253402300799ULL;
-
     void set_solvable(
         solv::ObjPool& pool,
         solv::ObjSolvableView solv,
@@ -443,7 +439,8 @@ namespace mamba::solver::libsolv
             const std::optional<nlohmann::json>& signatures,
             Filter&& filter,
             OnParsed&& on_parsed,
-            MatchSpecParser parser
+            MatchSpecParser parser,
+            std::optional<std::uint64_t> exclude_newer_timestamp = std::nullopt
         )
         {
             auto packages_as_object = packages.get_object();
@@ -466,7 +463,15 @@ namespace mamba::solver::libsolv
                     );
                     if (parsed)
                     {
-                        on_parsed(filename);
+                        if (exclude_newer_timestamp
+                            && solv.timestamp() > static_cast<std::int64_t>(*exclude_newer_timestamp))
+                        {
+                            repo.remove_solvable(id, /* reuse_id= */ true);
+                        }
+                        else
+                        {
+                            on_parsed(filename);
+                        }
                     }
                     else
                     {
@@ -486,7 +491,8 @@ namespace mamba::solver::libsolv
             const std::string& default_subdir,
             JSONObject& packages,
             const std::optional<nlohmann::json>& signatures,
-            MatchSpecParser parser
+            MatchSpecParser parser,
+            std::optional<std::uint64_t> exclude_newer_timestamp = std::nullopt
         )
         {
             return set_repo_solvables_impl(
@@ -499,7 +505,8 @@ namespace mamba::solver::libsolv
                 signatures,
                 /* filter= */ [](const auto&) { return true; },
                 /* on_parsed= */ [](const auto&) {},
-                parser
+                parser,
+                exclude_newer_timestamp
             );
         }
 
@@ -512,7 +519,8 @@ namespace mamba::solver::libsolv
             const std::string& default_subdir,
             JSONObject& packages,
             const std::optional<nlohmann::json>& signatures,
-            MatchSpecParser parser
+            MatchSpecParser parser,
+            std::optional<std::uint64_t> exclude_newer_timestamp = std::nullopt
         ) -> util::flat_set<std::string>
         {
             auto filenames = util::flat_set<std::string>();
@@ -528,7 +536,8 @@ namespace mamba::solver::libsolv
                 /* on_parsed= */
                 [&](const auto& fn)
                 { filenames.insert(std::string(specs::strip_archive_extension(fn))); },
-                parser
+                parser,
+                exclude_newer_timestamp
             );
             // Sort only once
             return filenames;
@@ -544,7 +553,8 @@ namespace mamba::solver::libsolv
             JSONObject& packages,
             const std::optional<nlohmann::json>& signatures,
             const SortedStringRange& added,
-            MatchSpecParser parser
+            MatchSpecParser parser,
+            std::optional<std::uint64_t> exclude_newer_timestamp = std::nullopt
         )
         {
             return set_repo_solvables_impl(
@@ -558,7 +568,8 @@ namespace mamba::solver::libsolv
                 /* filter= */
                 [&](const auto& fn) { return !added.contains(specs::strip_archive_extension(fn)); },
                 /* on_parsed= */ [&](const auto&) {},
-                parser
+                parser,
+                exclude_newer_timestamp
             );
         }
     }
@@ -623,7 +634,8 @@ namespace mamba::solver::libsolv
         const std::string& channel_id,
         PackageTypes package_types,
         MatchSpecParser ms_parser,
-        bool verify_artifacts
+        bool verify_artifacts,
+        std::optional<std::uint64_t> exclude_newer_timestamp
     ) -> expected_t<solv::ObjRepoView>
     {
         LOG_INFO << "Reading repodata.json file " << filename << " for repo " << repo.name()
@@ -739,7 +751,8 @@ namespace mamba::solver::libsolv
                     default_subdir,
                     pkgs,
                     json_signatures,
-                    ms_parser
+                    ms_parser,
+                    exclude_newer_timestamp
                 );
             }
             if (auto pkgs = repodata_doc["packages"]; !pkgs.error())
@@ -753,7 +766,8 @@ namespace mamba::solver::libsolv
                     pkgs,
                     json_signatures,
                     added,
-                    ms_parser
+                    ms_parser,
+                    exclude_newer_timestamp
                 );
             }
         }
@@ -770,7 +784,8 @@ namespace mamba::solver::libsolv
                     default_subdir,
                     pkgs,
                     json_signatures,
-                    ms_parser
+                    ms_parser,
+                    exclude_newer_timestamp
                 );
             }
 
@@ -785,7 +800,8 @@ namespace mamba::solver::libsolv
                     default_subdir,
                     pkgs,
                     json_signatures,
-                    ms_parser
+                    ms_parser,
+                    exclude_newer_timestamp
                 );
             }
         }

--- a/libmamba/src/solver/libsolv/helpers.cpp
+++ b/libmamba/src/solver/libsolv/helpers.cpp
@@ -1524,8 +1524,7 @@ namespace mamba::solver::libsolv
                             return true;
                         }
                     }
-                    if constexpr (std::is_same_v<Action, Solution::Reinstall>
-                                  || std::is_same_v<Action, Solution::Omit>)
+                    if constexpr (std::is_same_v<Action, Solution::Reinstall> || std::is_same_v<Action, Solution::Omit>)
                     {
                         if (action.what.name == pkg_name)
                         {

--- a/libmamba/src/solver/libsolv/helpers.cpp
+++ b/libmamba/src/solver/libsolv/helpers.cpp
@@ -68,9 +68,7 @@ namespace mamba::solver::libsolv
         // TODO conda timestamp are not Unix timestamp.
         // Libsolv normalize them this way, we need to do the same here otherwise the current
         // package may get arbitrary priority.
-        solv.set_timestamp(
-            (pkg.timestamp > MAX_CONDA_TIMESTAMP) ? (pkg.timestamp / 1000) : pkg.timestamp
-        );
+        solv.set_timestamp(normalize_conda_timestamp(pkg.timestamp));
         solv.set_md5(pkg.md5);
         solv.set_sha256(pkg.sha256);
         solv.set_python_site_packages_path(pkg.python_site_packages_path);
@@ -331,15 +329,26 @@ namespace mamba::solver::libsolv
             // TODO conda timestamp are not Unix timestamp.
             // Libsolv normalize them this way, we need to do the same here otherwise the current
             // package may get arbitrary priority.
+            std::optional<std::uint64_t> policy_timestamp;
+            if (auto indexed_timestamp = pkg["indexed_timestamp"]; !indexed_timestamp.error())
+            {
+                policy_timestamp = normalize_conda_timestamp(
+                    indexed_timestamp.get_uint64().value_unsafe()
+                );
+            }
+
             if (auto timestamp = pkg["timestamp"]; !timestamp.error())
             {
-                const auto time = timestamp.get_uint64().value_unsafe();
-                const auto normalized = (time > MAX_CONDA_TIMESTAMP) ? (time / 1000) : time;
+                const auto normalized = normalize_conda_timestamp(
+                    timestamp.get_uint64().value_unsafe()
+                );
                 solv.set_timestamp(normalized);
-                if (out_timestamp)
-                {
-                    *out_timestamp = normalized;
-                }
+                policy_timestamp = policy_timestamp.value_or(normalized);
+            }
+
+            if (out_timestamp && policy_timestamp)
+            {
+                *out_timestamp = *policy_timestamp;
             }
 
             if (auto depends = pkg["depends"].get_array(); !depends.error())
@@ -1524,7 +1533,8 @@ namespace mamba::solver::libsolv
                             return true;
                         }
                     }
-                    if constexpr (std::is_same_v<Action, Solution::Reinstall> || std::is_same_v<Action, Solution::Omit>)
+                    if constexpr (std::is_same_v<Action, Solution::Reinstall>
+                                  || std::is_same_v<Action, Solution::Omit>)
                     {
                         if (action.what.name == pkg_name)
                         {

--- a/libmamba/src/solver/libsolv/helpers.cpp
+++ b/libmamba/src/solver/libsolv/helpers.cpp
@@ -211,16 +211,15 @@ namespace mamba::solver::libsolv
         template <class JSONObject>
         [[nodiscard]] auto set_solvable(
             solv::ObjPool& pool,
-            // const std::string& repo_url_str,
             const specs::CondaURL& repo_url,
             const std::string& channel_id,
             solv::ObjSolvableView solv,
-
             const std::string& filename,
             JSONObject&& pkg,
             const std::optional<nlohmann::json>& signatures,
             const std::string& default_subdir,
-            MatchSpecParser parser
+            MatchSpecParser parser,
+            std::uint64_t* out_timestamp = nullptr
         ) -> bool
         {
             // Not available from RepoDataPackage
@@ -335,7 +334,12 @@ namespace mamba::solver::libsolv
             if (auto timestamp = pkg["timestamp"]; !timestamp.error())
             {
                 const auto time = timestamp.get_uint64().value_unsafe();
-                solv.set_timestamp((time > MAX_CONDA_TIMESTAMP) ? (time / 1000) : time);
+                const auto normalized = (time > MAX_CONDA_TIMESTAMP) ? (time / 1000) : time;
+                solv.set_timestamp(normalized);
+                if (out_timestamp)
+                {
+                    *out_timestamp = normalized;
+                }
             }
 
             if (auto depends = pkg["depends"].get_array(); !depends.error())
@@ -450,6 +454,7 @@ namespace mamba::solver::libsolv
                 if (filter(filename))
                 {
                     auto [id, solv] = repo.add_solvable();
+                    std::uint64_t pkg_timestamp = 0;
                     const bool parsed = set_solvable(
                         pool,
                         repo_url,
@@ -459,12 +464,12 @@ namespace mamba::solver::libsolv
                         pkg_field.value(),
                         signatures,
                         default_subdir,
-                        parser
+                        parser,
+                        &pkg_timestamp
                     );
                     if (parsed)
                     {
-                        if (exclude_newer_timestamp
-                            && solv.timestamp() > static_cast<std::int64_t>(*exclude_newer_timestamp))
+                        if (exclude_newer_timestamp && pkg_timestamp > *exclude_newer_timestamp)
                         {
                             repo.remove_solvable(id, /* reuse_id= */ true);
                         }

--- a/libmamba/src/solver/libsolv/helpers.hpp
+++ b/libmamba/src/solver/libsolv/helpers.hpp
@@ -7,6 +7,7 @@
 #ifndef MAMBA_SOLVER_LIBSOLV_HELPERS
 #define MAMBA_SOLVER_LIBSOLV_HELPERS
 
+#include <cstdint>
 #include <optional>
 #include <string>
 #include <string_view>
@@ -36,6 +37,10 @@ namespace mamba::fs
 
 namespace mamba::solver::libsolv
 {
+    // Beyond this value, the timestamp would be in milliseconds and therefore should be
+    // converted to seconds.
+    inline constexpr std::uint64_t MAX_CONDA_TIMESTAMP = 253402300799ULL;
+
     void set_solvable(
         solv::ObjPool& pool,
         solv::ObjSolvableView solv,
@@ -61,7 +66,8 @@ namespace mamba::solver::libsolv
         const std::string& channel_id,
         PackageTypes types,
         MatchSpecParser parser,
-        bool verify_artifacts
+        bool verify_artifacts,
+        std::optional<std::uint64_t> exclude_newer_timestamp = std::nullopt
     ) -> expected_t<solv::ObjRepoView>;
 
     [[nodiscard]] auto read_solv(

--- a/libmamba/src/solver/libsolv/helpers.hpp
+++ b/libmamba/src/solver/libsolv/helpers.hpp
@@ -7,6 +7,7 @@
 #ifndef MAMBA_SOLVER_LIBSOLV_HELPERS
 #define MAMBA_SOLVER_LIBSOLV_HELPERS
 
+#include <cstdint>
 #include <optional>
 #include <string>
 #include <string_view>
@@ -37,6 +38,10 @@ namespace mamba::fs
 
 namespace mamba::solver::libsolv
 {
+    // Beyond this value, the timestamp would be in milliseconds and therefore should be
+    // converted to seconds.
+    inline constexpr std::uint64_t MAX_CONDA_TIMESTAMP = 253402300799ULL;
+
     void set_solvable(
         solv::ObjPool& pool,
         solv::ObjSolvableView solv,
@@ -62,7 +67,8 @@ namespace mamba::solver::libsolv
         const std::string& channel_id,
         PackageTypes types,
         MatchSpecParser parser,
-        bool verify_artifacts
+        bool verify_artifacts,
+        std::optional<std::uint64_t> exclude_newer_timestamp = std::nullopt
     ) -> expected_t<solv::ObjRepoView>;
 
     [[nodiscard]] auto read_solv(

--- a/libmamba/src/solver/libsolv/helpers.hpp
+++ b/libmamba/src/solver/libsolv/helpers.hpp
@@ -38,13 +38,12 @@ namespace mamba::fs
 
 namespace mamba::solver::libsolv
 {
-    // Beyond this value, the timestamp would be in milliseconds and therefore should be
-    // converted to seconds.
-    inline constexpr std::uint64_t MAX_CONDA_TIMESTAMP = 253402300799ULL;
-
     [[nodiscard]] constexpr auto normalize_conda_timestamp(std::uint64_t timestamp) -> std::uint64_t
     {
-        return (timestamp > MAX_CONDA_TIMESTAMP) ? (timestamp / 1000) : timestamp;
+        // Beyond this value, the timestamp would be in milliseconds and therefore should be
+        // converted to seconds.
+        constexpr std::uint64_t max_conda_timestamp = 253402300799ULL;
+        return (timestamp > max_conda_timestamp) ? (timestamp / 1000) : timestamp;
     }
 
     void set_solvable(

--- a/libmamba/src/solver/libsolv/helpers.hpp
+++ b/libmamba/src/solver/libsolv/helpers.hpp
@@ -42,6 +42,11 @@ namespace mamba::solver::libsolv
     // converted to seconds.
     inline constexpr std::uint64_t MAX_CONDA_TIMESTAMP = 253402300799ULL;
 
+    [[nodiscard]] constexpr auto normalize_conda_timestamp(std::uint64_t timestamp) -> std::uint64_t
+    {
+        return (timestamp > MAX_CONDA_TIMESTAMP) ? (timestamp / 1000) : timestamp;
+    }
+
     void set_solvable(
         solv::ObjPool& pool,
         solv::ObjSolvableView solv,

--- a/libmamba/tests/src/solver/libsolv/test_database.cpp
+++ b/libmamba/tests/src/solver/libsolv/test_database.cpp
@@ -220,7 +220,7 @@ namespace
 
         SECTION("exclude_newer_timestamp normalizes millisecond timestamps")
         {
-            const std::uint64_t cutoff = 2000;
+            const std::uint64_t cutoff = 2000000000;
             auto db_filtered = libsolv::Database(
                 {},
                 { matchspec_parser, /* exclude_newer_timestamp= */ cutoff }
@@ -229,7 +229,7 @@ namespace
             auto ms_pkg = specs::PackageInfo();
             ms_pkg.name = "ms-pkg";
             ms_pkg.version = "1.0";
-            ms_pkg.timestamp = 1500000;  // 1500 seconds in ms
+            ms_pkg.timestamp = 1500000000000;  // 1.5e12 ms → 1.5e9 seconds, below cutoff
 
             auto repo1 = db_filtered.add_repo_from_packages(std::array{ ms_pkg }, "repo1");
             REQUIRE(repo1.package_count() == 1);

--- a/libmamba/tests/src/solver/libsolv/test_database.cpp
+++ b/libmamba/tests/src/solver/libsolv/test_database.cpp
@@ -5,6 +5,7 @@
 // The full license is in the file LICENSE, distributed with this software.
 
 #include <array>
+#include <cstdint>
 #include <functional>
 
 #include <catch2/catch_all.hpp>
@@ -189,6 +190,51 @@ namespace
             }
         }
 
+        SECTION("exclude_newer_timestamp filters packages from add_repo_from_packages")
+        {
+            const std::uint64_t cutoff = 2000;
+            auto db_filtered = libsolv::Database(
+                {},
+                { matchspec_parser, /* exclude_newer_timestamp= */ cutoff }
+            );
+
+            auto old_pkg = specs::PackageInfo();
+            old_pkg.name = "old-pkg";
+            old_pkg.version = "1.0";
+            old_pkg.timestamp = 1000;
+
+            auto new_pkg = specs::PackageInfo();
+            new_pkg.name = "new-pkg";
+            new_pkg.version = "1.0";
+            new_pkg.timestamp = 3000;
+
+            auto pkgs = std::array{ old_pkg, new_pkg };
+            auto repo1 = db_filtered.add_repo_from_packages(pkgs, "repo1");
+            REQUIRE(repo1.package_count() == 1);
+
+            db_filtered.for_each_package_in_repo(
+                repo1,
+                [](const auto& p) { REQUIRE(p.name == "old-pkg"); }
+            );
+        }
+
+        SECTION("exclude_newer_timestamp normalizes millisecond timestamps")
+        {
+            const std::uint64_t cutoff = 2000;
+            auto db_filtered = libsolv::Database(
+                {},
+                { matchspec_parser, /* exclude_newer_timestamp= */ cutoff }
+            );
+
+            auto ms_pkg = specs::PackageInfo();
+            ms_pkg.name = "ms-pkg";
+            ms_pkg.version = "1.0";
+            ms_pkg.timestamp = 1500000;  // 1500 seconds in ms
+
+            auto repo1 = db_filtered.add_repo_from_packages(std::array{ ms_pkg }, "repo1");
+            REQUIRE(repo1.package_count() == 1);
+        }
+
         SECTION("Add repo from repodata with no extra pip")
         {
             const auto repodata = mambatests::test_data_dir
@@ -216,6 +262,25 @@ namespace
                 }
             );
             REQUIRE(found_python);
+        }
+
+        SECTION("exclude_newer_timestamp filters packages from repodata JSON")
+        {
+            const auto repodata = mambatests::test_data_dir
+                                  / "repodata/conda-forge-numpy-linux-64.json";
+            auto db_filtered = libsolv::Database(
+                {},
+                { matchspec_parser, /* exclude_newer_timestamp= */ std::uint64_t(1700000000) }
+            );
+            auto repo1 = db_filtered.add_repo_from_repodata_json(
+                repodata,
+                "https://conda.anaconda.org/conda-forge/linux-64",
+                "conda-forge",
+                libsolv::PipAsPythonDependency::No
+            );
+            REQUIRE(repo1.has_value());
+            REQUIRE(repo1->package_count() < 33);
+            REQUIRE(repo1->package_count() > 0);
         }
 
         SECTION("Add repo from repodata with extra pip")

--- a/libmamba/tests/src/solver/libsolv/test_database.cpp
+++ b/libmamba/tests/src/solver/libsolv/test_database.cpp
@@ -6,6 +6,7 @@
 
 #include <array>
 #include <cstdint>
+#include <fstream>
 #include <functional>
 
 #include <catch2/catch_all.hpp>
@@ -281,6 +282,67 @@ namespace
             REQUIRE(repo1.has_value());
             REQUIRE(repo1->package_count() < 33);
             REQUIRE(repo1->package_count() > 0);
+
+            auto db_unfiltered = libsolv::Database({}, { matchspec_parser });
+            auto unfiltered_repo = db_unfiltered.add_repo_from_repodata_json(
+                repodata,
+                "https://conda.anaconda.org/conda-forge/linux-64",
+                "conda-forge",
+                libsolv::PipAsPythonDependency::No
+            );
+            REQUIRE(unfiltered_repo.has_value());
+            REQUIRE(unfiltered_repo->package_count() > repo1->package_count());
+        }
+
+        SECTION("exclude_newer_timestamp prefers indexed_timestamp from repodata JSON")
+        {
+            auto tmp_dir = TemporaryDirectory();
+            const auto repodata = tmp_dir.path() / "repodata.json";
+            std::ofstream out_file(repodata.std_path());
+            out_file << R"({
+                "packages": {
+                    "excluded-pkg-1.0-bld.tar.bz2": {
+                        "name": "excluded-pkg",
+                        "version": "1.0",
+                        "build": "bld",
+                        "build_number": 0,
+                        "subdir": "linux-64",
+                        "depends": [],
+                        "timestamp": 1000,
+                        "indexed_timestamp": 3000
+                    },
+                    "included-pkg-1.0-bld.tar.bz2": {
+                        "name": "included-pkg",
+                        "version": "1.0",
+                        "build": "bld",
+                        "build_number": 0,
+                        "subdir": "linux-64",
+                        "depends": [],
+                        "timestamp": 3000,
+                        "indexed_timestamp": 1000
+                    }
+                },
+                "packages.conda": {}
+            })";
+            out_file.close();
+
+            auto db_filtered = libsolv::Database(
+                {},
+                { matchspec_parser, /* exclude_newer_timestamp= */ std::uint64_t(2000) }
+            );
+            auto repo1 = db_filtered.add_repo_from_repodata_json(
+                repodata,
+                "https://conda.anaconda.org/conda-forge/linux-64",
+                "conda-forge",
+                libsolv::PipAsPythonDependency::No
+            );
+            REQUIRE(repo1.has_value());
+            REQUIRE(repo1->package_count() == 1);
+
+            db_filtered.for_each_package_in_repo(
+                *repo1,
+                [](const auto& p) { REQUIRE(p.name == "included-pkg"); }
+            );
         }
 
         SECTION("Add repo from repodata with extra pip")

--- a/libmambapy/bindings/solver_libsolv.cpp
+++ b/libmambapy/bindings/solver_libsolv.cpp
@@ -9,6 +9,7 @@
 #include <pybind11/functional.h>
 #include <pybind11/operators.h>
 #include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
 
 #include "mamba/solver/libsolv/database.hpp"
 #include "mamba/solver/libsolv/parameters.hpp"
@@ -142,18 +143,22 @@ namespace mambapy
         py::class_<Database>(m, "Database")
             .def(
                 py::init(
-                    [](specs::ChannelResolveParams channel_params, MatchSpecParser matchspec_parser)
+                    [](specs::ChannelResolveParams channel_params,
+                       MatchSpecParser matchspec_parser,
+                       std::optional<std::uint64_t> exclude_newer_timestamp)
                     {
                         return Database(
                             channel_params,
                             Database::Settings{
                                 matchspec_parser,
+                                exclude_newer_timestamp,
                             }
                         );
                     }
                 ),
                 py::arg("channel_params"),
-                py::arg("matchspec_parser") = MatchSpecParser::Libsolv
+                py::arg("matchspec_parser") = MatchSpecParser::Libsolv,
+                py::arg("exclude_newer_timestamp") = py::none()
             )
             .def("set_logger", &Database::set_logger, py::call_guard<py::gil_scoped_acquire>())
             .def(

--- a/libmambapy/tests/test_solver_libsolv.py
+++ b/libmambapy/tests/test_solver_libsolv.py
@@ -227,6 +227,8 @@ def test_Database_exclude_newer_timestamp_repodata(tmp_path):
                         "version": "1.0",
                         "build": "bld",
                         "build_number": 0,
+                        "subdir": "linux-64",
+                        "depends": [],
                         "timestamp": 1000,
                     },
                     "new-pkg-1.0-bld.tar.bz2": {
@@ -234,6 +236,8 @@ def test_Database_exclude_newer_timestamp_repodata(tmp_path):
                         "version": "1.0",
                         "build": "bld",
                         "build_number": 0,
+                        "subdir": "linux-64",
+                        "depends": [],
                         "timestamp": 3000,
                     },
                 },

--- a/libmambapy/tests/test_solver_libsolv.py
+++ b/libmambapy/tests/test_solver_libsolv.py
@@ -179,6 +179,82 @@ def test_Database_RepoInfo_from_packages(add_pip_as_python_dependency, matchspec
     assert db.installed_repo() is None
 
 
+def test_Database_exclude_newer_timestamp_filters_packages():
+    cutoff = 2000
+    db = libsolv.Database(
+        libmambapy.specs.ChannelResolveParams(),
+        exclude_newer_timestamp=cutoff,
+    )
+
+    old_pkg = libmambapy.specs.PackageInfo(name="old-pkg")
+    old_pkg.version = "1.0"
+    old_pkg.timestamp = 1000
+
+    new_pkg = libmambapy.specs.PackageInfo(name="new-pkg")
+    new_pkg.version = "1.0"
+    new_pkg.timestamp = 3000
+
+    repo = db.add_repo_from_packages([old_pkg, new_pkg], name="test")
+    assert repo.package_count() == 1
+
+    pkgs = db.packages_in_repo(repo)
+    assert len(pkgs) == 1
+    assert pkgs[0].name == "old-pkg"
+
+
+def test_Database_exclude_newer_timestamp_none_keeps_all():
+    db = libsolv.Database(
+        libmambapy.specs.ChannelResolveParams(),
+        exclude_newer_timestamp=None,
+    )
+
+    pkg = libmambapy.specs.PackageInfo(name="pkg")
+    pkg.version = "1.0"
+    pkg.timestamp = 9999
+
+    repo = db.add_repo_from_packages([pkg], name="test")
+    assert repo.package_count() == 1
+
+
+def test_Database_exclude_newer_timestamp_repodata(tmp_path):
+    repodata_file = tmp_path / "repodata.json"
+    with open(repodata_file, "w+") as f:
+        json.dump(
+            {
+                "packages": {
+                    "old-pkg-1.0-bld.tar.bz2": {
+                        "name": "old-pkg",
+                        "version": "1.0",
+                        "build": "bld",
+                        "build_number": 0,
+                        "timestamp": 1000,
+                    },
+                    "new-pkg-1.0-bld.tar.bz2": {
+                        "name": "new-pkg",
+                        "version": "1.0",
+                        "build": "bld",
+                        "build_number": 0,
+                        "timestamp": 3000,
+                    },
+                },
+                "packages.conda": {},
+            },
+            f,
+        )
+
+    db = libsolv.Database(
+        libmambapy.specs.ChannelResolveParams(),
+        exclude_newer_timestamp=2000,
+    )
+    repo = db.add_repo_from_repodata_json(
+        repodata_file,
+        "https://example.com/linux-64",
+        "test-channel",
+    )
+    assert repo is not None
+    assert repo.package_count() == 1
+
+
 @pytest.fixture
 def tmp_repodata_json(tmp_path):
     file = tmp_path / "repodata.json"

--- a/libmambapy/tests/test_solver_libsolv.py
+++ b/libmambapy/tests/test_solver_libsolv.py
@@ -182,6 +182,82 @@ def test_Database_RepoInfo_from_packages(add_pip_as_python_dependency, matchspec
     assert db.installed_repo() is None
 
 
+def test_Database_exclude_newer_timestamp_filters_packages():
+    cutoff = 2000
+    db = libsolv.Database(
+        libmambapy.specs.ChannelResolveParams(),
+        exclude_newer_timestamp=cutoff,
+    )
+
+    old_pkg = libmambapy.specs.PackageInfo(name="old-pkg")
+    old_pkg.version = "1.0"
+    old_pkg.timestamp = 1000
+
+    new_pkg = libmambapy.specs.PackageInfo(name="new-pkg")
+    new_pkg.version = "1.0"
+    new_pkg.timestamp = 3000
+
+    repo = db.add_repo_from_packages([old_pkg, new_pkg], name="test")
+    assert repo.package_count() == 1
+
+    pkgs = db.packages_in_repo(repo)
+    assert len(pkgs) == 1
+    assert pkgs[0].name == "old-pkg"
+
+
+def test_Database_exclude_newer_timestamp_none_keeps_all():
+    db = libsolv.Database(
+        libmambapy.specs.ChannelResolveParams(),
+        exclude_newer_timestamp=None,
+    )
+
+    pkg = libmambapy.specs.PackageInfo(name="pkg")
+    pkg.version = "1.0"
+    pkg.timestamp = 9999
+
+    repo = db.add_repo_from_packages([pkg], name="test")
+    assert repo.package_count() == 1
+
+
+def test_Database_exclude_newer_timestamp_repodata(tmp_path):
+    repodata_file = tmp_path / "repodata.json"
+    with open(repodata_file, "w+") as f:
+        json.dump(
+            {
+                "packages": {
+                    "old-pkg-1.0-bld.tar.bz2": {
+                        "name": "old-pkg",
+                        "version": "1.0",
+                        "build": "bld",
+                        "build_number": 0,
+                        "timestamp": 1000,
+                    },
+                    "new-pkg-1.0-bld.tar.bz2": {
+                        "name": "new-pkg",
+                        "version": "1.0",
+                        "build": "bld",
+                        "build_number": 0,
+                        "timestamp": 3000,
+                    },
+                },
+                "packages.conda": {},
+            },
+            f,
+        )
+
+    db = libsolv.Database(
+        libmambapy.specs.ChannelResolveParams(),
+        exclude_newer_timestamp=2000,
+    )
+    repo = db.add_repo_from_repodata_json(
+        repodata_file,
+        "https://example.com/linux-64",
+        "test-channel",
+    )
+    assert repo is not None
+    assert repo.package_count() == 1
+
+
 @pytest.fixture
 def tmp_repodata_json(tmp_path):
     file = tmp_path / "repodata.json"

--- a/libmambapy/tests/test_solver_libsolv.py
+++ b/libmambapy/tests/test_solver_libsolv.py
@@ -225,23 +225,25 @@ def test_Database_exclude_newer_timestamp_repodata(tmp_path):
         json.dump(
             {
                 "packages": {
-                    "old-pkg-1.0-bld.tar.bz2": {
-                        "name": "old-pkg",
+                    "excluded-pkg-1.0-bld.tar.bz2": {
+                        "name": "excluded-pkg",
                         "version": "1.0",
                         "build": "bld",
                         "build_number": 0,
                         "subdir": "linux-64",
                         "depends": [],
                         "timestamp": 1000,
+                        "indexed_timestamp": 3000,
                     },
-                    "new-pkg-1.0-bld.tar.bz2": {
-                        "name": "new-pkg",
+                    "included-pkg-1.0-bld.tar.bz2": {
+                        "name": "included-pkg",
                         "version": "1.0",
                         "build": "bld",
                         "build_number": 0,
                         "subdir": "linux-64",
                         "depends": [],
                         "timestamp": 3000,
+                        "indexed_timestamp": 1000,
                     },
                 },
                 "packages.conda": {},
@@ -260,6 +262,8 @@ def test_Database_exclude_newer_timestamp_repodata(tmp_path):
     )
     assert repo is not None
     assert repo.package_count() == 1
+    pkgs = db.packages_in_repo(repo)
+    assert pkgs[0].name == "included-pkg"
 
 
 @pytest.fixture

--- a/libmambapy/tests/test_solver_libsolv.py
+++ b/libmambapy/tests/test_solver_libsolv.py
@@ -230,6 +230,8 @@ def test_Database_exclude_newer_timestamp_repodata(tmp_path):
                         "version": "1.0",
                         "build": "bld",
                         "build_number": 0,
+                        "subdir": "linux-64",
+                        "depends": [],
                         "timestamp": 1000,
                     },
                     "new-pkg-1.0-bld.tar.bz2": {
@@ -237,6 +239,8 @@ def test_Database_exclude_newer_timestamp_repodata(tmp_path):
                         "version": "1.0",
                         "build": "bld",
                         "build_number": 0,
+                        "subdir": "linux-64",
+                        "depends": [],
                         "timestamp": 3000,
                     },
                 },


### PR DESCRIPTION
### Description

Adds an optional `exclude_newer_timestamp` field to `Database::Settings`, allowing callers to exclude packages with a timestamp newer than the given Unix epoch cutoff during repodata loading.

This enables conda's `--exclude-newer` feature to work with the libmamba solver backend, matching what rattler already supports natively. See [conda/conda#15759](https://github.com/conda/conda/issues/15759) for the full tracking and [conda/ceps#154](https://github.com/conda/ceps/pull/154) for the CEP proposing `indexed_timestamp` in repodata.

This PR adds only the low-level **global** libmamba API: a single cutoff timestamp applied when loading a repo. It intentionally does not implement conda's richer channel- or package-scoped `exclude_newer` policy; `conda-libmamba-solver` applies scoped policy in Python-side repodata filtering when needed and uses this native cutoff for the simple global-policy case.

Fix #4254.

### How it works

The cutoff is applied at load time in both ingestion paths:

- **JSON path** (`mamba_read_json` -> `set_repo_solvables_impl`): after a solvable is parsed, its policy timestamp is compared to the cutoff. If newer, the solvable is removed via `repo.remove_solvable(id, true)` -- the same pattern used for parse failures. For repodata JSON, `indexed_timestamp` is preferred over `timestamp` when present (matching conda semantics).
- **PackageInfo path** (`add_repo_from_packages_impl_loop`): the package timestamp (normalized from ms to seconds) is checked before adding a solvable. If newer, the package is skipped entirely.

The `.solv` cache path is **not** filtered. Callers (e.g. `conda-libmamba-solver`) are expected to invalidate the cache when `exclude_newer_timestamp` changes, the same way they handle `repodata_filters`.

### Other changes

- Moved `MAX_CONDA_TIMESTAMP` from the anonymous namespace in `helpers.cpp` to `helpers.hpp` and added `normalize_conda_timestamp` for shared timestamp normalization.
- Python bindings: `Database.__init__()` accepts an optional `exclude_newer_timestamp` keyword argument.

### Context

- `--exclude-newer` is a supply chain security feature that excludes recently published packages, giving security vendors time to flag malicious uploads. It's already supported by uv, pip, pixi, and rattler.
- CEP draft proposing `indexed_timestamp`: [conda/ceps#154](https://github.com/conda/ceps/pull/154)
- Andrew Nesbitt's overview: https://nesbitt.io/2026/03/04/package-managers-need-to-cool-down.html
- conda implementation: [conda/conda#15761](https://github.com/conda/conda/pull/15761)
- rattler support: [conda/rattler#654](https://github.com/conda/rattler/pull/654)
- micromamba CLI tracking: [mamba-org/mamba#4254](https://github.com/mamba-org/mamba/issues/4254)

### Test plan

- [x] C++ tests for `add_repo_from_packages`, millisecond normalization, repodata JSON filtering, unfiltered vs filtered `package_count`, and `indexed_timestamp` precedence
- [x] Python binding tests for packages API, repodata JSON, and `None` default