### PR TITLE
fix: Long paths support activation hint on Windows

### DIFF
--- a/docs/source/user_guide/troubleshooting.rst
+++ b/docs/source/user_guide/troubleshooting.rst
@@ -110,27 +110,29 @@ See :ref:`defaults_channels`.
 Windows long paths
 ------------------
 
-Windows API historically supports paths up to 260 characters. While it's now possible to used longer ones, there are still limitations related to that.
-
-``libmamba`` internally relies on ``\\?\`` prefixing to handle such paths. If you get error messages advertising such prefix, please have look at the following steps:
+Windows historically limits many Win32 paths to ``MAX_PATH`` (260 characters). Starting in
+Windows 10 version 1607, this restriction can be lifted for applications that opt in.
 
 
 Long paths support has to be activated
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-source: Robocop `troubleshooting documentation <https://sema4.ai/docs/automation/troubleshooting/windows-long-path>`_
+Microsoft documents the two required conditions in `Enable long paths in Windows 10, version 1607, and later
+<https://learn.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation?tabs=registry#enable-long-paths-in-windows-10-version-1607-and-later>`_:
 
-1. Open the Local Group Policy Editor application: - Start --> type gpedit.msc --> Enter:
-2. Navigate to Computer Configuration > Administrative Templates > System > Filesystem. On the right, find the "Enable win32 long paths" item and double-click it
-3. Change the setting to Enabled
-4. Exit the Local Group Policy Editor and restart your computer (or sign out and back in) to allow the changes to finish
+1. The system registry value ``LongPathsEnabled`` must be set to ``1`` under
+   ``HKLM\SYSTEM\CurrentControlSet\Control\FileSystem``.
+2. The application manifest must declare ``longPathAware`` (official micromamba builds ship with
+   ``longpath.manifest``).
 
-If the problem persists after those steps, try the following:
+``libmamba`` checks both conditions at runtime via ``are_long_paths_enabled()`` and logs a
+diagnostic when linking or filesystem operations fail while long paths are disabled.
 
-1. Open the Registry Editor application: - Start --> type regedit.msc and press Enter:
-2. Navigate to HKEY-LOCAL-MACHINE > SYSTEM > CurrentControlSet > Control > FileSystem. On the right, find the LongPathsEnabled item and double-click it
-3. Change the Value data: to 1
-4. Exit the Registry Editor
+Set the ``LongPathsEnabled`` registry value to ``1`` under
+``HKLM\SYSTEM\CurrentControlSet\Control\FileSystem``, or enable **Enable Win32 long paths** in
+Group Policy (**Computer Configuration > Administrative Templates > System > Filesystem**).
+Microsoft's guide linked above describes both approaches. A reboot or sign-out may be required
+for running processes to pick up the registry change.
 
 
 cmd.exe does not support calls to long prefixes

--- a/libmamba/include/mamba/core/util_os.hpp
+++ b/libmamba/include/mamba/core/util_os.hpp
@@ -38,7 +38,30 @@ namespace mamba
 #endif
 
     void run_as_admin(const std::string& args);
+
+#ifdef _WIN32
     bool enable_long_paths_support(bool force, Palette palette = Palette::no_color());
+
+    /**
+     * Return whether the current process can use paths longer than MAX_PATH.
+     *
+     * Requires Windows 10 version 1607 or later, ``LongPathsEnabled`` in the registry, and a
+     * ``longPathAware`` application manifest. See Microsoft's documentation:
+     * https://learn.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation?tabs=registry#enable-long-paths-in-windows-10-version-1607-and-later
+     */
+    [[nodiscard]] auto are_long_paths_enabled() -> bool;
+
+    /**
+     * Human-readable hint when long paths are disabled; empty string otherwise.
+     */
+    [[nodiscard]] auto format_long_paths_support_diagnostic() -> std::string;
+
+    /**
+     * Log a long-path diagnostic when @p error is a path-length related filesystem error and long
+     * paths are disabled.
+     */
+    void log_long_paths_support_hint_if_relevant(const std::exception& error);
+#endif
 
     void init_console();
     void reset_console();

--- a/libmamba/include/mamba/core/util_os.hpp
+++ b/libmamba/include/mamba/core/util_os.hpp
@@ -46,15 +46,16 @@ namespace mamba
      * Return whether the current process can use paths longer than MAX_PATH.
      *
      * Requires Windows 10 version 1607 or later, ``LongPathsEnabled`` in the registry, and a
-     * ``longPathAware`` application manifest. See Microsoft's documentation:
+     * ``longPathAware`` application manifest (micromamba ships ``longpath.manifest`` for this).
+     * See Microsoft's documentation:
      * https://learn.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation?tabs=registry#enable-long-paths-in-windows-10-version-1607-and-later
      */
     [[nodiscard]] auto are_long_paths_enabled() -> bool;
 
     /**
-     * Human-readable hint when long paths are disabled; empty string otherwise.
+     * Human-readable diagnostics for each unmet long-path requirement; empty string when enabled.
      */
