### PR TITLE
ci: Disable coverage env cache to avoid pygments package-cache errors

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -69,12 +69,6 @@ jobs:
             ccache-libmamba-${{ github.runner.os }}
       - name: Build mamba with coverage
         run: |
-          # Ensure ar/ranlib are found: conda compiler activation may not set AR when
-          # mixing envs (dev + micromamba-static); CMAKE_AR from preset uses $env{AR}
-          # which can resolve to a bare name, causing "x86_64-conda-linux-gnu-ar: not found"
-          # when building the static libmamba (micromamba requires BUILD_STATIC).
-          export AR="${CONDA_PREFIX}/bin/x86_64-conda-linux-gnu-ar"
-          export RANLIB="${CONDA_PREFIX}/bin/x86_64-conda-linux-gnu-ranlib"
           cmake -B build/ -G Ninja \
             --preset mamba-unix-shared-debug \
             -D CMAKE_CXX_COMPILER_LAUNCHER=sccache \

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -48,6 +48,10 @@ jobs:
         with:
           environment-file: ./dev/environment-dev.yml
           environment-name: build_env
+          # Most verbose micromamba logs to debug sporadic
+          # "Cannot find a valid extracted directory cache" failures
+          # after environment cache restore.
+          log-level: trace
           cache-environment: true
           cache-environment-key: >-
             coverage-${{
@@ -57,10 +61,60 @@ jobs:
                 'dev/environment-micromamba-static.yml'
               )
             }}-${{ github.event.pull_request.number || github.ref }}
+      - name: Dump package cache after environment restore
+        run: |
+          echo '::group::Package cache after environment restore'
+          echo "MAMBA_ROOT_PREFIX=${MAMBA_ROOT_PREFIX}"
+          micromamba --log-level=trace info -n build_env || true
+          pkgs="${MAMBA_ROOT_PREFIX}/pkgs"
+          if [[ -d "${pkgs}" ]]; then
+            echo "Package cache exists: ${pkgs}"
+            echo "Top-level entries: $(find "${pkgs}" -mindepth 1 -maxdepth 1 | wc -l)"
+            echo "pygments-related paths:"
+            find "${pkgs}" -iname '*pygments*' -print 2>/dev/null || echo "(none)"
+          else
+            echo "Package cache directory does not exist: ${pkgs}"
+          fi
+          echo "Installed pygments metadata:"
+          ls -la "${MAMBA_ROOT_PREFIX}/envs/build_env/conda-meta/"*pygments* 2>/dev/null || echo "(none)"
+          df -h
+          echo '::endgroup::'
       - name: Install dev-extra environment
-        run: micromamba install -n build_env -y -f ./dev/environment-dev-extra.yml
+        run: |
+          micromamba install -n build_env -y -vvv --log-level=trace \
+            -f ./dev/environment-dev-extra.yml
+          echo '::group::Package cache after dev-extra install'
+          pkgs="${MAMBA_ROOT_PREFIX}/pkgs"
+          echo "Top-level pkgs entries: $(find "${pkgs}" -mindepth 1 -maxdepth 1 | wc -l)"
+          echo "pygments-related paths:"
+          find "${pkgs}" -iname '*pygments*' -print 2>/dev/null || echo "(none)"
+          echo '::endgroup::'
       - name: Install micromamba-static environment
