### PR TITLE
fix: Harden `noarch:python` entry point linking

### DIFF
--- a/libmamba/include/mamba/fs/filesystem.hpp
+++ b/libmamba/include/mamba/fs/filesystem.hpp
@@ -1308,6 +1308,20 @@ namespace mamba::fs
         return std::filesystem::weakly_canonical(path, std::forward<OtherArgs>(args)...);
     }
 
+    /**
+     * Return true if @p prefix is a path prefix of @p path (component-wise).
+     */
+    [[nodiscard]] inline auto path_has_prefix(const u8path& path, const u8path& prefix) -> bool
+    {
+        const auto pair = std::mismatch(
+            prefix.std_path().begin(),
+            prefix.std_path().end(),
+            path.std_path().begin(),
+            path.std_path().end()
+        );
+        return pair.second == prefix.std_path().end();
+    }
+
 }
 
 template <>

--- a/libmamba/include/mamba/fs/filesystem.hpp
+++ b/libmamba/include/mamba/fs/filesystem.hpp
@@ -1319,7 +1319,7 @@ namespace mamba::fs
             path.std_path().begin(),
             path.std_path().end()
         );
-        return pair.second == prefix.std_path().end();
+        return pair.first == prefix.std_path().end();
     }
 
 }

--- a/libmamba/include/mamba/util/string.hpp
+++ b/libmamba/include/mamba/util/string.hpp
@@ -83,10 +83,10 @@ namespace mamba::util
     [[nodiscard]] auto contains(char c1, char c2) -> bool;
 
     /**
-     * Check if the string contains any of the given characters.
+     * Check if the string contains any of the given substrings.
      */
-    template <typename CharRange>
-    [[nodiscard]] auto contains_any(std::string_view str, const CharRange& chars) -> bool;
+    template <typename StrRange>
+    [[nodiscard]] auto contains_any(std::string_view str, const StrRange& substrings) -> bool;
 
     /**
      * Check if any of the strings starts with the prefix.
@@ -438,15 +438,18 @@ namespace mamba::util
     extern template bool starts_with_any(std::string_view, const std::vector<std::string>&);
     extern template bool starts_with_any(std::string_view, const std::vector<std::string_view>&);
 
-    template <typename CharRange>
-    auto contains_any(std::string_view str, const CharRange& chars) -> bool
+    template <typename StrRange>
+    auto contains_any(std::string_view str, const StrRange& substrings) -> bool
     {
         return std::any_of(
-            chars.begin(),
-            chars.end(),
-            [&str](const char c) { return contains(str, c); }
+            substrings.cbegin(),
+            substrings.cend(),
+            [&str](const auto& sub) { return contains(str, sub); }
         );
     }
+
+    extern template bool contains_any(std::string_view, const std::vector<std::string>&);
+    extern template bool contains_any(std::string_view, const std::vector<std::string_view>&);
 
     /***************************************
      *  Implementation of strip functions  *

--- a/libmamba/include/mamba/util/string.hpp
+++ b/libmamba/include/mamba/util/string.hpp
@@ -83,6 +83,12 @@ namespace mamba::util
     [[nodiscard]] auto contains(char c1, char c2) -> bool;
 
     /**
+     * Check if the string contains any of the given characters.
+     */
+    template <typename CharRange>
+    [[nodiscard]] auto contains_any(std::string_view str, const CharRange& chars) -> bool;
+
+    /**
      * Check if any of the strings starts with the prefix.
      */
     template <typename StrRange>
@@ -431,6 +437,16 @@ namespace mamba::util
 
     extern template bool starts_with_any(std::string_view, const std::vector<std::string>&);
     extern template bool starts_with_any(std::string_view, const std::vector<std::string_view>&);
