### PR TITLE
fix: Normalize MatchSpec's name to lowercase internally

### DIFF
--- a/libmamba/src/api/channel_loader.cpp
+++ b/libmamba/src/api/channel_loader.cpp
@@ -29,6 +29,7 @@
 #include "mamba/specs/match_spec.hpp"
 #include "mamba/specs/package_info.hpp"
 #include "mamba/specs/version.hpp"
+#include "mamba/util/string.hpp"
 
 #include "utils.hpp"
 
@@ -577,10 +578,12 @@ namespace mamba
             std::unordered_set<std::string> seen(root_packages.begin(), root_packages.end());
             auto add_from_spec = [&](const std::string& dep_str)
             {
-                if (auto name = specs::MatchSpec::extract_name(dep_str);
-                    name && !name->empty() && *name != "*" && seen.insert(*name).second)
+                if (auto name = specs::MatchSpec::extract_name(dep_str); name)
                 {
-                    root_packages.push_back(*name);
+                    if (!name->empty() && *name != "*" && seen.insert(*name).second)
+                    {
+                        root_packages.push_back(*name);
+                    }
                 }
             };
 

--- a/libmamba/src/core/shard_traversal.cpp
+++ b/libmamba/src/core/shard_traversal.cpp
@@ -16,6 +16,7 @@
 #include "mamba/core/output.hpp"
 #include "mamba/core/shard_traversal.hpp"
 #include "mamba/specs/match_spec.hpp"
+#include "mamba/util/string.hpp"
 
 namespace mamba
 {

--- a/libmamba/src/specs/match_spec.cpp
+++ b/libmamba/src/specs/match_spec.cpp
@@ -49,7 +49,7 @@ namespace mamba::specs
         {
             return make_unexpected_parse("Empty package name.");
         }
-        return { std::string(spec.substr(name_start, i - name_start)) };
+        return { util::to_lower(std::string(spec.substr(name_start, i - name_start))) };
     }
 
     auto MatchSpec::parse_url(std::string_view spec) -> expected_parse_t<MatchSpec>

--- a/libmamba/tests/src/core/test_sharded_repodata_integration.cpp
+++ b/libmamba/tests/src/core/test_sharded_repodata_integration.cpp
@@ -428,6 +428,49 @@ TEST_CASE("Sharded repodata - python root extraction adds python_abi", "[mamba::
     }
 }
 
+TEST_CASE(
+    "Sharded repodata - mixed-case root package names behave like lowercase",
+    "[mamba::core][sharded][.integration]"
+)
+{
+    auto& ctx = mambatests::context();
+    const std::vector<std::string> saved_channels = ctx.channels;
+    const bool saved_use_shards = ctx.use_sharded_repodata;
+    const bool saved_offline = ctx.offline;
+    on_scope_exit restore_ctx{ [&]
+                               {
+                                   ctx.channels = saved_channels;
+                                   ctx.use_sharded_repodata = saved_use_shards;
+                                   ctx.offline = saved_offline;
+                               } };
+
+    ctx.channels = { "conda-forge" };
+    ctx.use_sharded_repodata = true;
+    ctx.offline = false;
+
+    const TemporaryDirectory tmp_dir;
+    const fs::u8path cache_dir = tmp_dir.path() / "cache";
+    fs::create_directories(cache_dir);
+
+    auto channel_context = ChannelContext::make_conda_compatible(ctx);
+    init_channels(ctx, channel_context);
+
+    const auto assert_both_modes_succeed = [&](const std::vector<std::string>& specs)
+    {
+        auto flat_solution = solve_environment(ctx, channel_context, specs, false, cache_dir);
+        auto sharded_solution = solve_environment(ctx, channel_context, specs, true, cache_dir);
+
+        REQUIRE(flat_solution.has_value());
+        REQUIRE(sharded_solution.has_value());
+    };
+
+    // Regression matrix for case-insensitive package names with and without an additional root.
+    assert_both_modes_succeed({ "python>=3.11" });
+    assert_both_modes_succeed({ "PyThOn>=3.11" });
+    assert_both_modes_succeed({ "python>=3.11", "make" });
+    assert_both_modes_succeed({ "PyThOn>=3.11", "make" });
+}
+
 TEST_CASE("Sharded repodata - noarch-only root package is installable", "[mamba::core][sharded][.integration]")
 {
     auto& ctx = mambatests::context();

--- a/libmamba/tests/src/specs/test_match_spec.cpp
+++ b/libmamba/tests/src/specs/test_match_spec.cpp
@@ -797,6 +797,17 @@ namespace
             REQUIRE(name.value() == "scipy");
         }
 
+        SECTION("normalize extracted name to lowercase")
+        {
+            auto name = MatchSpec::extract_name("CppInterOp>=1.9");
+            REQUIRE(name.has_value());
+            REQUIRE(name.value() == "cppinterop");
+
+            name = MatchSpec::extract_name("   PyThOn >=3.11");
+            REQUIRE(name.has_value());
+            REQUIRE(name.value() == "python");
+        }
+
         SECTION("empty and operator-only specs return empty")
         {
             REQUIRE_FALSE(MatchSpec::extract_name("").has_value());


### PR DESCRIPTION
# Description

Fix cases like https://github.com/compiler-research/xeus-cpp/issues/482 (no pun intended).

## Type of Change

<!-- Please skip this part if you are already using conventional commit keywords in the PR title. -->

- [x] Bugfix
- [ ] Feature / enhancement
- [ ] CI / Documentation
- [ ] Maintenance

## Checklist

- [x] My code follows the general style and conventions of the codebase, ensuring consistency
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have run `pre-commit run --all` locally in the source folder and confirmed that there are no linter errors.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
