### PR TITLE
fix: Populate `python_site_packages_path` independently from host

### DIFF
--- a/libmamba/src/core/transaction_context.cpp
+++ b/libmamba/src/core/transaction_context.cpp
@@ -10,6 +10,7 @@
 #include <reproc++/drain.hpp>
 
 #include "mamba/core/output.hpp"
+#include "mamba/specs/platform.hpp"
 #include "mamba/util/environment.hpp"
 #include "mamba/util/string.hpp"
 
@@ -49,47 +50,53 @@ namespace mamba
         // Unix free-threaded installs use lib/pythonX.Yt/site-packages. Windows CPython (conda
         // layout) keeps third-party packages under Lib/site-packages for both GIL and free-threaded
         // builds — see https://github.com/mamba-org/mamba/issues/4267
-        const std::string unix_style_ft_site_packages = (short_ver.empty()
-                                                         || python_pkg.build_string.empty())
-                                                            ? std::string{}
-                                                            : (fs::u8path("lib")
-                                                               / util::concat("python", short_ver, "t")
-                                                               / "site-packages")
-                                                                  .generic_string();
+        const bool missing_version_info = short_ver.empty() || python_pkg.build_string.empty();
 
-#ifdef _WIN32
-        const std::string ft_site_packages = (short_ver.empty() || python_pkg.build_string.empty())
-                                                 ? std::string{}
-                                                 : (fs::u8path("Lib") / "site-packages").generic_string();
-#else
-        const std::string ft_site_packages = unix_style_ft_site_packages;
-#endif
+        // Use the package subdir, not the host OS (repoquery --platform must not rewrite linux
+        // repodata when mamba runs on Windows). See https://github.com/mamba-org/mamba/issues/4286
+        const bool use_windows_layout = !python_pkg.platform.empty()
+                                            ? specs::platform_is_win(python_pkg.platform)
+                                            : specs::platform_is_win(specs::build_platform());
+
+        const std::string free_threaded_site_packages_unix = missing_version_info
+                                                                 ? std::string{}
+                                                                 : (fs::u8path("lib")
+                                                                    / util::concat("python", short_ver, "t")
+                                                                    / "site-packages")
+                                                                       .generic_string();
+
+        const std::string std_site_packages_win = missing_version_info
+                                                      ? std::string{}
+                                                      : (fs::u8path("Lib") / "site-packages")
+                                                            .generic_string();
+
+        const std::string free_threaded_site_packages = use_windows_layout
+                                                            ? std_site_packages_win
+                                                            : free_threaded_site_packages_unix;
+
+        const std::string std_site_packages_gil_unix = missing_version_info
+                                                           ? std::string{}
+                                                           : (fs::u8path("lib")
+                                                              / util::concat("python", short_ver)
+                                                              / "site-packages")
+                                                                 .generic_string();
+
+        const std::string std_site_packages = use_windows_layout ? std_site_packages_win
+                                                                 : std_site_packages_gil_unix;
 
         if (!python_pkg.python_site_packages_path.empty())
         {
-            if (freethreaded_build && !ft_site_packages.empty())
+            if (freethreaded_build && !free_threaded_site_packages.empty())
             {
-                const std::string std_site_packages = short_ver.empty()
-                                                          ? std::string{}
-#ifdef _WIN32
-                                                          : (fs::u8path("Lib") / "site-packages")
-                                                                .generic_string();
-#else
-                                                          : (fs::u8path("lib")
-                                                             / util::concat("python", short_ver)
-                                                             / "site-packages")
-                                                                .generic_string();
-#endif
                 if (python_pkg.python_site_packages_path == std_site_packages)
                 {
-                    return ft_site_packages;
+                    return free_threaded_site_packages;
                 }
-#ifdef _WIN32
-                if (python_pkg.python_site_packages_path == unix_style_ft_site_packages)
+                if (use_windows_layout
+                    && python_pkg.python_site_packages_path == free_threaded_site_packages_unix)
                 {
-                    return ft_site_packages;
+                    return free_threaded_site_packages;
                 }
-#endif
             }
             return python_pkg.python_site_packages_path;
         }
@@ -102,7 +109,7 @@ namespace mamba
         {
             return {};
         }
-        return ft_site_packages;
+        return free_threaded_site_packages;
     }
 
     // supply short python version, e.g. 2.7, 3.5...

--- a/libmamba/tests/src/core/test_query.cpp
+++ b/libmamba/tests/src/core/test_query.cpp
@@ -285,3 +285,54 @@ TEST_CASE("QueryResult version sorting", "[mamba::core][mamba::core::query]")
         REQUIRE(versions[0] == expected_latest.value());
     }
 }