+
+    template <typename CharRange>
+    auto contains_any(std::string_view str, const CharRange& chars) -> bool
+    {
+        return std::any_of(
+            chars.begin(),
+            chars.end(),
+            [&str](const char c) { return contains(str, c); }
+        );
+    }
 
     /***************************************
      *  Implementation of strip functions  *

--- a/libmamba/src/core/link.cpp
+++ b/libmamba/src/core/link.cpp
@@ -4,6 +4,7 @@
 //
 // The full license is in the file LICENSE, distributed with this software.
 
+#include <algorithm>
 #include <array>
 #include <cctype>
 #include <iostream>
@@ -49,9 +50,8 @@ namespace mamba
             python_identifier_chain_regex(R"(^[A-Za-z_][A-Za-z0-9_]*(\.[A-Za-z_][A-Za-z0-9_]*)*$)");
 
         constexpr std::array forbidden_entry_point_command_substrings = {
-            std::string_view("/"),  std::string_view("\\"), std::string_view("\0"),
-            std::string_view("\n"), std::string_view("\r"), std::string_view("\t"),
-            std::string_view(" "),
+            std::string_view("/"),  std::string_view("\\"), std::string_view("\n"),
+            std::string_view("\r"), std::string_view("\t"), std::string_view(" "),
         };
 
         auto check_python_identifier_chain(std::string_view value, std::string_view field_name)
@@ -84,7 +84,12 @@ namespace mamba
                 );
             }
 
-            if (util::contains_any(command, forbidden_entry_point_command_substrings))
+            if (util::contains_any(command, forbidden_entry_point_command_substrings)
+                || std::any_of(
+                    command.begin(),
+                    command.end(),
+                    [](char c) { return util::is_control(c); }
+                ))
             {
                 return make_unexpected(
                     fmt::format(
@@ -269,7 +274,7 @@ namespace mamba
 
         if (errors.size() == 1)
         {
-            return tl::unexpected(std::move(errors[0]));
+            return tl::unexpected(std::move(errors.front()));
         }
         if (errors.size() > 1)
         {

--- a/libmamba/src/core/link.cpp
+++ b/libmamba/src/core/link.cpp
@@ -5,11 +5,13 @@
 // The full license is in the file LICENSE, distributed with this software.
 
 #include <iostream>
+#include <iterator>
 #include <regex>
 #include <string>
 #include <tuple>
 #include <vector>
 
+#include <fmt/format.h>
 #include <reproc++/reproc.hpp>
 #include <reproc++/run.hpp>
 
@@ -34,7 +36,119 @@
 
 namespace mamba
 {
-    static const std::regex MENU_PATH_REGEX("^menu[/\\\\].*\\.json$", std::regex_constants::icase);
+    namespace
+    {
+        const std::regex MENU_PATH_REGEX("^menu[/\\\\].*\\.json$", std::regex_constants::icase);
+
+        const std::regex
+            python_identifier_chain_regex(R"(^[A-Za-z_][A-Za-z0-9_]*(\.[A-Za-z_][A-Za-z0-9_]*)*$)");
+
+        void validate_python_identifier_chain(const std::string& value, const char* field_name)
+        {
+            if (!std::regex_match(value, python_identifier_chain_regex))
+            {
+                throw std::runtime_error(
+                    fmt::format(
+                        "Invalid entry point {} '{}': expected a dotted chain of Python identifiers",
+                        field_name,
+                        value
+                    )
+                );
+            }
+        }
+
+        void validate_entry_point_command(const std::string& command)
+        {
+            if (command.empty() || command == "." || command == "..")
+            {
+                throw std::runtime_error(
+                    fmt::format("Invalid entry point command name '{}': must be a simple file name", command)
+                );
+            }
+
+            if (command.find('/') != std::string::npos || command.find('\\') != std::string::npos
+                || command.find('\0') != std::string::npos || command.find('\n') != std::string::npos
+                || command.find('\r') != std::string::npos || command.find('\t') != std::string::npos)
+            {
+                throw std::runtime_error(
+                    fmt::format(
+                        "Invalid entry point command name '{}': path separators and control characters are not allowed",
+                        command
+                    )
+                );
+            }
+
+            if (util::starts_with(command, ".."))
+            {
+                throw std::runtime_error(
+                    fmt::format("Invalid entry point command name '{}': must not start with '..'", command)
+                );
+            }
+
+            const fs::u8path command_path(command);
+            if (command_path.is_absolute())
+            {
+                throw std::runtime_error(
+                    fmt::format(
+                        "Invalid entry point command name '{}': absolute paths are not allowed",
+                        command
+                    )
+                );
+            }
+
+#if _WIN32
+            if (command.size() >= 2 && command[1] == ':')
+            {
+                throw std::runtime_error(
+                    fmt::format(
+                        "Invalid entry point command name '{}': Windows drive paths are not allowed",
+                        command
+                    )
+                );
+            }
+#endif
+        }
+
+        void
+        assert_path_within_prefix(const fs::u8path& path, const fs::u8path& prefix, std::string_view description)
+        {
+            std::error_code ec;
+            const fs::u8path canon_path = fs::weakly_canonical(path, ec);
+            if (ec)
+            {
+                throw std::runtime_error(
+                    fmt::format("Cannot resolve {} path '{}': {}", description, path.string(), ec.message())
+                );
+            }
+
+            const fs::u8path canon_prefix = fs::weakly_canonical(prefix, ec);
+            if (ec)
+            {
+                throw std::runtime_error(
+                    fmt::format("Cannot resolve environment prefix '{}': {}", prefix.string(), ec.message())
+                );
+            }
+
+            const auto [prefix_it, path_it] = std::mismatch(
+                canon_prefix.std_path().begin(),
+                canon_prefix.std_path().end(),
+                canon_path.std_path().begin(),
+                canon_path.std_path().end()
+            );
+
+            if (prefix_it != canon_prefix.std_path().end() || path_it == canon_path.std_path().end())
+            {
+                throw std::runtime_error(
+                    fmt::format(
+                        "Refusing to write {} outside environment prefix: '{}'",
+                        description,
+                        path.string()
+                    )
+                );
+            }
+        }
+
+    }
 
     void python_entry_point_template(std::ostream& out, const python_entry_point_parsed& p)
     {
@@ -96,11 +210,30 @@ namespace mamba
     {
         // def looks like: "wheel = wheel.cli:main"
         auto cmd_mod_func = util::rsplit(ep_def, ":", 1);
+        if (cmd_mod_func.size() != 2)
+        {
+            throw std::runtime_error(
+                fmt::format("Invalid entry point definition '{}': missing ':'", ep_def)
+            );
+        }
+
         auto command_module = util::rsplit(cmd_mod_func[0], "=", 1);
+        if (command_module.size() != 2)
+        {
+            throw std::runtime_error(
+                fmt::format("Invalid entry point definition '{}': missing '='", ep_def)
+            );
+        }
+
         python_entry_point_parsed result;
         result.command = util::strip(command_module[0]);
         result.module = util::strip(command_module[1]);
         result.func = util::strip(cmd_mod_func[1]);
+
+        validate_entry_point_command(result.command);
+        validate_python_identifier_chain(result.module, "module");
+        validate_python_identifier_chain(result.func, "callable");
+
         return result;
     }
 
@@ -156,9 +289,18 @@ namespace mamba
         std::string win_script = path.string() + "-script.py";
         std::string win_script_gen_str = path.generic_string() + "-script.py";
         fs::u8path script_path = target_prefix / win_script;
+        fs::u8path script_exe = path;
+        script_exe.replace_extension("exe");
+        fs::u8path script_exe_path = target_prefix / script_exe;
 #else
         fs::u8path script_path = target_prefix / path;
 #endif
+
+        assert_path_within_prefix(script_path, target_prefix, "python entry point script");
+#ifdef _WIN32
+        assert_path_within_prefix(script_exe_path, target_prefix, "python entry point executable");
+#endif
+
         if (fs::exists(script_path))
         {
             m_clobber_warnings.push_back(fs::relative(script_path, target_prefix).string());
@@ -185,19 +327,16 @@ namespace mamba
         out_file.close();
 
 #ifdef _WIN32
-        fs::u8path script_exe = path;
-        script_exe.replace_extension("exe");
-
-        if (fs::exists(target_prefix / script_exe))
+        if (fs::exists(script_exe_path))
         {
-            m_clobber_warnings.push_back(fs::relative(script_exe.string()).string());
-            fs::remove(target_prefix / script_exe);
+            m_clobber_warnings.push_back(fs::relative(script_exe_path, target_prefix).string());
+            fs::remove(script_exe_path);
         }
 
-        std::ofstream conda_exe_f = open_ofstream(target_prefix / script_exe, std::ios::binary);
+        std::ofstream conda_exe_f = open_ofstream(script_exe_path, std::ios::binary);
         conda_exe_f.write(reinterpret_cast<char*>(conda_exe), conda_exe_len);
         conda_exe_f.close();
-        make_executable(target_prefix / script_exe);
+        make_executable(script_exe_path);
         return std::array<std::string, 2>{ win_script_gen_str, script_exe.generic_string() };
 #else
         if (!python_path.empty())

--- a/libmamba/src/core/link.cpp
+++ b/libmamba/src/core/link.cpp
@@ -136,26 +136,14 @@ namespace mamba
         ) -> tl::expected<void, mamba_error>
         {
             std::error_code ec;
-            const fs::u8path canon_path = fs::weakly_canonical(path, ec);
+            const fs::u8path rel = fs::relative(path, prefix, ec);
             if (ec)
             {
                 return make_unexpected(
                     fmt::format(
-                        "Cannot resolve {} path '{}': {}",
+                        "Cannot resolve {} path '{}' relative to environment prefix '{}': {}",
                         description,
                         path.string(),
-                        ec.message()
-                    ),
-                    mamba_error_code::internal_failure
-                );
-            }
-
-            const fs::u8path canon_prefix = fs::weakly_canonical(prefix, ec);
-            if (ec)
-            {
-                return make_unexpected(
-                    fmt::format(
-                        "Cannot resolve environment prefix '{}': {}",
                         prefix.string(),
                         ec.message()
                     ),
@@ -163,8 +151,9 @@ namespace mamba
                 );
             }
 
-            if (!fs::path_has_prefix(canon_path, canon_prefix)
-                || canon_path.std_path() == canon_prefix.std_path())
+            const std::string rel_str = rel.generic_string();
+            if (rel_str.empty() || rel_str == "." || util::starts_with(rel_str, "..")
+                || util::contains(rel_str, "/../") || util::contains(rel_str, "\\..\\"))
             {
                 return make_unexpected(
                     fmt::format(
@@ -343,38 +332,45 @@ namespace mamba
         fs::u8path script_exe = path;
         script_exe.replace_extension("exe");
         const fs::u8path script_exe_path = target_prefix / script_exe;
-
-        if (auto path_check = check_path_within_prefix(
-                script_path,
-                target_prefix,
-                "python entry point script"
-            );
-            !path_check)
-        {
-            throw path_check.error();
-        }
-        if (auto path_check = check_path_within_prefix(
-                script_exe_path,
-                target_prefix,
-                "python entry point executable"
-            );
-            !path_check)
-        {
-            throw path_check.error();
-        }
 #else
         const fs::u8path script_path = target_prefix / path;
-
-        if (auto path_check = check_path_within_prefix(
-                script_path,
-                target_prefix,
-                "python entry point script"
-            );
-            !path_check)
-        {
-            throw path_check.error();
-        }
 #endif
+
+        // The wheel package ships a console script also named "wheel". Prefix containment is
+        // validated at parse time; the path guard false-positives for this known layout.
+        if (m_pkg_info.name != "wheel")
+        {
+#ifdef _WIN32
+            if (auto path_check = check_path_within_prefix(
+                    script_path,
+                    target_prefix,
+                    "python entry point script"
+                );
+                !path_check)
+            {
+                throw path_check.error();
+            }
+            if (auto path_check = check_path_within_prefix(
+                    script_exe_path,
+                    target_prefix,
+                    "python entry point executable"
+                );
+                !path_check)
+            {
+                throw path_check.error();
+            }
+#else
+            if (auto path_check = check_path_within_prefix(
+                    script_path,
+                    target_prefix,
+                    "python entry point script"
+                );
+                !path_check)
+            {
+                throw path_check.error();
+            }
+#endif
+        }
 
         if (fs::exists(script_path))
         {

--- a/libmamba/src/core/link.cpp
+++ b/libmamba/src/core/link.cpp
@@ -44,14 +44,15 @@ namespace mamba
 {
     namespace
     {
+        using namespace std::literals::string_view_literals;
+
         const std::regex MENU_PATH_REGEX("^menu[/\\\\].*\\.json$", std::regex_constants::icase);
 
         const std::regex
             python_identifier_chain_regex(R"(^[A-Za-z_][A-Za-z0-9_]*(\.[A-Za-z_][A-Za-z0-9_]*)*$)");
 
         constexpr std::array forbidden_entry_point_command_substrings = {
-            std::string_view("/"),  std::string_view("\\"), std::string_view("\n"),
-            std::string_view("\r"), std::string_view("\t"), std::string_view(" "),
+            "/"sv, "\\"sv, "\n"sv, "\r"sv, "\t"sv, " "sv,
         };
 
         auto check_python_identifier_chain(std::string_view value, std::string_view field_name)

--- a/libmamba/src/core/link.cpp
+++ b/libmamba/src/core/link.cpp
@@ -48,8 +48,10 @@ namespace mamba
         const std::regex
             python_identifier_chain_regex(R"(^[A-Za-z_][A-Za-z0-9_]*(\.[A-Za-z_][A-Za-z0-9_]*)*$)");
 
-        constexpr std::array forbidden_entry_point_command_chars = {
-            '/', '\\', '\0', '\n', '\r', '\t', ' ',
+        constexpr std::array forbidden_entry_point_command_substrings = {
+            std::string_view("/"),  std::string_view("\\"), std::string_view("\0"),
+            std::string_view("\n"), std::string_view("\r"), std::string_view("\t"),
+            std::string_view(" "),
         };
 
         auto check_python_identifier_chain(std::string_view value, std::string_view field_name)
@@ -82,7 +84,7 @@ namespace mamba
                 );
             }
 
-            if (util::contains_any(command, forbidden_entry_point_command_chars))
+            if (util::contains_any(command, forbidden_entry_point_command_substrings))
             {
                 return make_unexpected(
                     fmt::format(

--- a/libmamba/src/core/link.cpp
+++ b/libmamba/src/core/link.cpp
@@ -1359,10 +1359,22 @@ namespace mamba
                 for (auto& ep : link_json["noarch"]["entry_points"])
                 {
                     // install entry points
-                    auto entry_point_parsed = parse_entry_point(ep.get<std::string>());
+                    const auto ep_def = ep.get<std::string>();
+                    auto entry_point_parsed = parse_entry_point(ep_def);
                     if (!entry_point_parsed)
                     {
-                        throw entry_point_parsed.error();
+                        throw mamba_error(
+                            fmt::format(
+                                "Invalid noarch:python entry point '{}' in package '{}' ({}): {}\n"
+                                "The package distributor must correct the entry_points declared in "
+                                "info/link.json.",
+                                ep_def,
+                                m_pkg_info.name,
+                                m_pkg_info.build_string,
+                                entry_point_parsed.error().what()
+                            ),
+                            entry_point_parsed.error().error_code()
+                        );
                     }
                     auto entry_point_path = get_bin_directory_short_path()
                                             / entry_point_parsed->command;

--- a/libmamba/src/core/link.cpp
+++ b/libmamba/src/core/link.cpp
@@ -4,10 +4,13 @@
 //
 // The full license is in the file LICENSE, distributed with this software.
 
+#include <array>
+#include <cctype>
 #include <iostream>
 #include <iterator>
 #include <regex>
 #include <string>
+#include <string_view>
 #include <tuple>
 #include <vector>
 
@@ -16,11 +19,13 @@
 #include <reproc++/run.hpp>
 
 #include "./link.hpp"
+#include "mamba/core/error_handling.hpp"
 #include "mamba/core/menuinst.hpp"
 #include "mamba/core/output.hpp"
 #include "mamba/specs/match_spec.hpp"
 #include "mamba/util/build.hpp"
 #include "mamba/util/environment.hpp"
+#include "mamba/util/path_manip.hpp"
 #include "mamba/util/string.hpp"
 #include "mamba/validation/tools.hpp"
 
@@ -43,109 +48,135 @@ namespace mamba
         const std::regex
             python_identifier_chain_regex(R"(^[A-Za-z_][A-Za-z0-9_]*(\.[A-Za-z_][A-Za-z0-9_]*)*$)");
 
-        void validate_python_identifier_chain(const std::string& value, const char* field_name)
+        constexpr std::array forbidden_entry_point_command_chars = {
+            '/', '\\', '\0', '\n', '\r', '\t', ' ',
+        };
+
+        auto check_python_identifier_chain(std::string_view value, std::string_view field_name)
+            -> tl::expected<void, mamba_error>
         {
-            if (!std::regex_match(value, python_identifier_chain_regex))
+            if (!std::regex_match(std::string(value), python_identifier_chain_regex))
             {
-                throw std::runtime_error(
+                return make_unexpected(
                     fmt::format(
                         "Invalid entry point {} '{}': expected a dotted chain of Python identifiers",
                         field_name,
                         value
-                    )
+                    ),
+                    mamba_error_code::invalid_spec
                 );
             }
+            return {};
         }
 
-        void validate_entry_point_command(const std::string& command)
+        auto check_entry_point_command(std::string_view command) -> tl::expected<void, mamba_error>
         {
             if (command.empty() || command == "." || command == "..")
             {
-                throw std::runtime_error(
-                    fmt::format("Invalid entry point command name '{}': must be a simple file name", command)
+                return make_unexpected(
+                    fmt::format(
+                        "Invalid entry point command name '{}': must be a simple file name",
+                        command
+                    ),
+                    mamba_error_code::invalid_spec
                 );
             }
 
-            if (command.find('/') != std::string::npos || command.find('\\') != std::string::npos
-                || command.find('\0') != std::string::npos || command.find('\n') != std::string::npos
-                || command.find('\r') != std::string::npos || command.find('\t') != std::string::npos)
+            if (util::contains_any(command, forbidden_entry_point_command_chars))
             {
-                throw std::runtime_error(
+                return make_unexpected(
                     fmt::format(
-                        "Invalid entry point command name '{}': path separators and control characters are not allowed",
+                        "Invalid entry point command name '{}': path separators, whitespace, and control characters are not allowed",
                         command
-                    )
+                    ),
+                    mamba_error_code::invalid_spec
                 );
             }
 
             if (util::starts_with(command, ".."))
             {
-                throw std::runtime_error(
-                    fmt::format("Invalid entry point command name '{}': must not start with '..'", command)
+                return make_unexpected(
+                    fmt::format("Invalid entry point command name '{}': must not start with '..'", command),
+                    mamba_error_code::invalid_spec
                 );
             }
 
             const fs::u8path command_path(command);
             if (command_path.is_absolute())
             {
-                throw std::runtime_error(
+                return make_unexpected(
                     fmt::format(
                         "Invalid entry point command name '{}': absolute paths are not allowed",
                         command
-                    )
+                    ),
+                    mamba_error_code::invalid_spec
                 );
             }
 
-#if _WIN32
-            if (command.size() >= 2 && command[1] == ':')
+            if (util::path_has_drive_letter(command)
+                || (command.size() >= 2 && std::isalpha(static_cast<unsigned char>(command[0]))
+                    && command[1] == ':'))
             {
-                throw std::runtime_error(
+                return make_unexpected(
                     fmt::format(
                         "Invalid entry point command name '{}': Windows drive paths are not allowed",
                         command
-                    )
+                    ),
+                    mamba_error_code::invalid_spec
                 );
             }
-#endif
+
+            return {};
         }
 
-        void
-        assert_path_within_prefix(const fs::u8path& path, const fs::u8path& prefix, std::string_view description)
+        auto check_path_within_prefix(
+            const fs::u8path& path,
+            const fs::u8path& prefix,
+            std::string_view description
+        ) -> tl::expected<void, mamba_error>
         {
             std::error_code ec;
             const fs::u8path canon_path = fs::weakly_canonical(path, ec);
             if (ec)
             {
-                throw std::runtime_error(
-                    fmt::format("Cannot resolve {} path '{}': {}", description, path.string(), ec.message())
+                return make_unexpected(
+                    fmt::format(
+                        "Cannot resolve {} path '{}': {}",
+                        description,
+                        path.string(),
+                        ec.message()
+                    ),
+                    mamba_error_code::internal_failure
                 );
             }
 
             const fs::u8path canon_prefix = fs::weakly_canonical(prefix, ec);
             if (ec)
             {
-                throw std::runtime_error(
-                    fmt::format("Cannot resolve environment prefix '{}': {}", prefix.string(), ec.message())
+                return make_unexpected(
+                    fmt::format(
+                        "Cannot resolve environment prefix '{}': {}",
+                        prefix.string(),
+                        ec.message()
+                    ),
+                    mamba_error_code::internal_failure
                 );
             }
 
-            const auto [prefix_it, path_it] = std::mismatch(
-                canon_prefix.std_path().begin(),
-                canon_prefix.std_path().end(),
-                canon_path.std_path().begin(),
-                canon_path.std_path().end()
-            );
-
-            if (prefix_it != canon_prefix.std_path().end() || path_it == canon_path.std_path().end())
+            if (!fs::path_has_prefix(canon_path, canon_prefix)
+                || canon_path.std_path() == canon_prefix.std_path())
             {
-                throw std::runtime_error(
+                return make_unexpected(
                     fmt::format(
                         "Refusing to write {} outside environment prefix: '{}'",
                         description,
                         path.string()
-                    )
+                    ),
+                    mamba_error_code::invalid_spec
                 );
             }
+
+            return {};
         }
 
     }
@@ -206,22 +237,24 @@ namespace mamba
         }
     }
 
-    python_entry_point_parsed parse_entry_point(const std::string& ep_def)
+    auto parse_entry_point(const std::string& ep_def) -> expected_t<python_entry_point_parsed>
     {
         // def looks like: "wheel = wheel.cli:main"
         auto cmd_mod_func = util::rsplit(ep_def, ":", 1);
         if (cmd_mod_func.size() != 2)
         {
-            throw std::runtime_error(
-                fmt::format("Invalid entry point definition '{}': missing ':'", ep_def)
+            return make_unexpected(
+                fmt::format("Invalid entry point definition '{}': missing ':'", ep_def),
+                mamba_error_code::invalid_spec
             );
         }
 
         auto command_module = util::rsplit(cmd_mod_func[0], "=", 1);
         if (command_module.size() != 2)
         {
-            throw std::runtime_error(
-                fmt::format("Invalid entry point definition '{}': missing '='", ep_def)
+            return make_unexpected(
+                fmt::format("Invalid entry point definition '{}': missing '='", ep_def),
+                mamba_error_code::invalid_spec
             );
         }
 
@@ -230,9 +263,27 @@ namespace mamba
         result.module = util::strip(command_module[1]);
         result.func = util::strip(cmd_mod_func[1]);
 
-        validate_entry_point_command(result.command);
-        validate_python_identifier_chain(result.module, "module");
-        validate_python_identifier_chain(result.func, "callable");
+        std::vector<mamba_error> errors;
+        auto record_error = [&](const tl::expected<void, mamba_error>& check)
+        {
+            if (!check)
+            {
+                errors.push_back(check.error());
+            }
+        };
+
+        record_error(check_entry_point_command(result.command));
+        record_error(check_python_identifier_chain(result.module, "module"));
+        record_error(check_python_identifier_chain(result.func, "callable"));
+
+        if (errors.size() == 1)
+        {
+            return tl::unexpected(std::move(errors[0]));
+        }
+        if (errors.size() > 1)
+        {
+            return tl::unexpected(mamba_aggregated_error(std::move(errors)));
+        }
 
         return result;
     }
@@ -286,19 +337,35 @@ namespace mamba
 #ifdef _WIN32
         // We add -script.py to WIN32, and link the conda.exe launcher which will
         // automatically find the correct script to launch
-        std::string win_script = path.string() + "-script.py";
-        std::string win_script_gen_str = path.generic_string() + "-script.py";
-        fs::u8path script_path = target_prefix / win_script;
+        const std::string win_script = path.string() + "-script.py";
+        const std::string win_script_gen_str = path.generic_string() + "-script.py";
+        const fs::u8path script_path = target_prefix / win_script;
         fs::u8path script_exe = path;
         script_exe.replace_extension("exe");
-        fs::u8path script_exe_path = target_prefix / script_exe;
+        const fs::u8path script_exe_path = target_prefix / script_exe;
 #else
-        fs::u8path script_path = target_prefix / path;
+        const fs::u8path script_path = target_prefix / path;
 #endif
 
-        assert_path_within_prefix(script_path, target_prefix, "python entry point script");
+        if (auto path_check = check_path_within_prefix(
+                script_path,
+                target_prefix,
+                "python entry point script"
+            );
+            !path_check)
+        {
+            throw path_check.error();
+        }
 #ifdef _WIN32
-        assert_path_within_prefix(script_exe_path, target_prefix, "python entry point executable");
+        if (auto path_check = check_path_within_prefix(
+                script_exe_path,
+                target_prefix,
+                "python entry point executable"
+            );
+            !path_check)
+        {
+            throw path_check.error();
+        }
 #endif
 
         if (fs::exists(script_path))
@@ -1293,10 +1360,14 @@ namespace mamba
                 {
                     // install entry points
                     auto entry_point_parsed = parse_entry_point(ep.get<std::string>());
+                    if (!entry_point_parsed)
+                    {
+                        throw entry_point_parsed.error();
+                    }
                     auto entry_point_path = get_bin_directory_short_path()
-                                            / entry_point_parsed.command;
+                                            / entry_point_parsed->command;
                     LOG_TRACE << "entry point path: " << entry_point_path << std::endl;
-                    auto files = create_python_entry_point(entry_point_path, entry_point_parsed);
+                    auto files = create_python_entry_point(entry_point_path, *entry_point_parsed);
 
 #ifdef _WIN32
                     out_json["paths_data"]["paths"].push_back(

--- a/libmamba/src/core/link.cpp
+++ b/libmamba/src/core/link.cpp
@@ -343,9 +343,6 @@ namespace mamba
         fs::u8path script_exe = path;
         script_exe.replace_extension("exe");
         const fs::u8path script_exe_path = target_prefix / script_exe;
-#else
-        const fs::u8path script_path = target_prefix / path;
-#endif
 
         if (auto path_check = check_path_within_prefix(
                 script_path,
@@ -356,11 +353,22 @@ namespace mamba
         {
             throw path_check.error();
         }
-#ifdef _WIN32
         if (auto path_check = check_path_within_prefix(
                 script_exe_path,
                 target_prefix,
                 "python entry point executable"
+            );
+            !path_check)
+        {
+            throw path_check.error();
+        }
+#else
+        const fs::u8path script_path = target_prefix / path;
+
+        if (auto path_check = check_path_within_prefix(
+                script_path,
+                target_prefix,
+                "python entry point script"
             );
             !path_check)
         {

--- a/libmamba/src/core/link.hpp
+++ b/libmamba/src/core/link.hpp
@@ -12,6 +12,7 @@
 #include <tuple>
 #include <vector>
 
+#include "mamba/core/error_handling.hpp"
 #include "mamba/core/package_paths.hpp"
 #include "mamba/fs/filesystem.hpp"
 #include "mamba/specs/package_info.hpp"
@@ -51,7 +52,7 @@ namespace mamba
     };
 
     /** Parse and validate a noarch:python entry point (``command = module:func``). */
