### PR TITLE
fix: remove any usage of `exit()`

### DIFF
--- a/libmamba/include/mamba/core/error_handling.hpp
+++ b/libmamba/include/mamba/core/error_handling.hpp
@@ -76,6 +76,16 @@ namespace mamba
         bool m_with_bug_report_message = true;
     };
 
+    /// Only used when we need to exit the program ASAP
+    /// but:
+    //  - we still need to go exit from `main()`;
+    /// - we want the program in control of what to do exactly.
+    /// This should NOT be considered an error and should
+    /// not result in an error report.
+    class mamba_early_exit_request : public std::exception
+    {
+    };
+
     /********************************
      * wrappers around tl::expected *
      ********************************/

--- a/libmamba/include/mamba/core/run.hpp
+++ b/libmamba/include/mamba/core/run.hpp
@@ -21,7 +21,9 @@ namespace mamba
     const fs::u8path& proc_dir();
     LockFile lock_proc_dir();
 
-    void daemonize();
+#ifndef _WIN32
+    auto daemonize() -> std::optional<int>;
+#endif
 
     class ScopedProcFile
     {

--- a/libmamba/src/api/configuration.cpp
+++ b/libmamba/src/api/configuration.cpp
@@ -2297,7 +2297,7 @@ namespace mamba
             int dump_opts = MAMBA_SHOW_CONFIG_VALUES | MAMBA_SHOW_CONFIG_SRCS
                             | MAMBA_SHOW_ALL_CONFIGS;
             print_dump(*this, dump_opts);
-            exit(0);
+            return;
         }
 
         m_context.set_log_level(m_context.output_params.logging_level);

--- a/libmamba/src/api/configuration.cpp
+++ b/libmamba/src/api/configuration.cpp
@@ -2297,7 +2297,7 @@ namespace mamba
             int dump_opts = MAMBA_SHOW_CONFIG_VALUES | MAMBA_SHOW_CONFIG_SRCS
                             | MAMBA_SHOW_ALL_CONFIGS;
             print_dump(*this, dump_opts);
-            return;
+            throw mamba_early_exit_request{};
         }
 
         m_context.set_log_level(m_context.output_params.logging_level);

--- a/libmamba/src/core/run.cpp
+++ b/libmamba/src/core/run.cpp
@@ -243,7 +243,7 @@ namespace mamba
     }
 
 #ifndef _WIN32
-    void daemonize()
+    auto daemonize() -> std::optional<int>
     {
         pid_t pid, sid;
         int fd;
@@ -251,20 +251,20 @@ namespace mamba
         // already a daemon
         if (getppid() == 1)
         {
-            return;
+            return {};
         }
 
         // fork parent process
         pid = fork();
         if (pid < 0)
         {
-            exit(1);
+            return 1;
         }
 
         // exit parent process
         if (pid > 0)
         {
-            exit(0);
+            return 0;
         }
 
         // at this point we are executing as the child process
@@ -272,7 +272,7 @@ namespace mamba
         sid = setsid();
         if (sid < 0)
         {
-            exit(1);
+            return 1;
         }
 
         fd = open("/dev/null", O_RDWR, 0);
@@ -291,6 +291,8 @@ namespace mamba
                 close(fd);
             }
         }
+
+        return {};
     }
 #endif
 
@@ -400,7 +402,11 @@ namespace mamba
                 "Running wrapped script {} in the background\n",
                 fmt::join(command, " ")
             );
-            daemonize();
+            auto result = daemonize();
+            if(result)
+            {
+                return *result;
+            }
         }
 #endif
         int status;

--- a/libmamba/src/core/run.cpp
+++ b/libmamba/src/core/run.cpp
@@ -403,7 +403,7 @@ namespace mamba
                 fmt::join(command, " ")
             );
             auto result = daemonize();
-            if(result)
+            if (result)
             {
                 return *result;
             }

--- a/libmamba/src/core/run.cpp
+++ b/libmamba/src/core/run.cpp
@@ -402,10 +402,10 @@ namespace mamba
                 "Running wrapped script {} in the background\n",
                 fmt::join(command, " ")
             );
