### PR TITLE
maint: Require at least spdlog 1.16.0 for micromamba

### DIFF
--- a/.github/workflows/static_build.yml
+++ b/.github/workflows/static_build.yml
@@ -171,7 +171,7 @@ jobs:
             cpp-expected
             nlohmann_json
             simdjson-static>=3.3.0
-            spdlog
+            spdlog>=1.16.0
             fmt>=11.1.0
             yaml-cpp-static>=0.8.0
             libsolv-static>=0.7.24

--- a/dev/environment-micromamba-static.yml
+++ b/dev/environment-micromamba-static.yml
@@ -16,7 +16,7 @@ dependencies:
   - cpp-expected
   - nlohmann_json
   - simdjson-static >=3.3.0
-  - spdlog
+  - spdlog >=1.16.0
   - fmt >=11.1.0
   - libsolv-static >=0.7.24
   - yaml-cpp-static >=0.8.0


### PR DESCRIPTION
# Description

Prevents old builds of spdlog to be picked when newer builds of `fmt` are published, due to the absence (or due to lenient or invalid) runtime requirements on `fmt` for those builds of `spdlog`.

## Type of Change

<!-- Please skip this part if you are already using conventional commit keywords in the PR title. -->

- [ ] Bugfix
- [ ] Feature / enhancement
- [ ] CI / Documentation
- [x] Maintenance

## Checklist

- [x] My code follows the general style and conventions of the codebase, ensuring consistency
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have run `pre-commit run --all` locally in the source folder and confirmed that there are no linter errors.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
