### PR TITLE
feat: Remove stop-reason mechanism from logging system

### DIFF
--- a/libmamba-spdlog/include/mamba/spdlog/logging_spdlog.hpp
+++ b/libmamba-spdlog/include/mamba/spdlog/logging_spdlog.hpp
@@ -75,7 +75,7 @@ namespace mamba::logging::spdlogimpl
         */
         ///@{
         auto start_log_handling(LoggingParams params, std::vector<log_source> sources) -> void;
-        auto stop_log_handling(stop_reason reason) -> void;
+        auto stop_log_handling() -> void;
 
         auto set_log_level(log_level new_level) -> void;
         auto set_params(LoggingParams new_params) -> void;

--- a/libmamba-spdlog/include/mamba/spdlog/logging_spdlog_impl.hpp
+++ b/libmamba-spdlog/include/mamba/spdlog/logging_spdlog_impl.hpp
@@ -120,34 +120,24 @@ namespace mamba::logging::spdlogimpl
         pimpl->is_active = true;
     }
 
-    auto LogHandler_spdlog::stop_log_handling(stop_reason reason) -> void
+    auto LogHandler_spdlog::stop_log_handling() -> void
     {
         if (not pimpl)
         {
+            // moved-from case, do nothing
             return;
         }
 
         pimpl->tasksync.join_tasks();
 
-        // BEWARE:
-        // When exiting the program, we need to let spdlog handle that
-        // gracefully by itself.
-        // spdlog should flush and properly cleanup, but here we cannot
-        // guarantee if spdlog has been shutdown or not already, which
-        // can lead to crashes if we try to do anything with spdlog
-        // after it has been shutdown.
-        // Instead we do nothing when we are exiting the program,
-        // otherwise we need to flush and unregister loggers.
-        if (reason != stop_reason::program_exit)
+        if (auto default_logger = spdlog::default_logger())
         {
-            if (auto default_logger = spdlog::default_logger())
-            {
-                default_logger->flush();
-            }
-
-            spdlog::drop_all();
-            pimpl->tasksync.reset();
+            default_logger->flush();
         }
+
+        spdlog::drop_all();
+        pimpl->tasksync.reset();
+
         pimpl->is_active = false;
     }
 

--- a/libmamba-spdlog/tests/test_logging_spdlog.cpp
+++ b/libmamba-spdlog/tests/test_logging_spdlog.cpp
@@ -28,7 +28,7 @@ namespace mamba::logging
         spdlogimpl::LogHandler_spdlog handler{ testing_options };
 
         // we need this handler to cleanup loggers properly at the end of this test
-        on_scope_exit _{ [&] { handler.stop_log_handling(stop_reason::manual_stop); } };
+        on_scope_exit _{ [&] { handler.stop_log_handling(); } };
 
         REQUIRE(not handler.is_started());
         handler.start_log_handling({}, testing::testing_log_sources());
@@ -40,7 +40,7 @@ namespace mamba::logging
             handler.start_log_handling({}, testing::testing_log_sources());
             REQUIRE(handler.is_started());
 
-            handler.stop_log_handling(stop_reason::manual_stop);
+            handler.stop_log_handling();
             REQUIRE(not handler.is_started());
         }
 
