### PR TITLE
Fix init/deinit test with `fish` on `macos`

### DIFF
--- a/micromamba/tests/test_activation.py
+++ b/micromamba/tests/test_activation.py
@@ -565,7 +565,11 @@ def test_shell_init_deinit_contents(
             rc_contents_after_deinit = fi.read()
     else:
         rc_contents_after_deinit = ""
-    assert rc_contents_after_deinit == prev_rc_contents
+    if interpreter == "powershell":
+        assert "#region mamba initialize" not in rc_contents_after_deinit
+    else:
+        assert "# >>> mamba initialize >>>" not in rc_contents_after_deinit
+    assert not find_path_in_str(tmp_root_prefix, rc_contents_after_deinit)
 
 
 @pytest.mark.parametrize("interpreter", get_interpreters())


### PR DESCRIPTION
# Description

`Fish` [4.8.0](https://github.com/fish-shell/fish-shell/releases/tag/4.8.0) now writes some boilerplate to `config.fish` when the file is first created (see https://github.com/fish-shell/fish-shell/commit/654041895bf9a4aa9b07335f2bd09d1bd95dd875).
The existing test is too strict as it assumes the shell configuration file is modified only by `mamba`, but the shell itself - or other tools - may legitimately modify the file.

The test is now only verifying that there is no mamba related block in the config file after `deinit`.

Note that this failure currently only occurs on `macOS` CI image because it ships the latest `fish` version (which is not the case for `Ubuntu`).

## Type of Change

<!-- Please skip this part if you are already using conventional commit keywords in the PR title. -->

- [x] Bugfix
- [ ] Feature / enhancement
- [ ] CI / Documentation
- [ ] Maintenance

## Checklist

- [x] My code follows the general style and conventions of the codebase, ensuring consistency
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have run `pre-commit run --all` locally in the source folder and confirmed that there are no linter errors.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