-            auto result = daemonize();
-            if (result)
+            const auto maybe_exit_code = daemonize();
+            if (maybe_exit_code)
             {
-                return *result;
+                return maybe_exit_code.value();
             }
         }
 #endif

--- a/micromamba/src/main.cpp
+++ b/micromamba/src/main.cpp
@@ -262,6 +262,13 @@ main(int argc, char** argv)
             config.load();
             Console::instance().print(app.get_subcommand("config")->help());
         }
+        if (auto maybe_exit_code = get_mamba_run_command_exit_code())  // the `run` subcommand was
+                                                                       // executed and resulted in
+                                                                       // an exit code that we must
+                                                                       // use
+        {
+            return_value = maybe_exit_code.value();
+        }
     }
     catch (const mamba::mamba_error& e)
     {

--- a/micromamba/src/main.cpp
+++ b/micromamba/src/main.cpp
@@ -194,7 +194,7 @@ main(int argc, char** argv)
 
     ctx.command_params.is_mamba_exe = true;
 
-    CLI::App app{ "Version: " + version() + "\n" };
+    CLI::App app{ umamba::app_name_with_version() };
     set_umamba_command(&app, config);
 
     char** utf8argv;
@@ -308,18 +308,24 @@ main(int argc, char** argv)
         // We only preserve CLI11 output behavior when errors from CLI11
         // occurs because of `--help` or `--version` is used. Otherwise we follow the
         // logic that `--json` outputs everything as JSON.
-        static constexpr std::array non_error_request_names = { "CallForHelp"sv,
-                                                                "CallForAllHelp"sv,
-                                                                "CallForVersion"sv };
-        const bool is_non_error_request = std::ranges::find(non_error_request_names, e.get_name())
+        static constexpr std::array non_error_request_names = { "CallForHelp"sv, "CallForAllHelp"sv };
+        static constexpr auto version_print_request = "CallForVersion"sv;
+        const auto error_name = e.get_name();
+        const bool is_non_error_request = std::ranges::find(non_error_request_names, error_name)
                                           != non_error_request_names.end();
+        const bool is_version_print_request = version_print_request == error_name;
 
-        if (ctx.output_params.json and not is_non_error_request)
+        if (ctx.output_params.json and (not is_non_error_request or is_version_print_request))
         {
             // we want the output to end up in the json log history
             std::stringstream output;
             return_value = app.exit(e, output, output);
-            LOG_WARNING << output.str();
+            if (not is_version_print_request)
+            {
+                // when using json output and just wanting the version, we don't need to report the
+                // rest of the output
+                LOG_WARNING << output.str();
+            }
         }
         else
         {

--- a/micromamba/src/main.cpp
+++ b/micromamba/src/main.cpp
@@ -137,6 +137,7 @@ report_error(
 
 namespace
 {
+    std::optional<int> requested_exit_code;
     std::atomic<bool> constructed_console{ false };
     std::optional<ContextOptions> pre_config_options;
 
@@ -172,6 +173,19 @@ namespace
         }
         logging::flush_logs();
         std::abort();
+    }
+}
+
+namespace mamba
+{
+    auto request_exit_code(int exit_code) -> void
+    {
+        requested_exit_code = exit_code;
+    }
+
+    auto get_requested_exit_code() -> std::optional<int>
+    {
+        return requested_exit_code;
     }
 }
 
@@ -262,10 +276,9 @@ main(int argc, char** argv)
             config.load();
             Console::instance().print(app.get_subcommand("config")->help());
         }
-        if (auto maybe_exit_code = get_mamba_run_command_exit_code())  // the `run` subcommand was
-                                                                       // executed and resulted in
-                                                                       // an exit code that we must
-                                                                       // use
+        if (auto maybe_exit_code = get_requested_exit_code())  // a subcommand was executed and
+                                                               // requested the program to exit with
+                                                               // an exit code
         {
             return_value = maybe_exit_code.value();
         }

