### PR TITLE
fix: Support dotless versions in wheels' filenames

### DIFF
--- a/libmamba/src/specs/package_info.cpp
+++ b/libmamba/src/specs/package_info.cpp
@@ -166,35 +166,32 @@ namespace mamba::specs
                     out.version = tail;
                     // The head is the name
                     out.name = head.value();  // There may be '-' in the name
-
-                    // Wheels lack `build` info in filename. See issue #4095.
-                    out.defaulted_keys.assign(
-                        wheel_targz_defaulted_keys.begin(),
-                        wheel_targz_defaulted_keys.end()
-                    );
                 }
                 else
                 {
-                    // The previous tail is the optional build tag
-                    std::tie(head, tail) = util::rsplit_once(head.value(), '-');
-                    // The tail is the version
-                    out.version = tail;
-                    if (!head.has_value())
+                    // The tail may be the version (no build tag) or an optional build tag.
+                    // Versions without dots (e.g. pywin32-312) are indistinguishable from
+                    // build tags by this property alone; check whether head still splits.
+                    auto [name_head, version_candidate] = util::rsplit_once(head.value(), '-');
+                    if (!name_head.has_value())
                     {
-                        return make_unexpected_parse(
-                            fmt::format(R"(Missing name in filename "{}".)", out.filename)
-                        );
+                        // head is the package name, tail is the version
+                        out.name = head.value();
+                        out.version = tail;
                     }
-
-                    // Name
-                    out.name = head.value();  // There may be '-' in the name
-
-                    // Wheels lack `build` info in filename. See issue #4095.
-                    out.defaulted_keys.assign(
-                        wheel_targz_defaulted_keys.begin(),
-                        wheel_targz_defaulted_keys.end()
-                    );
+                    else
+                    {
+                        // The previous tail is the optional build tag
+                        out.version = version_candidate;
+                        out.name = name_head.value();  // There may be '-' in the name
+                    }
                 }
+
+                // Wheels lack `build` info in filename. See issue #4095.
+                out.defaulted_keys.assign(
+                    wheel_targz_defaulted_keys.begin(),
+                    wheel_targz_defaulted_keys.end()
+                );
             }
             // PackageType::TarGz (.tar.gz): {pkg name}-{version}.tar.gz
             else if (out.package_type == PackageType::TarGz)

--- a/libmamba/tests/src/specs/test_package_info.cpp
+++ b/libmamba/tests/src/specs/test_package_info.cpp
@@ -414,6 +414,37 @@ namespace
             CHECK(pkg.version == "1.24.0");
         }
 
+        SECTION("Wheel package with dotless version (.whl)")
+        {
+            // Versions without dots (e.g. pywin32-312) must not be mistaken for build tags.
+            static constexpr std::string_view url = "https://files.pythonhosted.org/packages/ba/db/36a78e3403099d31d9746d13fdcde5accc43c1155f375a34d15983a479a7/pywin32-312-cp313-cp313-win_amd64.whl";
+            static constexpr std::string_view filename = "pywin32-312-cp313-cp313-win_amd64.whl";
+            auto pkg = PackageInfo::from_url(url).value();
+
+            REQUIRE(contains(pkg.defaulted_keys, defaulted_key::initialized));
+
+            CHECK(contains(pkg.defaulted_keys, defaulted_key::build_number));
+            CHECK(contains(pkg.defaulted_keys, defaulted_key::license));
+            CHECK(contains(pkg.defaulted_keys, defaulted_key::timestamp));
+            CHECK(contains(pkg.defaulted_keys, defaulted_key::track_features));
+            CHECK(contains(pkg.defaulted_keys, defaulted_key::depends));
+            CHECK(contains(pkg.defaulted_keys, defaulted_key::constrains));
+            CHECK(contains(pkg.defaulted_keys, defaulted_key::build));
+            CHECK(contains(pkg.defaulted_keys, defaulted_key::build_string));
+            CHECK(contains(pkg.defaulted_keys, defaulted_key::subdir));
+
+            CHECK(pkg.name == "pywin32");
+            CHECK(pkg.version == "312");
+            CHECK(pkg.filename == filename);
+            CHECK(pkg.package_url == url);
+            CHECK(pkg.package_type == PackageType::Wheel);
+            CHECK(pkg.channel.empty());
+            CHECK(pkg.platform.empty());
+            CHECK(pkg.build_string.empty());
+            CHECK(pkg.md5.empty());
+            CHECK(pkg.sha256.empty());
+        }
+
         SECTION("TarGz package (.tar.gz) has correct defaulted_keys")
         {
             // PURPOSE: Verify .tar.gz packages (like wheels) mark build info as defaulted


### PR DESCRIPTION
# Description

Fix https://github.com/mamba-org/mamba/issues/4332.

## Type of Change

<!-- Please skip this part if you are already using conventional commit keywords in the PR title. -->

- [x] Bugfix
- [ ] Feature / enhancement
- [ ] CI / Documentation
- [ ] Maintenance

## Checklist

- [x] My code follows the general style and conventions of the codebase, ensuring consistency
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have run `pre-commit run --all` locally in the source folder and confirmed that there are no linter errors.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
