### PR TITLE
maint: Remove `lzma`, `lz4` and `lzo` as dependencies

### DIFF
--- a/libmamba/CMakeLists.txt
+++ b/libmamba/CMakeLists.txt
@@ -617,9 +617,6 @@ macro(libmamba_create_target target_name linkage output_name)
             # For Windows we have a vcpkg based build system right now.
             find_package(LibArchive MODULE REQUIRED)
             find_package(CURL CONFIG REQUIRED)
-            find_library(LIBLZMA_LIBRARIES lzma REQUIRED)
-            find_library(LZ4_LIBRARY NAMES lz4)
-            find_library(LZO2_LIBRARY NAMES lzo2)
             find_package(zstd CONFIG REQUIRED)
             find_library(BZIP2_LIBRARIES NAMES bz2)
             find_library(CRYPTO_LIBRARIES NAMES libcrypto)
@@ -637,10 +634,7 @@ macro(libmamba_create_target target_name linkage output_name)
                     ${ICONV_LIBRARY}
                     ${CHARSET_LIBRARY}
                     zstd::libzstd_static
-                    ${LZ4_LIBRARY}
-                    ${LZO2_LIBRARY}
                     ${BZIP2_LIBRARIES}
-                    ${LIBLZMA_LIBRARIES}
                     CURL::libcurl
                     ${sodium_LIBRARY_RELEASE}
             )

--- a/libmamba/src/api/info.cpp
+++ b/libmamba/src/api/info.cpp
@@ -114,7 +114,6 @@ namespace mamba
                       "New BSD license, The libarchive distribution as a whole is Copyright by Tim Kientzle and is subject to the copyright notice reproduced at the bottom of this file." },
                     { "libev",
                       "BSD license, All files in libev are Copyright (c)2007,2008,2009,2010,2011,2012,2013 Marc Alexander Lehmann." },
-                    { "liblz4", "LZ4 Library, Copyright (c) 2011-2016, Yann Collet" },
                     { "libnghttp2",
                       "MIT license, Copyright (c) 2012, 2014, 2015, 2016 Tatsuhiro Tsujikawa; 2012, 2014, 2015, 2016 nghttp2 contributors" },
                     { "libopenssl_3", "Apache license, Version 2.0, January 2004" },

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -8,7 +8,7 @@
       "platform": "windows"
     },
     {
-      "features": ["bzip2", "lz4", "lzma", "lzo", "crypto", "zstd"],
+      "features": ["bzip2", "crypto", "zstd"],
       "name": "libarchive"
     },
     {


### PR DESCRIPTION
# Description

Being also tested on https://github.com/conda-forge/micromamba-feedstock/pull/293.

## Type of Change

<!-- Please skip this part if you are already using conventional commit keywords in the PR title. -->

- [ ] Bugfix
- [ ] Feature / enhancement
- [ ] CI / Documentation
- [x] Maintenance

## Checklist

- [x] My code follows the general style and conventions of the codebase, ensuring consistency
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have run `pre-commit run --all` locally in the source folder and confirmed that there are no linter errors.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