@@ -62,14 +62,7 @@ namespace mamba::logging
     {
         static constexpr std::size_t arbitrary_log_count = 123;
         static const testing::LogHandlerTestsOptions options{
-            .log_count = arbitrary_log_count,
-
-            // spdlog's log handler only cleanup explicitly when
-            // the stop is manual, otherwise it assumes spdlog will
-            // do the proper cleanup at program exit.
-            // Because we are in tests we need the cleanups between
-            // each test run, so we want all stops to be manual.
-            .last_stop_reason = stop_reason::manual_stop
+            .log_count = arbitrary_log_count
         };
 
         spdlogimpl::LogHandler_spdlog handler{ testing_options };

--- a/libmamba-spdlog/tests/test_logging_spdlog.cpp
+++ b/libmamba-spdlog/tests/test_logging_spdlog.cpp
@@ -61,9 +61,7 @@ namespace mamba::logging
     TEST_CASE("LogHandler_spdlog logging API basic tests")
     {
         static constexpr std::size_t arbitrary_log_count = 123;
-        static const testing::LogHandlerTestsOptions options{
-            .log_count = arbitrary_log_count
-        };
+        static const testing::LogHandlerTestsOptions options{ .log_count = arbitrary_log_count };
 
         spdlogimpl::LogHandler_spdlog handler{ testing_options };
 

--- a/libmamba/include/mamba/core/logging.hpp
+++ b/libmamba/include/mamba/core/logging.hpp
@@ -228,21 +228,6 @@ namespace mamba
             auto operator==(const LogRecord& other) const noexcept -> bool = default;
         };
 
-        /** Reason why we are stopping the logging system.
-            This is mainly used to inform implementations as to why
-            `stop_logging` is being called. Depending on the situation an implementation
-            can decide to do nothing if it is a program exit.
-
-            @see `mamba::logging::stop_logging` for details.
-        */
-        enum class stop_reason
-        {
-            manual_stop,  ///< The stop was requested by user-code, this is not a program exit
-                          ///< situation.
-            program_exit  ///< We are in the process of exiting the program (either after `main()`
-                          ///< or through `exit()` call).
-        };
-
         // clang-format off
         /** Requirements for types which provides log handling implementations.
 
@@ -305,16 +290,12 @@ namespace mamba
 
                 This operation must be thread-safe.
 
-                @param stop_reason Reason why this function was called, mainly used to inform the implementation about
-                                   the ongoing context while stopping the logging system.
-                                   @see `mamba::logging::stop_logging` for details.
-
                 @see `mamba::logging::set_log_handler`
                 @see `mamba::logging::stop_logging`
                 @see `mamba::logging::AnyLogHandler::~AnyLogHandler`
                 @see `mamba::logging::AnyLogHandler::stop_log_handling`
              */
-            handler.stop_log_handling(stop_reason::manual_stop);
+            handler.stop_log_handling();
 
 
             /** While registered in it, called by the logging system when it's current logging system log level changed.
@@ -624,7 +605,7 @@ namespace mamba
             */
             ///@{
             auto start_log_handling(LoggingParams params, std::vector<log_source> sources) -> void;
-            auto stop_log_handling(stop_reason reason = stop_reason::manual_stop) -> void;
+            auto stop_log_handling() -> void;
             auto set_log_level(log_level new_level) -> void;
             auto set_params(LoggingParams new_params) -> void;
             auto log(LogRecord record) -> void;
@@ -725,17 +706,9 @@ namespace mamba
 
             This call is NOT thread-safe.
 
-            @param reason The reason why this function has been called. This is to inform the
-                          implementation about the context of the stop. The implementation could
-                          decide to do something different if it could be re-used or when we know it
-                          is the end of the program. Implementations which relies on libraries
-                          having global objects will probably need to do nothing and expect the
-                          library to handle program exit adequately (spdlog is a good example
-                          of that case).
-
             @returns The registered log handler if any.
         */
-        auto stop_logging(stop_reason reason = stop_reason::manual_stop) -> AnyLogHandler;
+        auto stop_logging() -> AnyLogHandler;
 
         /** Registers a log handler to use in the logging system, or no log handler.
 
@@ -1080,7 +1053,7 @@ namespace mamba::logging
         virtual ~Interface() = default;
 
         virtual void start_log_handling(LoggingParams params, std::vector<log_source> sources) = 0;
-        virtual void stop_log_handling(stop_reason reason) = 0;
+        virtual void stop_log_handling() = 0;
         virtual void set_log_level(log_level new_level) = 0;
         virtual void set_params(LoggingParams new_params) = 0;
         virtual void log(LogRecord record) = 0;
@@ -1120,9 +1093,9 @@ namespace mamba::logging
             as_ref(object).start_log_handling(std::move(params), std::move(sources));
         }
 
-        void stop_log_handling(stop_reason reason) override
+        void stop_log_handling() override
         {
-            as_ref(object).stop_log_handling(reason);
+            as_ref(object).stop_log_handling();
         }
 
         void set_log_level(log_level new_level) override
@@ -1224,10 +1197,10 @@ namespace mamba::logging
         m_storage->start_log_handling(std::move(params), std::move(sources));
     }
 
-    inline auto AnyLogHandler::stop_log_handling(stop_reason reason) -> void
+    inline auto AnyLogHandler::stop_log_handling() -> void
     {
         assert(m_storage);
-        m_storage->stop_log_handling(reason);
+        m_storage->stop_log_handling();
     }
 
     inline auto AnyLogHandler::set_log_level(log_level new_level) -> void

--- a/libmamba/include/mamba/core/logging_tools.hpp
+++ b/libmamba/include/mamba/core/logging_tools.hpp
@@ -239,7 +239,7 @@ namespace mamba::logging
         */
         ///@{
         auto start_log_handling(LoggingParams params, const std::vector<log_source>&) -> void;
-        auto stop_log_handling(stop_reason reason) -> void;
+        auto stop_log_handling() -> void;
 
         auto set_log_level(log_level new_level) -> void;
         auto set_params(LoggingParams new_params) -> void;
@@ -356,7 +356,7 @@ namespace mamba::logging
         */
         ///@{
         auto start_log_handling(LoggingParams params, const std::vector<log_source>&) -> void;
-        auto stop_log_handling(stop_reason reason) -> void;
+        auto stop_log_handling() -> void;
 
         auto set_log_level(log_level new_level) -> void;
         auto set_params(LoggingParams new_params) -> void;
@@ -435,7 +435,7 @@ namespace mamba::logging
         pimpl->data.unsafe_get().backtrace.set_max_trace(params.log_backtrace);
     }
 
