### PR TITLE
fix: Avoid download busy-spin with parallel transfers

### DIFF
--- a/libmamba/src/download/downloader.cpp
+++ b/libmamba/src/download/downloader.cpp
@@ -1385,7 +1385,11 @@ namespace mamba::download
     {
         std::size_t still_running = m_curl_handle.perform();
 
-        if (still_running == m_waiting_count)
+        // Wait whenever transfers are active, not only when all pending downloads
+        // have been started. libcurl may perform DNS and other work on background
+        // threads; without yielding here the main thread can starve them (e.g. under
+        // SCHED_FIFO), leaving still_running unchanged indefinitely.
+        if (still_running > 0)
         {
             m_curl_handle.wait(m_curl_handle.get_timeout());
         }


### PR DESCRIPTION
# Description

Fix #4306.

## Type of Change

<!-- Please skip this part if you are already using conventional commit keywords in the PR title. -->

- [x] Bugfix
- [ ] Feature / enhancement
- [ ] CI / Documentation
- [ ] Maintenance

## Checklist

- [x] My code follows the general style and conventions of the codebase, ensuring consistency
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have run `pre-commit run --all` locally in the source folder and confirmed that there are no linter errors.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