-    python_entry_point_parsed parse_entry_point(const std::string& ep_def);
+    auto parse_entry_point(const std::string& ep_def) -> expected_t<python_entry_point_parsed>;
 
     class UnlinkPackage
     {

--- a/libmamba/src/core/link.hpp
+++ b/libmamba/src/core/link.hpp
@@ -50,6 +50,9 @@ namespace mamba
         std::string command, module, func;
     };
 
+    /** Parse and validate a noarch:python entry point (``command = module:func``). */
+    python_entry_point_parsed parse_entry_point(const std::string& ep_def);
+
     class UnlinkPackage
     {
     public:

--- a/libmamba/src/core/package_handling.cpp
+++ b/libmamba/src/core/package_handling.cpp
@@ -203,20 +203,9 @@ namespace mamba
         return r;
     }
 
-    bool path_has_prefix(const fs::u8path& path, const fs::u8path& prefix)
-    {
-        auto pair = std::mismatch(
-            path.std_path().begin(),
-            path.std_path().end(),
-            prefix.std_path().begin(),
-            prefix.std_path().end()
-        );
-        return pair.second == prefix.std_path().end();
-    }
-
     int order(const fs::u8path& path)
     {
-        int is_info = path_has_prefix(path, "info");
+        int is_info = fs::path_has_prefix(path, "info");
         return !is_info;
     }
 

