### PR TITLE
fix: Restore cross-channel expansion

### DIFF
--- a/libmamba/include/mamba/api/channel_loader.hpp
+++ b/libmamba/include/mamba/api/channel_loader.hpp
@@ -7,12 +7,14 @@
 #ifndef MAMBA_API_CHANNEL_LOADER_HPP
 #define MAMBA_API_CHANNEL_LOADER_HPP
 
+#include <map>
 #include <optional>
 #include <set>
 #include <string>
 #include <vector>
 
 #include "mamba/core/error_handling.hpp"
+#include "mamba/specs/package_info.hpp"
 #include "mamba/specs/version.hpp"
 
 namespace mamba
@@ -38,7 +40,8 @@ namespace mamba
      *
      * @param ctx Context (use_sharded_repodata, shard TTL, download params, etc.).
      * @param database Libsolv database to add repos into.
-     * @param root_packages Root package names for reachability (e.g. install specs).
+     * @param root_packages Root package names for reachability (e.g. install specs); may be
+     *                      extended with dependency names discovered in loaded shard packages.
      * @param subdirs All subdir loaders; \p subdir_idx is the one to load.
      * @param subdir_idx Index of the subdir to load in \p subdirs.
      * @param loaded_subdirs_with_shards Set of subdir names already loaded via shards (updated).
