### PR TITLE
fix: prompts should act as if `--yes` was used when `--json` or `--quiet`

### DIFF
--- a/libmamba/src/api/configuration.cpp
+++ b/libmamba/src/api/configuration.cpp
@@ -1632,7 +1632,8 @@ namespace mamba
                    .set_post_merge_hook<ChannelPriority>(
                        [&](ChannelPriority& value)
                        {
-                           m_context.solver_flags.strict_repo_priority = (value == ChannelPriority::Strict);
+                           m_context.solver_flags
+                               .strict_repo_priority = (value == ChannelPriority::Strict);
                        }
                    ));
 
@@ -1974,7 +1975,9 @@ namespace mamba
                        }
                    )
                    .set_env_var_names()
-                   .description("Report all output as json"));
+                   .description(
+                       "Report all output as json. Implicitly bypasses prompts as if `--yes` was used."
+                   ));
 
         insert(Configurable("changeps1", &m_context.change_ps1)
                    .group("Output, Prompt and Flow Control")
@@ -2062,7 +2065,9 @@ namespace mamba
                            }
                        }
                    )
-                   .description("Set quiet mode (print less output)"));
+                   .description(
+                       "Set quiet mode (print less output). Implicitly bypasses prompts as if `--yes` was used."
+                   ));
 
         insert(Configurable("verbose", 0)
                    .group("Output, Prompt and Flow Control")

--- a/libmamba/src/api/configuration.cpp
+++ b/libmamba/src/api/configuration.cpp
@@ -1632,8 +1632,7 @@ namespace mamba
                    .set_post_merge_hook<ChannelPriority>(
                        [&](ChannelPriority& value)
                        {
-                           m_context.solver_flags
-                               .strict_repo_priority = (value == ChannelPriority::Strict);
+                           m_context.solver_flags.strict_repo_priority = (value == ChannelPriority::Strict);
                        }
                    ));
 

--- a/libmamba/src/core/output.cpp
+++ b/libmamba/src/core/output.cpp
@@ -500,7 +500,8 @@ namespace mamba
 
     bool Console::prompt(std::string_view message, char fallback, std::istream& input_stream)
     {
-        if (instance().context().always_yes)
+        auto& context = instance().context();
+        if (context.always_yes or context.output_params.json or context.output_params.quiet)
         {
             return true;
         }


### PR DESCRIPTION
# Description

When `--json` or `--quiet` are used, we expect exclusively a JSON output or nothing, respectively. Before this change, prompts (confirmations mostly) are still visible in the standard ouput when these flags are used.
After this change, prompts will implicitly act as if `--yes` was used if `--json` or `--quiet` are used.

## Type of Change

<!-- Please skip this part if you are already using conventional commit keywords in the PR title. -->

- [x] Bugfix
- [ ] Feature / enhancement
- [ ] CI / Documentation
- [ ] Maintenance

## Checklist

- [x] My code follows the general style and conventions of the codebase, ensuring consistency
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have run `pre-commit run --all` locally in the source folder and confirmed that there are no linter errors.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