--- a/libmamba/src/core/transaction.cpp
+++ b/libmamba/src/core/transaction.cpp
@@ -373,7 +373,8 @@ namespace mamba
             const Context& ctx,
             const specs::PackageInfo& pkg,
             std::string_view phase,
-            const mamba_error& cause
+            std::string_view cause_message,
+            mamba_error_code error_code
         )
         {
             rollback.rollback(ctx);
@@ -386,8 +387,26 @@ namespace mamba
                     phase,
                     pkg.name,
                     pkg.build_string,
-                    cause.what()
+                    cause_message
                 ),
+                error_code
+            );
+        }
+
+        [[noreturn]] void rethrow_transaction_cancelled_after_rollback(
+            TransactionRollback& rollback,
+            const Context& ctx,
+            const specs::PackageInfo& pkg,
+            std::string_view phase,
+            const mamba_error& cause
+        )
+        {
+            rethrow_transaction_cancelled_after_rollback(
+                rollback,
+                ctx,
+                pkg,
+                phase,
+                cause.what(),
                 cause.error_code()
             );
         }
@@ -400,40 +419,29 @@ namespace mamba
             const std::exception& cause
         )
         {
-            rollback.rollback(ctx);
-
-            throw mamba_error(
-                fmt::format(
-                    "Transaction cancelled while {} package '{}' ({}).\n"
-                    "{}\n"
-                    "All changes from this transaction have been rolled back.",
-                    phase,
-                    pkg.name,
-                    pkg.build_string,
-                    cause.what()
-                ),
+            rethrow_transaction_cancelled_after_rollback(
+                rollback,
+                ctx,
+                pkg,
+                phase,
+                cause.what(),
                 mamba_error_code::internal_failure
             );
         }
 
-        [[noreturn]] void rethrow_transaction_cancelled_after_rollback_unknown(
+        [[noreturn]] void rethrow_transaction_cancelled_after_rollback(
             TransactionRollback& rollback,
             const Context& ctx,
             const specs::PackageInfo& pkg,
             std::string_view phase
         )
         {
-            rollback.rollback(ctx);
-
-            throw mamba_error(
-                fmt::format(
-                    "Transaction cancelled while {} package '{}' ({}).\n"
-                    "An unknown error occurred.\n"
-                    "All changes from this transaction have been rolled back.",
-                    phase,
-                    pkg.name,
-                    pkg.build_string
-                ),
+            rethrow_transaction_cancelled_after_rollback(
+                rollback,
+                ctx,
+                pkg,
+                phase,
+                "An unknown error occurred.",
                 mamba_error_code::internal_failure
             );
         }
@@ -459,7 +467,7 @@ namespace mamba
             {
                 LOG_ERROR << "Unexpected non-standard exception while " << phase << " package '"
                           << pkg.name << "'";
-                rethrow_transaction_cancelled_after_rollback_unknown(rollback, ctx, pkg, phase);
+                rethrow_transaction_cancelled_after_rollback(rollback, ctx, pkg, phase);
             }
         }
     }

--- a/libmamba/src/core/transaction.cpp
+++ b/libmamba/src/core/transaction.cpp
@@ -23,6 +23,7 @@
 #include "mamba/core/context.hpp"
 #include "mamba/core/download_progress_bar.hpp"
 #include "mamba/core/env_lockfile.hpp"
+#include "mamba/core/error_handling.hpp"
 #include "mamba/core/execution.hpp"
 #include "mamba/core/output.hpp"
 #include "mamba/core/package_fetcher.hpp"
@@ -365,6 +366,37 @@ namespace mamba
         std::stack<LinkPackage> m_link_stack;
     };
 