+
+// Regression: https://github.com/mamba-org/mamba/issues/4286
+TEST_CASE(
+    "Query::find python_site_packages_path respects package platform #4286",
+    "[mamba::core][mamba::core::query][regression][4286]"
+)
+{
+    auto& ctx = mambatests::context();
+    auto channel_context = ChannelContext::make_conda_compatible(ctx);
+
+    auto linux_python = mkpkg("python", "3.14.1", "h4724d56_1_cp313t", 1);
+    linux_python.python_site_packages_path = "lib/python3.13t/site-packages";
+
+    auto win_python = mkpkg("python", "3.14.1", "h7c1dbca_0_cp314t", 0);
+    win_python.platform = "win-64";
+    win_python.python_site_packages_path = "Lib/site-packages";
+    win_python.filename = "python-3.14.1-h7c1dbca_0_cp314t.conda";
+    win_python.package_url = fmt::format(
+        "https://conda.anaconda.org/{}/{}/{}",
+        win_python.channel,
+        win_python.platform,
+        win_python.filename
+    );
+
+    const std::vector<specs::PackageInfo> packages{ linux_python, win_python };
+    auto db = solver::libsolv::Database(channel_context.params());
+    db.add_repo_from_packages(packages, "test-repo");
+
+    SECTION("linux-64 search keeps unix repodata path on any host")
+    {
+        auto result = Query::find(db, { "python=3.14.1=h4724d56_1_cp313t" });
+        REQUIRE_FALSE(result.empty());
+
+        const auto json_output = result.json();
+        REQUIRE(json_output["result"]["pkgs"].size() == 1);
+        REQUIRE(
+            json_output["result"]["pkgs"][0]["python_site_packages_path"]
+            == "lib/python3.13t/site-packages"
+        );
+    }
+
+    SECTION("win-64 search keeps windows repodata path on any host")
+    {
+        auto result = Query::find(db, { "python=3.14.1=h7c1dbca_0_cp314t" });
+        REQUIRE_FALSE(result.empty());
+
+        const auto json_output = result.json();
+        REQUIRE(json_output["result"]["pkgs"].size() == 1);
+        REQUIRE(json_output["result"]["pkgs"][0]["python_site_packages_path"] == "Lib/site-packages");
+    }
+}

--- a/libmamba/tests/src/core/test_transaction_context.cpp
+++ b/libmamba/tests/src/core/test_transaction_context.cpp
@@ -55,33 +55,50 @@ namespace mamba
             python_pkg.version = "3.13.1";
             python_pkg.build_string = "h9a34b6e_5_cp313t";
 
-            SECTION("freethreaded site-packages path")
+            SECTION("linux package keeps repodata path on any host")
             {
+                python_pkg.platform = "linux-64";
                 python_pkg.python_site_packages_path = "lib/python3.13t/site-packages";
 
-#ifdef _WIN32
-                const auto expected = std::string("Lib/site-packages");
-#else
-                const auto expected = std::string("lib/python3.13t/site-packages");
-#endif
-                REQUIRE(effective_python_site_packages_path(python_pkg) == expected);
+                REQUIRE(
+                    effective_python_site_packages_path(python_pkg) == "lib/python3.13t/site-packages"
+                );
             }
 
-            SECTION("rewrites standard path for freethreaded builds")
+            SECTION("freethreaded site-packages path on Windows")
             {
-                python_pkg.python_site_packages_path =
-#ifdef _WIN32
-                    "Lib/site-packages";
-#else
-                    "lib/python3.13/site-packages";
-#endif
+                python_pkg.platform = "win-64";
+                python_pkg.python_site_packages_path = "lib/python3.13t/site-packages";
 
-#ifdef _WIN32
-                const auto expected = std::string("Lib/site-packages");
-#else
-                const auto expected = std::string("lib/python3.13t/site-packages");
-#endif
-                REQUIRE(effective_python_site_packages_path(python_pkg) == expected);
+                REQUIRE(effective_python_site_packages_path(python_pkg) == "Lib/site-packages");
+            }
+
+            SECTION("freethreaded site-packages path on Unix")
+            {
+                python_pkg.platform = "linux-64";
+                python_pkg.python_site_packages_path = "lib/python3.13t/site-packages";
+
+                REQUIRE(
+                    effective_python_site_packages_path(python_pkg) == "lib/python3.13t/site-packages"
+                );
+            }
+
+            SECTION("rewrites standard path for freethreaded Windows builds")
+            {
+                python_pkg.platform = "win-64";
+                python_pkg.python_site_packages_path = "Lib/site-packages";
+
+                REQUIRE(effective_python_site_packages_path(python_pkg) == "Lib/site-packages");
+            }
+
+            SECTION("rewrites standard path for freethreaded Unix builds")
+            {
+                python_pkg.platform = "linux-64";
+                python_pkg.python_site_packages_path = "lib/python3.13/site-packages";
+
+                REQUIRE(
+                    effective_python_site_packages_path(python_pkg) == "lib/python3.13t/site-packages"
+                );
             }
         }
 