-    [[nodiscard]] auto format_long_paths_support_diagnostic() -> std::string;
+    [[nodiscard]] auto long_paths_support_diagnostic() -> std::string;
 
     /**
      * Log a long-path diagnostic when @p error is a path-length related filesystem error and long

--- a/libmamba/src/core/package_fetcher.cpp
+++ b/libmamba/src/core/package_fetcher.cpp
@@ -10,6 +10,7 @@
 #include "mamba/core/output.hpp"
 #include "mamba/core/package_fetcher.hpp"
 #include "mamba/core/util.hpp"
+#include "mamba/core/util_os.hpp"
 #include "mamba/specs/archive.hpp"
 #include "mamba/util/string.hpp"
 #include "mamba/validation/tools.hpp"
@@ -371,6 +372,9 @@ namespace mamba
             {
                 Console::instance().print(filename() + " extraction failed");
                 LOG_ERROR << "Error when extracting package: " << e.what();
+#ifdef _WIN32
+                log_long_paths_support_hint_if_relevant(e);
+#endif
                 update_monitor(cb, PackageExtractEvent::extract_failure);
                 return false;
             }

--- a/libmamba/src/core/transaction.cpp
+++ b/libmamba/src/core/transaction.cpp
@@ -468,23 +468,13 @@ namespace mamba
                 LOG_ERROR << "Unexpected error while " << phase << " package '" << pkg.name
                           << "': " << e.what();
 #ifdef _WIN32
-                if (phase == "linking" || phase == "unlinking")
+                if ((phase == "linking" || phase == "unlinking") && !are_long_paths_enabled())
                 {
-                    if (!are_long_paths_enabled())
-                    {
-                        LOG_WARNING << "Windows long path support is disabled, which can cause "
-                                    << phase << " failures with deep cache or prefix paths. "
-                                    << format_long_paths_support_diagnostic();
-                    }
-                    else
-                    {
-                        log_long_paths_support_hint_if_relevant(e);
-                    }
+                    LOG_WARNING << "Windows long path support is disabled, which can cause "
+                                << phase << " failures with deep cache or prefix paths. "
+                                << long_paths_support_diagnostic();
                 }
-                else
-                {
-                    log_long_paths_support_hint_if_relevant(e);
-                }
+                log_long_paths_support_hint_if_relevant(e);
 #endif
                 rethrow_transaction_cancelled_after_rollback(rollback, ctx, pkg, phase, e);
             }

--- a/libmamba/src/core/transaction.cpp
+++ b/libmamba/src/core/transaction.cpp
@@ -30,6 +30,7 @@
 #include "mamba/core/thread_utils.hpp"
 #include "mamba/core/transaction.hpp"
 #include "mamba/core/util.hpp"
+#include "mamba/core/util_os.hpp"
 #include "mamba/core/util_scope.hpp"
 #include "mamba/solver/libsolv/database.hpp"
 #include "mamba/specs/match_spec.hpp"
@@ -466,6 +467,25 @@ namespace mamba
             {
                 LOG_ERROR << "Unexpected error while " << phase << " package '" << pkg.name
                           << "': " << e.what();
+#ifdef _WIN32
+                if (phase == "linking" || phase == "unlinking")
+                {
+                    if (!are_long_paths_enabled())
+                    {
+                        LOG_WARNING << "Windows long path support is disabled, which can cause "
+                                    << phase << " failures with deep cache or prefix paths. "
+                                    << format_long_paths_support_diagnostic();
+                    }
+                    else
+                    {
+                        log_long_paths_support_hint_if_relevant(e);
+                    }
+                }
+                else
+                {
+                    log_long_paths_support_hint_if_relevant(e);
+                }
+#endif
                 rethrow_transaction_cancelled_after_rollback(rollback, ctx, pkg, phase, e);
             }
             catch (...)

--- a/libmamba/src/core/util_os.cpp
+++ b/libmamba/src/core/util_os.cpp
@@ -21,6 +21,7 @@
 #include <intrin.h>
 #include <io.h>
 #include <shlobj_core.h>
+#include <versionhelpers.h>
 #include <windows.h>
 // Incomplete header included last
 #include <tlhelp32.h>
@@ -174,12 +175,19 @@ namespace mamba
             }
         };
 
-        auto windows_supports_long_paths_registry() -> bool
+        auto windows_version_supports_long_paths() -> bool
         {
-            const DWORD version = ::GetVersion();
-            const DWORD major = LOBYTE(LOWORD(version));
-            const DWORD build = HIWORD(version);
-            return major >= 10 && build >= 14352;
+            OSVERSIONINFOEXW version_info = {};
+            version_info.dwOSVersionInfoSize = sizeof(version_info);
+            version_info.dwMajorVersion = 10;
+            version_info.dwBuildNumber = 14352;
+
+            DWORDLONG condition_mask = 0;
+            VER_SET_CONDITION(condition_mask, VER_MAJORVERSION, VER_GREATER_EQUAL);
+            VER_SET_CONDITION(condition_mask, VER_BUILDNUMBER, VER_GREATER_EQUAL);
+
+            return ::VerifyVersionInfoW(&version_info, VER_MAJORVERSION | VER_BUILDNUMBER, condition_mask)
+                   != FALSE;
         }
 
         auto read_long_paths_registry_enabled() -> bool
@@ -283,7 +291,7 @@ namespace mamba
         auto query_long_paths_support() -> LongPathsSupportInfo
         {
             LongPathsSupportInfo info;
-            info.os_supports = windows_supports_long_paths_registry();
+            info.os_supports = windows_version_supports_long_paths();
             info.registry_enabled = read_long_paths_registry_enabled();
             info.manifest_long_path_aware = read_long_path_aware_manifest();
             return info;

--- a/libmamba/src/core/util_os.cpp
+++ b/libmamba/src/core/util_os.cpp
@@ -155,13 +155,13 @@ namespace mamba
     namespace
     {
         // https://learn.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation
-        static constexpr std::string_view windows_long_paths_doc_url = "https://learn.microsoft.com/en-us/windows/win32/fileio/"
-                                                                       "maximum-file-path-limitation?tabs=registry"
-                                                                       "#enable-long-paths-in-windows-10-version-1607-and-later";
+        constexpr std::string_view windows_long_paths_doc_url = "https://learn.microsoft.com/en-us/windows/win32/fileio/"
+                                                                "maximum-file-path-limitation?tabs=registry"
+                                                                "#enable-long-paths-in-windows-10-version-1607-and-later";
 
-        static constexpr auto file_system_registry_path = L"SYSTEM\\CurrentControlSet\\Control\\FileSystem";
-        static constexpr std::string_view file_system_registry_subkey = "SYSTEM\\CurrentControlSet\\Control\\FileSystem";
-        static constexpr auto long_path_windows_settings_namespace = L"http://schemas.microsoft.com/SMI/2016/WindowsSettings";
+        constexpr auto file_system_registry_path = L"SYSTEM\\CurrentControlSet\\Control\\FileSystem";
+        constexpr std::string_view file_system_registry_subkey = "SYSTEM\\CurrentControlSet\\Control\\FileSystem";
+        constexpr auto long_path_windows_settings_namespace = L"http://schemas.microsoft.com/SMI/2016/WindowsSettings";
 
         struct LongPathsSupportInfo
         {

--- a/libmamba/src/core/util_os.cpp
+++ b/libmamba/src/core/util_os.cpp
@@ -290,11 +290,11 @@ namespace mamba
 
         auto query_long_paths_support() -> LongPathsSupportInfo
         {
-            LongPathsSupportInfo info;
-            info.os_supports = windows_version_supports_long_paths();
-            info.registry_enabled = read_long_paths_registry_enabled();
-            info.manifest_long_path_aware = read_long_path_aware_manifest();
-            return info;
+            return LongPathsSupportInfo{
+                .os_supports = windows_version_supports_long_paths(),
+                .registry_enabled = read_long_paths_registry_enabled(),
+                .manifest_long_path_aware = read_long_path_aware_manifest(),
+            };
         }
 
         auto make_long_paths_support_diagnostic(const LongPathsSupportInfo& info) -> std::string
@@ -346,7 +346,7 @@ namespace mamba
                 );
             }
 
-            return util::join(" ", messages);
+            return util::join("\n", messages);
         }
 
         auto is_path_length_related_error(const std::error_code& ec) -> bool

--- a/libmamba/src/core/util_os.cpp
+++ b/libmamba/src/core/util_os.cpp
@@ -36,6 +36,7 @@
 #include "mamba/core/error_handling.hpp"
 #include "mamba/core/output.hpp"
 #include "mamba/core/util_os.hpp"
+#include "mamba/fs/filesystem.hpp"
 #include "mamba/util/build.hpp"
 #include "mamba/util/environment.hpp"
 #include "mamba/util/os_win.hpp"
@@ -149,6 +150,178 @@ namespace mamba
     }
 
 #ifdef _WIN32
+    namespace
+    {
+        // https://learn.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation
+        static constexpr std::string_view k_windows_long_paths_doc_url = "https://learn.microsoft.com/en-us/windows/win32/fileio/"
+                                                                         "maximum-file-path-limitation?tabs=registry"
+                                                                         "#enable-long-paths-in-windows-10-version-1607-and-later";
+
+        static constexpr wchar_t k_file_system_registry_path[] = L"SYSTEM\\CurrentControlSet\\Control\\FileSystem";
+        static constexpr std::string_view k_file_system_registry_subkey = "SYSTEM\\CurrentControlSet\\Control\\FileSystem";
+
+        struct LongPathsSupportInfo
+        {
+            bool enabled = false;
+            bool os_supports = false;
+            bool registry_enabled = false;
+            bool process_long_path_aware = false;
+        };
+
+        auto windows_supports_long_paths_registry() -> bool
+        {
+            const auto win_ver = util::windows_version();
+            if (!win_ver.has_value())
+            {
+                return false;
+            }
+
+            const auto split_out = util::split(win_ver.value(), ".");
+            return split_out.size() >= 3 && std::stoull(split_out[0]) >= 10
+                   && std::stoull(split_out[2]) >= 14352;
+        }
+
+        auto read_long_paths_registry_enabled() -> bool
+        {
+            winreg::RegKey key;
+            key.Open(HKEY_LOCAL_MACHINE, k_file_system_registry_path, KEY_QUERY_VALUE);
+            return key.GetDwordValue(L"LongPathsEnabled") == 1;
+        }
+
+        auto is_process_long_path_aware() -> bool
+        {
+            const auto kernel32 = ::GetModuleHandleW(L"kernel32.dll");
+            if (kernel32 == nullptr)
+            {
+                return false;
+            }
+
+            using AreLongPathsEnabledFn = BOOL(WINAPI*)();
+            const auto are_long_paths_enabled = reinterpret_cast<AreLongPathsEnabledFn>(
+                ::GetProcAddress(kernel32, "AreLongPathsEnabled")
+            );
+            if (are_long_paths_enabled == nullptr)
+            {
+                return false;
+            }
+            return are_long_paths_enabled() != FALSE;
+        }
+
+        auto query_long_paths_support() -> LongPathsSupportInfo
+        {
+            LongPathsSupportInfo info;
+            info.os_supports = windows_supports_long_paths_registry();
+            if (!info.os_supports)
+            {
+                return info;
+            }
+
+            try
+            {
+                info.registry_enabled = read_long_paths_registry_enabled();
+            }
+            catch (const winreg::RegException&)
+            {
+                return info;
+            }
+
+            if (info.registry_enabled)
+            {
+                info.process_long_path_aware = is_process_long_path_aware();
+            }
+
+            info.enabled = info.process_long_path_aware;
+            return info;
+        }
+
+        auto make_long_paths_support_diagnostic(const LongPathsSupportInfo& info) -> std::string
+        {
+            if (info.enabled)
+            {
+                return {};
+            }
+
+            if (!info.os_supports)
+            {
+                return fmt::format(
+                    "Windows long path support requires Windows 10 version 1607 (build 14352) or newer. "
+                    "See {}",
+                    k_windows_long_paths_doc_url
+                );
+            }
+
+            if (!info.registry_enabled)
+            {
+                return fmt::format(
+                    "Windows long path support is disabled at the OS level "
+                    "(LongPathsEnabled registry key). "
+                    "Run 'micromamba shell enable_long_path_support' or follow Microsoft's guide: {}",
+                    k_windows_long_paths_doc_url
+                );
+            }
+
+            if (!info.process_long_path_aware)
+            {
+                return fmt::format(
+                    "This executable is not long-path aware (missing longPathAware in the "
+                    "application manifest). Use an official micromamba build or embed "
+                    "longpath.manifest in your application. See {}",
+                    k_windows_long_paths_doc_url
+                );
+            }
+
+            return fmt::format(
+                "Windows long path support appears to be disabled. See {}",
+                k_windows_long_paths_doc_url
+            );
+        }
+
+        auto is_path_length_related_error(const std::error_code& ec) -> bool
+        {
+            // ERROR_FILENAME_EXCEED_RANGE; see
+            // https://learn.microsoft.com/en-us/windows/win32/debug/system-error-codes--0-499-
+#ifndef ERROR_FILENAME_EXCEED_RANGE
+#define ERROR_FILENAME_EXCEED_RANGE 206
+#endif
+            return ec.category() == std::system_category()
+                   && ec.value() == static_cast<int>(ERROR_FILENAME_EXCEED_RANGE);
+        }
+
+        auto is_path_length_related_error(const std::exception& error) -> bool
+        {
+            const auto* fs_error = dynamic_cast<const fs::filesystem_error*>(&error);
+            if (fs_error == nullptr)
+            {
+                return false;
+            }
+            return is_path_length_related_error(fs_error->code());
+        }
+    }
+
+    auto are_long_paths_enabled() -> bool
+    {
+        return query_long_paths_support().enabled;
+    }
+
+    auto format_long_paths_support_diagnostic() -> std::string
+    {
+        return make_long_paths_support_diagnostic(query_long_paths_support());
+    }
+
+    void log_long_paths_support_hint_if_relevant(const std::exception& error)
+    {
+        if (!is_path_length_related_error(error))
+        {
+            return;
+        }
+
+        const auto hint = format_long_paths_support_diagnostic();
+        if (!hint.empty())
+        {
+            LOG_WARNING << "This error may be caused by disabled Windows long path support. " << hint;
+        }
+    }
+
     bool run_as_admin(const std::string& exe, const std::string& args)
     {
         SHELLEXECUTEINFO excinfo;
@@ -188,6 +361,25 @@ namespace mamba
     bool enable_long_paths_support(bool force, Palette palette)
     {
         // Needs to be set system-wide & can only be run as admin ...
+        const auto status = query_long_paths_support();
+        if (status.enabled)
+        {
+            const auto win_ver = util::windows_version();
+            auto out = Console::stream();
+            fmt::print(
+                out,
+                "{} (Windows version = {})",
+                fmt::styled("Windows long-path support already enabled.", palette.ignored),
+                win_ver ? win_ver.value() : "unknown"
+            );
+            return true;
+        }
+
+        if (status.registry_enabled && !status.process_long_path_aware)
+        {
+            LOG_WARNING << make_long_paths_support_diagnostic(status);
+            return false;
+        }
 
         const auto win_ver = util::windows_version();
         LOG_DEBUG << fmt::format(
@@ -198,54 +390,27 @@ namespace mamba
         static constexpr auto error_message_wrong_version = "Not setting long path registry key;"
                                                             "Windows version must be at least 10 with the fall 2016 \"Anniversary update\" or newer.";
 
-        if (!win_ver.has_value())
+        if (!status.os_supports)
         {
-            LOG_WARNING << "failed to acquire Windows version - " << error_message_wrong_version;
+            LOG_WARNING << "Windows version found:" << (win_ver ? win_ver.value() : "unknown")
+                        << " - " << error_message_wrong_version;
             return false;
         }
 
-
-        auto split_out = util::split(win_ver.value(), ".");
-        if (!(split_out.size() >= 3 && std::stoull(split_out[0]) >= 10
-              && std::stoull(split_out[2]) >= 14352))
-        {
-            LOG_WARNING << "Windows version found:" << win_ver.value() << " - "
-                        << error_message_wrong_version;
-            return false;
-        }
-
-        winreg::RegKey key;
-        key.Open(HKEY_LOCAL_MACHINE, L"SYSTEM\\CurrentControlSet\\Control\\FileSystem", KEY_QUERY_VALUE);
-        DWORD prev_value;
         try
         {
-            prev_value = key.GetDwordValue(L"LongPathsEnabled");
+            [[maybe_unused]] const bool long_paths_registry_readable = read_long_paths_registry_enabled();
         }
         catch (const winreg::RegException& /*e*/)
         {
-            LOG_INFO << "No LongPathsEnabled key detected. (Windows version = " << win_ver.value()
-                     << ")";
+            LOG_INFO << "No LongPathsEnabled key detected. (Windows version = "
+                     << (win_ver ? win_ver.value() : "unknown") << ")";
             return false;
-        }
-
-        if (prev_value == 1)
-        {
-            auto out = Console::stream();
-            fmt::print(
-                out,
-                "{} (Windows version = {})",
-                fmt::styled("Windows long-path support already enabled.", palette.ignored),
-                win_ver.value()
-            );
-            return true;
         }
 
         if (force || is_admin())
         {
-            winreg::RegKey key_for_write(
-                HKEY_LOCAL_MACHINE,
-                L"SYSTEM\\CurrentControlSet\\Control\\FileSystem"
-            );
+            winreg::RegKey key_for_write(HKEY_LOCAL_MACHINE, k_file_system_registry_path);
             key_for_write.SetDwordValue(L"LongPathsEnabled", 1);
         }
         else
