### PR TITLE
maint: Adapt `fmt` headers' inclusion

### DIFF
--- a/libmamba/include/mamba/core/invoke.hpp
+++ b/libmamba/include/mamba/core/invoke.hpp
@@ -3,7 +3,7 @@
 
 #include <functional>
 
-#include <fmt/core.h>  // TODO: replace by `<format>` once available on all ci compilers
+#include <fmt/format.h>  // TODO: replace by `<format>` once available on all ci compilers
 
 #include "mamba/core/error_handling.hpp"
 

--- a/libmamba/include/mamba/core/logging_tools.hpp
+++ b/libmamba/include/mamba/core/logging_tools.hpp
@@ -12,7 +12,7 @@
 #include <iostream>
 #include <optional>
 
-#include <fmt/core.h>  // TODO: replace by `<format>` once available on all ci compilers
+#include <fmt/format.h>  // TODO: replace by `<format>` once available on all ci compilers
 
 #include <mamba/core/logging.hpp>
 #include <mamba/util/synchronized_value.hpp>

--- a/libmamba/include/mamba/core/util_scope.hpp
+++ b/libmamba/include/mamba/core/util_scope.hpp
@@ -4,7 +4,7 @@
 
 #include <stdexcept>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include "mamba/core/logging.hpp"
 

--- a/libmamba/src/core/env_lockfile_conda.cpp
+++ b/libmamba/src/core/env_lockfile_conda.cpp
@@ -6,7 +6,7 @@
 
 #include <algorithm>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <yaml-cpp/yaml.h>
 
 #include "mamba/core/env_lockfile.hpp"

--- a/libmamba/src/core/env_lockfile_mambajs.cpp
+++ b/libmamba/src/core/env_lockfile_mambajs.cpp
@@ -8,7 +8,7 @@
 #include <fstream>
 #include <ranges>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <nlohmann/json.hpp>
 
 #include "mamba/core/env_lockfile.hpp"

--- a/libmamba/src/core/logging.cpp
+++ b/libmamba/src/core/logging.cpp
@@ -10,7 +10,7 @@
 #include <utility>
 #include <vector>
 
-#include <fmt/core.h>  // TODO: replace by `<format>` once available on all ci compilers
+#include <fmt/format.h>  // TODO: replace by `<format>` once available on all ci compilers
 
 #include <mamba/core/context.hpp>
 #include <mamba/core/error_handling.hpp>

--- a/libmamba/src/download/compression.cpp
+++ b/libmamba/src/download/compression.cpp
@@ -4,6 +4,8 @@
 //
 // The full license is in the file LICENSE, distributed with this software.
 
+#include <fmt/format.h>
+
 #include "mamba/core/logging.hpp"
 #include "mamba/util/string.hpp"
 

--- a/libmamba/src/download/curl.hpp
+++ b/libmamba/src/download/curl.hpp
@@ -19,7 +19,7 @@ extern "C"
 #include <curl/curl.h>
 }
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <tl/expected.hpp>
 
 namespace mamba::download

--- a/libmamba/tests/libmamba_logging/include/mamba/testing/test_logging_common.hpp
+++ b/libmamba/tests/libmamba_logging/include/mamba/testing/test_logging_common.hpp
@@ -11,7 +11,7 @@
 #include <vector>
 
 #include <catch2/catch_all.hpp>
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <fmt/std.h>
 
 #include <mamba/core/logging.hpp>

--- a/libmamba/tests/libmamba_logging/test_logging_tools.cpp
+++ b/libmamba/tests/libmamba_logging/test_logging_tools.cpp
@@ -9,7 +9,7 @@
 #include <string>
 
 #include <catch2/catch_all.hpp>
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <mamba/core/logging_tools.hpp>
 #include <mamba/testing/test_logging_common.hpp>


### PR DESCRIPTION
# Description

The Homebrew macOS build fails because `fmt::format` lives in `<fmt/format.h>`, not `<fmt/core.h>`. On that platform nothing was pulling in the full header transitively.

This matches the pattern used elsewhere in libmamba, _e.g._ `package_info.cpp` includes both headers when needed.


## Type of Change

<!-- Please skip this part if you are already using conventional commit keywords in the PR title. -->

- [ ] Bugfix
- [ ] Feature / enhancement
- [ ] CI / Documentation
- [x] Maintenance

## Checklist

- [x] My code follows the general style and conventions of the codebase, ensuring consistency
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have run `pre-commit run --all` locally in the source folder and confirmed that there are no linter errors.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