-    inline auto LogHandler_History::stop_log_handling(stop_reason) -> void
+    inline auto LogHandler_History::stop_log_handling() -> void
     {
         if (options.clear_on_stop)
         {
@@ -601,7 +601,7 @@ namespace mamba::logging
     }
 
     template <OutputStream T>
-    inline auto LogHandler_Stream<T>::stop_log_handling(stop_reason) -> void
+    inline auto LogHandler_Stream<T>::stop_log_handling() -> void
     {
         assert(out);
         assert(pimpl);

--- a/libmamba/src/core/logging.cpp
+++ b/libmamba/src/core/logging.cpp
@@ -69,7 +69,7 @@ namespace mamba::logging
             std::call_once(flag, [&]{
                 // We dont want to propagate the error if any, just log it and continue;
                 // we dont need the resulting value if any.
-                [[maybe_unused]] auto result = safe_invoke([this] { this->stop_log_handling(stop_reason::program_exit); })
+                [[maybe_unused]] auto result = safe_invoke([this] { this->stop_log_handling(); })
                     .map_error([](const mamba_error& error){
                             // Here with report the error in the standard output to avoid any logging
                             // implementation.
@@ -91,13 +91,12 @@ namespace mamba::logging
         auto change_log_handler(
             AnyLogHandler new_handler,
             std::optional<LoggingParams> maybe_new_params,
-            stop_reason reason,
             std::vector<log_source> sources
         ) -> AnyLogHandler
         {
             if (details::current_log_handler)
             {
-                details::current_log_handler.stop_log_handling(reason);
+                details::current_log_handler.stop_log_handling();
             }
 
             auto previous_handler = std::exchange(details::current_log_handler, std::move(new_handler));
@@ -114,14 +113,14 @@ namespace mamba::logging
 
     }
 
-    auto stop_logging(stop_reason reason) -> AnyLogHandler
+    auto stop_logging() -> AnyLogHandler
     {
         if (not details::current_log_handler)
         {
             // No installed log-handler: do nothing.
             return {};
         }
-        return change_log_handler({}, {}, reason, {});
+        return change_log_handler({}, {}, {});
     }
 
     auto set_log_handler(
@@ -133,7 +132,6 @@ namespace mamba::logging
         return change_log_handler(
             std::move(new_handler),
             std::move(maybe_new_params),
-            stop_reason::manual_stop,
             std::move(new_log_sources)
         );
     }

--- a/libmamba/tests/libmamba_logging/include/mamba/testing/test_logging_common.hpp
+++ b/libmamba/tests/libmamba_logging/include/mamba/testing/test_logging_common.hpp
@@ -80,7 +80,7 @@ namespace mamba::logging::testing
             stats->current_params = std::move(params);
         }
 
-        auto stop_log_handling(stop_reason) -> void
+        auto stop_log_handling() -> void
         {
             ++pimpl->stats->stop_count;
         }
@@ -178,7 +178,7 @@ namespace mamba::logging::testing
 
         // clang-format off
             auto start_log_handling(LoggingParams, const std::vector<log_source>&) -> void {}
-            auto stop_log_handling(stop_reason) -> void {}
+            auto stop_log_handling() -> void {}
             auto set_log_level(log_level) -> void {}
             auto set_params(LoggingParams) -> void {}
             auto log(LogRecord) -> void {}
@@ -211,7 +211,6 @@ namespace mamba::logging::testing
         std::string format_log_message_backtrace_without_guard = "test log in backtrace without guards {}";
         log_level level = log_level::warn;
         std::size_t backtrace_size = 5;
-        stop_reason last_stop_reason = stop_reason::program_exit;
         std::vector<log_source> log_sources = testing_log_sources();
     };
 
@@ -225,7 +224,7 @@ namespace mamba::logging::testing
         }
 
         // clear previous log handler if any
-        stop_logging(stop_reason::manual_stop);
+        stop_logging();
 
         testing::Stats stats;
 
@@ -236,7 +235,7 @@ namespace mamba::logging::testing
             REQUIRE(get_log_handler().has_value());
             ++stats.start_count;
 
-            auto original_handler = stop_logging(stop_reason::manual_stop);
+            auto original_handler = stop_logging();
             REQUIRE(original_handler.has_value());
             REQUIRE(not get_log_handler().has_value());
             ++stats.stop_count;
@@ -375,7 +374,7 @@ namespace mamba::logging::testing
         }
 
         ++stats.stop_count;
-        return { .stats = std::move(stats), .handler = stop_logging(options.last_stop_reason) };
+        return { .stats = std::move(stats), .handler = stop_logging() };
     }
 
     // This generator must be kept in sync with testing::test_classic_inline_logging_api_usage()

--- a/libmamba/tests/libmamba_logging/test_logging_tools.cpp
+++ b/libmamba/tests/libmamba_logging/test_logging_tools.cpp
@@ -235,7 +235,7 @@ namespace mamba::logging
             handler.start_log_handling({}, {});
             REQUIRE(handler.is_started());
 
-            handler.stop_log_handling(stop_reason::manual_stop);
+            handler.stop_log_handling();
             REQUIRE(not handler.is_started());
         }
 
