### PR TITLE
fix: Adapt `noarch` unlink path normalization for conda interoperability

### DIFF
--- a/libmamba/src/core/link.cpp
+++ b/libmamba/src/core/link.cpp
@@ -490,6 +490,22 @@ namespace mamba
         const fs::u8path& target_prefix = m_context->prefix_params().target_prefix;
         fs::u8path dst = target_prefix / subtarget;
 
+        // Conda metadata for noarch Python packages can store short paths like
+        // `site-packages/...` or `python-scripts/...`. Resolve those to the
+        // actual prefix-relative destination before unlinking.
+        if (!fs::exists(dst))
+        {
+            const auto resolved_subtarget = get_python_noarch_target_path(
+                subtarget,
+                m_context->python_params().site_packages_path
+            );
+            fs::u8path resolved_dst = target_prefix / resolved_subtarget;
+            if (resolved_dst != dst)
+            {
+                dst = std::move(resolved_dst);
+            }
+        }
+
         LOG_TRACE << "Unlinking '" << dst.string() << "'";
         std::error_code err;
 
@@ -576,7 +592,32 @@ namespace mamba
         nlohmann::json json_record;
         json_file >> json_record;
 
-        for (auto& path : json_record["paths_data"]["paths"])
+        nlohmann::json paths_to_unlink = nlohmann::json::array();
+        if (json_record.contains("paths_data") && json_record["paths_data"].is_object()
+            && json_record["paths_data"].contains("paths")
+            && json_record["paths_data"]["paths"].is_array())
+        {
+            paths_to_unlink = json_record["paths_data"]["paths"];
+        }
+        else if (json_record.contains("files") && json_record["files"].is_array())
+        {
+            LOG_DEBUG << "Using legacy `files` list from metadata for package '" << m_specifier
+                      << "'";
+            for (const auto& file : json_record["files"])
+            {
+                if (file.is_string())
+                {
+                    paths_to_unlink.push_back({ { "_path", file.get<std::string>() } });
+                }
+            }
+        }
+        else
+        {
+            LOG_WARNING << "No unlinkable file list found in conda-meta JSON for package '"
+                        << m_specifier << "'";
+        }
+
+        for (auto& path : paths_to_unlink)
         {
             std::string fpath = path["_path"];
             if (std::regex_match(fpath, MENU_PATH_REGEX))

--- a/libmamba/tests/src/core/test_transaction_context.cpp
+++ b/libmamba/tests/src/core/test_transaction_context.cpp
@@ -7,6 +7,12 @@
 #include <catch2/catch_all.hpp>
 
 // Private libmamba header
+#include "core/link.hpp"
+// Private libmamba header
+#include "mamba/core/context_params.hpp"
+#include "mamba/core/util.hpp"
+#include "mamba/specs/package_info.hpp"
+
 #include "core/transaction_context.hpp"
 
 namespace mamba
@@ -177,6 +183,106 @@ namespace mamba
             REQUIRE(ps_path_str == "bin/some_random_file");
             REQUIRE(ps_path_gen_str == "bin/some_random_file");
 #endif
+        }
+
+        TEST_CASE("unlink noarch metadata paths")
+        {
+            const auto tmp_dir = TemporaryDirectory();
+            const fs::u8path prefix = tmp_dir.path() / "prefix";
+            const fs::u8path conda_meta_dir = prefix / "conda-meta";
+            fs::create_directories(conda_meta_dir);
+
+            const fs::u8path site_packages = prefix / "lib" / "python3.14" / "site-packages";
+            fs::create_directories(site_packages / "httpx");
+            fs::create_directories(site_packages / "httpx-0.27.2.dist-info");
+
+            {
+                auto out = open_ofstream(site_packages / "httpx" / "__init__.py");
+                out << "print('old')\n";
+            }
+            {
+                auto out = open_ofstream(site_packages / "httpx-0.27.2.dist-info" / "METADATA");
+                out << "metadata\n";
+            }
+
+            const auto mk_tx_context = [&]
+            {
+                TransactionParams tx_params{
+                    .is_mamba_exe = false,
+                    .json_output = false,
+                    .verbosity = 0,
+                    .shortcuts = false,
+                    .envs_dirs = {},
+                    .platform = "linux-64",
+                    .prefix_params =
+                        PrefixParams{
+                            .target_prefix = prefix,
+                            .root_prefix = prefix,
+                            .conda_prefix = prefix,
+                            .relocate_prefix = prefix,
+                        },
+                    .link_params = {},
+                    .threads_params = {},
+                };
+
+                return TransactionContext(
+                    tx_params,
+                    { "3.14.4", "3.14.4" },
+                    "lib/python3.14/site-packages",
+                    {}
+                );
+            };
+
+            specs::PackageInfo pkg("httpx");
+            pkg.version = "0.27.2";
+            pkg.build_string = "pyhd8ed1ab_0";
+
+            SECTION("paths_data with short noarch paths is resolved")
+            {
+                {
+                    auto out = open_ofstream(conda_meta_dir / "httpx-0.27.2-pyhd8ed1ab_0.json");
+                    out << R"({
+  "name": "httpx",
+  "version": "0.27.2",
+  "build_string": "pyhd8ed1ab_0",
+  "paths_data": {
+    "paths": [
+      { "_path": "site-packages/httpx/__init__.py" },
+      { "_path": "site-packages/httpx-0.27.2.dist-info/METADATA" }
+    ],
+    "paths_version": 1
+  }
+})";
+                }
+
+                auto tx_context = mk_tx_context();
+                UnlinkPackage unlink_pkg(pkg, prefix, &tx_context);
+                REQUIRE(unlink_pkg.execute());
+                REQUIRE_FALSE(fs::exists(site_packages / "httpx" / "__init__.py"));
+                REQUIRE_FALSE(fs::exists(site_packages / "httpx-0.27.2.dist-info" / "METADATA"));
+            }
+
+            SECTION("legacy files list with noarch short paths is resolved")
+            {
+                {
+                    auto out = open_ofstream(conda_meta_dir / "httpx-0.27.2-pyhd8ed1ab_0.json");
+                    out << R"({
+  "name": "httpx",
+  "version": "0.27.2",
+  "build_string": "pyhd8ed1ab_0",
+  "files": [
+    "site-packages/httpx/__init__.py",
+    "site-packages/httpx-0.27.2.dist-info/METADATA"
+  ]
+})";
+                }
+
+                auto tx_context = mk_tx_context();
+                UnlinkPackage unlink_pkg(pkg, prefix, &tx_context);
+                REQUIRE(unlink_pkg.execute());
+                REQUIRE_FALSE(fs::exists(site_packages / "httpx" / "__init__.py"));
+                REQUIRE_FALSE(fs::exists(site_packages / "httpx-0.27.2.dist-info" / "METADATA"));
+            }
         }
     }
 }  // namespace mamba

