### PR TITLE
maint: Remove `libxml2` as a dependency

### DIFF
--- a/libmamba/CMakeLists.txt
+++ b/libmamba/CMakeLists.txt
@@ -598,10 +598,9 @@ macro(libmamba_create_target target_name linkage output_name)
             find_library(BZIP2_LIBRARIES NAMES bz2)
             find_library(CRYPTO_LIBRARIES NAMES libcrypto)
 
-            find_library(LIBXML2_LIBRARY NAMES libxml2)
             find_library(ICONV_LIBRARY NAMES libiconv iconv)
             find_library(CHARSET_LIBRARY NAMES libcharset charset)
-            message("Found: ${LIBXML2_LIBRARY} ${ICONV_LIBRARY} ${CHARSET_LIBRARY}")
+            message("Found: ${ICONV_LIBRARY} ${CHARSET_LIBRARY}")
 
             target_link_libraries(
                 ${target_name}
@@ -609,7 +608,6 @@ macro(libmamba_create_target target_name linkage output_name)
                     ${CRYPTO_LIBRARIES}
                     ${SYSTEM_PROVIDED_LIBRARIES}
                     ${LibArchive_LIBRARY}
-                    ${LIBXML2_LIBRARY}
                     ${ICONV_LIBRARY}
                     ${CHARSET_LIBRARY}
                     zstd::libzstd_static

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -3,7 +3,6 @@
   "dependencies": [
     "curl",
     "libiconv",
-    "libxml2",
     {
       "name": "winreg",
       "platform": "windows"


### PR DESCRIPTION
# Description

Being also tested on https://github.com/conda-forge/micromamba-feedstock/pull/294.

## Type of Change

<!-- Please skip this part if you are already using conventional commit keywords in the PR title. -->

- [ ] Bugfix
- [ ] Feature / enhancement
- [ ] CI / Documentation
- [x] Maintenance

## Checklist

- [x] My code follows the general style and conventions of the codebase, ensuring consistency
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have run `pre-commit run --all` locally in the source folder and confirmed that there are no linter errors.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