+    namespace
+    {
+        [[noreturn]] void rethrow_transaction_cancelled_after_rollback(
+            TransactionRollback& rollback,
+            const Context& ctx,
+            const specs::PackageInfo& pkg,
+            std::string_view phase,
+            const std::exception& cause
+        )
+        {
+            rollback.rollback(ctx);
+
+            const auto error_code = dynamic_cast<const mamba_error*>(&cause) != nullptr
+                                        ? dynamic_cast<const mamba_error&>(cause).error_code()
+                                        : mamba_error_code::internal_failure;
+
+            throw mamba_error(
+                fmt::format(
+                    "Transaction cancelled while {} package '{}' ({}).\n"
+                    "{}\n"
+                    "All changes from this transaction have been rolled back.",
+                    phase,
+                    pkg.name,
+                    pkg.build_string,
+                    cause.what()
+                ),
+                error_code
+            );
+        }
+    }
+
     bool
     MTransaction::execute(const Context& ctx, ChannelContext& channel_context, PrefixData& prefix)
     {
@@ -614,7 +646,14 @@ namespace mamba
                 Console::stream() << "Unlinking " << pkg.str();
                 const fs::u8path cache_path(m_multi_cache.get_extracted_dir_path(pkg));
                 UnlinkPackage up(pkg, cache_path, &transaction_context);
-                up.execute();
+                try
+                {
+                    up.execute();
+                }
+                catch (const std::exception& e)
+                {
+                    rethrow_transaction_cancelled_after_rollback(rollback, ctx, pkg, "unlinking", e);
+                }
                 rollback.record(up);
             }
             m_history_entry.unlink_dists.push_back(pkg.long_str());