--- a/micromamba/tests/test_linking.py
+++ b/micromamba/tests/test_linking.py
@@ -28,25 +28,36 @@ class TestLinking:
 
     @staticmethod
     def _httpx_dist_info_resolved(env_prefix: Path, httpx_version: str) -> set[Path]:
-        """Paths to httpx-*.dist-info under lib/Lib, deduplicated by real path.
+        """Paths to httpx-*.dist-info, deduplicated by inode.
 
         Conda Python may expose ``lib/python3.1`` as a symlink to ``lib/python3.10``;
         ``python*/site-packages/`` then matches the same directory twice.
         On Windows, site-packages live under ``Lib/site-packages/``.
+        On case-insensitive macOS, ``lib`` and ``Lib`` refer to the same tree; inode
+        deduplication avoids counting it twice when both names are probed.
         """
         marker = f"httpx-{httpx_version}.dist-info"
-        patterns = (
-            f"python*/site-packages/{marker}",
-            f"site-packages/{marker}",
-        )
-        found: set[Path] = set()
-        for lib_dir in ("lib", "Lib"):
+        if sys.platform == "win32":
+            lib_dirs = ("Lib",)
+            patterns = (f"site-packages/{marker}",)
+        else:
+            lib_dirs = ("lib",)
+            patterns = (f"python*/site-packages/{marker}",)
+
+        found: dict[tuple[int, int], Path] = {}
+        for lib_dir in lib_dirs:
             base = env_prefix / lib_dir
             if not base.is_dir():
                 continue
             for pattern in patterns:
-                found.update(p.resolve() for p in base.glob(pattern))
-        return found
+                for path in base.glob(pattern):
+                    resolved = path.resolve()
+                    try:
+                        st = resolved.stat()
+                    except OSError:
+                        continue
+                    found.setdefault((st.st_dev, st.st_ino), resolved)
+        return set(found.values())
 
     @staticmethod
     def _resolved_paths_from_conda_meta_record(env_prefix: Path, record: dict) -> set[Path]:

--- a/micromamba/tests/test_linking.py
+++ b/micromamba/tests/test_linking.py
@@ -22,6 +22,40 @@ class TestLinking:
     root_prefix = os.path.expanduser(os.path.join("~", "tmproot" + helpers.random_string()))
     prefix = os.path.join(root_prefix, "envs", env_name)
 
+    # httpx unlink / conda-metadata interoperability tests
+    _HTTPX_UNLINK_OLD_VER = "0.27.0"
+    _HTTPX_UNLINK_NEW_VER = "0.28.1"
+
+    @staticmethod
+    def _httpx_dist_info_resolved(env_prefix: Path, httpx_version: str) -> set[Path]:
+        """Paths to httpx-*.dist-info under lib, deduplicated by real path.
+
+        Conda Python may expose ``lib/python3.1`` as a symlink to ``lib/python3.10``;
+        ``python*/site-packages/`` then matches the same directory twice.
+        """
+        pattern = f"python*/site-packages/httpx-{httpx_version}.dist-info"
+        return {p.resolve() for p in (env_prefix / "lib").glob(pattern)}
+
+    @staticmethod
+    def _resolved_paths_from_conda_meta_record(env_prefix: Path, record: dict) -> set[Path]:
+        """Absolute resolved paths declared by a conda-meta package record."""
+        rels: list[str] = []
+        if "paths_data" in record:
+            rels = [entry["_path"] for entry in record["paths_data"]["paths"]]
+        elif "files" in record:
+            rels = list(record["files"])
+        return {(env_prefix / rel).resolve() for rel in rels}
+
+    @staticmethod
+    def _paths_under_httpx_dist_info(paths: set[Path], httpx_version: str) -> set[Path]:
+        marker = f"httpx-{httpx_version}.dist-info"
+        return {p for p in paths if marker in p.parts}
+
+    @staticmethod
+    def _assert_paths_removed(paths: set[Path], *, label: str) -> None:
+        stale = sorted(p for p in paths if p.exists())
+        assert not stale, f"{label} should be removed but still exist: {stale}"
+
     @classmethod
     def setup_class(cls):
         os.environ["MAMBA_ROOT_PREFIX"] = TestLinking.root_prefix
@@ -160,9 +194,12 @@ class TestLinking:
         helpers.remove(package_to_test, "-n", TestLinking.env_name)
 
     def test_unlink_legacy_files_metadata(self):
+        old_ver = self._HTTPX_UNLINK_OLD_VER
+        new_ver = self._HTTPX_UNLINK_NEW_VER
+
         helpers.create(
             "python=3.10",
-            "httpx=0.27.0",
+            f"httpx={old_ver}",
             "-n",
             TestLinking.env_name,
             "--json",
@@ -170,9 +207,15 @@ class TestLinking:
         )
 
         env_prefix = Path(helpers.get_env(TestLinking.env_name))
-        old_meta = next((env_prefix / "conda-meta").glob("httpx-0.27.0-*.json"))
+        old_meta = next((env_prefix / "conda-meta").glob(f"httpx-{old_ver}-*.json"))
         with old_meta.open() as f:
             old_record = json.load(f)
+
+        prev_dist_info_paths = self._paths_under_httpx_dist_info(
+            self._resolved_paths_from_conda_meta_record(env_prefix, old_record),
+            old_ver,
+        )
+        assert prev_dist_info_paths, "expected previous httpx dist-info files before upgrade"
 
         # Simulate conda metadata that only stores the legacy `files` list.
         old_record["files"] = [p["_path"] for p in old_record["paths_data"]["paths"]]
@@ -181,26 +224,27 @@ class TestLinking:
             json.dump(old_record, f)
 
         helpers.install(
-            "httpx=0.28.1",
+            f"httpx={new_ver}",
             "-n",
             TestLinking.env_name,
             "--json",
             no_dry_run=True,
         )
 
-        old_dist_info = list(
-            (env_prefix / "lib").glob("python*/site-packages/httpx-0.27.0.dist-info")
+        self._assert_paths_removed(
+            prev_dist_info_paths,
+            label=f"httpx {old_ver} dist-info",
         )
-        new_dist_info = list(
-            (env_prefix / "lib").glob("python*/site-packages/httpx-0.28.1.dist-info")
-        )
-        assert len(old_dist_info) == 0
-        assert len(new_dist_info) == 1
+        assert len(self._httpx_dist_info_resolved(env_prefix, old_ver)) == 0
+        assert len(self._httpx_dist_info_resolved(env_prefix, new_ver)) == 1
 
     def test_unlink_noarch_short_paths_metadata(self):
+        old_ver = self._HTTPX_UNLINK_OLD_VER
+        new_ver = self._HTTPX_UNLINK_NEW_VER
+
         helpers.create(
             "python=3.10",
-            "httpx=0.27.0",
+            f"httpx={old_ver}",
             "-n",
             TestLinking.env_name,
             "--json",
@@ -208,9 +252,15 @@ class TestLinking:
         )
 
         env_prefix = Path(helpers.get_env(TestLinking.env_name))
-        old_meta = next((env_prefix / "conda-meta").glob("httpx-0.27.0-*.json"))
+        old_meta = next((env_prefix / "conda-meta").glob(f"httpx-{old_ver}-*.json"))
         with old_meta.open() as f:
             old_record = json.load(f)
+
+        prev_dist_info_paths = self._paths_under_httpx_dist_info(
+            self._resolved_paths_from_conda_meta_record(env_prefix, old_record),
+            old_ver,
+        )
+        assert prev_dist_info_paths, "expected previous httpx dist-info files before upgrade"
 
         # Simulate conda-generated noarch metadata where `paths_data.paths[*]._path`
         # uses short paths like `site-packages/...` instead of full
@@ -225,21 +275,19 @@ class TestLinking:
             json.dump(old_record, f)
 
         helpers.install(
-            "httpx=0.28.1",
+            f"httpx={new_ver}",
             "-n",
             TestLinking.env_name,
             "--json",
             no_dry_run=True,
         )
 
-        old_dist_info = list(
-            (env_prefix / "lib").glob("python*/site-packages/httpx-0.27.0.dist-info")
+        self._assert_paths_removed(
+            prev_dist_info_paths,
+            label=f"httpx {old_ver} dist-info",
         )
-        new_dist_info = list(
-            (env_prefix / "lib").glob("python*/site-packages/httpx-0.28.1.dist-info")
-        )
-        assert len(old_dist_info) == 0
-        assert len(new_dist_info) == 1
+        assert len(self._httpx_dist_info_resolved(env_prefix, old_ver)) == 0
+        assert len(self._httpx_dist_info_resolved(env_prefix, new_ver)) == 1
 
     @pytest.mark.skipif(
         sys.platform == "darwin" and platform.machine() == "arm64",

--- a/micromamba/tests/test_linking.py
+++ b/micromamba/tests/test_linking.py
@@ -28,13 +28,25 @@ class TestLinking:
 
     @staticmethod
     def _httpx_dist_info_resolved(env_prefix: Path, httpx_version: str) -> set[Path]:
-        """Paths to httpx-*.dist-info under lib, deduplicated by real path.
+        """Paths to httpx-*.dist-info under lib/Lib, deduplicated by real path.
 
         Conda Python may expose ``lib/python3.1`` as a symlink to ``lib/python3.10``;
         ``python*/site-packages/`` then matches the same directory twice.
+        On Windows, site-packages live under ``Lib/site-packages/``.
         """