@@ -50,7 +53,7 @@ namespace mamba
     auto load_subdir_with_shards(
         Context& ctx,
         solver::libsolv::Database& database,
-        const std::vector<std::string>& root_packages,
+        std::vector<std::string>& root_packages,
         std::vector<SubdirIndexLoader>& subdirs,
         std::size_t subdir_idx,
         std::set<std::string>& loaded_subdirs_with_shards,
@@ -84,6 +87,18 @@ namespace mamba
     void expand_shard_root_packages_from_full_repodata_repos(
         const solver::libsolv::Database& database,
         const std::vector<solver::libsolv::RepoInfo>& full_repos,
+        std::vector<std::string>& root_packages
+    );
+
+    /**
+     * Extend \p root_packages with dependency names from shard-loaded package records.
+     *
+     * Only walks packages already fetched for the current shard subset (typically tens to
+     * hundreds of records), not full repodata. Used for cross-channel / cross-subdir shard
+     * closure (#4245).
+     */
+    void expand_shard_root_packages_from_shard_loaded_packages(
+        const std::map<std::string, std::vector<specs::PackageInfo>>& packages_by_url,
         std::vector<std::string>& root_packages
     );
 

--- a/libmamba/include/mamba/api/channel_loader.hpp
+++ b/libmamba/include/mamba/api/channel_loader.hpp
@@ -48,6 +48,8 @@ namespace mamba
      * @param priorities Repo priorities aligned with \p subdirs.
      * @param python_minor_version_for_prefilter Optional python minor for shard record prefiltering
      * (from \c prepare_solver_context).
+     * @param expand_shard_roots_from_loaded_shards When true, extend \p root_packages from
+     *        dependency names in loaded shard records (all-sharded channel sets only).
      * @return The repo for the requested subdir, or unexpected mamba_error on failure.
      */
     auto load_subdir_with_shards(
@@ -58,7 +60,8 @@ namespace mamba
         std::size_t subdir_idx,
         std::set<std::string>& loaded_subdirs_with_shards,
         const std::vector<solver::libsolv::Priorities>& priorities,
-        std::optional<specs::Version> python_minor_version_for_prefilter = std::nullopt
+        std::optional<specs::Version> python_minor_version_for_prefilter = std::nullopt,
+        bool expand_shard_roots_from_loaded_shards = false
     ) -> expected_t<solver::libsolv::RepoInfo>;
 
     class ChannelContext;
@@ -95,7 +98,7 @@ namespace mamba
      *
      * Only walks packages already fetched for the current shard subset (typically tens to
      * hundreds of records), not full repodata. Used for cross-channel / cross-subdir shard
-     * closure (#4245).
+     * closure (#4245). Skipped when flat (non-sharded) channels were loaded first (e.g. bioconda).
      */
     void expand_shard_root_packages_from_shard_loaded_packages(
         const std::map<std::string, std::vector<specs::PackageInfo>>& packages_by_url,

--- a/libmamba/include/mamba/api/channel_loader.hpp
+++ b/libmamba/include/mamba/api/channel_loader.hpp
@@ -14,6 +14,7 @@
 #include <vector>
 
 #include "mamba/core/error_handling.hpp"
+#include "mamba/solver/libsolv/repo_info.hpp"
 #include "mamba/specs/package_info.hpp"
 #include "mamba/specs/version.hpp"
 
@@ -23,7 +24,6 @@ namespace mamba
     {
         class Database;
         struct Priorities;
-        class RepoInfo;
     }
     class Context;
     class SubdirIndexLoader;
@@ -44,7 +44,8 @@ namespace mamba
      *                      extended with dependency names discovered in loaded shard packages.
      * @param subdirs All subdir loaders; \p subdir_idx is the one to load.
      * @param subdir_idx Index of the subdir to load in \p subdirs.
-     * @param loaded_subdirs_with_shards Set of subdir names already loaded via shards (updated).
+     * @param loaded_subdirs_with_shards Subdir names already loaded via shards → their libsolv
+     *        repos (updated; repos are removed before a follow-up shard pass).
      * @param priorities Repo priorities aligned with \p subdirs.
      * @param python_minor_version_for_prefilter Optional python minor for shard record prefiltering
      * (from \c prepare_solver_context).
@@ -58,7 +59,7 @@ namespace mamba
         std::vector<std::string>& root_packages,
         std::vector<SubdirIndexLoader>& subdirs,
         std::size_t subdir_idx,
-        std::set<std::string>& loaded_subdirs_with_shards,
+        std::map<std::string, solver::libsolv::RepoInfo>& loaded_subdirs_with_shards,
         const std::vector<solver::libsolv::Priorities>& priorities,
         std::optional<specs::Version> python_minor_version_for_prefilter = std::nullopt,
         bool expand_shard_roots_from_loaded_shards = false

--- a/libmamba/include/mamba/api/channel_loader.hpp
+++ b/libmamba/include/mamba/api/channel_loader.hpp
@@ -98,7 +98,8 @@ namespace mamba
      *
      * Only walks packages already fetched for the current shard subset (typically tens to
      * hundreds of records), not full repodata. Used for cross-channel / cross-subdir shard
-     * closure (#4245). Skipped when flat (non-sharded) channels were loaded first (e.g. bioconda).
+     * closure (#4245). Skipped when flat channels were loaded first (e.g. bioconda) or when only
+     * one channel has shards (conda-forge alone already closes over subdirs in one BFS).
      */
     void expand_shard_root_packages_from_shard_loaded_packages(
         const std::map<std::string, std::vector<specs::PackageInfo>>& packages_by_url,

--- a/libmamba/include/mamba/api/channel_loader.hpp
+++ b/libmamba/include/mamba/api/channel_loader.hpp
@@ -9,7 +9,6 @@
 
 #include <map>
 #include <optional>
-#include <set>
 #include <string>
 #include <vector>
 
@@ -24,47 +23,10 @@ namespace mamba
     {
         class Database;
         struct Priorities;
+        class RepoInfo;
     }
     class Context;
     class SubdirIndexLoader;
-
-    /**
-     * Load a single subdir using sharded repodata (only reachable packages).
-     *
-     * Uses the shard index and per-package shards to load just the packages reachable from
-     * \p root_packages via dependencies, instead of the full repodata.
-     *
-     * Precondition: the caller must only invoke this when shards are applicable for the
-     * targeted subdir (e.g. sharded repodata is enabled, metadata is up to date, and
-     * \p root_packages is non-empty).
-     *
-     * @param ctx Context (use_sharded_repodata, shard TTL, download params, etc.).
-     * @param database Libsolv database to add repos into.
-     * @param root_packages Root package names for reachability (e.g. install specs); may be
-     *                      extended with dependency names discovered in loaded shard packages.
-     * @param subdirs All subdir loaders; \p subdir_idx is the one to load.
-     * @param subdir_idx Index of the subdir to load in \p subdirs.
-     * @param loaded_subdirs_with_shards Subdir names already loaded via shards → their libsolv
-     *        repos (updated; repos are removed before a follow-up shard pass).
-     * @param priorities Repo priorities aligned with \p subdirs.
-     * @param python_minor_version_for_prefilter Optional python minor for shard record prefiltering
-     * (from \c prepare_solver_context).
-     * @param expand_shard_roots_from_loaded_shards When true, extend \p root_packages from
-     *        dependency names in loaded shard records (all-sharded channel sets only).
-     * @return The repo for the requested subdir, or unexpected mamba_error on failure.
-     */
-    auto load_subdir_with_shards(
-        Context& ctx,
-        solver::libsolv::Database& database,
-        std::vector<std::string>& root_packages,
-        std::vector<SubdirIndexLoader>& subdirs,
-        std::size_t subdir_idx,
-        std::map<std::string, solver::libsolv::RepoInfo>& loaded_subdirs_with_shards,
-        const std::vector<solver::libsolv::Priorities>& priorities,
-        std::optional<specs::Version> python_minor_version_for_prefilter = std::nullopt,
-        bool expand_shard_roots_from_loaded_shards = false
-    ) -> expected_t<solver::libsolv::RepoInfo>;
-
     class ChannelContext;
     class MultiPackageCache;
 

--- a/libmamba/include/mamba/api/channel_loader.hpp
+++ b/libmamba/include/mamba/api/channel_loader.hpp
@@ -7,7 +7,6 @@
 #ifndef MAMBA_API_CHANNEL_LOADER_HPP
 #define MAMBA_API_CHANNEL_LOADER_HPP
 
-#include <map>
 #include <optional>
 #include <string>
 #include <vector>
@@ -53,19 +52,6 @@ namespace mamba
     void expand_shard_root_packages_from_full_repodata_repos(
         const solver::libsolv::Database& database,
         const std::vector<solver::libsolv::RepoInfo>& full_repos,
-        std::vector<std::string>& root_packages
-    );
-
-    /**
-     * Extend \p root_packages with dependency names from shard-loaded package records.
-     *
-     * Only walks packages already fetched for the current shard subset (typically tens to
-     * hundreds of records), not full repodata. Used for cross-channel / cross-subdir shard
-     * closure (#4245). Skipped when flat channels were loaded first (e.g. bioconda) or when only
-     * one channel has shards (conda-forge alone already closes over subdirs in one BFS).
-     */
-    void expand_shard_root_packages_from_shard_loaded_packages(
-        const std::map<std::string, std::vector<specs::PackageInfo>>& packages_by_url,
         std::vector<std::string>& root_packages
     );
 

--- a/libmamba/src/api/channel_loader.cpp
+++ b/libmamba/src/api/channel_loader.cpp
@@ -35,43 +35,6 @@
 
 namespace mamba
 {
-    /**
-     * Load a single subdir using sharded repodata (only reachable packages).
-     *
-     * Uses the shard index and per-package shards to load just the packages reachable from
-     * ``root_packages`` via dependencies, instead of the full repodata.
-     *
-     * Precondition: the caller must only invoke this when shards are applicable for the
-     * targeted subdir (e.g. sharded repodata is enabled, metadata is up to date, and
-     * ``root_packages`` is non-empty).
-     *
-     * @param ctx Context (use_sharded_repodata, shard TTL, download params, etc.).
-     * @param database Libsolv database to add repos into.
-     * @param root_packages Root package names for reachability (e.g. install specs); may be
-     *                      extended with dependency names discovered in loaded shard packages.
-     * @param subdirs All subdir loaders; ``subdir_idx`` is the one to load.
-     * @param subdir_idx Index of the subdir to load in ``subdirs``.
-     * @param loaded_subdirs_with_shards Subdir names already loaded via shards → their libsolv
-     *        repos (updated; repos are removed before a follow-up shard pass).
-     * @param priorities Repo priorities aligned with ``subdirs``.
-     * @param python_minor_version_for_prefilter Optional python minor for shard record
-     *        prefiltering (from ``prepare_solver_context``).
-     * @param expand_shard_roots_from_loaded_shards When true, extend ``root_packages`` from
-     *        dependency names in loaded shard records (multi-sharded channel sets only).
-     * @return The repo for the requested subdir, or unexpected mamba_error on failure.
-     */
-    auto load_subdir_with_shards(
-        Context& ctx,
-        solver::libsolv::Database& database,
-        std::vector<std::string>& root_packages,
-        std::vector<SubdirIndexLoader>& subdirs,
-        std::size_t subdir_idx,
-        std::map<std::string, solver::libsolv::RepoInfo>& loaded_subdirs_with_shards,
-        const std::vector<solver::libsolv::Priorities>& priorities,
-        std::optional<specs::Version> python_minor_version_for_prefilter,
-        bool expand_shard_roots_from_loaded_shards
-    ) -> expected_t<solver::libsolv::RepoInfo>;
-
     namespace
     {
         [[nodiscard]] auto count_distinct_sharded_channel_urls(
@@ -332,6 +295,216 @@ namespace mamba
                     }
                 }
             }
+        }
+
+        std::optional<solver::libsolv::RepoInfo> add_repos_from_packages_by_url(
+            Context& ctx,
+            solver::libsolv::Database& database,
+            const std::map<std::string, std::vector<specs::PackageInfo>>& packages_by_url,
+            std::vector<SubdirIndexLoader>& subdirs,
+            const std::map<std::string, std::size_t>& url_to_subdir_idx,
+            const std::vector<solver::libsolv::Priorities>& priorities,
+            const std::string& current_repodata_url,
+            std::map<std::string, solver::libsolv::RepoInfo>& loaded_subdirs_with_shards
+        )
+        {
+            std::optional<solver::libsolv::RepoInfo> result_repo;
+            for (const auto& [channel_url, pkgs] : packages_by_url)
+            {
+                std::string repo_name = subdirs.at(url_to_subdir_idx.at(channel_url)).name();
+                if (loaded_subdirs_with_shards.contains(repo_name))
+                {
+                    continue;
+                }
+
+                auto sorted_pkgs = pkgs;
+                specs::sort_packages_by_version_and_build_desc(sorted_pkgs);
+                auto repo = database.add_repo_from_packages(
+                    sorted_pkgs,
+                    repo_name,
+                    solver::libsolv::PipAsPythonDependency(ctx.add_pip_as_python_dependency)
+                );
+                loaded_subdirs_with_shards.emplace(repo_name, repo);
+                std::size_t idx = url_to_subdir_idx.at(channel_url);
+                database.set_repo_priority(repo, priorities[idx]);
+                if (!result_repo.has_value() || channel_url == current_repodata_url)
+                {
+                    result_repo = std::move(repo);
+                }
+            }
+            return result_repo;
+        }
+
+        /**
+         * Load a single subdir using sharded repodata (only reachable packages).
+         *
+         * Uses the shard index and per-package shards to load just the packages reachable from
+         * ``root_packages`` via dependencies, instead of the full repodata.
+         *
+         * Precondition: the caller must only invoke this when shards are applicable for the
+         * targeted subdir (e.g. sharded repodata is enabled, metadata is up to date, and
+         * ``root_packages`` is non-empty).
+         *
+         * @param ctx Context (use_sharded_repodata, shard TTL, download params, etc.).
+         * @param database Libsolv database to add repos into.
+         * @param root_packages Root package names for reachability (e.g. install specs); may be
+         *                      extended with dependency names discovered in loaded shard packages.
+         * @param subdirs All subdir loaders; ``subdir_idx`` is the one to load.
+         * @param subdir_idx Index of the subdir to load in ``subdirs``.
+         * @param loaded_subdirs_with_shards Subdir names already loaded via shards → their libsolv
+         *        repos (updated; repos are removed before a follow-up shard pass).
+         * @param priorities Repo priorities aligned with ``subdirs``.
+         * @param python_minor_version_for_prefilter Optional python minor for shard record
+         *        prefiltering (from ``prepare_solver_context``).
+         * @param expand_shard_roots_from_loaded_shards When true, extend ``root_packages`` from
+         *        dependency names in loaded shard records (multi-sharded channel sets only).
+         * @return The repo for the requested subdir, or unexpected mamba_error on failure.
+         */
+        auto load_subdir_with_shards(
+            Context& ctx,
+            solver::libsolv::Database& database,
+            std::vector<std::string>& root_packages,
+            std::vector<SubdirIndexLoader>& subdirs,
+            std::size_t subdir_idx,
+            std::map<std::string, solver::libsolv::RepoInfo>& loaded_subdirs_with_shards,
+            const std::vector<solver::libsolv::Priorities>& priorities,
+            std::optional<specs::Version> python_minor_version_for_prefilter,
+            bool expand_shard_roots_from_loaded_shards
+        ) -> expected_t<solver::libsolv::RepoInfo>
+        {
+            auto& subdir = subdirs[subdir_idx];
+            LOG_DEBUG << "Attempting to load subdir with shards: " << subdir.name();
+
+            // Fetch and parse the shard index for the requested subdir (subdir_idx).
+            auto subdir_params = ctx.subdir_download_params();
+            auto shard_index_result = ShardIndexLoader::fetch_and_parse_shard_index(
+                subdir,
+                subdir_params,
+                ctx.authentication_info(),
+                ctx.mirrors,
+                ctx.download_options(),
+                ctx.remote_fetch_params,
+                ctx.repodata_shards_ttl
+            );
+            if (!shard_index_result || !shard_index_result.value().has_value())
+            {
+                LOG_WARNING << "Failed to fetch shard index for " << subdir.name();
+                return tl::unexpected(mamba_error(
+                    "Failed to fetch shard index for " + subdir.name(),
+                    mamba_error_code::subdirdata_not_loaded
+                ));
+            }
+
+            LOG_DEBUG << "Shard index fetched for " << subdir.name();
+            const auto& channel = subdir.channel();
+            std::string current_repodata_url = subdir.repodata_url().str();
+            if (python_minor_version_for_prefilter.has_value())
+            {
+                LOG_DEBUG << "Shard prefilter on python minor version enabled with "
+                          << python_minor_version_for_prefilter.value().to_string();
+            }
+            else
+            {
+                LOG_DEBUG << "Shard prefilter on python minor version disabled.";
+            }
+
+            // For all subdirs sharing the same channel URL, fetch their shard indices and build
+            //    a Shards instance per subdir; collect them into a RepodataSubset.
+            std::vector<Shards> all_shards;
+            std::map<std::string, std::size_t> url_to_subdir_idx;
+            for (std::size_t j = 0; j < subdirs.size(); ++j)
+            {
+                if (subdirs[j].channel().url() == channel.url())
+                {
+                    auto sidx_result = (j == subdir_idx)
+                                           ? std::move(shard_index_result)
+                                           : ShardIndexLoader::fetch_and_parse_shard_index(
+                                                 subdirs[j],
+                                                 subdir_params,
+                                                 ctx.authentication_info(),
+                                                 ctx.mirrors,
+                                                 ctx.download_options(),
+                                                 ctx.remote_fetch_params,
+                                                 ctx.repodata_shards_ttl
+                                             );
+                    if (!sidx_result || !sidx_result.value().has_value())
+                    {
+                        continue;
+                    }
+                    auto si = std::move(sidx_result.value().value());
+                    std::string sdir_url = subdirs[j].repodata_url().str();
+                    all_shards.emplace_back(
+                        std::move(si),
+                        sdir_url,
+                        subdirs[j].channel(),
+                        ctx.authentication_info(),
+                        ctx.remote_fetch_params,
+                        normalize_to_affinity_concurrency(static_cast<int>(ctx.repodata_shards_threads)),
+                        std::cref(ctx.mirrors),
+                        python_minor_version_for_prefilter,
+                        ctx.repodata_shards_ttl
+                    );
+                    url_to_subdir_idx[sdir_url] = j;
+                }
+            }
+
+            // Compute the reachable subset from root_packages (BFS) so only needed shards
+            //    are considered.
+            RepodataSubset subset(std::move(all_shards));
+            subset.reachable(root_packages, "bfs", std::nullopt);
+            LOG_DEBUG << "Reachable subset computed for " << subdir.name() << " ("
+                      << subset.shards().size() << " shards, " << subset.nodes().size() << " nodes)";
+
+            // For each visited node in the subset, visit the corresponding package shard and
+            //    convert records to PackageInfo; collect packages by channel URL. Exceptions
+            //    from individual packages are logged and skipped.
+            auto packages_by_url = build_packages_by_url_from_subset(subset, subdirs, url_to_subdir_idx);
+            if (!packages_by_url)
+            {
+                return tl::unexpected(mamba_error(
+                    "Failed to build package list from shards for " + subdir.name(),
+                    mamba_error_code::subdirdata_not_loaded
+                ));
+            }
+
+            if (expand_shard_roots_from_loaded_shards)
+            {
+                const std::size_t roots_before = root_packages.size();
+                expand_shard_root_packages_from_shard_loaded_packages(
+                    packages_by_url.value(),
+                    root_packages
+                );
+                if (root_packages.size() > roots_before)
+                {
+                    LOG_DEBUG << "Shard root packages expanded by "
+                              << (root_packages.size() - roots_before)
+                              << " name(s) from shard-loaded package metadata.";
+                }
+            }
+
+            // For each channel URL with packages, add a repo to database (unless already in
+            //    loaded_subdirs_with_shards), sort packages by version/build, and set repo
+            //    priority. The repo for the requested subdir's repodata URL is returned on success.
+            std::optional<solver::libsolv::RepoInfo> result_repo = add_repos_from_packages_by_url(
+                ctx,
+                database,
+                packages_by_url.value(),
+                subdirs,
+                url_to_subdir_idx,
+                priorities,
+                current_repodata_url,
+                loaded_subdirs_with_shards
+            );
+            // If no packages were loaded for the requested subdir, return an error.
+            if (result_repo)
+            {
+                LOG_INFO << "Loaded subdir with shards: " << subdir.name();
+                return std::move(*result_repo);
+            }
+            LOG_DEBUG << "No packages loaded from shards for " << subdir.name();
+            return tl::unexpected(
+                mamba_error("No packages for " + subdir.name(), mamba_error_code::subdirdata_not_loaded)
+            );
         }
 
         /**
@@ -831,44 +1004,6 @@ namespace mamba
             }
         }
 
-        std::optional<solver::libsolv::RepoInfo> add_repos_from_packages_by_url(
-            Context& ctx,
-            solver::libsolv::Database& database,
-            const std::map<std::string, std::vector<specs::PackageInfo>>& packages_by_url,
-            std::vector<SubdirIndexLoader>& subdirs,
-            const std::map<std::string, std::size_t>& url_to_subdir_idx,
-            const std::vector<solver::libsolv::Priorities>& priorities,
-            const std::string& current_repodata_url,
-            std::map<std::string, solver::libsolv::RepoInfo>& loaded_subdirs_with_shards
-        )
-        {
-            std::optional<solver::libsolv::RepoInfo> result_repo;
-            for (const auto& [channel_url, pkgs] : packages_by_url)
-            {
-                std::string repo_name = subdirs.at(url_to_subdir_idx.at(channel_url)).name();
-                if (loaded_subdirs_with_shards.contains(repo_name))
-                {
-                    continue;
-                }
-
-                auto sorted_pkgs = pkgs;
-                specs::sort_packages_by_version_and_build_desc(sorted_pkgs);
-                auto repo = database.add_repo_from_packages(
-                    sorted_pkgs,
-                    repo_name,
-                    solver::libsolv::PipAsPythonDependency(ctx.add_pip_as_python_dependency)
-                );
-                loaded_subdirs_with_shards.emplace(repo_name, repo);
-                std::size_t idx = url_to_subdir_idx.at(channel_url);
-                database.set_repo_priority(repo, priorities[idx]);
-                if (!result_repo.has_value() || channel_url == current_repodata_url)
-                {
-                    result_repo = std::move(repo);
-                }
-            }
-            return result_repo;
-        }
-
         void create_mirrors(const specs::Channel& channel, download::mirror_map& mirrors)
         {
             if (!mirrors.has_mirrors(channel.id()))
@@ -884,149 +1019,6 @@ namespace mamba
         }
 
     }  // anonymous namespace
-
-    auto load_subdir_with_shards(
-        Context& ctx,
-        solver::libsolv::Database& database,
-        std::vector<std::string>& root_packages,
-        std::vector<SubdirIndexLoader>& subdirs,
-        std::size_t subdir_idx,
-        std::map<std::string, solver::libsolv::RepoInfo>& loaded_subdirs_with_shards,
-        const std::vector<solver::libsolv::Priorities>& priorities,
-        std::optional<specs::Version> python_minor_version_for_prefilter,
-        bool expand_shard_roots_from_loaded_shards
-    ) -> expected_t<solver::libsolv::RepoInfo>
-    {
-        auto& subdir = subdirs[subdir_idx];
-        LOG_DEBUG << "Attempting to load subdir with shards: " << subdir.name();
-
-        // Fetch and parse the shard index for the requested subdir (subdir_idx).
-        auto subdir_params = ctx.subdir_download_params();
-        auto shard_index_result = ShardIndexLoader::fetch_and_parse_shard_index(
-            subdir,
-            subdir_params,
-            ctx.authentication_info(),
-            ctx.mirrors,
-            ctx.download_options(),
-            ctx.remote_fetch_params,
-            ctx.repodata_shards_ttl
-        );
-        if (!shard_index_result || !shard_index_result.value().has_value())
-        {
-            LOG_WARNING << "Failed to fetch shard index for " << subdir.name();
-            return tl::unexpected(mamba_error(
-                "Failed to fetch shard index for " + subdir.name(),
-                mamba_error_code::subdirdata_not_loaded
-            ));
-        }
-
-        LOG_DEBUG << "Shard index fetched for " << subdir.name();
-        const auto& channel = subdir.channel();
-        std::string current_repodata_url = subdir.repodata_url().str();
-        if (python_minor_version_for_prefilter.has_value())
-        {
-            LOG_DEBUG << "Shard prefilter on python minor version enabled with "
-                      << python_minor_version_for_prefilter.value().to_string();
-        }
-        else
-        {
-            LOG_DEBUG << "Shard prefilter on python minor version disabled.";
-        }
-
-        // For all subdirs sharing the same channel URL, fetch their shard indices and build
-        //    a Shards instance per subdir; collect them into a RepodataSubset.
-        std::vector<Shards> all_shards;
-        std::map<std::string, std::size_t> url_to_subdir_idx;
-        for (std::size_t j = 0; j < subdirs.size(); ++j)
-        {
-            if (subdirs[j].channel().url() == channel.url())
-            {
-                auto sidx_result = (j == subdir_idx) ? std::move(shard_index_result)
-                                                     : ShardIndexLoader::fetch_and_parse_shard_index(
-                                                           subdirs[j],
-                                                           subdir_params,
-                                                           ctx.authentication_info(),
-                                                           ctx.mirrors,
-                                                           ctx.download_options(),
-                                                           ctx.remote_fetch_params,
-                                                           ctx.repodata_shards_ttl
-                                                       );
-                if (!sidx_result || !sidx_result.value().has_value())
-                {
-                    continue;
-                }
-                auto si = std::move(sidx_result.value().value());
-                std::string sdir_url = subdirs[j].repodata_url().str();
-                all_shards.emplace_back(
-                    std::move(si),
-                    sdir_url,
-                    subdirs[j].channel(),
-                    ctx.authentication_info(),
-                    ctx.remote_fetch_params,
-                    normalize_to_affinity_concurrency(static_cast<int>(ctx.repodata_shards_threads)),
-                    std::cref(ctx.mirrors),
-                    python_minor_version_for_prefilter,
-                    ctx.repodata_shards_ttl
-                );
-                url_to_subdir_idx[sdir_url] = j;
-            }
-        }
-
-        // Compute the reachable subset from root_packages (BFS) so only needed shards
-        //    are considered.
-        RepodataSubset subset(std::move(all_shards));
-        subset.reachable(root_packages, "bfs", std::nullopt);
-        LOG_DEBUG << "Reachable subset computed for " << subdir.name() << " ("
-                  << subset.shards().size() << " shards, " << subset.nodes().size() << " nodes)";
-
-        // For each visited node in the subset, visit the corresponding package shard and
-        //    convert records to PackageInfo; collect packages by channel URL. Exceptions
-        //    from individual packages are logged and skipped.
-        auto packages_by_url = build_packages_by_url_from_subset(subset, subdirs, url_to_subdir_idx);
-        if (!packages_by_url)
-        {
-            return tl::unexpected(mamba_error(
-                "Failed to build package list from shards for " + subdir.name(),
-                mamba_error_code::subdirdata_not_loaded
-            ));
-        }
-
-        if (expand_shard_roots_from_loaded_shards)
-        {
-            const std::size_t roots_before = root_packages.size();
-            expand_shard_root_packages_from_shard_loaded_packages(packages_by_url.value(), root_packages);
-            if (root_packages.size() > roots_before)
-            {
-                LOG_DEBUG << "Shard root packages expanded by "
-                          << (root_packages.size() - roots_before)
-                          << " name(s) from shard-loaded package metadata.";
-            }
-        }
-
-        // For each channel URL with packages, add a repo to database (unless already in
-        //    loaded_subdirs_with_shards), sort packages by version/build, and set repo
-        //    priority. The repo for the requested subdir's repodata URL is returned on success.
-        std::optional<solver::libsolv::RepoInfo> result_repo = add_repos_from_packages_by_url(
-            ctx,
-            database,
-            packages_by_url.value(),
-            subdirs,
-            url_to_subdir_idx,
-            priorities,
-            current_repodata_url,
-            loaded_subdirs_with_shards
-        );
-        // If no packages were loaded for the requested subdir, return an error.
-        if (result_repo)
-        {
-            LOG_INFO << "Loaded subdir with shards: " << subdir.name();
-            return std::move(*result_repo);
-        }
-        LOG_DEBUG << "No packages loaded from shards for " << subdir.name();
-        return tl::unexpected(
-            mamba_error("No packages for " + subdir.name(), mamba_error_code::subdirdata_not_loaded)
-        );
-    }
 
     namespace
     {

--- a/libmamba/src/api/channel_loader.cpp
+++ b/libmamba/src/api/channel_loader.cpp
@@ -35,6 +35,43 @@
 
 namespace mamba
 {
+    /**
+     * Load a single subdir using sharded repodata (only reachable packages).
+     *
+     * Uses the shard index and per-package shards to load just the packages reachable from
+     * ``root_packages`` via dependencies, instead of the full repodata.
+     *
+     * Precondition: the caller must only invoke this when shards are applicable for the
+     * targeted subdir (e.g. sharded repodata is enabled, metadata is up to date, and
+     * ``root_packages`` is non-empty).
+     *
+     * @param ctx Context (use_sharded_repodata, shard TTL, download params, etc.).
+     * @param database Libsolv database to add repos into.
+     * @param root_packages Root package names for reachability (e.g. install specs); may be
+     *                      extended with dependency names discovered in loaded shard packages.
+     * @param subdirs All subdir loaders; ``subdir_idx`` is the one to load.
+     * @param subdir_idx Index of the subdir to load in ``subdirs``.
+     * @param loaded_subdirs_with_shards Subdir names already loaded via shards → their libsolv
+     *        repos (updated; repos are removed before a follow-up shard pass).
+     * @param priorities Repo priorities aligned with ``subdirs``.
+     * @param python_minor_version_for_prefilter Optional python minor for shard record
+     *        prefiltering (from ``prepare_solver_context``).
+     * @param expand_shard_roots_from_loaded_shards When true, extend ``root_packages`` from
+     *        dependency names in loaded shard records (multi-sharded channel sets only).
+     * @return The repo for the requested subdir, or unexpected mamba_error on failure.
+     */
+    auto load_subdir_with_shards(
+        Context& ctx,
+        solver::libsolv::Database& database,
+        std::vector<std::string>& root_packages,
+        std::vector<SubdirIndexLoader>& subdirs,
+        std::size_t subdir_idx,
+        std::map<std::string, solver::libsolv::RepoInfo>& loaded_subdirs_with_shards,
+        const std::vector<solver::libsolv::Priorities>& priorities,
+        std::optional<specs::Version> python_minor_version_for_prefilter,
+        bool expand_shard_roots_from_loaded_shards
+    ) -> expected_t<solver::libsolv::RepoInfo>;
+
     namespace
     {
         [[nodiscard]] auto count_distinct_sharded_channel_urls(
@@ -702,9 +739,8 @@ namespace mamba
                 LOG_DEBUG << "Shard root packages expanded by "
                           << (root_packages.size() - roots_after_full_repodata_pass)
                           << " additional name(s) during shard pass; re-running shard pass once.";
-                for (auto& [subdir_name, repo] : loaded_subdirs_with_shards)
+                for (auto& [_, repo] : loaded_subdirs_with_shards)
                 {
-                    static_cast<void>(subdir_name);
                     database.remove_repo(std::move(repo));
                 }
                 loaded_subdirs_with_shards.clear();

--- a/libmamba/src/api/channel_loader.cpp
+++ b/libmamba/src/api/channel_loader.cpp
@@ -37,6 +37,22 @@ namespace mamba
 {
     namespace
     {
+        [[nodiscard]] auto count_distinct_sharded_channel_urls(
+            const std::vector<SubdirIndexLoader>& subdirs,
+            std::size_t repodata_shards_ttl
+        ) -> std::size_t
+        {
+            std::set<std::string> urls;
+            for (const auto& subdir : subdirs)
+            {
+                if (subdir.metadata().has_up_to_date_shards(repodata_shards_ttl))
+                {
+                    urls.insert(subdir.channel().url().str());
+                }
+            }
+            return urls.size();
+        }
+
         auto shorten_status_label(std::string label) -> std::string
         {
             if (label.length() > 85)
@@ -660,10 +676,16 @@ namespace mamba
                               << " name(s) from full-repodata subdirs (cross-channel closure seeds).";
                 }
                 roots_after_full_repodata_pass = root_packages.size();
-                // Shard-metadata closure (#4245) is only for all-sharded channel sets (e.g.
-                // emscripten-forge + conda-forge). Flat channels (e.g. bioconda) already seed
-                // roots via expand_shard_root_packages_from_full_repodata_repos above.
-                expand_shard_roots_from_loaded_shards = full_repos_for_shard_roots.empty();
+                // Shard-metadata closure (#4245) is for multiple sharded channels (e.g.
+                // emscripten-forge + conda-forge). Skip when flat channels were loaded (bioconda
+                // seeds roots via expand_shard_root_packages_from_full_repodata_repos) or when only
+                // one sharded channel exists (conda-forge alone: shard BFS already crosses
+                // subdirs).
+                expand_shard_roots_from_loaded_shards = full_repos_for_shard_roots.empty()
+                                                        && count_distinct_sharded_channel_urls(
+                                                               subdirs,
+                                                               ctx.repodata_shards_ttl
+                                                           ) > 1;
             }
 
             for (std::size_t i = 0; i < subdirs.size(); ++i)

--- a/libmamba/src/api/channel_loader.cpp
+++ b/libmamba/src/api/channel_loader.cpp
@@ -303,6 +303,7 @@ namespace mamba
             const SubdirDownloadParams& subdir_params,
             const std::vector<solver::libsolv::Priorities>& priorities,
             std::optional<specs::Version> python_minor_version_for_prefilter,
+            bool expand_shard_roots_from_loaded_shards,
             bool* used_flat_repodata,
             std::optional<std::chrono::steady_clock::time_point>* flat_repodata_started_at
         )
@@ -350,7 +351,8 @@ namespace mamba
                     subdir_idx,
                     loaded_subdirs_with_shards,
                     priorities,
-                    python_minor_version_for_prefilter
+                    python_minor_version_for_prefilter,
+                    expand_shard_roots_from_loaded_shards
                 );
 
                 if (!res)
@@ -549,6 +551,7 @@ namespace mamba
             );
             std::size_t roots_after_full_repodata_pass = root_packages.size();
             std::vector<solver::libsolv::RepoInfo> full_repos_for_shard_roots;
+            bool expand_shard_roots_from_loaded_shards = false;
             bool used_flat_repodata = false;
             std::optional<std::chrono::steady_clock::time_point> flat_repodata_started_at;
 
@@ -598,6 +601,7 @@ namespace mamba
                     subdir_params,
                     priorities,
                     python_minor_version_for_prefilter,
+                    expand_shard_roots_from_loaded_shards,
                     &used_flat_repodata,
                     &flat_repodata_started_at
                 );
@@ -656,6 +660,10 @@ namespace mamba
                               << " name(s) from full-repodata subdirs (cross-channel closure seeds).";
                 }
                 roots_after_full_repodata_pass = root_packages.size();
+                // Shard-metadata closure (#4245) is only for all-sharded channel sets (e.g.
+                // emscripten-forge + conda-forge). Flat channels (e.g. bioconda) already seed
+                // roots via expand_shard_root_packages_from_full_repodata_repos above.
+                expand_shard_roots_from_loaded_shards = full_repos_for_shard_roots.empty();
             }
 
             for (std::size_t i = 0; i < subdirs.size(); ++i)
@@ -664,8 +672,10 @@ namespace mamba
             }
 
             // One extra shard pass when shard loads discovered new root names (cross-channel
-            // closure). Skipped on pure-flat channel sets (#4277) and when nothing new appeared.
-            if (shard_then_expand && root_packages.size() > roots_after_full_repodata_pass)
+            // closure). Skipped on pure-flat channel sets (#4277), when flat channels were
+            // loaded in the first pass (e.g. bioconda), and when nothing new appeared.
+            if (expand_shard_roots_from_loaded_shards
+                && root_packages.size() > roots_after_full_repodata_pass)
             {
                 LOG_DEBUG << "Shard root packages expanded by "
                           << (root_packages.size() - roots_after_full_repodata_pass)
@@ -675,6 +685,12 @@ namespace mamba
                 {
                     try_load(i, /*full_repodata_only_pass=*/false);
                 }
+            }
+            else if (shard_then_expand && !expand_shard_roots_from_loaded_shards
+                     && root_packages.size() > roots_after_full_repodata_pass)
+            {
+                LOG_DEBUG << "Skipping follow-up shard pass: flat (non-sharded) channel(s) "
+                             "already loaded; shard-metadata closure not needed.";
             }
 
             if (used_flat_repodata)
@@ -814,7 +830,8 @@ namespace mamba
         std::size_t subdir_idx,
         std::set<std::string>& loaded_subdirs_with_shards,
         const std::vector<solver::libsolv::Priorities>& priorities,
-        std::optional<specs::Version> python_minor_version_for_prefilter
+        std::optional<specs::Version> python_minor_version_for_prefilter,
+        bool expand_shard_roots_from_loaded_shards
     ) -> expected_t<solver::libsolv::RepoInfo>
     {
         auto& subdir = subdirs[subdir_idx];
@@ -911,12 +928,16 @@ namespace mamba
             ));
         }
 
