### PR TITLE
fix: preserve credentials for sharded repodata URLs

### DIFF
--- a/libmamba/src/api/channel_loader.cpp
+++ b/libmamba/src/api/channel_loader.cpp
@@ -437,7 +437,9 @@ namespace mamba
 
             LOG_DEBUG << "Shard index fetched for " << subdir.name();
             const auto& channel = subdir.channel();
-            std::string current_repodata_url = subdir.repodata_url().str();
+            std::string current_repodata_url = subdir.repodata_url().str(
+                specs::CondaURL::Credentials::Show
+            );
             if (python_minor_version_for_prefilter.has_value())
             {
                 LOG_DEBUG << "Shard prefilter on python minor version enabled with "
@@ -472,7 +474,9 @@ namespace mamba
                         continue;
                     }
                     auto si = std::move(sidx_result.value().value());
-                    std::string sdir_url = subdirs[j].repodata_url().str();
+                    std::string sdir_url = subdirs[j].repodata_url().str(
+                        specs::CondaURL::Credentials::Show
+                    );
                     all_shards.emplace_back(
                         std::move(si),
                         sdir_url,


### PR DESCRIPTION
# Description

Fix sharded repodata downloads when a channel URL contains credentials.

The sharded repodata path was deriving shard URLs from `repodata_url().str()` with the default credential policy, which masks embedded credentials as `*****`. Those masked credentials can then be preserved when constructing shard URLs, causing authenticated mirrors/proxies to reject shard requests and making libmamba fall back to flat `repodata.json`.

This changes the sharded repodata URL construction to preserve credentials explicitly when deriving the current repodata URL and subdir repodata URLs.

## Type of Change

- [x] Bugfix
- [ ] Feature / enhancement
- [ ] CI / Documentation
- [ ] Maintenance

## Checklist

- [x] My code follows the general style and conventions of the codebase, ensuring consistency
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have run `pre-commit run --all` locally in the source folder and confirmed that there are no linter errors.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