-        pattern = f"python*/site-packages/httpx-{httpx_version}.dist-info"
-        return {p.resolve() for p in (env_prefix / "lib").glob(pattern)}
+        marker = f"httpx-{httpx_version}.dist-info"
+        patterns = (
+            f"python*/site-packages/{marker}",
+            f"site-packages/{marker}",
+        )
+        found: set[Path] = set()
+        for lib_dir in ("lib", "Lib"):
+            base = env_prefix / lib_dir
+            if not base.is_dir():
+                continue
+            for pattern in patterns:
+                found.update(p.resolve() for p in base.glob(pattern))
+        return found
 
     @staticmethod
     def _resolved_paths_from_conda_meta_record(env_prefix: Path, record: dict) -> set[Path]:
@@ -264,11 +276,14 @@ class TestLinking:
 
         # Simulate conda-generated noarch metadata where `paths_data.paths[*]._path`
         # uses short paths like `site-packages/...` instead of full
-        # `lib/pythonX.Y/site-packages/...` entries.
+        # `lib/pythonX.Y/site-packages/...` or `Lib/site-packages/...` entries.
         for path in old_record["paths_data"]["paths"]:
             current_path = path.get("_path", "")
             if current_path.startswith("lib/python") and "/site-packages/" in current_path:
                 path["_path"] = current_path.split("/site-packages/", 1)[1]