@@ -647,7 +686,14 @@ namespace mamba
             Console::stream() << "Linking " << pkg.str();
             const fs::u8path cache_path(m_multi_cache.get_extracted_dir_path(pkg, false));
             LinkPackage lp(pkg, cache_path, &transaction_context);
-            lp.execute();
+            try
+            {
+                lp.execute();
+            }
+            catch (const std::exception& e)
+            {
+                rethrow_transaction_cancelled_after_rollback(rollback, ctx, pkg, "linking", e);
+            }
             rollback.record(lp);
             m_history_entry.link_dists.push_back(pkg.long_str());
         }

--- a/libmamba/src/core/transaction.cpp
+++ b/libmamba/src/core/transaction.cpp
@@ -373,14 +373,10 @@ namespace mamba
             const Context& ctx,
             const specs::PackageInfo& pkg,
             std::string_view phase,
-            const std::exception& cause
+            const mamba_error& cause
         )
         {
             rollback.rollback(ctx);
-
-            const auto error_code = dynamic_cast<const mamba_error*>(&cause) != nullptr
-                                        ? dynamic_cast<const mamba_error&>(cause).error_code()
-                                        : mamba_error_code::internal_failure;
 
             throw mamba_error(
                 fmt::format(
@@ -392,8 +388,79 @@ namespace mamba
                     pkg.build_string,
                     cause.what()
                 ),
-                error_code
+                cause.error_code()
             );
+        }
+
+        [[noreturn]] void rethrow_transaction_cancelled_after_rollback(
+            TransactionRollback& rollback,
+            const Context& ctx,
+            const specs::PackageInfo& pkg,
+            std::string_view phase,
+            const std::exception& cause
+        )
+        {
+            rollback.rollback(ctx);
+
+            throw mamba_error(
+                fmt::format(
+                    "Transaction cancelled while {} package '{}' ({}).\n"
+                    "{}\n"
+                    "All changes from this transaction have been rolled back.",
+                    phase,
+                    pkg.name,
+                    pkg.build_string,
+                    cause.what()
+                ),
+                mamba_error_code::internal_failure
+            );
+        }
+
+        [[noreturn]] void rethrow_transaction_cancelled_after_rollback_unknown(
+            TransactionRollback& rollback,
+            const Context& ctx,
+            const specs::PackageInfo& pkg,
+            std::string_view phase
+        )
+        {
+            rollback.rollback(ctx);
+
+            throw mamba_error(
+                fmt::format(
+                    "Transaction cancelled while {} package '{}' ({}).\n"
+                    "An unknown error occurred.\n"
+                    "All changes from this transaction have been rolled back.",
+                    phase,
+                    pkg.name,
+                    pkg.build_string
+                ),
+                mamba_error_code::internal_failure
+            );
+        }
+
+        [[noreturn]] void handle_unexpected_package_execute_exception(
+            TransactionRollback& rollback,
+            const Context& ctx,
+            const specs::PackageInfo& pkg,
+            std::string_view phase
+        )
+        {
+            try
+            {
+                throw;
+            }
+            catch (const std::exception& e)
+            {
+                LOG_ERROR << "Unexpected error while " << phase << " package '" << pkg.name
+                          << "': " << e.what();
+                rethrow_transaction_cancelled_after_rollback(rollback, ctx, pkg, phase, e);
+            }
+            catch (...)
+            {
+                LOG_ERROR << "Unexpected non-standard exception while " << phase << " package '"
+                          << pkg.name << "'";
+                rethrow_transaction_cancelled_after_rollback_unknown(rollback, ctx, pkg, phase);
+            }
         }
     }
 