-        const std::size_t roots_before = root_packages.size();
-        expand_shard_root_packages_from_shard_loaded_packages(packages_by_url.value(), root_packages);
-        if (root_packages.size() > roots_before)
+        if (expand_shard_roots_from_loaded_shards)
         {
-            LOG_DEBUG << "Shard root packages expanded by " << (root_packages.size() - roots_before)
-                      << " name(s) from shard-loaded package metadata.";
+            const std::size_t roots_before = root_packages.size();
+            expand_shard_root_packages_from_shard_loaded_packages(packages_by_url.value(), root_packages);
+            if (root_packages.size() > roots_before)
+            {
+                LOG_DEBUG << "Shard root packages expanded by "
+                          << (root_packages.size() - roots_before)
+                          << " name(s) from shard-loaded package metadata.";
+            }
         }
 
         // For each channel URL with packages, add a repo to database (unless already in

--- a/libmamba/src/api/channel_loader.cpp
+++ b/libmamba/src/api/channel_loader.cpp
@@ -336,6 +336,46 @@ namespace mamba
         }
 
         /**
+         * Extend \p root_packages with dependency names from shard-loaded package records.
+         *
+         * Only walks packages already fetched for the current shard subset (typically tens to
+         * hundreds of records), not full repodata. Used for cross-channel / cross-subdir shard
+         * closure (#4245). Skipped when flat channels were loaded first (e.g. bioconda) or when
+         * only one channel has shards (conda-forge alone already closes over subdirs in one BFS).
+         */
+        void expand_shard_root_packages_from_shard_loaded_packages(
+            const std::map<std::string, std::vector<specs::PackageInfo>>& packages_by_url,
+            std::vector<std::string>& root_packages
+        )
+        {
+            std::unordered_set<std::string> seen(root_packages.begin(), root_packages.end());
+            auto add_from_spec = [&](const std::string& dep_str)
+            {
+                if (auto name = specs::MatchSpec::extract_name(dep_str))
+                {
+                    if (!name->empty() && *name != "*" && seen.insert(*name).second)
+                    {
+                        root_packages.push_back(*name);
+                    }
+                }
+            };
+            for (const auto& [url, packages] : packages_by_url)
+            {
+                for (const auto& pkg : packages)
+                {
+                    for (const auto& dep : pkg.dependencies)
+                    {
+                        add_from_spec(dep);
+                    }
+                    for (const auto& constrain : pkg.constrains)
+                    {
+                        add_from_spec(constrain);
+                    }
+                }
+            }
+        }
+
+        /**
          * Load a single subdir using sharded repodata (only reachable packages).
          *
          * Uses the shard index and per-package shards to load just the packages reachable from
@@ -1169,38 +1209,6 @@ namespace mamba
             for (const specs::Channel& channel : channel_context.make_channel(pkg_info.channel))
             {
                 create_mirrors(channel, context.mirrors);
-            }
-        }
-    }
-
-    void expand_shard_root_packages_from_shard_loaded_packages(
-        const std::map<std::string, std::vector<specs::PackageInfo>>& packages_by_url,
-        std::vector<std::string>& root_packages
-    )
-    {
-        std::unordered_set<std::string> seen(root_packages.begin(), root_packages.end());
-        auto add_from_spec = [&](const std::string& dep_str)
-        {
-            if (auto name = specs::MatchSpec::extract_name(dep_str))
-            {
-                if (!name->empty() && *name != "*" && seen.insert(*name).second)
-                {
-                    root_packages.push_back(*name);
-                }
-            }
-        };
-        for (const auto& [url, packages] : packages_by_url)
-        {
-            for (const auto& pkg : packages)
-            {
-                for (const auto& dep : pkg.dependencies)
-                {
-                    add_from_spec(dep);
-                }
-                for (const auto& constrain : pkg.constrains)
-                {
-                    add_from_spec(constrain);
-                }
             }
         }
     }

--- a/libmamba/src/api/channel_loader.cpp
+++ b/libmamba/src/api/channel_loader.cpp
@@ -296,7 +296,7 @@ namespace mamba
         expected_t<solver::libsolv::RepoInfo> load_single_subdir(
             Context& ctx,
             solver::libsolv::Database& database,
-            const std::vector<std::string>& root_packages,
+            std::vector<std::string>& root_packages,
             std::vector<SubdirIndexLoader>& subdirs,
             std::size_t subdir_idx,
             std::set<std::string>& loaded_subdirs_with_shards,
@@ -547,6 +547,7 @@ namespace mamba
                 subdirs,
                 ctx.repodata_shards_ttl
             );
+            std::size_t roots_after_full_repodata_pass = root_packages.size();
             std::vector<solver::libsolv::RepoInfo> full_repos_for_shard_roots;
             bool used_flat_repodata = false;
             std::optional<std::chrono::steady_clock::time_point> flat_repodata_started_at;
@@ -654,11 +655,26 @@ namespace mamba
                               << (root_packages.size() - roots_before)
                               << " name(s) from full-repodata subdirs (cross-channel closure seeds).";
                 }
+                roots_after_full_repodata_pass = root_packages.size();
             }
 
             for (std::size_t i = 0; i < subdirs.size(); ++i)
             {
                 try_load(i, /*full_repodata_only_pass=*/false);