--- a/micromamba/src/main.cpp
+++ b/micromamba/src/main.cpp
@@ -137,7 +137,6 @@ report_error(
 
 namespace
 {
-    std::optional<int> requested_exit_code;
     std::atomic<bool> constructed_console{ false };
     std::optional<ContextOptions> pre_config_options;
 
@@ -173,19 +172,6 @@ namespace
         }
         logging::flush_logs();
         std::abort();
-    }
-}
-
-namespace mamba
-{
-    auto request_exit_code(int exit_code) -> void
-    {
-        requested_exit_code = exit_code;
-    }
-
-    auto get_requested_exit_code() -> std::optional<int>
-    {
-        return requested_exit_code;
     }
 }
 
@@ -276,9 +262,9 @@ main(int argc, char** argv)
             config.load();
             Console::instance().print(app.get_subcommand("config")->help());
         }
-        if (auto maybe_exit_code = get_requested_exit_code())  // a subcommand was executed and
-                                                               // requested the program to exit with
-                                                               // an exit code
+        if (auto maybe_exit_code = umamba::get_requested_exit_code())  // a subcommand was executed
+                                                                       // and requested the program
+                                                                       // to exit with an exit code
         {
             return_value = maybe_exit_code.value();
         }

--- a/micromamba/src/main.cpp
+++ b/micromamba/src/main.cpp
@@ -269,6 +269,11 @@ main(int argc, char** argv)
             return_value = maybe_exit_code.value();
         }
     }
+    catch (const mamba::mamba_early_exit_request&)
+    {
+        // Gracefully exit the program without noise.
+        LOG_DEBUG << "early exit request received, exiting now";
+    }
     catch (const mamba::mamba_error& e)
     {
         // We treat interruptions (ctrl-c) specially by not logging a critical error.

--- a/micromamba/src/run.cpp
+++ b/micromamba/src/run.cpp
@@ -244,7 +244,7 @@ set_run_command(CLI::App* subcom, Configuration& config)
                 specific_process_name
             );
 
-            mamba::request_exit_code(exit_code);
+            umamba::request_exit_code(exit_code);
         }
     );
 }

--- a/micromamba/src/run.cpp
+++ b/micromamba/src/run.cpp
@@ -137,6 +137,16 @@ set_ps_command(CLI::App* subcom, Context& context)
     );
 }
 
+namespace
+{
+    std::optional<int> mamba_run_command_exit_code;
+}
+
+auto get_mamba_run_command_exit_code() -> std::optional<int>
+{
+    return mamba_run_command_exit_code;
+}
+
 void
 set_run_command(CLI::App* subcom, Configuration& config)
 {
@@ -193,8 +203,9 @@ set_run_command(CLI::App* subcom, Configuration& config)
             std::vector<std::string> command = subcom->remaining();
             if (command.empty())
             {
-                LOG_ERROR << "Did not receive any command to run inside environment";
-                exit(1);
+                const auto message = "Did not receive any command to run inside environment";
+                LOG_ERROR << message;
+                throw mamba_error(message, mamba_error_code::incorrect_usage);
             }
 
             // create a copy before inserting additional things
@@ -242,7 +253,7 @@ set_run_command(CLI::App* subcom, Configuration& config)
                 specific_process_name
             );
 
-            exit(exit_code);
+            mamba_run_command_exit_code = exit_code;
         }
     );
 }

--- a/micromamba/src/run.cpp
+++ b/micromamba/src/run.cpp
@@ -24,6 +24,7 @@
 #include "mamba/util/random.hpp"
 
 #include "common_options.hpp"
+#include "umamba.hpp"
 
 #ifndef _WIN32
 extern "C"
@@ -137,16 +138,6 @@ set_ps_command(CLI::App* subcom, Context& context)
     );
 }
 
-namespace
-{
-    std::optional<int> mamba_run_command_exit_code;
-}
-
-auto get_mamba_run_command_exit_code() -> std::optional<int>
-{
-    return mamba_run_command_exit_code;
-}
-
 void
 set_run_command(CLI::App* subcom, Configuration& config)
 {
@@ -253,7 +244,7 @@ set_run_command(CLI::App* subcom, Configuration& config)
                 specific_process_name
             );
 
-            mamba_run_command_exit_code = exit_code;
+            mamba::request_exit_code(exit_code);
         }
     );
 }