@@ -95,42 +112,136 @@ namespace mamba
             python_pkg.version = "3.14.0";
             python_pkg.build_string = "habcdef_0_cp314t";
 
-            SECTION("rewrites std site-packages from repodata for free-threaded 3.14")
+            SECTION("rewrites std site-packages from repodata for free-threaded 3.14 on Windows")
             {
-                python_pkg.python_site_packages_path =
-#ifdef _WIN32
-                    "Lib/site-packages";
-#else
-                    "lib/python3.14/site-packages";
-#endif
+                python_pkg.platform = "win-64";
+                python_pkg.python_site_packages_path = "Lib/site-packages";
 
-#ifdef _WIN32
-                const auto expected = std::string("Lib/site-packages");
-#else
-                const auto expected = std::string("lib/python3.14t/site-packages");
-#endif
-                REQUIRE(effective_python_site_packages_path(python_pkg) == expected);
+                REQUIRE(effective_python_site_packages_path(python_pkg) == "Lib/site-packages");
             }
 
-#ifdef _WIN32
+            SECTION("rewrites std site-packages from repodata for free-threaded 3.14 on Unix")
+            {
+                python_pkg.platform = "linux-64";
+                python_pkg.python_site_packages_path = "lib/python3.14/site-packages";
+
+                REQUIRE(
+                    effective_python_site_packages_path(python_pkg) == "lib/python3.14t/site-packages"
+                );
+            }
+
             SECTION("normalizes unix-style free-threaded path on Windows")
             {
+                python_pkg.platform = "win-64";
                 python_pkg.python_site_packages_path = "lib/python3.14t/site-packages";
 
                 REQUIRE(effective_python_site_packages_path(python_pkg) == "Lib/site-packages");
             }
-#endif
 
-            SECTION("infers site-packages when repodata omits python_site_packages_path")
+            SECTION("infers site-packages when repodata omits python_site_packages_path on Windows")
             {
+                python_pkg.platform = "win-64";
+                python_pkg.python_site_packages_path.clear();
+
+                REQUIRE(effective_python_site_packages_path(python_pkg) == "Lib/site-packages");
+            }
+
+            SECTION("infers site-packages when repodata omits python_site_packages_path on Unix")
+            {
+                python_pkg.platform = "linux-64";
+                python_pkg.python_site_packages_path.clear();
+
+                REQUIRE(
+                    effective_python_site_packages_path(python_pkg) == "lib/python3.14t/site-packages"
+                );
+            }
+        }
+
+        // Regression: https://github.com/mamba-org/mamba/issues/4286
+        // `mamba repoquery search ... --platform linux-64` on a Windows host must not rewrite
+        // linux repodata `python_site_packages_path` to `Lib/site-packages`.
+        TEST_CASE("effective_python_site_packages_path repoquery cross-platform #4286", "[regression][4286]")
+        {
+            SECTION("linux-64 free-threaded python from issue report")
+            {
+                auto python_pkg = specs::PackageInfo("python");
+                python_pkg.version = "3.14.1";
+                python_pkg.build_string = "h4724d56_1_cp313t";
+                python_pkg.platform = "linux-64";
+                python_pkg.python_site_packages_path = "lib/python3.13t/site-packages";
+
+                REQUIRE(
+                    effective_python_site_packages_path(python_pkg) == "lib/python3.13t/site-packages"
+                );
+            }
+
+            SECTION("win-64 free-threaded python from issue report")
+            {
+                auto python_pkg = specs::PackageInfo("python");
+                python_pkg.version = "3.14.1";
+                python_pkg.build_string = "h7c1dbca_0_cp314t";
+                python_pkg.platform = "win-64";
+                python_pkg.python_site_packages_path = "Lib/site-packages";
+
+                REQUIRE(effective_python_site_packages_path(python_pkg) == "Lib/site-packages");
+            }
+
+            SECTION("linux repodata path is not normalized to Windows layout")
+            {
+                auto python_pkg = specs::PackageInfo("python");
+                python_pkg.version = "3.13.1";
+                python_pkg.build_string = "h9a34b6e_5_cp313t";
+                python_pkg.platform = "linux-64";
+                python_pkg.python_site_packages_path = "lib/python3.13t/site-packages";
+
+                REQUIRE(effective_python_site_packages_path(python_pkg) != "Lib/site-packages");
+                REQUIRE(
+                    effective_python_site_packages_path(python_pkg) == "lib/python3.13t/site-packages"
+                );
+            }
+
+            SECTION("win-64 repodata path is not rewritten to unix free-threaded layout")
+            {
+                auto python_pkg = specs::PackageInfo("python");
+                python_pkg.version = "3.13.1";
+                python_pkg.build_string = "h9a34b6e_5_cp313t";
+                python_pkg.platform = "win-64";
+                python_pkg.python_site_packages_path = "Lib/site-packages";
+
+                REQUIRE(
+                    effective_python_site_packages_path(python_pkg) != "lib/python3.13t/site-packages"
+                );
+                REQUIRE(effective_python_site_packages_path(python_pkg) == "Lib/site-packages");
+            }
+
+            SECTION("non-Windows subdirs never use Lib/site-packages inference")
+            {
+                auto python_pkg = specs::PackageInfo("python");
+                python_pkg.version = "3.14.0";
+                python_pkg.build_string = "habcdef_0_cp314t";
+                python_pkg.platform = "osx-arm64";
+                python_pkg.python_site_packages_path.clear();
+
+                REQUIRE(
+                    effective_python_site_packages_path(python_pkg) == "lib/python3.14t/site-packages"
+                );
+            }
+
+            SECTION("empty platform falls back to build platform for local installs")
+            {
+                auto python_pkg = specs::PackageInfo("python");
+                python_pkg.version = "3.14.0";
+                python_pkg.build_string = "habcdef_0_cp314t";
+                python_pkg.platform.clear();
                 python_pkg.python_site_packages_path.clear();
 
 #ifdef _WIN32
-                const auto expected = std::string("Lib/site-packages");
+                REQUIRE(effective_python_site_packages_path(python_pkg) == "Lib/site-packages");
 #else
-                const auto expected = std::string("lib/python3.14t/site-packages");
+                REQUIRE(
+                    effective_python_site_packages_path(python_pkg) == "lib/python3.14t/site-packages"
+                );
 #endif
-                REQUIRE(effective_python_site_packages_path(python_pkg) == expected);
             }
         }
 

