### PR TITLE
fix: Keep and use `RepoDataPackage`'s raw version

### DIFF
--- a/libmamba/include/mamba/specs/repo_data.hpp
+++ b/libmamba/include/mamba/specs/repo_data.hpp
@@ -44,6 +44,14 @@ namespace mamba::specs
         /** The version of the package. */
         Version version = Version(0, { { { 0 } } });
 
+        /**
+         * Optional original version string as found in repodata/shards.
+         *
+         * This is used for user-facing representations to preserve formatting details
+         * (e.g. leading zeros) while keeping ``version`` as the canonical parsed form.
+         */
+        std::optional<std::string> raw_version = {};
+
         /** The build string of the package. */
         std::string build_string = {};
 

--- a/libmamba/src/core/shard_types.cpp
+++ b/libmamba/src/core/shard_types.cpp
@@ -45,7 +45,7 @@ namespace mamba
 
         specs::PackageInfo pkg_info;
         pkg_info.name = record.name;
-        pkg_info.version = record.version.to_string();
+        pkg_info.version = record.raw_version.value_or(record.version.to_string());
         pkg_info.build_string = record.build_string;
         pkg_info.build_number = record.build_number;
         pkg_info.channel = channel_id;

--- a/libmamba/src/core/shards.cpp
+++ b/libmamba/src/core/shards.cpp
@@ -226,6 +226,7 @@ namespace mamba
                     else if (key == "version")
                     {
                         const auto version_str = msgpack_object_to_string(val_obj);
+                        record.raw_version = version_str;
                         auto parsed = specs::Version::parse(version_str);
                         record.version = parsed ? parsed.value() : specs::Version(0, { { { 0 } } });
                     }

--- a/libmamba/src/specs/repo_data.cpp
+++ b/libmamba/src/specs/repo_data.cpp
@@ -16,7 +16,7 @@ namespace mamba::specs
     void to_json(nlohmann::json& j, const RepoDataPackage& p)
     {
         j["name"] = p.name;
-        j["version"] = p.version.to_string();
+        j["version"] = p.raw_version.value_or(p.version.to_string());
         j["build"] = p.build_string;
         j["build_number"] = p.build_number;
         j["subdir"] = p.subdir;
@@ -43,7 +43,9 @@ namespace mamba::specs
         using mamba::util::deserialize_maybe_missing;
 
         p.name = j.at("name");
-        p.version = Version::parse(j.at("version").template get<std::string_view>())
+        const auto raw_version = j.at("version").template get<std::string>();
+        p.raw_version = raw_version;
+        p.version = Version::parse(raw_version)
                         .or_else([](ParseError&& error) { throw std::move(error); })
                         .value();
         p.build_string = j.at("build");

--- a/libmamba/tests/src/core/test_shard_types.cpp
+++ b/libmamba/tests/src/core/test_shard_types.cpp
@@ -222,4 +222,23 @@ TEST_CASE("to_package_info conversion", "[mamba::core][mamba::core::shard_types]
         REQUIRE(pkg_info.dependencies.empty());
         REQUIRE(pkg_info.constrains.empty());
     }
+
+    SECTION("Preserve raw version formatting when available")
+    {
+        specs::RepoDataPackage record;
+        record.name = "conda-forge-pinning";
+        record.version = specs::Version::parse("2026.04.07.10.45.57").value();
+        record.raw_version = "2026.04.07.10.45.57";
+        record.build_string = "hd8ed1ab_0";
+
+        specs::PackageInfo pkg_info = to_package_info(
+            record,
+            "conda-forge-pinning-2026.04.07.10.45.57-hd8ed1ab_0.conda",
+            "conda-forge",
+            "noarch",
+            "https://conda.anaconda.org/conda-forge/noarch"
+        );
+
+        REQUIRE(pkg_info.version == "2026.04.07.10.45.57");
+    }
 }


### PR DESCRIPTION
# Description

@h-vetinari identified this issue with 2.6.0.rc0, with version number rendered incorrectly. For instance, when updating an environment with `conda-forge-pinning  2026.04.07.10.45.57`, one gets with 2.6.0.rc0:

```
  - conda-forge-pinning  2026.04.07.10.45.57  hd8ed1ab_0       conda-forge      66kB
  + conda-forge-pinning     2026.4.9.7.25.35  hd8ed1ab_0       conda-forge      66kB
```

IIUC, `MatchSpec::parse` removes the trailing zeros in version number, so we might need to keep the original string representation also.

## Type of Change

<!-- Please skip this part if you are already using conventional commit keywords in the PR title. -->

- [x] Bugfix
- [ ] Feature / enhancement
- [ ] CI / Documentation
- [ ] Maintenance

## Checklist

- [x] My code follows the general style and conventions of the codebase, ensuring consistency
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have run `pre-commit run --all` locally in the source folder and confirmed that there are no linter errors.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
