### PR TITLE
fix: Use `zlib<1.3.2` for static builds

### DIFF
--- a/dev/environment-micromamba-static.yml
+++ b/dev/environment-micromamba-static.yml
@@ -34,6 +34,7 @@ dependencies:
   - openssl
   - libopenssl-static
   - zstd-static
+  # zlib 1.3.2 has breaking changes on Windows: https://github.com/madler/zlib/issues/1181
   - zlib <1.3.2
   - libnghttp2-static
   - lz4-c-static

--- a/dev/environment-micromamba-static.yml
+++ b/dev/environment-micromamba-static.yml
@@ -34,7 +34,7 @@ dependencies:
   - openssl
   - libopenssl-static
   - zstd-static
-  - zlib
+  - zlib <1.3.2
   - libnghttp2-static
   - lz4-c-static
   # libmamba test dependencies

--- a/libmamba/CMakeLists.txt
+++ b/libmamba/CMakeLists.txt
@@ -608,12 +608,6 @@ macro(libmamba_create_target target_name linkage output_name)
             set(SYSTEM_PROVIDED_LIBRARIES XmlLite.lib) # required by libarchive
             set(ENABLE_WIN32_XMLLITE ON)
 
-            # vcpkg zlib 1.3.2+: FindZLIB.cmake does not match Windows library names (z/zs, debug
-            # suffixes). LibArchive and CURL both pull zlib via find_package before CONFIG is
-            # preferred; load ZLIB's CMake package first. See
-            # https://github.com/microsoft/vcpkg/pull/51235
-            find_package(ZLIB REQUIRED NO_MODULE)
-
             # For Windows we have a vcpkg based build system right now.
             find_package(LibArchive MODULE REQUIRED)
             find_package(CURL CONFIG REQUIRED)

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
+  "$comment": "Pin zlib 1.3.1 for Windows static builds: https://github.com/mamba-org/mamba/pull/4281",
   "overrides": [
     {
       "name": "zlib",
@@ -29,5 +30,6 @@
   "homepage": "https://github.com/mamba-org/mamba",
   "license": "BSD-3-Clause",
   "name": "micromamba",
-  "supports": "x64 | (arm64 & !windows)"
+  "supports": "x64 | (arm64 & !windows)",
+  "builtin-baseline": "ac56141cba73a968d4a615aec7f48c966b73b6d0"
 }

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,5 +1,11 @@
 {
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
+  "overrides": [
+    {
+      "name": "zlib",
+      "version": "1.3.1"
+    }
+  ],
   "dependencies": [
     "curl",
     "libiconv",

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
-  "$comment": "Pin zlib 1.3.1 for Windows static builds: https://github.com/mamba-org/mamba/pull/4281",
+  "$comment": "zlib 1.3.2 has breaking changes on Windows: https://github.com/madler/zlib/issues/1181",
   "overrides": [
     {
       "name": "zlib",


### PR DESCRIPTION
# Description

Fix #4276.

zlib 1.3.2 came with breaking changes for the CMake setup (see https://github.com/madler/zlib/issues/1181).

For now let's explicitly use zlib 1.3.1.


## Type of Change

<!-- Please skip this part if you are already using conventional commit keywords in the PR title. -->

- [x] Bugfix
- [ ] Feature / enhancement
- [ ] CI / Documentation
- [ ] Maintenance

## Checklist

- [x] My code follows the general style and conventions of the codebase, ensuring consistency
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have run `pre-commit run --all` locally in the source folder and confirmed that there are no linter errors.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