+            }
+
+            // One extra shard pass when shard loads discovered new root names (cross-channel
+            // closure). Skipped on pure-flat channel sets (#4277) and when nothing new appeared.
+            if (shard_then_expand && root_packages.size() > roots_after_full_repodata_pass)
+            {
+                LOG_DEBUG << "Shard root packages expanded by "
+                          << (root_packages.size() - roots_after_full_repodata_pass)
+                          << " additional name(s) during shard pass; re-running shard pass once.";
+                loaded_subdirs_with_shards.clear();
+                for (std::size_t i = 0; i < subdirs.size(); ++i)
+                {
+                    try_load(i, /*full_repodata_only_pass=*/false);
+                }
             }
 
             if (used_flat_repodata)
@@ -793,7 +809,7 @@ namespace mamba
     auto load_subdir_with_shards(
         Context& ctx,
         solver::libsolv::Database& database,
-        const std::vector<std::string>& root_packages,
+        std::vector<std::string>& root_packages,
         std::vector<SubdirIndexLoader>& subdirs,
         std::size_t subdir_idx,
         std::set<std::string>& loaded_subdirs_with_shards,
@@ -893,6 +909,14 @@ namespace mamba
                 "Failed to build package list from shards for " + subdir.name(),
                 mamba_error_code::subdirdata_not_loaded
             ));
