### PR TITLE
maint: Uniformly use `W1` for external warnings on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,9 @@ include("cmake/Checks.cmake")
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/modules")
 
 if(MSVC)
+    # Match CMake's default for imported SYSTEM includes (otherwise /external:W0) so we do not
+    # override it later with /external:W1 from mamba_target_add_compile_warnings (D9025).
+    set(CMAKE_INCLUDE_SYSTEM_FLAG_CXX_WARNING "-external:W1 ")
     # NOMINMAX : prevent tons of code to be included when having to `#include <windows.h>` /EHsc :
     # enable C++ exceptions (otherwise exceptions do not work) /Zc:__cplusplus : makes sure
     # `__cplusplus` is set to the current C++ version language. Otherwise it is always set to an
@@ -44,7 +47,7 @@ if(MSVC)
     # project.
     set(
         CMAKE_CXX_FLAGS
-        "${CMAKE_CXX_FLAGS} /D_CRT_SECURE_NO_WARNINGS /DNOMINMAX /EHsc /Zc:__cplusplus /utf-8 /MP /experimental:external /external:I $ENV{CONDA_PREFIX}"
+        "${CMAKE_CXX_FLAGS} /D_CRT_SECURE_NO_WARNINGS /DNOMINMAX /EHsc /Zc:__cplusplus /utf-8 /MP /experimental:external /external:W1 /external:I $ENV{CONDA_PREFIX}"
     )
     # Force release mode to avoid debug libraries to be linked
     set(

--- a/cmake/CompilerWarnings.cmake
+++ b/cmake/CompilerWarnings.cmake
@@ -22,9 +22,8 @@ function(mamba_target_add_compile_warnings target)
 
     set(
         msvc_warnings
-        # External sever warnings
-        /experimental:external
-        /external:W1
+        # /experimental:external and /external:W1 are set globally in the top-level CMakeLists.txt
+        # on MSVC (including CMAKE_INCLUDE_SYSTEM_FLAG_CXX_WARNING for imported targets).
         # Baseline reasonable warnings
         /W4
         # "identifier": conversion from "type1" to "type1", possible loss of data


### PR DESCRIPTION
# Description

The setting for `W0` warnings is being overridden by another one for `W1` warnings on Windows, leading to this specific warnings in the logs:

```
cl : Command line warning D9025 : overriding '/external:W0' with '/external:W1'
```

This configures `W1` warnings uniformly for Windows.

## Type of Change

<!-- Please skip this part if you are already using conventional commit keywords in the PR title. -->

- [ ] Bugfix
- [ ] Feature / enhancement
- [ ] CI / Documentation
- [x] Maintenance

## Checklist

- [x] My code follows the general style and conventions of the codebase, ensuring consistency
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have run `pre-commit run --all` locally in the source folder and confirmed that there are no linter errors.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