-        run: micromamba install -n build_env -y -f ./dev/environment-micromamba-static.yml
+        run: |
+          dump_pygments_cache() {
+            echo '::group::Package cache dump (pygments / pkgs)'
+            pkgs="${MAMBA_ROOT_PREFIX}/pkgs"
+            echo "Package cache: ${pkgs}"
+            if [[ -d "${pkgs}" ]]; then
+              echo "Top-level pkgs entries: $(find "${pkgs}" -mindepth 1 -maxdepth 1 | wc -l)"
+              echo "pygments-related paths:"
+              find "${pkgs}" -iname '*pygments*' -ls 2>/dev/null || echo "(none)"
+              echo "Extracted pygments directories:"
+              find "${pkgs}" -type d -iname 'pygments-*' -print 2>/dev/null || echo "(none)"
+              echo "pygments tarballs:"
+              find "${pkgs}" -type f \( -iname 'pygments-*.conda' -o -iname 'pygments-*.tar.bz2' \) -ls 2>/dev/null || echo "(none)"
+            else
+              echo "Package cache directory does not exist"
+            fi
+            echo "Installed pygments metadata:"
+            ls -la "${MAMBA_ROOT_PREFIX}/envs/build_env/conda-meta/"*pygments* 2>/dev/null || echo "(none)"
+            df -h
+            echo '::endgroup::'
+          }
+          dump_pygments_cache
+          micromamba install -n build_env -y -vvv --log-level=trace \
+            -f ./dev/environment-micromamba-static.yml \
+            || { dump_pygments_cache; exit 1; }
       - uses: hendrikmuhs/ccache-action@main
         with:
           variant: sccache

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -48,10 +48,15 @@ jobs:
         with:
           environment-file: ./dev/environment-dev.yml
           environment-name: build_env
-          # Most verbose micromamba logs to debug sporadic
-          # "Cannot find a valid extracted directory cache" failures
-          # after environment cache restore.
-          log-level: trace
+          # Create the full coverage env in one shot. Follow-up `micromamba install`
+          # of extra/static files after a cache-environment hit restores the prefix
+          # without `pkgs/` and then upgrades Python, which reinstalls noarch
+          # packages such as pygments. Released micromamba 2.9.0 then fails with
+          # "Cannot find a valid extracted directory cache" because of a stale
+          # negative package-cache entry (fixed on main in #4328, not shipped yet).
+          create-args: >-
+            -f ./dev/environment-dev-extra.yml
+            -f ./dev/environment-micromamba-static.yml
           cache-environment: true
           cache-environment-key: >-
             coverage-${{
@@ -61,60 +66,6 @@ jobs:
                 'dev/environment-micromamba-static.yml'
               )
             }}-${{ github.event.pull_request.number || github.ref }}
-      - name: Dump package cache after environment restore
-        run: |
-          echo '::group::Package cache after environment restore'
-          echo "MAMBA_ROOT_PREFIX=${MAMBA_ROOT_PREFIX}"
-          micromamba --log-level=trace info -n build_env || true
-          pkgs="${MAMBA_ROOT_PREFIX}/pkgs"
-          if [[ -d "${pkgs}" ]]; then
-            echo "Package cache exists: ${pkgs}"
-            echo "Top-level entries: $(find "${pkgs}" -mindepth 1 -maxdepth 1 | wc -l)"
-            echo "pygments-related paths:"
-            find "${pkgs}" -iname '*pygments*' -print 2>/dev/null || echo "(none)"
-          else
-            echo "Package cache directory does not exist: ${pkgs}"
-          fi
-          echo "Installed pygments metadata:"
-          ls -la "${MAMBA_ROOT_PREFIX}/envs/build_env/conda-meta/"*pygments* 2>/dev/null || echo "(none)"
-          df -h
-          echo '::endgroup::'
-      - name: Install dev-extra environment
-        run: |
-          micromamba install -n build_env -y -vvv --log-level=trace \
-            -f ./dev/environment-dev-extra.yml
-          echo '::group::Package cache after dev-extra install'
-          pkgs="${MAMBA_ROOT_PREFIX}/pkgs"
-          echo "Top-level pkgs entries: $(find "${pkgs}" -mindepth 1 -maxdepth 1 | wc -l)"
-          echo "pygments-related paths:"
-          find "${pkgs}" -iname '*pygments*' -print 2>/dev/null || echo "(none)"
-          echo '::endgroup::'
-      - name: Install micromamba-static environment
-        run: |
-          dump_pygments_cache() {
-            echo '::group::Package cache dump (pygments / pkgs)'
-            pkgs="${MAMBA_ROOT_PREFIX}/pkgs"
-            echo "Package cache: ${pkgs}"
-            if [[ -d "${pkgs}" ]]; then
-              echo "Top-level pkgs entries: $(find "${pkgs}" -mindepth 1 -maxdepth 1 | wc -l)"
-              echo "pygments-related paths:"
-              find "${pkgs}" -iname '*pygments*' -ls 2>/dev/null || echo "(none)"
-              echo "Extracted pygments directories:"
-              find "${pkgs}" -type d -iname 'pygments-*' -print 2>/dev/null || echo "(none)"
-              echo "pygments tarballs:"
-              find "${pkgs}" -type f \( -iname 'pygments-*.conda' -o -iname 'pygments-*.tar.bz2' \) -ls 2>/dev/null || echo "(none)"
-            else
-              echo "Package cache directory does not exist"
-            fi
-            echo "Installed pygments metadata:"
-            ls -la "${MAMBA_ROOT_PREFIX}/envs/build_env/conda-meta/"*pygments* 2>/dev/null || echo "(none)"
-            df -h
-            echo '::endgroup::'
-          }
-          dump_pygments_cache
-          micromamba install -n build_env -y -vvv --log-level=trace \
-            -f ./dev/environment-micromamba-static.yml \
-            || { dump_pygments_cache; exit 1; }
       - uses: hendrikmuhs/ccache-action@main
         with:
           variant: sccache

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -48,24 +48,17 @@ jobs:
         with:
           environment-file: ./dev/environment-dev.yml
           environment-name: build_env