+        }
+
+        const std::size_t roots_before = root_packages.size();
+        expand_shard_root_packages_from_shard_loaded_packages(packages_by_url.value(), root_packages);
+        if (root_packages.size() > roots_before)
+        {
+            LOG_DEBUG << "Shard root packages expanded by " << (root_packages.size() - roots_before)
+                      << " name(s) from shard-loaded package metadata.";
         }
 
         // For each channel URL with packages, add a repo to database (unless already in
@@ -1069,6 +1093,38 @@ namespace mamba
             for (const specs::Channel& channel : channel_context.make_channel(pkg_info.channel))
             {
                 create_mirrors(channel, context.mirrors);
+            }
+        }
+    }
+
+    void expand_shard_root_packages_from_shard_loaded_packages(
+        const std::map<std::string, std::vector<specs::PackageInfo>>& packages_by_url,
+        std::vector<std::string>& root_packages
+    )
+    {
+        std::unordered_set<std::string> seen(root_packages.begin(), root_packages.end());
+        auto add_from_spec = [&](const std::string& dep_str)
+        {
+            if (auto name = specs::MatchSpec::extract_name(dep_str))
+            {
+                if (!name->empty() && *name != "*" && seen.insert(*name).second)
+                {
+                    root_packages.push_back(*name);
+                }
+            }
+        };
+        for (const auto& [url, packages] : packages_by_url)
+        {
+            for (const auto& pkg : packages)
+            {
+                for (const auto& dep : pkg.dependencies)
+                {
+                    add_from_spec(dep);
+                }
+                for (const auto& constrain : pkg.constrains)
+                {
+                    add_from_spec(constrain);
+                }
             }
         }
     }

