### PR TITLE
fix: python_binary_compatible 

### DIFF
--- a/libmamba/src/solver/helpers.cpp
+++ b/libmamba/src/solver/helpers.cpp
@@ -22,9 +22,18 @@ namespace mamba::solver
         return std::nullopt;
     }
 
-    auto python_binary_compatible(const specs::Version& older, const specs::Version& newer) -> bool
+    auto python_binary_compatible(const specs::Version& a, const specs::Version& b) -> bool
     {
-        // Python binary compatibility is defined at the same MINOR level.
-        return older.compatible_with(newer, /* level= */ 2);
+        // Python binary compatibility is defined at the same major + minor
+        // level. This matches conda's noarch:python relink gate in
+        // conda/core/solve.py, which compares
+        //   get_major_minor_version(prev) != get_major_minor_version(curr)
+        // and is symmetric across upgrade/downgrade.
+        const auto& a_ver = a.version();
+        const auto& b_ver = b.version();
+        return a.epoch() == b.epoch()                     //
+               && a_ver.size() >= 2 && b_ver.size() >= 2  //
+               && a_ver[0] == b_ver[0]                    //
+               && a_ver[1] == b_ver[1];
     }
 }

--- a/libmamba/tests/CMakeLists.txt
+++ b/libmamba/tests/CMakeLists.txt
@@ -70,6 +70,7 @@ set(
     src/specs/test_version_spec.cpp
     src/specs/test_version.cpp
     # Solver tests
+    src/solver/test_helpers.cpp
     src/solver/test_problems_graph.cpp
     src/solver/test_request.cpp
     src/solver/test_solution.cpp

--- a/libmamba/tests/src/solver/test_helpers.cpp
+++ b/libmamba/tests/src/solver/test_helpers.cpp
@@ -1,0 +1,71 @@
+// Copyright (c) 2026, QuantStack and Mamba Contributors
+//
+// Distributed under the terms of the BSD 3-Clause License.
+//
+// The full license is in the file LICENSE, distributed with this software.
+
+#include <catch2/catch_all.hpp>
+
+#include "mamba/specs/version.hpp"
+
+#include "solver/helpers.hpp"
+
+using namespace mamba;
+using namespace mamba::solver;
+
+namespace
+{
+    auto parse_version(std::string_view s) -> specs::Version
+    {
+        return specs::Version::parse(s).value();
+    }
+
+    TEST_CASE("python_binary_compatible", "[mamba::solver]")
+    {
+        SECTION("identical versions are compatible")
+        {
+            const auto v = parse_version("3.11.14");
+            REQUIRE(python_binary_compatible(v, v));
+        }
+
+        SECTION("same-minor micro upgrade is compatible")
+        {
+            // Regression test for the argument-order bug in
+            // python_binary_compatible: the body used to call
+            //   older.compatible_with(newer, 2)
+            // but Version::compatible_with follows the convention
+            //   newer.compatible_with(older, level)
+            // (cf. libmamba/tests/src/specs/test_version.cpp).  The reversed
+            // call reported every real Python upgrade as ABI-incompatible,
+            // which caused solution_needs_python_relink() to emit a
+            // Solution::Reinstall for every installed noarch:python package
+            // on every micro upgrade.
+            const auto older = parse_version("3.11.14");
+            const auto newer = parse_version("3.11.15");
+            REQUIRE(python_binary_compatible(older, newer));
+        }
+
+        SECTION("same-minor micro downgrade is compatible")
+        {
+            // Python ABI compatibility is symmetric within a minor series,
+            // matching conda's get_major_minor_version equality check.
+            const auto newer = parse_version("3.11.15");
+            const auto older = parse_version("3.11.14");
+            REQUIRE(python_binary_compatible(newer, older));
+        }
+
+        SECTION("different minor versions are not compatible")
+        {
+            const auto older = parse_version("3.11.14");
+            const auto newer = parse_version("3.12.0");
+            REQUIRE_FALSE(python_binary_compatible(older, newer));
+        }
+
+        SECTION("different major versions are not compatible")
+        {
+            const auto older = parse_version("2.7.18");
+            const auto newer = parse_version("3.11.14");
+            REQUIRE_FALSE(python_binary_compatible(older, newer));
+        }
+    }
+}


### PR DESCRIPTION
# Description

Currently micromamba relinks all noarch python packages when upgrading python patch versions. As far as I can tell this is an unintentional bug and it differs from conda's behavior (see below). This PR fixes the comparision and adds a corrosponding test.

### Conda

```bash
$ micromamba create --prefix $PWD/conda-env-up python=3.14.3 pytz
$ conda install -c conda-forge --prefix $PWD/conda-env-up python=3.14.4

The following packages will be UPDATED:

  python                          3.14.3-h4c637c5_101_cp314 --> 3.14.4-h4c637c5_100_cp314
...
```

```bash
$ micromamba create --prefix $PWD/conda-env-down python=3.14.4 pytz
$ conda install -c conda-forge --prefix $PWD/conda-env-down python=3.14.3

The following packages will be DOWNGRADED:

  python                          3.14.4-h4c637c5_100_cp314 --> 3.14.3-h4c637c5_101_cp314
...
```

### Micromamba

```bash
$ micromamba create --prefix $PWD/micromamba-env-up python=3.14.3 pytz
$ micromamba install -c conda-forge --prefix $PWD/micromamba-env-up python=3.14.4
  Reinstall:
──────────────────────────────────────────────────────────────────────

  o pip           26.0.1  pyh145f28c_0        conda-forge     Cached
  o pytz    2026.1.post1  pyhcf101f3_0        conda-forge     Cached

  Upgrade:
──────────────────────────────────────────────────────────────────────

  - python        3.14.3  h4c637c5_101_cp314  conda-forge     Cached
  + python        3.14.4  h4c637c5_100_cp314  conda-forge     Cached
...
```

```bash
$ micromamba create --prefix $PWD/micromamba-env-down python=3.14.4 pytz
$ micromamba install -c conda-forge --prefix $PWD/micromamba-env-down python=3.14.3
  Downgrade:
─────────────────────────────────────────────────────────────────

  - python   3.14.4  h4c637c5_100_cp314  conda-forge     Cached
  + python   3.14.3  h4c637c5_101_cp314  conda-forge     Cached
...
```



## Type of Change

<!-- Please skip this part if you are already using conventional commit keywords in the PR title. -->

- [x] Bugfix
- [ ] Feature / enhancement
- [ ] CI / Documentation
- [ ] Maintenance

## Checklist

- [x] My code follows the general style and conventions of the codebase, ensuring consistency
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have run `pre-commit run --all` locally in the source folder and confirmed that there are no linter errors.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