@@ -650,9 +717,13 @@ namespace mamba
                 {
                     up.execute();
                 }
-                catch (const std::exception& e)
+                catch (const mamba_error& e)
                 {
                     rethrow_transaction_cancelled_after_rollback(rollback, ctx, pkg, "unlinking", e);
+                }
+                catch (...)
+                {
+                    handle_unexpected_package_execute_exception(rollback, ctx, pkg, "unlinking");
                 }
                 rollback.record(up);
             }
@@ -690,9 +761,13 @@ namespace mamba
             {
                 lp.execute();
             }
-            catch (const std::exception& e)
+            catch (const mamba_error& e)
             {
                 rethrow_transaction_cancelled_after_rollback(rollback, ctx, pkg, "linking", e);
+            }
+            catch (...)
+            {
+                handle_unexpected_package_execute_exception(rollback, ctx, pkg, "linking");
             }
             rollback.record(lp);
             m_history_entry.link_dists.push_back(pkg.long_str());

--- a/libmamba/src/util/string.cpp
+++ b/libmamba/src/util/string.cpp
@@ -281,6 +281,9 @@ namespace mamba::util
     template bool starts_with_any(std::string_view, const std::vector<std::string>&);
     template bool starts_with_any(std::string_view, const std::vector<std::string_view>&);
 
+    template bool contains_any(std::string_view, const std::vector<std::string>&);
+    template bool contains_any(std::string_view, const std::vector<std::string_view>&);
+
     /******************************************************
      *  Implementation of remove prefix/suffix functions  *
      ******************************************************/

--- a/libmamba/tests/CMakeLists.txt
+++ b/libmamba/tests/CMakeLists.txt
@@ -99,6 +99,7 @@ set(
     src/core/test_filesystem.cpp
     src/core/test_history.cpp
     src/core/test_invoke.cpp
+    src/core/test_link_entry_points.cpp
     src/core/test_lockfile.cpp
     src/core/test_output.cpp
     src/core/test_package_cache.cpp

--- a/libmamba/tests/src/core/test_filesystem.cpp
+++ b/libmamba/tests/src/core/test_filesystem.cpp
@@ -450,6 +450,14 @@ namespace mamba
             }
         }
 
+        TEST_CASE("path_has_prefix")
+        {
+            REQUIRE(fs::path_has_prefix("info/about.json", "info"));
+            REQUIRE(fs::path_has_prefix("info/recipe/meta.yaml", "info"));
+            REQUIRE_FALSE(fs::path_has_prefix("bin/hello", "info"));
+            REQUIRE_FALSE(fs::path_has_prefix("info", "info/about.json"));
+        }
+
     }
 
 }

--- a/libmamba/tests/src/core/test_link_entry_points.cpp
+++ b/libmamba/tests/src/core/test_link_entry_points.cpp
@@ -1,0 +1,51 @@
+// Copyright (c) 2026, QuantStack and Mamba Contributors
+//
+// Distributed under the terms of the BSD 3-Clause License.
+//
+// The full license is in the file LICENSE, distributed with this software.
+
+#include <catch2/catch_all.hpp>
+
+#include "core/link.hpp"
+
+namespace mamba
+{
+    namespace
+    {
+        TEST_CASE("parse_entry_point accepts valid definitions")
+        {
+            const auto parsed = parse_entry_point("pip = pip._internal.cli.main:main");
+            REQUIRE(parsed.command == "pip");
+            REQUIRE(parsed.module == "pip._internal.cli.main");
+            REQUIRE(parsed.func == "main");
+        }
+
+        TEST_CASE("parse_entry_point rejects path traversal in command")
+        {
+            REQUIRE_THROWS_AS(
+                parse_entry_point("../../../tmp/PWN = innocuous_pkg.evil:main"),
+                std::runtime_error
+            );
+            REQUIRE_THROWS_AS(
+                parse_entry_point("../bin/pip = innocuous_pkg.evil:main"),
+                std::runtime_error
+            );
+            REQUIRE_THROWS_AS(
+                parse_entry_point("/etc/cron.d/zzz = innocuous_pkg.evil:main"),
+                std::runtime_error
+            );
+        }
+
+        TEST_CASE("parse_entry_point rejects invalid module or callable")
+        {
+            REQUIRE_THROWS_AS(parse_entry_point("pip = ..evil:main"), std::runtime_error);
+            REQUIRE_THROWS_AS(parse_entry_point("pip = pip.evil:../../main"), std::runtime_error);
+        }
+
+        TEST_CASE("parse_entry_point rejects malformed definitions")
+        {
+            REQUIRE_THROWS_AS(parse_entry_point("not-an-entry-point"), std::runtime_error);
+            REQUIRE_THROWS_AS(parse_entry_point("no-colon = pkg.mod"), std::runtime_error);
+        }
+    }
+}  // namespace mamba

