### PR TITLE
ci: Use verbose pytest runs

### DIFF
--- a/.github/workflows/unix_impl.yml
+++ b/.github/workflows/unix_impl.yml
@@ -194,7 +194,8 @@ jobs:
         run: |
           # Only rerun flaky tests on the `main` branch
           python -m pytest libmambapy/tests/ \
-              ${{ runner.debug == 'true' && '-v --capture=tee-sys' || '--exitfirst' }} \
+              -vv --durations=50 \
+              ${{ runner.debug == 'true' && '--capture=tee-sys' || '--exitfirst' }} \
               ${{ github.ref == 'refs/heads/main' && '--reruns 3' || '' }}
       - name: Test generation of libmambapy stubs
         run: stubgen -o stubs/ -p libmambapy -p libmambapy.bindings
@@ -280,7 +281,8 @@ jobs:
           unset CONDARC  # Interferes with tests
           # Only rerun flaky tests on the `main` branch
           python -m pytest micromamba/tests/ \
-              ${{ runner.debug == 'true' && '-v --capture=tee-sys' || '' }} \
+              -vv --durations=50 \
+              ${{ runner.debug == 'true' && '--capture=tee-sys' || '' }} \
               ${{ github.ref == 'refs/heads/main' && '--reruns 3' || '' }}
 
   verify_pkg_and_auth_tests:

--- a/.github/workflows/windows_impl.yml
+++ b/.github/workflows/windows_impl.yml
@@ -130,7 +130,8 @@ jobs:
         run: |
           # Only rerun flaky tests on the `main` branch
           python -m pytest libmambapy/tests/ ^
-            ${{ runner.debug == 'true' && '-v --capture=tee-sys' || '--exitfirst' }} ^
+            -vv --durations=50 ^
+            ${{ runner.debug == 'true' && '--capture=tee-sys' || '--exitfirst' }} ^
             ${{ github.ref == 'refs/heads/main' && '--reruns 3' || '' }}
 
   mamba_integration_tests_win:
@@ -166,5 +167,6 @@ jobs:
           Remove-Item -Path "env:CONDARC"
           # Only rerun flaky tests on the `main` branch
           python -m pytest micromamba/tests/ `
-            ${{ runner.debug == 'true' && '-v --capture=tee-sys' || '' }} `
+            -vv --durations=50 `
+            ${{ runner.debug == 'true' && '--capture=tee-sys' || '' }} `
             ${{ github.ref == 'refs/heads/main' && '--reruns 3' || '' }}


### PR DESCRIPTION
# Description

Some motivation:
 - useful to catch a regression a few days or weeks after it has been introduced
 - understand which tests are costly (and to rewrite them in C++)
 - be able to spot a test hanging indefinitely while the CI runs, so that we could start to debug locally ASAP

## Type of Change

<!-- Please skip this part if you are already using conventional commit keywords in the PR title. -->

- [ ] Bugfix
- [ ] Feature / enhancement
- [x] CI / Documentation
- [ ] Maintenance

## Checklist

- [x] My code follows the general style and conventions of the codebase, ensuring consistency
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have run `pre-commit run --all` locally in the source folder and confirmed that there are no linter errors.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
