### PR TITLE
  fix: gate cross-channel shard-root expansion on actual sharded subdirs (channel_loader.cpp)

### DIFF
--- a/libmamba/src/api/channel_loader.cpp
+++ b/libmamba/src/api/channel_loader.cpp
@@ -634,7 +634,17 @@ namespace mamba
         {
             std::set<std::string> loaded_subdirs_with_shards;
             bool loading_failed = false;
-            const bool shard_then_expand = ctx.use_sharded_repodata && !root_packages.empty();
+            // Only run the cross-channel root expansion when at least one subdir in the
+            // load list actually advertises shards. On pure-flat channel sets the expansion
+            // has no consumer and its O(records x names) full-repo scan is pure overhead.
+            const bool any_sharded = std::any_of(
+                subdirs.begin(),
+                subdirs.end(),
+                [&](const SubdirIndexLoader& s)
+                { return s.metadata().has_up_to_date_shards(ctx.repodata_shards_ttl); }
+            );
+            const bool shard_then_expand = ctx.use_sharded_repodata && !root_packages.empty()
+                                           && any_sharded;
             std::size_t roots_after_full_repodata_pass = root_packages.size();
             std::vector<solver::libsolv::RepoInfo> full_repos_for_shard_roots;
             bool used_flat_repodata = false;


### PR DESCRIPTION
  ## Summary

  `load_all_subdirs` in `libmamba/src/api/channel_loader.cpp` runs a cross-channel root-package expansion
  (`expand_shard_root_packages_from_full_repodata_repos`) whenever `use_sharded_repodata` is on and at least one spec is provided. The intent of that pass is to seed `root_packages` for *sharded* loads on *other* channels so the shard load stays complete across a mixed flat/sharded channel set.

  The current guard does **not** check whether any subdir in the load list actually advertises shards. As a result, on **pure-flat channel sets** (e.g. an Artifactory conda proxy fronting conda-forge that doesn't republish `repodata_shards.msgpack.zst`), the expansion runs and produces output that nothing consumes — its only customer (a sharded subdir) doesn't exist.

  The expansion implementation is `O(records × unique transitive names)` with no name index — for a ~100K-record flat channel and Python's transitive name closure, that's tens of millions of name comparisons. Concretely, this turns a `python=3.11` cold solve into a ~13-minute CPU-bound run instead of ~17 s.

  ## Change

  One-line guard extension at `load_all_subdirs`:

  ```cpp
  const bool any_sharded = std::any_of(
      subdirs.begin(), subdirs.end(),
      [&](const SubdirIndexLoader& s)
      { return s.metadata().has_up_to_date_shards(ctx.repodata_shards_ttl); });
  const bool shard_then_expand = ctx.use_sharded_repodata && !root_packages.empty()
                                 && any_sharded;
  ```

  `std::any_of` is from `<algorithm>` which is already included, `SubdirIndexLoader` is in scope (the function takes
  `std::vector<SubdirIndexLoader>&`), `has_up_to_date_shards` is the same method used by `use_shards` a few lines below (line 647 in tag `2.6.2`), and
  `ctx.repodata_shards_ttl` is already in scope. No other edits needed; no API change.

  ## Validation

  Built the patched binary from tag `2.6.2` with this one change. Reran the 12-cell cold-cache matrix used in the original report (3 python versions ×
  2 channels × 2 `use_sharded_repodata` settings, `rm -rf ~/micromamba/pkgs` before and after every iteration, `--dry-run` to isolate channel +
  repodata + solve from download/install).

  | Channel | python= | 2.6.2 default (`shards=true`) | **2.6.2 + patch (`shards=true`)** | 2.6.2 (`shards=false`) | **2.6.2 + patch (`shards=false`)**  |
  |---|---|---:|---:|---:|---:|
  | non-sharded | 3.11 | 846.79 s | **42.49 s** | 31.45 s | 17.16 s |
  | non-sharded | 3.12 | 790.05 s | **18.41 s** | 18.90 s | 18.54 s |
  | non-sharded | 3.14 | 806.55 s | **18.37 s** | 18.43 s | 18.14 s |
  | conda-forge | 3.11 | 3.72 s | 2.14 s | 16.68 s | 16.63 s |
  | conda-forge | 3.12 | 1.64 s | 1.56 s | 16.64 s | 17.05 s |
  | conda-forge | 3.14 | 1.59 s | 1.45 s | 16.91 s | 17.03 s |

  Observations:

  - **Non-sharded `shards=true` cold solves drop ~20–44×** (846 s → 42 s for 3.11; 790–806 s → 18 s for 3.12 / 3.14). Patched timings match the
  `shards=false` / 2.5.0-cold baseline (~17–30 s).
  - **Sharded fast path on conda-forge is preserved** — 1.5–2.1 s vs 1.6–3.7 s unpatched (within noise).
  - **`shards=false` cells are unchanged** — confirms the change is scoped to the on-path guard and doesn't affect the off path.
  - Total wall time across the full 12-cell matrix: **~3 min patched** vs **~43 min unpatched**.

  ## Notes / discussion

  - The expansion loop itself remains `O(records × unique names)` with a sequential `for_each_package_in_repo` scan per name. For mixed flat/sharded channel sets that legitimately do run the pass, this could still be a bottleneck on large flat channels. A follow-up worth considering: build a
  `std::unordered_map<std::string, std::vector<const PackageInfo*>>` (or use `Database::packages_by_name` if such an accessor exists) once before the loop, dropping per-name lookup from O(N) to O(1). I'm happy to do that as a separate PR if you'd like.
  - This PR does not modify or remove `expand_shard_root_packages_from_full_repodata_repos`; the behavior for genuinely-mixed channel sets is unchanged.

  ## Type of Change

  - [x] Bugfix
  - [ ] Feature / enhancement
  - [ ] CI / Documentation
  - [ ] Maintenance

  ## Checklist

  - [ ] My code follows the general style and conventions of the codebase
  - [ ] I have performed a self-review of my code
  - [x] I have commented the change explaining the *why*
  - [ ] My changes generate no new warnings
  - [ ] I have added tests covering the change — _open question, see below_
  - [x] I have manually verified the fix on the regression scenario (table above)