--- a/micromamba/src/shell.cpp
+++ b/micromamba/src/shell.cpp
@@ -362,8 +362,7 @@ namespace
                         return util::get_env("SHELL").value_or("bash");
                     };
 
-                    exit(
-                        mamba::run_in_environment(
+                    const auto exit_code = mamba::run_in_environment(
                             config.context(),
                             config.context().prefix_params.target_prefix,
                             { get_shell() },
@@ -373,8 +372,8 @@ namespace
                             false,
                             {},
                             ""
-                        )
-                    );
+                        );
+                    mamba::request_exit_code(exit_code);
                 }
             }
         );

--- a/micromamba/src/shell.cpp
+++ b/micromamba/src/shell.cpp
@@ -373,7 +373,7 @@ namespace
                             {},
                             ""
                         );
-                    mamba::request_exit_code(exit_code);
+                    umamba::request_exit_code(exit_code);
                 }
             }
         );

--- a/micromamba/src/shell.cpp
+++ b/micromamba/src/shell.cpp
@@ -363,16 +363,16 @@ namespace
                     };
 
                     const auto exit_code = mamba::run_in_environment(
-                            config.context(),
-                            config.context().prefix_params.target_prefix,
-                            { get_shell() },
-                            ".",
-                            static_cast<int>(STREAM_OPTIONS::ALL_STREAMS),
-                            false,
-                            false,
-                            {},
-                            ""
-                        );
+                        config.context(),
+                        config.context().prefix_params.target_prefix,
+                        { get_shell() },
+                        ".",
+                        static_cast<int>(STREAM_OPTIONS::ALL_STREAMS),
+                        false,
+                        false,
+                        {},
+                        ""
+                    );
                     umamba::request_exit_code(exit_code);
                 }
             }

--- a/micromamba/src/umamba.cpp
+++ b/micromamba/src/umamba.cpp
@@ -4,9 +4,12 @@
 //
 // The full license is in the file LICENSE, distributed with this software.
 
+#include <format>
+
 #include "mamba/api/configuration.hpp"
 #include "mamba/core/channel_context.hpp"
 #include "mamba/core/context.hpp"
+#include "mamba/core/util_os.hpp"
 #include "mamba/version.hpp"
 
 #include "common_options.hpp"
@@ -14,8 +17,6 @@
 #include "version.hpp"
 
 using namespace mamba;  // NOLINT(build/namespaces)
-
-
 
 namespace umamba
 {
@@ -30,8 +31,17 @@ namespace umamba
     {
         return requested_exit_code;
     }
-}
 
+    auto app_name() -> std::string
+    {
+        return mamba::get_self_exe_path().stem().string();
+    }
+
+    auto app_name_with_version() -> std::string
+    {
+        return std::format("{} v{}", umamba::app_name(), umamba::version());
+    }
+}
 
 void
 init_umamba_options(CLI::App* subcom, Configuration& config)
@@ -49,20 +59,20 @@ set_umamba_command(CLI::App* com, mamba::Configuration& config)
 
     context.command_params.caller_version = umamba::version();
 
-    auto print_version = [&](int /*count*/)
+    auto print_version = [&]() -> std::string
     {
         if (config.context().output_params.json)
         {
             Console::instance().set_json_output("/version"_json_pointer, umamba::version());
+            return "";
         }
         else
         {
-            std::cout << umamba::version() << std::endl;
-            exit(0);
+            return umamba::app_name_with_version();
         }
     };
 
-    com->add_flag_function("--version", print_version);
+    com->set_version_flag("--version", print_version);
 
     CLI::App* shell_subcom = com->add_subcommand("shell", "Generate shell init scripts");
     set_shell_command(shell_subcom, config);

--- a/micromamba/src/umamba.cpp
+++ b/micromamba/src/umamba.cpp
@@ -15,6 +15,24 @@
 
 using namespace mamba;  // NOLINT(build/namespaces)
 
