### PR TITLE
fix: Accept arguments separator for `run` subcommand

### DIFF
--- a/micromamba/src/main.cpp
+++ b/micromamba/src/main.cpp
@@ -15,6 +15,9 @@
 #include "mamba/util/os_win.hpp"
 #endif
 
+#include <cstring>
+#include <vector>
+
 #include <CLI/CLI.hpp>
 
 #include "mamba/api/configuration.hpp"
@@ -30,6 +33,60 @@
 
 
 using namespace mamba;  // NOLINT(build/namespaces)
+
+namespace
+{
+    /// Remove a `--` separator after `micromamba run` before CLI11 parsing.
+    ///
+    /// Older CLI11 rejects arguments following `--` unless a vector positional is defined,
+    /// which breaks `prefix_command()` for the common case. Conda documents `conda run ... -- cmd`.
+    /// See https://github.com/mamba-org/mamba/issues/4216
+    void strip_run_command_separator(
+        int& argc,
+        char**& argv,
+        std::vector<std::string>& storage,
+        std::vector<char*>& pointers
+    )
+    {
+        if (argc < 3 || std::strcmp(argv[1], "run") != 0)
+        {
+            return;
+        }
+
+        int separator_index = -1;
+        for (int i = 2; i < argc; ++i)
+        {
+            if (std::strcmp(argv[i], "--") == 0)
+            {
+                separator_index = i;
+                break;
+            }
+        }
+
+        if (separator_index < 0)
+        {
+            return;
+        }
+
+        storage.clear();
+        pointers.clear();
+        storage.reserve(static_cast<std::size_t>(argc) - 1);
+        pointers.reserve(static_cast<std::size_t>(argc) - 1);
+
+        for (int i = 0; i < argc; ++i)
+        {
+            if (i == separator_index)
+            {
+                continue;
+            }
+            storage.push_back(argv[i]);
+            pointers.push_back(storage.back().data());
+        }
+
+        argc = static_cast<int>(pointers.size());
+        argv = pointers.data();
+    }
+}  // namespace
 
 int
 main(int argc, char** argv)
@@ -95,6 +152,10 @@ main(int argc, char** argv)
         error_to_report = e.what();
         set_sig_interrupted();
     };
+
+    std::vector<std::string> run_argv_storage;
+    std::vector<char*> run_argv_pointers;
+    strip_run_command_separator(argc, utf8argv, run_argv_storage, run_argv_pointers);
 
     try
     {

--- a/micromamba/tests/test_run.py
+++ b/micromamba/tests/test_run.py
@@ -74,6 +74,15 @@ class TestRun:
         print(res)
         assert len(res) > 0
 
+    def test_double_dash_separator(self):
+        """`micromamba run` accepts `--` like `conda run` (mamba#4216)."""
+        res = umamba_run("--", "echo", "hello")
+        assert res.strip() == "hello"
+
+    def test_double_dash_separator_with_prefix(self):
+        res = umamba_run("-p", os.environ["CONDA_PREFIX"], "--", "echo", "hello")
+        assert res.strip() == "hello"
+
     @pytest.mark.skipif(platform == "win32", reason="bash specific test")
     @pytest.mark.parametrize("inp", ["(", "a\nb", "a'b\""])
     def test_quoting(self, inp):


### PR DESCRIPTION
# Description

Fix #4216.

## Type of Change

<!-- Please skip this part if you are already using conventional commit keywords in the PR title. -->

- [x] Bugfix
- [ ] Feature / enhancement
- [ ] CI / Documentation
- [ ] Maintenance

## Checklist

- [x] My code follows the general style and conventions of the codebase, ensuring consistency
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have run `pre-commit run --all` locally in the source folder and confirmed that there are no linter errors.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