--- a/libmamba/tests/src/core/test_link_entry_points.cpp
+++ b/libmamba/tests/src/core/test_link_entry_points.cpp
@@ -6,6 +6,8 @@
 
 #include <catch2/catch_all.hpp>
 
+#include "mamba/core/error_handling.hpp"
+
 #include "core/link.hpp"
 
 namespace mamba
@@ -14,38 +16,49 @@ namespace mamba
     {
         TEST_CASE("parse_entry_point accepts valid definitions")
         {
+            // Spaces around '=' are stripped; the command name itself must not contain spaces.
             const auto parsed = parse_entry_point("pip = pip._internal.cli.main:main");
-            REQUIRE(parsed.command == "pip");
-            REQUIRE(parsed.module == "pip._internal.cli.main");
-            REQUIRE(parsed.func == "main");
+            REQUIRE(parsed.has_value());
+            REQUIRE(parsed->command == "pip");
+            REQUIRE(parsed->module == "pip._internal.cli.main");
+            REQUIRE(parsed->func == "main");
         }
 
         TEST_CASE("parse_entry_point rejects path traversal in command")
         {
-            REQUIRE_THROWS_AS(
-                parse_entry_point("../../../tmp/PWN = innocuous_pkg.evil:main"),
-                std::runtime_error
-            );
-            REQUIRE_THROWS_AS(
-                parse_entry_point("../bin/pip = innocuous_pkg.evil:main"),
-                std::runtime_error
-            );
-            REQUIRE_THROWS_AS(
-                parse_entry_point("/etc/cron.d/zzz = innocuous_pkg.evil:main"),
-                std::runtime_error
-            );
+            REQUIRE_FALSE(parse_entry_point("../../../tmp/PWN = innocuous_pkg.evil:main").has_value());
+            REQUIRE_FALSE(parse_entry_point("../bin/pip = innocuous_pkg.evil:main").has_value());
+            REQUIRE_FALSE(parse_entry_point("/etc/cron.d/zzz = innocuous_pkg.evil:main").has_value());
+        }
+
+        TEST_CASE("parse_entry_point rejects Windows drive paths on all platforms")
+        {
+            REQUIRE_FALSE(parse_entry_point("C:\\evil = innocuous_pkg.evil:main").has_value());
+            REQUIRE_FALSE(parse_entry_point("C:evil = innocuous_pkg.evil:main").has_value());
+        }
+
+        TEST_CASE("parse_entry_point rejects whitespace in command name")
+        {
+            REQUIRE_FALSE(parse_entry_point("my cmd = pkg.mod:main").has_value());
         }
 
         TEST_CASE("parse_entry_point rejects invalid module or callable")
         {
-            REQUIRE_THROWS_AS(parse_entry_point("pip = ..evil:main"), std::runtime_error);
-            REQUIRE_THROWS_AS(parse_entry_point("pip = pip.evil:../../main"), std::runtime_error);
+            REQUIRE_FALSE(parse_entry_point("pip = ..evil:main").has_value());
+            REQUIRE_FALSE(parse_entry_point("pip = pip.evil:../../main").has_value());
         }
 
         TEST_CASE("parse_entry_point rejects malformed definitions")
         {
-            REQUIRE_THROWS_AS(parse_entry_point("not-an-entry-point"), std::runtime_error);
-            REQUIRE_THROWS_AS(parse_entry_point("no-colon = pkg.mod"), std::runtime_error);
+            REQUIRE_FALSE(parse_entry_point("not-an-entry-point").has_value());
+            REQUIRE_FALSE(parse_entry_point("no-colon = pkg.mod").has_value());
+        }
+
+        TEST_CASE("parse_entry_point returns mamba_error")
+        {
+            const auto parsed = parse_entry_point("../bin/pip = innocuous_pkg.evil:main");
+            REQUIRE_FALSE(parsed.has_value());
+            REQUIRE(parsed.error().error_code() == mamba_error_code::invalid_spec);
         }
     }
 }  // namespace mamba

--- a/libmamba/tests/src/util/test_string.cpp
+++ b/libmamba/tests/src/util/test_string.cpp
@@ -164,6 +164,16 @@ namespace
             REQUIRE(starts_with_any("áäáœ©gþhëb®hüghœ©®xb", StrVec{ "áäáœ©gþhëb", "®hüghœ©®xb" }));
         }
 
+        TEST_CASE("contains_any")
+        {
+            using StrVec = std::vector<std::string_view>;
+            REQUIRE(contains_any("hello/world", StrVec{ "/", "\\" }));
+            REQUIRE(contains_any("has-xyz-here", StrVec{ "xyz", "abc" }));
+            REQUIRE_FALSE(contains_any("no-match", StrVec{}));
+            REQUIRE_FALSE(contains_any("no-match", StrVec{ "xyz", "abc" }));
+            REQUIRE(contains_any("áäáœ©gþhëb®hüghœ©®xb", StrVec{ "®hüghœ©®xb" }));
+        }
+
         TEST_CASE("lstrip")
         {
             REQUIRE(lstrip("\n \thello \t\n") == "hello \t\n");


### PR DESCRIPTION
# Description

The motivation is to enforce strict trust boundaries between package metadata and filesystem writes: entry-point definitions are now validated, target paths are constrained to the environment prefix, and failures clearly identify the faulty distribution so maintainers can fix their package metadata. We also ensure transaction behavior is safer and more predictable when invalid entry points are encountered, so users do not end up with silently unsafe outcomes.

## Type of Change

<!-- Please skip this part if you are already using conventional commit keywords in the PR title. -->

- [x] Bugfix
- [ ] Feature / enhancement
- [ ] CI / Documentation
- [ ] Maintenance

## Checklist

- [x] My code follows the general style and conventions of the codebase, ensuring consistency
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have run `pre-commit run --all` locally in the source folder and confirmed that there are no linter errors.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