@@ -301,7 +301,7 @@ namespace mamba::logging
             handler.start_log_handling({}, {});
             REQUIRE(handler.is_started());
 
-            handler.stop_log_handling(stop_reason::manual_stop);
+            handler.stop_log_handling();
             REQUIRE(not handler.is_started());
         }
 

--- a/libmambapy/tests/test_legacy.py
+++ b/libmambapy/tests/test_legacy.py
@@ -2,6 +2,7 @@ import subprocess
 import sys
 import libmambapy
 
+
 def test_context_instance_scoped():
     ctx = libmambapy.Context()  # Initialize and then terminate libmamba internals
     assert ctx is not None
@@ -26,6 +27,7 @@ def test_channel_context():
     cc = libmambapy.ChannelContext.make_simple(ctx)
     assert cc.make_channel("pkgs/main")[0].url.str() == "https://conda.anaconda.org/pkgs/main"
     assert len(cc.params().custom_channels) == 0
+
 
 def test_context_survives_interpreter_shutdown():
     # Regression for mamba-org/mamba#4378 / conda/constructor#1319:

--- a/libmambapy/tests/test_legacy.py
+++ b/libmambapy/tests/test_legacy.py
@@ -1,5 +1,6 @@
+import subprocess
+import sys
 import libmambapy
-
 
 def test_context_instance_scoped():
     ctx = libmambapy.Context()  # Initialize and then terminate libmamba internals
@@ -25,3 +26,15 @@ def test_channel_context():
     cc = libmambapy.ChannelContext.make_simple(ctx)
     assert cc.make_channel("pkgs/main")[0].url.str() == "https://conda.anaconda.org/pkgs/main"
     assert len(cc.params().custom_channels) == 0
+
+def test_context_survives_interpreter_shutdown():
+    # Regression for mamba-org/mamba#4378 / conda/constructor#1319:
+    # destroying Context while the process exits must not segfault.
+    script = """
+import libmambapy
+ctx = libmambapy.Context()
+assert ctx is not None
+# Intentionally keep the Context alive until interpreter shutdown.
+"""
+    result = subprocess.run([sys.executable, "-c", script], capture_output=True, text=True)
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
# Description

<!-- Please include a summary of the changes and the related issue. -->

The stop-reason mechanism in the logging system of `mamba` was initially introduced because of the behavior of `spdlog` when a call to `exit()` was done. In essence, `spdlog` will do the proper work of de-initializing itself at some point after `main()` but we cannot guarantee when if `exit()` is called. The proper way to use `spdlog` or any library that relies on static objects is to explicitly end their usage through RAII and scope that usage within the boundaries of `main()`.
Our usage of `exit()` prevented that scenario so we had to add a way to inform the currently active log handler (in `mamba`'s logging system) why it was being stopped so that in the specific case of `spdlog` we would either explicitly stop `spdlog` or do nothing because we dont know if `spdlog` internals were destroyed or not (`exit()` case).

However, that mechanism doesnt work well in contexts where libmamba is used inside another program than `(micro)mamba`, as reported by  #4378 . [A workaround](https://github.com/mamba-org/mamba/pull/4379) was being developed but we discussed better alternatives and realized that if we didn't have `exit()` calls, we could simply always assume that we can stop `spdlog` explicitly without any issue.

#4397 removed any call to `exit()` from the library or executable, forcing execution to go through `main()` properly (which also helps with reasoning about the flow in the program).
Now we have no reason anymore to keep the stop-reason mechanism which was kind of workwaround. This PR removes that mechanism and simplifies the logic of the logging system.

This PR also adds a test for `libmambapy` for the [reported crash](https://github.com/mamba-org/mamba/issues/4378), that test comes from [the workaround pr](https://github.com/mamba-org/mamba/pull/4379).

## Type of Change

<!-- Please skip this part if you are already using conventional commit keywords in the PR title. -->

- [ ] Bugfix
- [x] Feature / enhancement
- [ ] CI / Documentation
- [ ] Maintenance

## Checklist

- [x] My code follows the general style and conventions of the codebase, ensuring consistency
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have run `pre-commit run --all` locally in the source folder and confirmed that there are no linter errors.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
