### PR TITLE
fix: Add `deactivate` command to the help message

### DIFF
--- a/micromamba/src/activate.cpp
+++ b/micromamba/src/activate.cpp
@@ -46,6 +46,35 @@ namespace
         }
         return "";
     }
+    // When 'activate' / 'deactivate' is run as subprocess, it cannot modify the parent shell.
+    // In that case, print instructions to initialize the shell and throw an exception to stop execution.
+    // If the shell is initialized, the 'activate' / 'deactivate' command are intercepted by the shell.
+    // The shell calls 'shell activate' / 'shell deactivate' instead, in that case the code below is never executed.
+    [[noreturn]] void notify_shell_not_initialized()
+    {
+        const std::string guessed_shell = guess_shell();
+
+        const std::string message = fmt::format(
+            "\n'{exe}' is running as a subprocess and can't modify the parent shell.\n"
+            "Thus you must initialize your shell before using activate and deactivate.\n"
+            "\n"
+            "{0}\n"
+            "To automatically initialize all future ({1}) shells, run:\n"
+            "    $ {exe} shell init --shell {1} --root-prefix=~/.local/share/mamba\n"
+            "If your shell was already initialized, reinitialize your shell with:\n"
+            "    $ {exe} shell reinit --shell {1}\n"
+            "Otherwise, this may be an issue. In the meantime you can run commands. See:\n"
+            "    $ {exe} run --help\n"
+            "\n"
+            "Supported shells are {{bash, zsh, csh, posix, xonsh, cmd.exe, powershell, fish, nu}}.\n",
+            get_shell_hook(guessed_shell),
+            guessed_shell,
+            fmt::arg("exe", get_self_exe_path().stem().string())
+        );
+
+        std::cout << message;
+        throw std::runtime_error("Shell not initialized");
+    }
 }
 
 void
@@ -61,31 +90,11 @@ set_activate_command(CLI::App* subcom)
         "Activate the specified environment without first deactivating the current one"
     );
 
-    subcom->callback(
-        [&]()
-        {
-            const std::string guessed_shell = guess_shell();
+    subcom->callback([&]() { notify_shell_not_initialized(); });
+}
 
-            const std::string message = fmt::format(
-                "\n'{exe}' is running as a subprocess and can't modify the parent shell.\n"
-                "Thus you must initialize your shell before using activate and deactivate.\n"
-                "\n"
-                "{0}\n"
-                "To automatically initialize all future ({1}) shells, run:\n"
-                "    $ {exe} shell init --shell {1} --root-prefix=~/.local/share/mamba\n"
-                "If your shell was already initialized, reinitialize your shell with:\n"
-                "    $ {exe} shell reinit --shell {1}\n"
-                "Otherwise, this may be an issue. In the meantime you can run commands. See:\n"
-                "    $ {exe} run --help\n"
-                "\n"
-                "Supported shells are {{bash, zsh, csh, posix, xonsh, cmd.exe, powershell, fish, nu}}.\n",
-                get_shell_hook(guessed_shell),
-                guessed_shell,
-                fmt::arg("exe", get_self_exe_path().stem().string())
-            );
-
-            std::cout << message;
-            throw std::runtime_error("Shell not initialized");
-        }
-    );
+void
+set_deactivate_command(CLI::App* subcom)
+{
+    subcom->callback([]() { notify_shell_not_initialized(); });
 }

--- a/micromamba/src/activate.cpp
+++ b/micromamba/src/activate.cpp
@@ -46,10 +46,12 @@ namespace
         }
         return "";
     }
+
     // When 'activate' / 'deactivate' is run as subprocess, it cannot modify the parent shell.
-    // In that case, print instructions to initialize the shell and throw an exception to stop execution.
-    // If the shell is initialized, the 'activate' / 'deactivate' command are intercepted by the shell.
-    // The shell calls 'shell activate' / 'shell deactivate' instead, in that case the code below is never executed.
+    // In that case, print instructions to initialize the shell and throw an exception to stop
+    // execution. If the shell is initialized, the 'activate' / 'deactivate' command are intercepted
+    // by the shell. The shell calls 'shell activate' / 'shell deactivate' instead, in that case the
+    // code below is never executed.
     [[noreturn]] void notify_shell_not_initialized()
     {
         const std::string guessed_shell = guess_shell();

--- a/micromamba/src/umamba.cpp
+++ b/micromamba/src/umamba.cpp
@@ -103,6 +103,9 @@ set_umamba_command(CLI::App* com, mamba::Configuration& config)
     CLI::App* activate_subcom = com->add_subcommand("activate", "Activate an environment");
     set_activate_command(activate_subcom);
 
+    CLI::App* deactivate_subcom = com->add_subcommand("deactivate", "Deactivate the active environment");
+    set_deactivate_command(deactivate_subcom);
+
     CLI::App* run_subcom = com->add_subcommand("run", "Run an executable in an environment");
     set_run_command(run_subcom, config);
 

--- a/micromamba/src/umamba.hpp
+++ b/micromamba/src/umamba.hpp
@@ -76,6 +76,9 @@ void
 set_activate_command(CLI::App* subcom);
 
 void
+set_deactivate_command(CLI::App* subcom);
+
+void
 set_run_command(CLI::App* subcom, mamba::Configuration& config);
 
 void

--- a/micromamba/tests/test_shell.py
+++ b/micromamba/tests/test_shell.py
@@ -193,6 +193,7 @@ def test_activate_target_prefix_checks(tmp_home, tmp_root_prefix):
     assert not res["use_default_prefix_fallback"]
     assert not res["use_root_prefix_fallback"]
 
+
 @pytest.mark.parametrize(
     "command, description",
     [

--- a/micromamba/tests/test_shell.py
+++ b/micromamba/tests/test_shell.py
@@ -193,6 +193,28 @@ def test_activate_target_prefix_checks(tmp_home, tmp_root_prefix):
     assert not res["use_default_prefix_fallback"]
     assert not res["use_root_prefix_fallback"]
 
+@pytest.mark.parametrize(
+    "command, description",
+    [
+        ("activate", "Activate an environment"),
+        ("deactivate", "Deactivate the active environment"),
+    ],
+)
+def test_top_level_activate_deactivate_not_initialized(
+    tmp_home, tmp_root_prefix, command, description
+):
+    """Test that top-level activate/deactivate commands are not initialized."""
+    umamba = helpers.get_umamba()
+
+    # Commands must be listed in top-level help.
+    top_help = helpers.subprocess_run(umamba, "--help").decode()
+    assert description in top_help
+
+    # Commands run directly with no shell function aborts with error message.
+    with pytest.raises(subprocess.CalledProcessError) as excinfo:
+        helpers.subprocess_run(umamba, command)
+    assert "Shell not initialized" in excinfo.value.stderr.decode()
+
 
 @pytest.mark.parametrize("shell_type", ["bash", "powershell", "cmd.exe"])
 @pytest.mark.parametrize("prefix_selector", [None, "prefix"])


### PR DESCRIPTION
# Description

<!-- Please include a summary of the changes and the related issue. -->
Adds visibility to one of the missing commands mentioned in #3535 

## Type of Change

<!-- Please skip this part if you are already using conventional commit keywords in the PR title. -->

- [x] Bugfix
- [ ] Feature / enhancement
- [ ] CI / Documentation
- [ ] Maintenance

## Checklist

- [x] My code follows the general style and conventions of the codebase, ensuring consistency
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have run `pre-commit run --all` locally in the source folder and confirmed that there are no linter errors.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
