### PR TITLE
fix: Set environment variables for `use_sharded_repodata`

### DIFF
--- a/libmamba/src/api/configuration.cpp
+++ b/libmamba/src/api/configuration.cpp
@@ -1513,6 +1513,7 @@ namespace mamba
         insert(Configurable("use_sharded_repodata", &m_context.use_sharded_repodata)
                    .group("Repodata")
                    .set_rc_configurable()
+                   .set_env_var_names()
                    .description(
                        "Use sharded repodata when available for faster dependency resolution (default: true)"
                    ));

--- a/libmamba/tests/src/core/test_configuration.cpp
+++ b/libmamba/tests/src/core/test_configuration.cpp
@@ -1127,6 +1127,8 @@ namespace mamba
 
             TEST_BOOL_CONFIGURABLE(retry_clean_cache, config.at("retry_clean_cache").value<bool>());
 
+            TEST_BOOL_CONFIGURABLE(use_sharded_repodata, ctx.use_sharded_repodata);
+
             TEST_BOOL_CONFIGURABLE(allow_softlinks, ctx.link_params.allow_softlinks);
 
             TEST_BOOL_CONFIGURABLE(always_softlink, ctx.link_params.always_softlink);


### PR DESCRIPTION
# Description

`MAMBA_USE_SHARDED_REPODATA` can be now used to specify the value of `use_sharded_repodata`.

## Type of Change

<!-- Please skip this part if you are already using conventional commit keywords in the PR title. -->

- [x] Bugfix
- [ ] Feature / enhancement
- [ ] CI / Documentation
- [ ] Maintenance

## Checklist

- [x] My code follows the general style and conventions of the codebase, ensuring consistency
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have run `pre-commit run --all` locally in the source folder and confirmed that there are no linter errors.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