-          # Create the full coverage env in one shot. Follow-up `micromamba install`
-          # of extra/static files after a cache-environment hit restores the prefix
-          # without `pkgs/` and then upgrades Python, which reinstalls noarch
-          # packages such as pygments. Released micromamba 2.9.0 then fails with
-          # "Cannot find a valid extracted directory cache" because of a stale
-          # negative package-cache entry (fixed on main in #4328, not shipped yet).
-          create-args: >-
-            -f ./dev/environment-dev-extra.yml
-            -f ./dev/environment-micromamba-static.yml
-          cache-environment: true
-          cache-environment-key: >-
-            coverage-${{
-              hashFiles(
-                'dev/environment-dev.yml',
-                'dev/environment-dev-extra.yml',
-                'dev/environment-micromamba-static.yml'
-              )
-            }}-${{ github.event.pull_request.number || github.ref }}
+          # Do not cache the env prefix. A cache hit restores it without pkgs/,
+          # and the follow-up static install then upgrades Python and reinstalls
+          # noarch packages. Micromamba 2.9.0 fails that relink with a stale
+          # negative extracted-dir cache (#4328, not in 2.9.0). Combining the
+          # extra/static files into this create is also unsatisfiable (shared vs
+          # static libs, python>=3.12 vs bcrypt==4.0.1).
+          cache-environment: false
+      - name: Install dev-extra environment
+        run: micromamba install -n build_env -y -f ./dev/environment-dev-extra.yml
+      - name: Install micromamba-static environment
+        run: micromamba install -n build_env -y -f ./dev/environment-micromamba-static.yml
       - uses: hendrikmuhs/ccache-action@main
         with:
           variant: sccache

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,16 @@ cmake_minimum_required(VERSION 3.16)
 
 project(mamba)
 
+# cxx-compiler >=2 no longer injects LDFLAGS. GNU ld does not search -L for DT_NEEDED of linked
+# shared libraries; it needs -rpath-link at link time.
+if(
+    UNIX
+    AND NOT APPLE
+    AND DEFINED ENV{CONDA_PREFIX}
+)
+    add_link_options("-Wl,-rpath-link,$ENV{CONDA_PREFIX}/lib")
+endif()
+
 # Build options
 # =============
 