+                path["_path"] = f"site-packages/{path['_path']}"
+            elif current_path.startswith("Lib/site-packages/"):
+                path["_path"] = current_path.removeprefix("Lib/site-packages/")
                 path["_path"] = f"site-packages/{path['_path']}"
 
         with old_meta.open("w") as f:

--- a/micromamba/tests/test_linking.py
+++ b/micromamba/tests/test_linking.py
@@ -1,6 +1,7 @@
+import json
 import os
-import sys
 import platform
+import sys
 from pathlib import Path
 
 import pytest
@@ -157,6 +158,88 @@ class TestLinking:
 
         os.remove(linked_file_path)
         helpers.remove(package_to_test, "-n", TestLinking.env_name)
+
+    def test_unlink_legacy_files_metadata(self):
+        helpers.create(
+            "python=3.10",
+            "httpx=0.27.0",
+            "-n",
+            TestLinking.env_name,
+            "--json",
+            no_dry_run=True,
+        )
+
+        env_prefix = Path(helpers.get_env(TestLinking.env_name))
+        old_meta = next((env_prefix / "conda-meta").glob("httpx-0.27.0-*.json"))
+        with old_meta.open() as f:
+            old_record = json.load(f)
+
+        # Simulate conda metadata that only stores the legacy `files` list.
+        old_record["files"] = [p["_path"] for p in old_record["paths_data"]["paths"]]
+        old_record.pop("paths_data", None)
+        with old_meta.open("w") as f:
+            json.dump(old_record, f)
+
+        helpers.install(
+            "httpx=0.28.1",
+            "-n",
+            TestLinking.env_name,
+            "--json",
+            no_dry_run=True,
+        )
+
+        old_dist_info = list(
+            (env_prefix / "lib").glob("python*/site-packages/httpx-0.27.0.dist-info")
+        )
+        new_dist_info = list(
+            (env_prefix / "lib").glob("python*/site-packages/httpx-0.28.1.dist-info")
+        )
+        assert len(old_dist_info) == 0
+        assert len(new_dist_info) == 1
+
+    def test_unlink_noarch_short_paths_metadata(self):
+        helpers.create(
+            "python=3.10",
+            "httpx=0.27.0",
+            "-n",
+            TestLinking.env_name,
+            "--json",
+            no_dry_run=True,
+        )
+
+        env_prefix = Path(helpers.get_env(TestLinking.env_name))
+        old_meta = next((env_prefix / "conda-meta").glob("httpx-0.27.0-*.json"))
+        with old_meta.open() as f:
+            old_record = json.load(f)
+
+        # Simulate conda-generated noarch metadata where `paths_data.paths[*]._path`
+        # uses short paths like `site-packages/...` instead of full
+        # `lib/pythonX.Y/site-packages/...` entries.
+        for path in old_record["paths_data"]["paths"]:
+            current_path = path.get("_path", "")
+            if current_path.startswith("lib/python") and "/site-packages/" in current_path:
+                path["_path"] = current_path.split("/site-packages/", 1)[1]
+                path["_path"] = f"site-packages/{path['_path']}"
+
+        with old_meta.open("w") as f:
+            json.dump(old_record, f)
+
+        helpers.install(
+            "httpx=0.28.1",
+            "-n",
+            TestLinking.env_name,
+            "--json",
+            no_dry_run=True,
+        )
+
+        old_dist_info = list(
+            (env_prefix / "lib").glob("python*/site-packages/httpx-0.27.0.dist-info")
+        )
+        new_dist_info = list(
+            (env_prefix / "lib").glob("python*/site-packages/httpx-0.28.1.dist-info")
+        )
+        assert len(old_dist_info) == 0
+        assert len(new_dist_info) == 1
 
     @pytest.mark.skipif(
         sys.platform == "darwin" and platform.machine() == "arm64",


### PR DESCRIPTION
# Description

Fix #4242.

## Type of Change

<!-- Please skip this part if you are already using conventional commit keywords in the PR title. -->

- [x] Bugfix
- [ ] Feature / enhancement
- [ ] CI / Documentation
- [ ] Maintenance

## Checklist

- [x] My code follows the general style and conventions of the codebase, ensuring consistency
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have run `pre-commit run --all` locally in the source folder and confirmed that there are no linter errors.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