@@ -254,7 +419,10 @@ namespace mamba
             {
                 if (!run_as_admin(
                         "reg.exe",
-                        "ADD HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Control\\FileSystem /v LongPathsEnabled /d 1 /t REG_DWORD /f"
+                        fmt::format(
+                            "ADD HKEY_LOCAL_MACHINE\\{} /v LongPathsEnabled /d 1 /t REG_DWORD /f",
+                            k_file_system_registry_subkey
+                        )
                     ))
                 {
                     return false;
@@ -267,8 +435,7 @@ namespace mamba
             }
         }
 
-        prev_value = key.GetDwordValue(L"LongPathsEnabled");
-        if (prev_value == 1)
+        if (read_long_paths_registry_enabled())
         {
             auto out = Console::stream();
             fmt::print(out, "{}", fmt::styled("Windows long-path support enabled.", palette.success));

--- a/libmamba/src/core/util_os.cpp
+++ b/libmamba/src/core/util_os.cpp
@@ -1,5 +1,6 @@
 #include <iostream>
 #include <regex>
+#include <vector>
 
 #ifndef _WIN32
 #include <clocale>
@@ -153,127 +154,191 @@ namespace mamba
     namespace
     {
         // https://learn.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation
-        static constexpr std::string_view k_windows_long_paths_doc_url = "https://learn.microsoft.com/en-us/windows/win32/fileio/"
-                                                                         "maximum-file-path-limitation?tabs=registry"
-                                                                         "#enable-long-paths-in-windows-10-version-1607-and-later";
+        static constexpr std::string_view windows_long_paths_doc_url = "https://learn.microsoft.com/en-us/windows/win32/fileio/"
+                                                                       "maximum-file-path-limitation?tabs=registry"
+                                                                       "#enable-long-paths-in-windows-10-version-1607-and-later";
 
-        static constexpr wchar_t k_file_system_registry_path[] = L"SYSTEM\\CurrentControlSet\\Control\\FileSystem";
-        static constexpr std::string_view k_file_system_registry_subkey = "SYSTEM\\CurrentControlSet\\Control\\FileSystem";
+        static constexpr auto file_system_registry_path = L"SYSTEM\\CurrentControlSet\\Control\\FileSystem";
+        static constexpr std::string_view file_system_registry_subkey = "SYSTEM\\CurrentControlSet\\Control\\FileSystem";
+        static constexpr auto long_path_windows_settings_namespace = L"http://schemas.microsoft.com/SMI/2016/WindowsSettings";
 
         struct LongPathsSupportInfo
         {
-            bool enabled = false;
             bool os_supports = false;
             bool registry_enabled = false;
-            bool process_long_path_aware = false;
+            bool manifest_long_path_aware = false;
+
+            [[nodiscard]] auto is_enabled() const -> bool
+            {
+                return os_supports && registry_enabled && manifest_long_path_aware;
+            }
         };
 
         auto windows_supports_long_paths_registry() -> bool
         {
-            const auto win_ver = util::windows_version();
-            if (!win_ver.has_value())
-            {
-                return false;
-            }
-
-            const auto split_out = util::split(win_ver.value(), ".");
-            return split_out.size() >= 3 && std::stoull(split_out[0]) >= 10
-                   && std::stoull(split_out[2]) >= 14352;
+            const DWORD version = ::GetVersion();
+            const DWORD major = LOBYTE(LOWORD(version));
+            const DWORD build = HIWORD(version);
+            return major >= 10 && build >= 14352;
         }
 
         auto read_long_paths_registry_enabled() -> bool
         {
-            winreg::RegKey key;
-            key.Open(HKEY_LOCAL_MACHINE, k_file_system_registry_path, KEY_QUERY_VALUE);
-            return key.GetDwordValue(L"LongPathsEnabled") == 1;
+            HKEY key = nullptr;
+            const LSTATUS open_status = RegOpenKeyExW(
+                HKEY_LOCAL_MACHINE,
+                file_system_registry_path,
+                0,
+                KEY_QUERY_VALUE,
+                &key
+            );
+            if (open_status == ERROR_FILE_NOT_FOUND)
+            {
+                return false;
+            }
+            if (open_status != ERROR_SUCCESS)
+            {
+                throw mamba_error(
+                    fmt::format(
+                        "Failed to open registry key '{}': {}",
+                        file_system_registry_subkey,
+                        open_status
+                    ),
+                    mamba_error_code::internal_failure
+                );
+            }
+
+            DWORD value = 0;
+            DWORD value_size = sizeof(value);
+            DWORD type = 0;
+            const LSTATUS query_status = RegQueryValueExW(
+                key,
+                L"LongPathsEnabled",
+                nullptr,
+                &type,
+                reinterpret_cast<LPBYTE>(&value),
+                &value_size
+            );
+            RegCloseKey(key);
+
+            if (query_status == ERROR_FILE_NOT_FOUND)
+            {
+                return false;
+            }
+            if (query_status != ERROR_SUCCESS)
+            {
+                throw mamba_error(
+                    fmt::format("Failed to read LongPathsEnabled registry value: {}", query_status),
+                    mamba_error_code::internal_failure
+                );
+            }
+            return value == 1;
         }
 
-        auto is_process_long_path_aware() -> bool
+        auto read_long_path_aware_manifest() -> bool
         {
-            const auto kernel32 = ::GetModuleHandleW(L"kernel32.dll");
-            if (kernel32 == nullptr)
+            // https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-queryactctxsettingsw
+            wchar_t buffer[16] = {};
+            SIZE_T written = 0;
+            if (::QueryActCtxSettingsW(
+                    0,
+                    nullptr,
+                    long_path_windows_settings_namespace,
+                    L"longPathAware",
+                    buffer,
+                    std::size(buffer),
+                    &written
+                ))
+            {
+                return wcscmp(buffer, L"true") == 0;
+            }
+
+            const DWORD error = ::GetLastError();
+            if (error != ERROR_INSUFFICIENT_BUFFER || written == 0)
             {
                 return false;
             }
 
-            using AreLongPathsEnabledFn = BOOL(WINAPI*)();
-            const auto are_long_paths_enabled = reinterpret_cast<AreLongPathsEnabledFn>(
-                ::GetProcAddress(kernel32, "AreLongPathsEnabled")
-            );
-            if (are_long_paths_enabled == nullptr)
+            std::wstring large_buffer(written, L'\0');
+            if (!::QueryActCtxSettingsW(
+                    0,
+                    nullptr,
+                    long_path_windows_settings_namespace,
+                    L"longPathAware",
+                    large_buffer.data(),
+                    large_buffer.size(),
+                    &written
+                ))
             {
                 return false;
             }
-            return are_long_paths_enabled() != FALSE;
+
+            if (written > 0 && large_buffer[written - 1] == L'\0')
+            {
+                large_buffer.resize(written - 1);
+            }
+            return large_buffer == L"true";
         }
 
         auto query_long_paths_support() -> LongPathsSupportInfo
         {
             LongPathsSupportInfo info;
             info.os_supports = windows_supports_long_paths_registry();
-            if (!info.os_supports)
-            {
-                return info;
-            }
-
-            try
-            {
-                info.registry_enabled = read_long_paths_registry_enabled();
-            }
-            catch (const winreg::RegException&)
-            {
-                return info;
-            }
-
-            if (info.registry_enabled)
-            {
-                info.process_long_path_aware = is_process_long_path_aware();
-            }
-
-            info.enabled = info.process_long_path_aware;
+            info.registry_enabled = read_long_paths_registry_enabled();
+            info.manifest_long_path_aware = read_long_path_aware_manifest();
             return info;
         }
 
         auto make_long_paths_support_diagnostic(const LongPathsSupportInfo& info) -> std::string
         {
-            if (info.enabled)
+            if (info.is_enabled())
             {
                 return {};
             }
 
+            std::vector<std::string> messages;
             if (!info.os_supports)
             {
-                return fmt::format(
-                    "Windows long path support requires Windows 10 version 1607 (build 14352) or newer. "
-                    "See {}",
-                    k_windows_long_paths_doc_url
+                messages.push_back(
+                    fmt::format(
+                        "Windows long path support requires Windows 10 version 1607 (build 14352) or newer. "
+                        "See {}",
+                        windows_long_paths_doc_url
+                    )
                 );
             }
-
             if (!info.registry_enabled)
             {
-                return fmt::format(
-                    "Windows long path support is disabled at the OS level "
-                    "(LongPathsEnabled registry key). "
-                    "Run 'micromamba shell enable_long_path_support' or follow Microsoft's guide: {}",
-                    k_windows_long_paths_doc_url
+                messages.push_back(
+                    fmt::format(
+                        "Windows long path support is disabled at the OS level "
+                        "(LongPathsEnabled registry key). "
+                        "Run 'micromamba shell enable_long_path_support' or follow Microsoft's guide: {}",
+                        windows_long_paths_doc_url
+                    )
+                );
+            }
+            if (!info.manifest_long_path_aware)
+            {
+                messages.push_back(
+                    fmt::format(
+                        "This executable is not long-path aware (missing longPathAware in the "
+                        "application manifest). Use an official micromamba build or embed "
+                        "longpath.manifest in your application. See {}",
+                        windows_long_paths_doc_url
+                    )
                 );
             }
 
-            if (!info.process_long_path_aware)
+            if (messages.empty())
             {
                 return fmt::format(
-                    "This executable is not long-path aware (missing longPathAware in the "
-                    "application manifest). Use an official micromamba build or embed "
-                    "longpath.manifest in your application. See {}",
-                    k_windows_long_paths_doc_url
+                    "Windows long path support appears to be disabled. See {}",
+                    windows_long_paths_doc_url
                 );
             }
 
-            return fmt::format(
-                "Windows long path support appears to be disabled. See {}",
-                k_windows_long_paths_doc_url
-            );
+            return util::join(" ", messages);
         }
 
         auto is_path_length_related_error(const std::error_code& ec) -> bool
@@ -284,7 +349,7 @@ namespace mamba
 #define ERROR_FILENAME_EXCEED_RANGE 206
 #endif
             return ec.category() == std::system_category()
-                   && ec.value() == static_cast<int>(ERROR_FILENAME_EXCEED_RANGE);
+                   && ec.value() == ERROR_FILENAME_EXCEED_RANGE;
         }
 
         auto is_path_length_related_error(const std::exception& error) -> bool
@@ -300,10 +365,10 @@ namespace mamba
 
     auto are_long_paths_enabled() -> bool
     {
-        return query_long_paths_support().enabled;
+        return query_long_paths_support().is_enabled();
     }
 
-    auto format_long_paths_support_diagnostic() -> std::string
+    auto long_paths_support_diagnostic() -> std::string
     {
         return make_long_paths_support_diagnostic(query_long_paths_support());
     }
@@ -315,7 +380,7 @@ namespace mamba
             return;
         }
 
-        const auto hint = format_long_paths_support_diagnostic();
+        const auto hint = long_paths_support_diagnostic();
         if (!hint.empty())
         {
             LOG_WARNING << "This error may be caused by disabled Windows long path support. " << hint;
@@ -362,20 +427,15 @@ namespace mamba
     {
         // Needs to be set system-wide & can only be run as admin ...
         const auto status = query_long_paths_support();
-        if (status.enabled)
+        if (status.is_enabled())
         {
             const auto win_ver = util::windows_version();
-            auto out = Console::stream();
-            fmt::print(
-                out,
-                "{} (Windows version = {})",
-                fmt::styled("Windows long-path support already enabled.", palette.ignored),
-                win_ver ? win_ver.value() : "unknown"
-            );
+            LOG_INFO << "Windows long-path support already enabled. (Windows version = "
+                     << (win_ver ? win_ver.value() : "unknown") << ")";
             return true;
         }
 
-        if (status.registry_enabled && !status.process_long_path_aware)
+        if (status.registry_enabled && !status.manifest_long_path_aware)
         {
             LOG_WARNING << make_long_paths_support_diagnostic(status);
             return false;
@@ -397,20 +457,15 @@ namespace mamba
             return false;
         }
 
-        try
-        {
-            [[maybe_unused]] const bool long_paths_registry_readable = read_long_paths_registry_enabled();
-        }
-        catch (const winreg::RegException& /*e*/)
+        if (!status.registry_enabled)
         {
             LOG_INFO << "No LongPathsEnabled key detected. (Windows version = "
                      << (win_ver ? win_ver.value() : "unknown") << ")";
-            return false;
         }
 
         if (force || is_admin())
         {
-            winreg::RegKey key_for_write(HKEY_LOCAL_MACHINE, k_file_system_registry_path);
+            winreg::RegKey key_for_write(HKEY_LOCAL_MACHINE, file_system_registry_path);
             key_for_write.SetDwordValue(L"LongPathsEnabled", 1);
         }
         else
@@ -421,7 +476,7 @@ namespace mamba
                         "reg.exe",
                         fmt::format(
                             "ADD HKEY_LOCAL_MACHINE\\{} /v LongPathsEnabled /d 1 /t REG_DWORD /f",
-                            k_file_system_registry_subkey
+                            file_system_registry_subkey
                         )
                     ))
                 {

--- a/libmamba/tests/src/core/test_package_cache.cpp
+++ b/libmamba/tests/src/core/test_package_cache.cpp
@@ -153,5 +153,27 @@ namespace mamba
 
             REQUIRE(cache.get_tarball_path(pkg_no_val) == pkgs_dir);
         }
+
+        SECTION("Hierarchical cache under a long path")
+        {
+            constexpr std::size_t min_pkgs_dir_path_length = 300;
+            constexpr auto segment = "very_long_directory_name_segment";
+
+            fs::u8path long_pkgs_dir = temp_dir.path();
+            while ((long_pkgs_dir / segment / "pkgs").generic_string().size()
+                   <= min_pkgs_dir_path_length)
+            {
+                long_pkgs_dir /= segment;
+            }
+            long_pkgs_dir /= "pkgs";
+            fs::create_directories(long_pkgs_dir);
+
+            const fs::u8path long_hierarchical_dir = long_pkgs_dir / rel_path
+                                                     / "test-pkg-1.0.0-h123456_0";
+            write_repodata_record(long_hierarchical_dir / "info" / "repodata_record.json", pkg_info);
+
+            MultiPackageCache cache({ long_pkgs_dir }, params);
+            REQUIRE(cache.get_extracted_dir_path(pkg_info) == long_pkgs_dir / rel_path);
+        }
     }
 }  // namespace mamba