--- a/libmamba/src/api/channel_loader.cpp
+++ b/libmamba/src/api/channel_loader.cpp
@@ -315,7 +315,7 @@ namespace mamba
             std::vector<std::string>& root_packages,
             std::vector<SubdirIndexLoader>& subdirs,
             std::size_t subdir_idx,
-            std::set<std::string>& loaded_subdirs_with_shards,
+            std::map<std::string, solver::libsolv::RepoInfo>& loaded_subdirs_with_shards,
             const SubdirDownloadParams& subdir_params,
             const std::vector<solver::libsolv::Priorities>& priorities,
             std::optional<specs::Version> python_minor_version_for_prefilter,
@@ -557,7 +557,7 @@ namespace mamba
             std::optional<specs::Version> python_minor_version_for_prefilter
         )
         {
-            std::set<std::string> loaded_subdirs_with_shards;
+            std::map<std::string, solver::libsolv::RepoInfo> loaded_subdirs_with_shards;
             bool loading_failed = false;
             const bool shard_then_expand = should_shard_then_expand_roots(
                 ctx.use_sharded_repodata,
@@ -702,6 +702,11 @@ namespace mamba
                 LOG_DEBUG << "Shard root packages expanded by "
                           << (root_packages.size() - roots_after_full_repodata_pass)
                           << " additional name(s) during shard pass; re-running shard pass once.";
+                for (auto& [subdir_name, repo] : loaded_subdirs_with_shards)
+                {
+                    static_cast<void>(subdir_name);
+                    database.remove_repo(std::move(repo));
+                }
                 loaded_subdirs_with_shards.clear();
                 for (std::size_t i = 0; i < subdirs.size(); ++i)
                 {
@@ -798,7 +803,7 @@ namespace mamba
             const std::map<std::string, std::size_t>& url_to_subdir_idx,
             const std::vector<solver::libsolv::Priorities>& priorities,
             const std::string& current_repodata_url,
-            std::set<std::string>& loaded_subdirs_with_shards
+            std::map<std::string, solver::libsolv::RepoInfo>& loaded_subdirs_with_shards
         )
         {
             std::optional<solver::libsolv::RepoInfo> result_repo;
@@ -809,7 +814,6 @@ namespace mamba
                 {
                     continue;
                 }
-                loaded_subdirs_with_shards.insert(repo_name);
 
                 auto sorted_pkgs = pkgs;
                 specs::sort_packages_by_version_and_build_desc(sorted_pkgs);
@@ -818,6 +822,7 @@ namespace mamba
                     repo_name,
                     solver::libsolv::PipAsPythonDependency(ctx.add_pip_as_python_dependency)
                 );
+                loaded_subdirs_with_shards.emplace(repo_name, repo);
                 std::size_t idx = url_to_subdir_idx.at(channel_url);
                 database.set_repo_priority(repo, priorities[idx]);
                 if (!result_repo.has_value() || channel_url == current_repodata_url)
@@ -850,7 +855,7 @@ namespace mamba
         std::vector<std::string>& root_packages,
         std::vector<SubdirIndexLoader>& subdirs,
         std::size_t subdir_idx,
-        std::set<std::string>& loaded_subdirs_with_shards,
+        std::map<std::string, solver::libsolv::RepoInfo>& loaded_subdirs_with_shards,
         const std::vector<solver::libsolv::Priorities>& priorities,
         std::optional<specs::Version> python_minor_version_for_prefilter,
         bool expand_shard_roots_from_loaded_shards

--- a/libmamba/tests/src/core/test_sharded_repodata_integration.cpp
+++ b/libmamba/tests/src/core/test_sharded_repodata_integration.cpp
@@ -726,6 +726,57 @@ TEST_CASE("Sharded repodata - solve xeus-python-dev specs on emscripten", "[mamb
     }
 }
 
+TEST_CASE(
+    "Sharded repodata - solve xeus-python on emscripten-forge-dev and conda-forge",
+    "[mamba::core][sharded][.integration][issue_4245]"
+)
+{
+    // Regression: cross-channel shard root expansion (noarch deps on conda-forge).
+    auto& ctx = mambatests::context();
+    const std::vector<std::string> saved_channels = ctx.channels;
+    const std::string saved_platform = ctx.platform;
+    const bool saved_use_shards = ctx.use_sharded_repodata;
+    const bool saved_offline = ctx.offline;
+    on_scope_exit restore_ctx{ [&]
+                               {
+                                   ctx.channels = saved_channels;
+                                   ctx.platform = saved_platform;
+                                   ctx.use_sharded_repodata = saved_use_shards;
+                                   ctx.offline = saved_offline;
+                               } };
+
+    ctx.channels = {
+        "https://prefix.dev/emscripten-forge-dev",
+        "conda-forge",
+    };
+    ctx.platform = "emscripten-wasm32";
+    ctx.use_sharded_repodata = true;
+    ctx.offline = false;
+
+    const TemporaryDirectory tmp_dir;
+    const fs::u8path cache_dir = tmp_dir.path() / "cache";
+    fs::create_directories(cache_dir);
+
+    auto channel_context = ChannelContext::make_conda_compatible(ctx);
+    init_channels(ctx, channel_context);
+
+    const std::vector<std::string> specs = { "python=3.13", "xeus-python" };
+
+    auto sharded_solution = solve_environment(ctx, channel_context, specs, true, cache_dir);
+    REQUIRE(sharded_solution.has_value());
+
+    std::unordered_set<std::string> solved_names;
+    for (const auto& pkg : sharded_solution->packages())
+    {
+        solved_names.insert(pkg.name);
+    }
+
+    REQUIRE(solved_names.count("python") == 1);
+    REQUIRE(solved_names.count("xeus-python") == 1);
+    REQUIRE(solved_names.count("xeus-python-shell-lite") == 1);
+    REQUIRE(solved_names.count("ipython") == 1);
+}
+
 TEST_CASE("Sharded repodata - solve pyjs-obspy env specs on emscripten", "[mamba::core][sharded][.integration]")
 {
     auto& ctx = mambatests::context();

--- a/micromamba/tests/test_create.py
+++ b/micromamba/tests/test_create.py
@@ -918,6 +918,7 @@ def test_clone_environment_with_many_packages(tmp_home, tmp_root_prefix, tmp_pat
 
 # Only run this test on Linux, as it is the only platform where xeus-cling
 # (which is part of the environment) is available.
+@pytest.mark.timeout(20)
 @pytest.mark.skipif(platform.system() != "Linux", reason="Test only available on Linux")
 @pytest.mark.parametrize("shared_pkgs_dirs", [True], indirect=True)
 def test_env_logging_overhead_regression(tmp_home, tmp_root_prefix, tmp_path):

--- a/micromamba/tests/test_create.py
+++ b/micromamba/tests/test_create.py
@@ -918,7 +918,6 @@ def test_clone_environment_with_many_packages(tmp_home, tmp_root_prefix, tmp_pat
 
 # Only run this test on Linux, as it is the only platform where xeus-cling
 # (which is part of the environment) is available.
-@pytest.mark.timeout(20)
 @pytest.mark.skipif(platform.system() != "Linux", reason="Test only available on Linux")
 @pytest.mark.parametrize("shared_pkgs_dirs", [True], indirect=True)
 def test_env_logging_overhead_regression(tmp_home, tmp_root_prefix, tmp_path):


### PR DESCRIPTION
# Description: Reintroduce cross-channel expansion

When sharded repodata is enabled and at least one channel has shards, channel loading runs in two phases:

1. **Flat-first pass** — subdirs **without** a shard index (e.g. **bioconda**) which loads the full `repodata.json`.
2. **Shard pass** — subdirs **with** shards (e.g. **conda-forge**, **emscripten-forge-dev**) load only shards reachable from `root_packages`.

### Flat channels: `expand_shard_root_packages_from_full_repodata_repos`

After the flat-first pass, dependency names reachable from the current roots are collected from those **full-repodata** repos (indexed BFS by package name). That extends `root_packages` before the shard pass so sharded channels (e.g. conda-forge) can fetch the right shards when a flat channel already contributed the closure (typical **conda-forge + bioconda** case, e.g. omni env).

### All-sharded channels: `expand_shard_root_packages_from_shard_loaded_packages`

When **no** flat channel was loaded in the first pass (`full_repos_for_shard_roots` is empty), shard-loaded package metadata is used to extend `root_packages` and, if needed, **one** extra shard pass runs. That fixes **shard-only** cross-channel / cross-subdir cases (e.g. **xeus-python** on emscripten-forge-dev with **noarch** deps on conda-forge) where flat repodata never ran.

### Why shard-metadata closure is skipped when flat channels are present?

If bioconda (or any non-sharded channel) was already loaded flat, roots are seeded via `expand_shard_root_packages_from_full_repodata_repos`. Running shard-metadata expansion and a follow-up shard reload on top of that would duplicate work and can explode cost (large env files + conda-forge shards). So `expand_shard_root_packages_from_shard_loaded_packages` and the second shard pass are **disabled** whenever the flat-first pass loaded at least one repo.

Pure flat channel sets still skip the whole path via `should_shard_then_expand_roots()` (no shards at all).

---

Also adapt the visibility of some functions.

## Type of Change

- [x] Bugfix
- [ ] Feature / enhancement
- [ ] CI / Documentation
- [ ] Maintenance

## Checklist

- [x] My code follows the general style and conventions of the codebase, ensuring consistency
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have run `pre-commit run --all` locally in the source folder and confirmed that there are no linter errors.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
