### PR TITLE
feat: remove restriction that channels from conda env-lockfile were not taken into account

### DIFF
--- a/libmamba/src/core/env_lockfile_conda.cpp
+++ b/libmamba/src/core/env_lockfile_conda.cpp
@@ -128,7 +128,6 @@ namespace mamba
             -> tl::expected<EnvironmentLockFile::Meta, mamba_error>
         {
             EnvironmentLockFile::Meta metadata;
-            metadata.enable_channels = false;  // we ignore the channels specified by the file
 
             for (const auto& platform_node : metadata_node["platforms"])
             {

--- a/libmamba/src/core/env_lockfile_conda.cpp
+++ b/libmamba/src/core/env_lockfile_conda.cpp
@@ -160,8 +160,21 @@ namespace mamba
             for (const auto& channel_node : metadata_node["channels"])
             {
                 EnvironmentLockFile::Channel channel;
-                // FIXME: how to get the name?
-                channel.urls.push_back(channel_node["url"].as<std::string>());
+
+                const auto name_node = channel_node["name"];
+                const auto channel_url = channel_node["url"].as<std::string>();
+
+                // Use the channel name if provided, or url as a name instead.
+                if (not name_node.IsNull())
+                {
+                    channel.name = name_node.as<std::string>();
+                }
+                else
+                {
+                    channel.name = channel_url;
+                }
+
+                channel.urls.push_back(channel_url);
                 channel.used_env_vars = channel_node["used_env_vars"].as<std::vector<std::string>>();
                 metadata.channels.push_back(std::move(channel));
             }

--- a/libmamba/src/core/env_lockfile_conda.cpp
+++ b/libmamba/src/core/env_lockfile_conda.cpp
@@ -160,21 +160,8 @@ namespace mamba
             for (const auto& channel_node : metadata_node["channels"])
             {
                 EnvironmentLockFile::Channel channel;
-
-                const auto name_node = channel_node["name"];
-                const auto channel_url = channel_node["url"].as<std::string>();
-
-                // Use the channel name if provided, or url as a name instead.
-                if (not name_node.IsNull())
-                {
-                    channel.name = name_node.as<std::string>();
-                }
-                else
-                {
-                    channel.name = channel_url;
-                }
-
-                channel.urls.push_back(channel_url);
+                // FIXME: how to get the name?
+                channel.urls.push_back(channel_node["url"].as<std::string>());
                 channel.used_env_vars = channel_node["used_env_vars"].as<std::vector<std::string>>();
                 metadata.channels.push_back(std::move(channel));
             }

--- a/libmamba/src/core/transaction.cpp
+++ b/libmamba/src/core/transaction.cpp
@@ -1580,7 +1580,7 @@ namespace mamba
         {
             // We need to recreate the channel context using updated channel values
             auto channel_context_params = channel_context.params();
-            const auto zst_channels = channel_context.zst_channels();
+            auto zst_channels = channel_context.zst_channels();
 
             for (const EnvironmentLockFile::Channel& channel_info :
                  lockfile_data.get_metadata().channels)


### PR DESCRIPTION
# Description

#4126 implemented the handling of channels specifications coming from environment lockfiles but only with mambajs lockfiles. This PR enables the same feature for conda lockfiles.

## Type of Change

<!-- Please skip this part if you are already using conventional commit keywords in the PR title. -->

- [ ] Bugfix
- [x] Feature / enhancement
- [ ] CI / Documentation
- [ ] Maintenance

## Checklist

- [x] My code follows the general style and conventions of the codebase, ensuring consistency
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have run `pre-commit run --all` locally in the source folder and confirmed that there are no linter errors.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