--- a/libmamba/tests/src/core/test_package_cache.cpp
+++ b/libmamba/tests/src/core/test_package_cache.cpp
@@ -156,6 +156,8 @@ namespace mamba
 
         SECTION("Hierarchical cache under a long path")
         {
+            // Needs OS-level long paths and a longPathAware manifest for this process;
+            // otherwise create_directories may fail before cache logic is exercised.
             constexpr std::size_t min_pkgs_dir_path_length = 300;
             constexpr auto segment = "very_long_directory_name_segment";
 

--- a/libmamba/tests/src/core/test_util.cpp
+++ b/libmamba/tests/src/core/test_util.cpp
@@ -9,6 +9,7 @@
 #include "mamba/core/context.hpp"
 #include "mamba/core/fsutil.hpp"
 #include "mamba/core/util.hpp"
+#include "mamba/core/util_os.hpp"
 #include "mamba/core/util_scope.hpp"
 #include "mamba/fs/filesystem.hpp"
 #include "mamba/util/path_manip.hpp"
@@ -143,4 +144,18 @@ namespace mamba
             REQUIRE_FALSE(proxy_match_with_context("http://example.com/channel").has_value());
         }
     }
+
+#ifdef _WIN32
+    TEST_CASE("are_long_paths_enabled")
+    {
+        if (are_long_paths_enabled())
+        {
+            REQUIRE(format_long_paths_support_diagnostic().empty());
+        }
+        else
+        {
+            REQUIRE_FALSE(format_long_paths_support_diagnostic().empty());
+        }
+    }
+#endif
 }

--- a/libmamba/tests/src/core/test_util.cpp
+++ b/libmamba/tests/src/core/test_util.cpp
@@ -150,11 +150,11 @@ namespace mamba
     {
         if (are_long_paths_enabled())
         {
-            REQUIRE(format_long_paths_support_diagnostic().empty());
+            REQUIRE(long_paths_support_diagnostic().empty());
         }
         else
         {
-            REQUIRE_FALSE(format_long_paths_support_diagnostic().empty());
+            REQUIRE_FALSE(long_paths_support_diagnostic().empty());
         }
     }
 #endif


### PR DESCRIPTION
# Description

Fix https://github.com/mamba-org/mamba/issues/4275.

## Type of Change

<!-- Please skip this part if you are already using conventional commit keywords in the PR title. -->

- [x] Bugfix
- [ ] Feature / enhancement
- [ ] CI / Documentation
- [ ] Maintenance

## Checklist

- [x] My code follows the general style and conventions of the codebase, ensuring consistency
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have run `pre-commit run --all` locally in the source folder and confirmed that there are no linter errors.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
