### PR TITLE
fix: Use `stop_reason::program_exit` when destructing  `Context`

### DIFF
--- a/libmamba-spdlog/include/mamba/spdlog/logging_spdlog_impl.hpp
+++ b/libmamba-spdlog/include/mamba/spdlog/logging_spdlog_impl.hpp
@@ -92,6 +92,11 @@ namespace mamba::logging::spdlogimpl
 
         const auto main_source = sources.front();
 
+        // A previous `Context` may have been destroyed with `stop_reason::program_exit`,
+        // which intentionally leaves spdlog loggers registered. Clear them before
+        // re-registering so starting logging again after such a shutdown is safe.
+        spdlog::drop_all();
+
         spdlog::set_default_logger(
             std::make_shared<Logger>(name_of(main_source), params.log_pattern, "\n")
         );

--- a/libmamba-spdlog/tests/test_logging_spdlog.cpp
+++ b/libmamba-spdlog/tests/test_logging_spdlog.cpp
@@ -93,6 +93,38 @@ namespace mamba::logging
         }
     }
 
+    TEST_CASE("LogHandler_spdlog restart after program_exit stop")
+    {
+        // Regression: Context::~Context stops logging with program_exit, which leaves
+        // spdlog loggers registered. Starting logging again must still succeed
+        // (mamba-org/mamba#4378).
+        spdlogimpl::LogHandler_spdlog handler{ testing_options };
+        on_scope_exit _{ [&] { handler.stop_log_handling(stop_reason::manual_stop); } };
+
+        handler.start_log_handling({}, testing::testing_log_sources());
+        REQUIRE(handler.is_started());
+        handler.log(
+            LogRecord{
+                .message = "before program_exit stop",
+                .level = log_level::warn,
+                .source = log_source::tests,
+            }
+        );
+
+        handler.stop_log_handling(stop_reason::program_exit);
+        REQUIRE(not handler.is_started());
+
+        handler.start_log_handling({}, testing::testing_log_sources());
+        REQUIRE(handler.is_started());
+        handler.log(
+            LogRecord{
+                .message = "after restart",
+                .level = log_level::warn,
+                .source = log_source::tests,
+            }
+        );
+    }
+
     TEST_CASE("LogHandler_spdlog concurrency")
     {
         spdlogimpl::LogHandler_spdlog handler{ testing_options };

--- a/libmamba/src/core/context.cpp
+++ b/libmamba/src/core/context.cpp
@@ -130,7 +130,19 @@ namespace mamba
 
     Context::~Context()
     {
-        logging::stop_logging();
+        // Use `program_exit` rather than the default `manual_stop`.
+        //
+        // `Context` often outlives `main()` / is destroyed from Python during
+        // interpreter or process shutdown (`atexit`, module teardown). In that
+        // situation, touching spdlog (flush / `drop_all`) is unsafe: its static
+        // registry or sinks may already have been destroyed, which leads to a
+        // segfault in `stop_logging` (see mamba-org/mamba#4378,
+        // conda/constructor#1319).
+        //
+        // `program_exit` lets the log-handler skip that cleanup and leave it to
+        // the backend's own shutdown. Mid-lifetime reuse is handled by clearing
+        // leftover loggers when logging is started again.
+        logging::stop_logging(logging::stop_reason::program_exit);
     }
 
     void Context::set_verbosity(int lvl)

--- a/libmambapy/tests/test_legacy.py
+++ b/libmambapy/tests/test_legacy.py
@@ -1,3 +1,6 @@
+import subprocess
+import sys
+
 import libmambapy
 
 
@@ -25,3 +28,16 @@ def test_channel_context():
     cc = libmambapy.ChannelContext.make_simple(ctx)
     assert cc.make_channel("pkgs/main")[0].url.str() == "https://conda.anaconda.org/pkgs/main"
     assert len(cc.params().custom_channels) == 0
+
+
+def test_context_survives_interpreter_shutdown():
+    # Regression for mamba-org/mamba#4378 / conda/constructor#1319:
+    # destroying Context while the process exits must not segfault.
+    script = """
+import libmambapy
+ctx = libmambapy.Context()
+assert ctx is not None
+# Intentionally keep the Context alive until interpreter shutdown.
+"""
+    result = subprocess.run([sys.executable, "-c", script], capture_output=True, text=True)
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
# Description

Fix https://github.com/mamba-org/mamba/issues/4378.
Fix https://github.com/conda/constructor/issues/1319.


`Context::~Context` called `stop_logging` with manual_stop, which flushes and drops `spdlog` loggers even during interpreter/`atexit` teardown, when `spdlog`'s static state may already be gone. Use `program_exit` instead, and drop leftover loggers when restarting.


## Type of Change

<!-- Please skip this part if you are already using conventional commit keywords in the PR title. -->

- [x] Bugfix
- [ ] Feature / enhancement
- [ ] CI / Documentation
- [ ] Maintenance

## Checklist

- [x] My code follows the general style and conventions of the codebase, ensuring consistency
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have run `pre-commit run --all` locally in the source folder and confirmed that there are no linter errors.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