--- a/libmamba/tests/src/core/test_transaction_context.cpp
+++ b/libmamba/tests/src/core/test_transaction_context.cpp
@@ -194,7 +194,6 @@ namespace mamba
                 python_pkg.platform = "linux-64";
                 python_pkg.python_site_packages_path = "lib/python3.13t/site-packages";
 
-                REQUIRE(effective_python_site_packages_path(python_pkg) != "Lib/site-packages");
                 REQUIRE(
                     effective_python_site_packages_path(python_pkg) == "lib/python3.13t/site-packages"
                 );
@@ -208,9 +207,6 @@ namespace mamba
                 python_pkg.platform = "win-64";
                 python_pkg.python_site_packages_path = "Lib/site-packages";
 
-                REQUIRE(
-                    effective_python_site_packages_path(python_pkg) != "lib/python3.13t/site-packages"
-                );
                 REQUIRE(effective_python_site_packages_path(python_pkg) == "Lib/site-packages");
             }
 

--- a/micromamba/tests/test_repoquery.py
+++ b/micromamba/tests/test_repoquery.py
@@ -261,10 +261,8 @@ def test_remote_search_python_site_packages_path(yaml_env: Path):
     assert package_info["name"] == "python"
     assert package_info["version"] == "3.13.1"
     assert package_info["track_features"] == "py_freethreading"
-    expected_site_packages_path = (
-        "Lib/site-packages" if platform.system() == "Windows" else "lib/python3.13t/site-packages"
-    )
-    assert package_info["python_site_packages_path"] == expected_site_packages_path
+    # Must follow queried subdir, not the host OS (see mamba-org/mamba#4286).
+    assert package_info["python_site_packages_path"] == "lib/python3.13t/site-packages"
 
 
 @pytest.mark.parametrize("wildcard", [False, True])


### PR DESCRIPTION
# Description

Fix #4286.

## Type of Change

<!-- Please skip this part if you are already using conventional commit keywords in the PR title. -->

- [x] Bugfix
- [ ] Feature / enhancement
- [ ] CI / Documentation
- [ ] Maintenance

## Checklist

- [x] My code follows the general style and conventions of the codebase, ensuring consistency
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have run `pre-commit run --all` locally in the source folder and confirmed that there are no linter errors.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