--- a/cmake/CompilerWarnings.cmake
+++ b/cmake/CompilerWarnings.cmake
@@ -141,6 +141,10 @@ function(mamba_target_add_compile_warnings target)
         -Wlogical-op
         # Warn if you perform a cast to the same type
         -Wuseless-cast
+        # GCC 13+ false positives on std::variant of types containing std::string (libstdc++
+        # basic_string inlined through variant). Keep the warning, do not fail the build. See GCC PR
+        # 105329 / PR 109561.
+        -Wno-error=maybe-uninitialized
     )
 
     if(MSVC)

--- a/dev/CMakePresetsUnix.json
+++ b/dev/CMakePresetsUnix.json
@@ -3,22 +3,9 @@
     {
       "binaryDir": "${sourceDir}/build/${presetName}",
       "cacheVariables": {
-        "CMAKE_AR": "$env{AR}",
-        "CMAKE_CXX_COMPILER": "$env{CXX}",
-        "CMAKE_CXX_FLAGS_DEBUG": "$env{DEBUG_CXXFLAGS}",
-        "CMAKE_CXX_FLAGS_RELEASE": "$env{CXXFLAGS}",
-        "CMAKE_C_COMPILER": "$env{CC}",
-        "CMAKE_C_FLAGS_DEBUG": "$env{DEBUG_CFLAGS}",
-        "CMAKE_C_FLAGS_RELEASE": "$env{CFLAGS}",
-        "CMAKE_EXE_LINKER_FLAGS": "$env{LDFLAGS}",
-        "CMAKE_Fortran_COMPILER": "$env{FC}",
-        "CMAKE_Fortran_FLAGS_DEBUG": "$env{DEBUG_FORTRANFLAGS}",
-        "CMAKE_Fortran_FLAGS_RELEASE": "$env{FORTRANFLAGS}",
         "CMAKE_INSTALL_LIBDIR": "lib",
         "CMAKE_INSTALL_PREFIX": "$env{CONDA_PREFIX}",
-        "CMAKE_LINKER": "$env{LD}",
-        "CMAKE_PREFIX_PATH": "$env{CONDA_PREFIX}",
-        "CMAKE_RANLIB": "$env{RANLIB}"
+        "CMAKE_PREFIX_PATH": "$env{CONDA_PREFIX}"
       },
       "description": "Base profile using conda libraries and compilers on Unix",
       "displayName": "Conda Unix",
@@ -27,12 +14,9 @@
     },
     {
       "cacheVariables": {
-        "CMAKE_AR": "$env{GCC_AR}",
-        "CMAKE_CXX_COMPILER": "$env{GXX}",
-        "CMAKE_C_COMPILER": "$env{GCC}",
-        "CMAKE_Fortran_COMPILER": "$env{GFORTRAN}",
-        "CMAKE_LINKER": "$env{LD_GOLD}",
-        "CMAKE_RANLIB": "$env{GCC_RANLIB}"
+        "CMAKE_CXX_COMPILER": "g++",
+        "CMAKE_C_COMPILER": "gcc",
+        "CMAKE_Fortran_COMPILER": "gfortran"
       },
       "description": "Base profile using conda libraries and GNU compilers",
       "displayName": "Conda GNU",

--- a/dev/CMakePresetsUnix.json
+++ b/dev/CMakePresetsUnix.json
@@ -3,9 +3,12 @@
     {
       "binaryDir": "${sourceDir}/build/${presetName}",
       "cacheVariables": {
+        "CMAKE_EXE_LINKER_FLAGS": "-L$env{CONDA_PREFIX}/lib",
         "CMAKE_INSTALL_LIBDIR": "lib",
         "CMAKE_INSTALL_PREFIX": "$env{CONDA_PREFIX}",
-        "CMAKE_PREFIX_PATH": "$env{CONDA_PREFIX}"
+        "CMAKE_MODULE_LINKER_FLAGS": "-L$env{CONDA_PREFIX}/lib",
+        "CMAKE_PREFIX_PATH": "$env{CONDA_PREFIX}",
+        "CMAKE_SHARED_LINKER_FLAGS": "-L$env{CONDA_PREFIX}/lib"
       },
       "description": "Base profile using conda libraries and compilers on Unix",
       "displayName": "Conda Unix",

--- a/dev/CMakePresetsUnix.json
+++ b/dev/CMakePresetsUnix.json
@@ -3,12 +3,9 @@
     {
       "binaryDir": "${sourceDir}/build/${presetName}",
       "cacheVariables": {
-        "CMAKE_EXE_LINKER_FLAGS": "-L$env{CONDA_PREFIX}/lib",
         "CMAKE_INSTALL_LIBDIR": "lib",
         "CMAKE_INSTALL_PREFIX": "$env{CONDA_PREFIX}",
-        "CMAKE_MODULE_LINKER_FLAGS": "-L$env{CONDA_PREFIX}/lib",
-        "CMAKE_PREFIX_PATH": "$env{CONDA_PREFIX}",
-        "CMAKE_SHARED_LINKER_FLAGS": "-L$env{CONDA_PREFIX}/lib"
+        "CMAKE_PREFIX_PATH": "$env{CONDA_PREFIX}"
       },
       "description": "Base profile using conda libraries and compilers on Unix",
       "displayName": "Conda Unix",

--- a/dev/environment-dev.yml
+++ b/dev/environment-dev.yml
@@ -4,6 +4,8 @@ dependencies:
   # libmamba build dependencies
   # Workaround `mamba-org/mamba#4043`
   - sel(linux): sysroot_linux-64==2.17
+  # compilers >=2.0 install unprefixed compilers on PATH and no longer set CC/CXX.
+  # See conda-forge/compilers-feedstock#78 and conda-forge/conda-forge.github.io#2595.
   - cxx-compiler
   - cmake >=3.16
   - pkg-config # Used by some CMake dependencies

--- a/dev/environment-micromamba-static.yml
+++ b/dev/environment-micromamba-static.yml
@@ -4,11 +4,10 @@ dependencies:
   - python >=3.12
   # libmamba build dependencies
   # Workaround `mamba-org/mamba#4043`
-  # TODO: Understand the linkage issue with GCC 14
-  - sel(linux): cxx-compiler <1.11 #       GCC 13
   - sel(linux): sysroot_linux-64==2.17
-  - sel(osx): cxx-compiler
-  - sel(win): cxx-compiler
+  # compilers >=2.0 install unprefixed compilers on PATH and no longer set CC/CXX.
+  # See conda-forge/compilers-feedstock#78 and conda-forge/conda-forge.github.io#2595.
+  - cxx-compiler
   - cmake >=3.16
   - pkg-config # Used by some CMake dependencies
   - ninja

--- a/libmamba/src/core/util_os.cpp
+++ b/libmamba/src/core/util_os.cpp
@@ -1,4 +1,5 @@
 #include <iostream>
+#include <map>
 #include <regex>
 #include <vector>
 
@@ -12,6 +13,8 @@
 #if defined(__APPLE__)
 #include <libproc.h>
 #include <mach-o/dyld.h>
+#include <sys/resource.h>
+#include <sys/syslimits.h>
 #endif
 #include <inttypes.h>
 #include <limits.h>
@@ -38,6 +41,7 @@
 #include "mamba/core/error_handling.hpp"
 #include "mamba/core/output.hpp"
 #include "mamba/core/util_os.hpp"
+#include "mamba/core/util_scope.hpp"
 #include "mamba/fs/filesystem.hpp"
 #include "mamba/util/build.hpp"
 #include "mamba/util/environment.hpp"
@@ -746,7 +750,45 @@ namespace mamba
     void codesign(const fs::u8path& path, bool verbose)
     {
         reproc::options options;
+        // Keep DYLD_* out of the child. A fully empty environment makes
+        // posix_spawn fail with EINVAL on macOS (GitHub Actions runners).
+        // PATH/HOME/TMPDIR are enough for /usr/bin/codesign.
         options.env.behavior = reproc::env::empty;
+        std::map<std::string, std::string> envmap;
+        envmap["PATH"] = "/usr/bin:/bin";
+        if (auto home = util::get_env("HOME"))
+        {
+            envmap["HOME"] = *home;
+        }
+        envmap["TMPDIR"] = util::get_env("TMPDIR").value_or("/tmp");
+        options.env.extra = envmap;
+
+#if defined(__APPLE__)
+        // posix_spawn also returns EINVAL when RLIMIT_NOFILE is above OPEN_MAX.
+        struct rlimit previous_nofile{};
+        bool restore_nofile = false;
+        if (getrlimit(RLIMIT_NOFILE, &previous_nofile) == 0 && previous_nofile.rlim_cur > OPEN_MAX)
+        {
+            struct rlimit capped = previous_nofile;
+            capped.rlim_cur = OPEN_MAX;
+            if (setrlimit(RLIMIT_NOFILE, &capped) == 0)
+            {
+                restore_nofile = true;
+            }
+            else
+            {
+                LOG_WARNING << "Could not cap RLIMIT_NOFILE for codesign";
+            }
+        }
+        on_scope_exit restore_nofile_limit{ [&]
+                                            {
+                                                if (restore_nofile)
+                                                {
+                                                    setrlimit(RLIMIT_NOFILE, &previous_nofile);
+                                                }
+                                            } };
+#endif
+
         if (!verbose)
         {
             reproc::redirect silence;

--- a/libmamba/src/download/downloader.cpp
+++ b/libmamba/src/download/downloader.cpp
@@ -612,19 +612,11 @@ namespace mamba::download
         if (colon_idx != std::string_view::npos)
         {
             std::string_view key = header.substr(0, colon_idx);
-            colon_idx++;
-            // remove spaces
-            while (std::isspace(header[colon_idx]))
-            {
-                ++colon_idx;
-            }
-
-            // remove \r\n header ending
-            const auto header_end = header.find_first_of("\r\n");
-            std::string_view value = header.substr(
-                colon_idx,
-                (header_end > colon_idx) ? header_end - colon_idx : 0
-            );
+            // Servers such as GHCR send empty values ("Content-Disposition: \r\n").
+            // Indexing past the end here aborts debug libstdc++ (_GLIBCXX_ASSERTIONS).
+            std::string_view remainder = util::lstrip(header.substr(colon_idx + 1));
+            const auto header_end = remainder.find_first_of("\r\n");
+            std::string_view value = remainder.substr(0, header_end);
 
             // http headers are case insensitive!
             const std::string lkey = util::to_lower(key);


### PR DESCRIPTION
## Summary

- The Code Coverage workflow sporadically failed while linking `pygments` after a `cache-environment` hit, with a stale negative extracted-dir cache in micromamba 2.9.0 (#4328 is on \`main\` but not in that release).
- Combining \`environment-dev.yml\`, extra, and static into one \`micromamba create\` is unsatisfiable (shared vs static libraries, \`python>=3.12\` vs \`bcrypt==4.0.1\`).
- Workaround: keep the sequential extra/static installs and set \`cache-environment: false\` so \`pkgs/\` is present when Python is upgraded.

## Type of Change

- [ ] Bugfix
- [ ] Feature / enhancement
- [x] CI / Documentation
- [ ] Maintenance

## Test plan

- [ ] Code Coverage creates \`build_env\` from \`environment-dev.yml\`, then extra, then static, without a solver conflict
- [ ] Static install (\`python>=3.12\`) links pygments successfully
- [ ] Coverage job proceeds past env setup