### PR TITLE
Increase test timeout

### DIFF
--- a/.github/workflows/unix_impl.yml
+++ b/.github/workflows/unix_impl.yml
@@ -279,7 +279,7 @@ jobs:
           export TEST_MAMBA_EXE=$(pwd)/build/micromamba/mamba
           unset CONDARC  # Interferes with tests
           # Only rerun flaky tests on the `main` branch
-          python -m pytest micromamba/tests/ --durations=30 \
+          python -m pytest micromamba/tests/ \
               ${{ runner.debug == 'true' && '-v --capture=tee-sys' || '' }} \
               ${{ github.ref == 'refs/heads/main' && '--reruns 3' || '' }}
 

--- a/.github/workflows/unix_impl.yml
+++ b/.github/workflows/unix_impl.yml
@@ -279,7 +279,7 @@ jobs:
           export TEST_MAMBA_EXE=$(pwd)/build/micromamba/mamba
           unset CONDARC  # Interferes with tests
           # Only rerun flaky tests on the `main` branch
-          python -m pytest micromamba/tests/ --durations=10 \
+          python -m pytest micromamba/tests/ --durations=30 \
               ${{ runner.debug == 'true' && '-v --capture=tee-sys' || '' }} \
               ${{ github.ref == 'refs/heads/main' && '--reruns 3' || '' }}
 

--- a/.github/workflows/unix_impl.yml
+++ b/.github/workflows/unix_impl.yml
@@ -279,7 +279,7 @@ jobs:
           export TEST_MAMBA_EXE=$(pwd)/build/micromamba/mamba
           unset CONDARC  # Interferes with tests
           # Only rerun flaky tests on the `main` branch
-          python -m pytest micromamba/tests/ \
+          python -m pytest micromamba/tests/ --durations=10 \
               ${{ runner.debug == 'true' && '-v --capture=tee-sys' || '' }} \
               ${{ github.ref == 'refs/heads/main' && '--reruns 3' || '' }}
 

--- a/micromamba/tests/test_create.py
+++ b/micromamba/tests/test_create.py
@@ -918,7 +918,7 @@ def test_clone_environment_with_many_packages(tmp_home, tmp_root_prefix, tmp_pat
 
 # Only run this test on Linux, as it is the only platform where xeus-cling
 # (which is part of the environment) is available.
-@pytest.mark.timeout(60)
+@pytest.mark.timeout(120)
 @pytest.mark.skipif(platform.system() != "Linux", reason="Test only available on Linux")
 @pytest.mark.parametrize("shared_pkgs_dirs", [True], indirect=True)
 def test_env_logging_overhead_regression(tmp_home, tmp_root_prefix, tmp_path):


### PR DESCRIPTION
# Description

The `test_env_logging_overhead_regression` test duration varies significantly on CI (roughly between just under 60s and ~80s). This is still reasonable (not considered as hanging) as CI timing can fluctuate due to different factors (network variability, test parallelism and scheduling differences, etc).
So bumping the timeout duration to 120s to avoid irrelevant failures.

<!-- Please include a summary of the changes and the related issue. -->

## Type of Change

<!-- Please skip this part if you are already using conventional commit keywords in the PR title. -->

- [ ] Bugfix
- [ ] Feature / enhancement
- [ ] CI / Documentation
- [x] Maintenance

## Checklist

- [x] My code follows the general style and conventions of the codebase, ensuring consistency
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have run `pre-commit run --all` locally in the source folder and confirmed that there are no linter errors.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