+
+
+namespace umamba
+{
+    std::optional<int> requested_exit_code;
+
+    auto request_exit_code(int exit_code) -> void
+    {
+        requested_exit_code = exit_code;
+    }
+
+    auto get_requested_exit_code() -> std::optional<int>
+    {
+        return requested_exit_code;
+    }
+}
+
+
 void
 init_umamba_options(CLI::App* subcom, Configuration& config)
 {

--- a/micromamba/src/umamba.cpp
+++ b/micromamba/src/umamba.cpp
@@ -68,7 +68,7 @@ set_umamba_command(CLI::App* com, mamba::Configuration& config)
         }
         else
         {
-            return umamba::app_name_with_version();
+            return umamba::version();
         }
     };
 

--- a/micromamba/src/umamba.hpp
+++ b/micromamba/src/umamba.hpp
@@ -91,4 +91,9 @@ get_completions(CLI::App* app, mamba::Configuration& config, int argc, char** ar
 void
 set_auth_command(CLI::App* subcom);
 
+/// @returns An exit code to return from `main()` IFF the `run` sub-command
+///          has been executed and resulted an exit code.
+auto
+get_mamba_run_command_exit_code() -> std::optional<int>;
+
 #endif

--- a/micromamba/src/umamba.hpp
+++ b/micromamba/src/umamba.hpp
@@ -91,9 +91,14 @@ get_completions(CLI::App* app, mamba::Configuration& config, int argc, char** ar
 void
 set_auth_command(CLI::App* subcom);
 
-/// @returns An exit code to return from `main()` IFF the `run` sub-command
-///          has been executed and resulted an exit code.
-auto
-get_mamba_run_command_exit_code() -> std::optional<int>;
+namespace mamba
+{
+    /// @returns An exit code to return from `main()` IFF a sub-command
+    ///          has been executed and requested the program to exit with that code.
+    auto get_requested_exit_code() -> std::optional<int>;
+
+    /// Requests `main()` to exit with the specified exit code if possible.
+    auto request_exit_code(int exit_code) -> void;
+}
 
 #endif

--- a/micromamba/src/umamba.hpp
+++ b/micromamba/src/umamba.hpp
@@ -99,6 +99,12 @@ namespace umamba
 
     /// Requests `main()` to exit with the specified exit code if possible.
     auto request_exit_code(int exit_code) -> void;
+
+    /// Current application name ("micromamba" or "mamba")
+    auto app_name() -> std::string;
+
+    /// Current application name ("micromamba" or "mamba") with a version number.
+    auto app_name_with_version() -> std::string;
 }
 
 #endif

--- a/micromamba/src/umamba.hpp
+++ b/micromamba/src/umamba.hpp
@@ -91,7 +91,7 @@ get_completions(CLI::App* app, mamba::Configuration& config, int argc, char** ar
 void
 set_auth_command(CLI::App* subcom);
 
-namespace mamba
+namespace umamba
 {
     /// @returns An exit code to return from `main()` IFF a sub-command
     ///          has been executed and requested the program to exit with that code.


### PR DESCRIPTION
# Description

<!-- Please include a summary of the changes and the related issue. -->

Removes any call to `exit()` or similar from libmamba and mamba exe.
This makes the handling of static objects clearer (everything depends on main and singletons explicit lifetimes) and helps solve related issues.
It also gives back the control of program exit to the program using `libmamba` when the exit call was done in the library.
Discussed [there](https://github.com/mamba-org/mamba/pull/4379#issuecomment-5538429616), needed to remove the logging termination reason system while also solving [this crash](https://github.com/conda/constructor/issues/1319).

To replace some of the exit calls, this PR:
- adds a mechanism in `(micro)mamba` executable to request a specific exit value, mainly used by `run` subcommand;
- adds a C++ exception type only used as a request to exit the program early, [discussed there](https://github.com/mamba-org/mamba/pull/4397#issuecomment-5583903107).

IMPORTANT: This also changes the output of `--version` to something like `(micro)mamba v2.x.y`. This is due to the exit call that was removed hiding the rest of the execution which had to be adjusted to output correctly.

<!-- Please skip this part if you are already using conventional commit keywords in the PR title. -->

- [x] Bugfix
- [ ] Feature / enhancement
- [ ] CI / Documentation
- [ ] Maintenance

## Checklist

- [x] My code follows the general style and conventions of the codebase, ensuring consistency
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have run `pre-commit run --all` locally in the source folder and confirmed that there are no linter errors.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
